### PR TITLE
chore: quality audit fixes for Units 1-6

### DIFF
--- a/src/data/course/unit-5.ts
+++ b/src/data/course/unit-5.ts
@@ -285,7 +285,7 @@ export const powerVerbBlocks: SentenceBlock[] = [
       },
       {
         english: "I just saw her and she told me the truth about what happened.",
-        spanish: "Acabo de verla y me dijo la verdad sobre qué pasó.",
+        spanish: "Acabo de verla y me dijo la verdad sobre lo que pasó.",
         highlight: "about what happened",
       },
       {
@@ -364,7 +364,7 @@ export const connectorSentences = {
     english:
       "I just found out about the problem at the party last night and she told me the truth about what happened with him, and now I have to be at the house all day because it's very important.",
     spanish:
-      "Acabo de enterarme del problema en la fiesta anoche y ella me dijo la verdad sobre qué pasó con él, y ahora tengo que estar en la casa todo el día porque es muy importante.",
+      "Acabo de enterarme del problema en la fiesta anoche y ella me dijo la verdad sobre lo que pasó con él, y ahora tengo que estar en la casa todo el día porque es muy importante.",
   },
 };
 

--- a/src/data/course/unit-6.ts
+++ b/src/data/course/unit-6.ts
@@ -292,7 +292,7 @@ export const powerVerbBlocks: SentenceBlock[] = [
       },
       {
         english: "Someone should be able to tell me the truth about what happened at the party last night.",
-        spanish: "Alguien debería poder decirme la verdad sobre qué pasó en la fiesta anoche.",
+        spanish: "Alguien debería poder decirme la verdad sobre lo que pasó en la fiesta anoche.",
       },
     ],
   },
@@ -353,7 +353,7 @@ export const connectorSentences = {
     english:
       "Everyone already knows the truth about what happened, so someone should explain the reason why, because it's too important and nobody should have to wait.",
     spanish:
-      "Todos ya saben la verdad sobre qué pasó, entonces alguien debería explicar el porqué, porque es demasiado importante y nadie debería tener que esperar.",
+      "Todos ya saben la verdad sobre lo que pasó, entonces alguien debería explicar el porqué, porque es demasiado importante y nadie debería tener que esperar.",
   },
 };
 
@@ -365,7 +365,7 @@ export const pronunciationDrills: PronunciationDrill[] = [
     spanishStress: "es-pe-CIAL",
     englishStress: "SPE-shul — NO 'e' before the S",
     tip: "In Spanish, words starting with S + consonant always add an 'e' sound: 'especial.' In English, go straight to the S: 'SPECIAL', not 'e-special.' This is one of the biggest giveaways of a Spanish accent.",
-    tipEs: "En español, las palabras que empiezan con S + consonante siempre añaden un sonido 'e': 'especial.' En inglés, ve directo a la S: 'SPECIAL', no 'e-special.' Este es uno de los mayores indicadores de acento español.",
+    tipEs: "En español, las palabras que empiezan con S + consonante siempre añaden un sonido 'e': 'especial.' En inglés, ve directo a la S: 'SPECIAL', no 'e-special.' Este es uno de los mayores indicadores de acento en español.",
   },
   {
     word: "stop / start",

--- a/src/pages/en/course/beginners/index.astro
+++ b/src/pages/en/course/beginners/index.astro
@@ -127,7 +127,7 @@ const iconMap: Record<string, any> = {
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
         {units.map((unit) => {
           const Icon = iconMap[unit.icon];
-          const isAvailable = [1, 2, 3, 4].includes(unit.id);
+          const isAvailable = [1, 2, 3, 4, 5, 6].includes(unit.id);
           return (
             <a
               href={isAvailable ? `/en/course/beginners/${unit.slug}/` : undefined}

--- a/src/pages/en/course/beginners/unit-1.astro
+++ b/src/pages/en/course/beginners/unit-1.astro
@@ -46,7 +46,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
 <Base
   lang={lang}
   tkey={tkey}
-  title="Unit 1: You Already Know English — First Steps Into English | NY English Teacher"
+  title="Unit 1: You Already Know English | NY English Teacher"
   description="Discover the 100+ English words hiding in your Spanish. Build your first English sentences — from 'It is possible' to complex structures. Free interactive lesson with audio."
 >
   <!-- Course progress bar -->

--- a/src/pages/en/course/beginners/unit-2.astro
+++ b/src/pages/en/course/beginners/unit-2.astro
@@ -45,7 +45,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
 <Base
   lang={lang}
   tkey={tkey}
-  title="Unit 2: What You Like — First Steps Into English | NY English Teacher"
+  title="Unit 2: What You Like | NY English Teacher"
   description="Learn to express preferences in English: I like, I don't like, I would like. Talk about food, daily activities, and the past. Free interactive lesson with audio."
 >
   <CourseProgress

--- a/src/pages/en/course/beginners/unit-3.astro
+++ b/src/pages/en/course/beginners/unit-3.astro
@@ -44,7 +44,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
 <Base
   lang={lang}
   tkey={tkey}
-  title="Unit 3: Talking About Others — First Steps Into English | NY English Teacher"
+  title="Unit 3: Talking About Others | NY English Teacher"
   description="Learn to talk about what he, she, and it can do, wants, and has to do in English. Third person modal verbs, questions, and himself/herself. Free interactive lesson."
 >
   <CourseProgress

--- a/src/pages/en/course/beginners/unit-4.astro
+++ b/src/pages/en/course/beginners/unit-4.astro
@@ -44,7 +44,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
 <Base
   lang={lang}
   tkey={tkey}
-  title="Unit 4: Talking to Someone — First Steps Into English | NY English Teacher"
+  title="Unit 4: Talking to Someone | NY English Teacher"
   description="Learn to address someone directly in English: you can, you have to, tell me the truth, what happened. Indirect objects and TH pronunciation. Free interactive lesson."
 >
   <CourseProgress

--- a/src/pages/en/course/beginners/unit-5.astro
+++ b/src/pages/en/course/beginners/unit-5.astro
@@ -44,7 +44,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
 <Base
   lang={lang}
   tkey={tkey}
-  title="Unit 5: What Just Happened — First Steps Into English | NY English Teacher"
+  title="Unit 5: What Just Happened | NY English Teacher"
   description="Learn to talk about recent events in English with 'just': I just ate, she just told me, he just found out. Past tense -ed pronunciation. Free interactive lesson."
 >
   <CourseProgress

--- a/src/pages/en/course/beginners/unit-6.astro
+++ b/src/pages/en/course/beginners/unit-6.astro
@@ -43,7 +43,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
 <Base
   lang={lang}
   tkey={tkey}
-  title="Unit 6: Everyone, Someone, No One — First Steps Into English | NY English Teacher"
+  title="Unit 6: Everyone, Someone, No One | NY English Teacher"
   description="Learn indefinite pronouns in English: everyone, someone, nobody. Plus should, shouldn't, and initial S pronunciation. Free interactive lesson for Spanish speakers."
 >
   <CourseProgress

--- a/src/pages/es/curso/principiantes/index.astro
+++ b/src/pages/es/curso/principiantes/index.astro
@@ -127,7 +127,7 @@ const iconMap: Record<string, any> = {
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
         {units.map((unit) => {
           const Icon = iconMap[unit.icon];
-          const isAvailable = [1, 2, 3, 4].includes(unit.id);
+          const isAvailable = [1, 2, 3, 4, 5, 6].includes(unit.id);
           return (
             <a
               href={isAvailable ? `/es/curso/principiantes/${unit.slugEs}/` : undefined}

--- a/src/pages/es/curso/principiantes/unidad-1.astro
+++ b/src/pages/es/curso/principiantes/unidad-1.astro
@@ -46,7 +46,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
 <Base
   lang={lang}
   tkey={tkey}
-  title="Unidad 1: Ya Sabes Inglés — Primeros Pasos en Inglés | NY English Teacher"
+  title="Unidad 1: Ya Sabes Inglés | NY English Teacher"
   description="Descubre las más de 100 palabras en inglés escondidas en tu español. Construye tus primeras oraciones en inglés — desde 'It is possible' hasta estructuras complejas. Lección interactiva gratuita con audio."
 >
   <!-- Course progress bar -->
@@ -253,7 +253,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
             <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
           </svg>
         </div>
-        <h2 class="text-3xl font-bold text-white">Unidad 1 Completada!</h2>
+        <h2 class="text-3xl font-bold text-white">¡Unidad 1 Completada!</h2>
         <p class="text-lg text-slate-100 leading-relaxed">
           Acabas de descubrir que ya conoces cientos de palabras en inglés, construiste oraciones complejas,
           y aprendiste cuatro verbos modales poderosos. Eso no es nivel principiante — eso es inglés real.
@@ -274,7 +274,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
         </div>
         <div class="pt-8 border-t border-slate-700 mt-8">
           <p class="text-slate-200 text-sm mb-3">
-            Quieres coaching personalizado de inglés?
+            ¿Quieres coaching personalizado de inglés?
           </p>
           <a
             href="/es/contact/"

--- a/src/pages/es/curso/principiantes/unidad-2.astro
+++ b/src/pages/es/curso/principiantes/unidad-2.astro
@@ -45,7 +45,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
 <Base
   lang={lang}
   tkey={tkey}
-  title="Unidad 2: Lo Que Te Gusta — Primeros Pasos en Inglés | NY English Teacher"
+  title="Unidad 2: Lo Que Te Gusta | NY English Teacher"
   description="Aprende a expresar preferencias en inglés: I like, I don't like, I would like. Habla de comida, actividades y el pasado. Lección interactiva gratuita con audio."
 >
   <CourseProgress
@@ -248,7 +248,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
             <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
           </svg>
         </div>
-        <h2 class="text-3xl font-bold text-white">Unidad 2 Completada!</h2>
+        <h2 class="text-3xl font-bold text-white">¡Unidad 2 Completada!</h2>
         <p class="text-lg text-slate-100 leading-relaxed">
           Ahora puedes expresar gustos, preferencias y hablar del pasado. Combinado con la Unidad 1,
           puedes construir oraciones que la mayoría de "principiantes" no podrían imaginar.
@@ -270,7 +270,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
         </div>
         <div class="pt-8 border-t border-slate-700 mt-8">
           <p class="text-slate-200 text-sm mb-3">
-            Quieres coaching personalizado de inglés?
+            ¿Quieres coaching personalizado de inglés?
           </p>
           <a
             href="/es/contact/"

--- a/src/pages/es/curso/principiantes/unidad-3.astro
+++ b/src/pages/es/curso/principiantes/unidad-3.astro
@@ -43,7 +43,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
 <Base
   lang={lang}
   tkey={tkey}
-  title="Unidad 3: Hablando de Otros — Primeros Pasos en Inglés | NY English Teacher"
+  title="Unidad 3: Hablando de Otros | NY English Teacher"
   description="Aprende a hablar de lo que él, ella puede hacer, quiere y tiene que hacer en inglés. Verbos modales en tercera persona, preguntas y él mismo/ella misma. Lección gratuita."
 >
   <CourseProgress
@@ -247,7 +247,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
             <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
           </svg>
         </div>
-        <h2 class="text-3xl font-bold text-white">Unidad 3 Completada!</h2>
+        <h2 class="text-3xl font-bold text-white">¡Unidad 3 Completada!</h2>
         <p class="text-lg text-slate-100 leading-relaxed">
           Ahora puedes hablar de lo que otras personas pueden hacer, quieren, tienen que hacer y les gustaría.
           Son tres unidades de inglés — y estás construyendo oraciones que la mayoría de principiantes no pueden.
@@ -269,7 +269,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
         </div>
         <div class="pt-8 border-t border-slate-700 mt-8">
           <p class="text-slate-200 text-sm mb-3">
-            Quieres coaching personalizado de inglés?
+            ¿Quieres coaching personalizado de inglés?
           </p>
           <a
             href="/es/contact/"

--- a/src/pages/es/curso/principiantes/unidad-4.astro
+++ b/src/pages/es/curso/principiantes/unidad-4.astro
@@ -44,7 +44,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
 <Base
   lang={lang}
   tkey={tkey}
-  title="Unidad 4: Hablando con Alguien — Primeros Pasos en Inglés | NY English Teacher"
+  title="Unidad 4: Hablando con Alguien | NY English Teacher"
   description="Aprende a dirigirte a alguien directamente en inglés: you can, you have to, dime la verdad, qué pasó. Objetos indirectos y pronunciación TH. Lección gratuita."
 >
   <CourseProgress
@@ -223,7 +223,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
             <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
           </svg>
         </div>
-        <h2 class="text-3xl font-bold text-white">Unidad 4 Completada!</h2>
+        <h2 class="text-3xl font-bold text-white">¡Unidad 4 Completada!</h2>
         <p class="text-lg text-slate-100 leading-relaxed">
           Ahora puedes tener conversaciones directas — hacer preguntas, decir cosas,
           explicar qué pasó. Cuatro unidades y estás construyendo inglés que funciona en la vida real.
@@ -237,7 +237,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
           </a>
         </div>
         <div class="pt-8 border-t border-slate-700 mt-8">
-          <p class="text-slate-200 text-sm mb-3">Quieres coaching personalizado de inglés?</p>
+          <p class="text-slate-200 text-sm mb-3">¿Quieres coaching personalizado de inglés?</p>
           <a href="/es/contact/" class="text-amber-400 hover:text-amber-300 font-medium underline underline-offset-2">
             Agenda una consulta gratuita con Robert →
           </a>

--- a/src/pages/es/curso/principiantes/unidad-5.astro
+++ b/src/pages/es/curso/principiantes/unidad-5.astro
@@ -44,7 +44,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
 <Base
   lang={lang}
   tkey={tkey}
-  title="Unidad 5: Lo Que Acaba de Pasar — Primeros Pasos en Inglés | NY English Teacher"
+  title="Unidad 5: Lo Que Acaba de Pasar | NY English Teacher"
   description="Aprende a hablar de eventos recientes en inglés con 'just': I just ate, she just told me, he just found out. Pronunciación del pasado -ed. Lección gratuita."
 >
   <CourseProgress
@@ -224,7 +224,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
             <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
           </svg>
         </div>
-        <h2 class="text-3xl font-bold text-white">Unidad 5 Completada!</h2>
+        <h2 class="text-3xl font-bold text-white">¡Unidad 5 Completada!</h2>
         <p class="text-lg text-slate-100 leading-relaxed">
           Ahora puedes narrar eventos recientes — qué acaba de pasar, quién acaba de llegar, qué acabas de descubrir.
           Cinco unidades y ya estás contando historias reales en inglés.
@@ -238,7 +238,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
           </a>
         </div>
         <div class="pt-8 border-t border-slate-700 mt-8">
-          <p class="text-slate-200 text-sm mb-3">Quieres coaching personalizado de inglés?</p>
+          <p class="text-slate-200 text-sm mb-3">¿Quieres coaching personalizado de inglés?</p>
           <a href="/es/contact/" class="text-amber-400 hover:text-amber-300 font-medium underline underline-offset-2">
             Agenda una consulta gratuita con Robert →
           </a>

--- a/src/pages/es/curso/principiantes/unidad-6.astro
+++ b/src/pages/es/curso/principiantes/unidad-6.astro
@@ -43,7 +43,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
 <Base
   lang={lang}
   tkey={tkey}
-  title="Unidad 6: Todos, Alguien, Nadie — Primeros Pasos en Inglés | NY English Teacher"
+  title="Unidad 6: Todos, Alguien, Nadie | NY English Teacher"
   description="Aprende pronombres indefinidos en inglés: everyone, someone, nobody. Más should, shouldn't y pronunciación de la S inicial. Lección gratuita interactiva."
 >
   <CourseProgress
@@ -224,7 +224,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
             <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
           </svg>
         </div>
-        <h2 class="text-3xl font-bold text-white">Unidad 6 Completada!</h2>
+        <h2 class="text-3xl font-bold text-white">¡Unidad 6 Completada!</h2>
         <p class="text-lg text-slate-100 leading-relaxed">
           Ahora puedes hablar de todos, alguien y nadie — además de dar consejos con "should."
           Seis unidades y ya expresas opiniones y expectativas en inglés real.
@@ -238,7 +238,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
           </a>
         </div>
         <div class="pt-8 border-t border-slate-700 mt-8">
-          <p class="text-slate-200 text-sm mb-3">Quieres coaching personalizado de inglés?</p>
+          <p class="text-slate-200 text-sm mb-3">¿Quieres coaching personalizado de inglés?</p>
           <a href="/es/contact/" class="text-amber-400 hover:text-amber-300 font-medium underline underline-offset-2">
             Agenda una consulta gratuita con Robert →
           </a>


### PR DESCRIPTION
## Summary
Quality audit across all 6 course units covering Spanish translation, hreflang, SEO, and code quality.

**Spanish punctuation (Units 1-6)**
- Added missing ¡ and ¿ marks on all 6 Spanish unit completion/CTA sections

**Spanish grammar (Units 5-6 data files)**
- Fixed "sobre qué pasó" → "sobre lo que pasó" in relative clause contexts (4 instances)
- Fixed "acento español" → "acento en español" to avoid Spain/Spanish-language ambiguity

**SEO titles (Units 1-6, all 12 pages)**
- Shortened all unit page titles to ≤60 chars by dropping redundant "First Steps Into English" / "Primeros Pasos en Inglés"

**Landing page availability gate**
- Unlocked Units 5 and 6 on both EN and ES course overview pages (were showing "Coming Soon")

## Audit results
- Hreflang: all tkeys match, routes correct, slug/slugEs usage correct
- TypeScript: zero errors from `astro check`
- Code consistency: all patterns match established unit structure
- Build: 339 pages, clean

## Test plan
- [ ] Verify Units 5+6 are clickable on `/en/course/beginners/` and `/es/curso/principiantes/`
- [ ] Verify ¡ and ¿ render correctly on all 6 Spanish unit pages
- [ ] Spot-check title tags in page source (should be ≤60 chars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)