### PR TITLE
feat: add final exam for beginner English course

### DIFF
--- a/src/components/course/CourseExam.tsx
+++ b/src/components/course/CourseExam.tsx
@@ -1,0 +1,426 @@
+import { useState, useMemo, useCallback } from "react";
+import type { ExamQuestion, ExamResult } from "@data/course/exam";
+import { calculateExamResult, getScoreTier } from "@data/course/exam";
+
+interface Props {
+  questions: ExamQuestion[];
+  lang: "en" | "es";
+  passingScore: number;
+  courseBasePath: string;
+}
+
+export default function CourseExam({ questions, lang, passingScore, courseBasePath }: Props) {
+  const [phase, setPhase] = useState<"intro" | "exam" | "results">("intro");
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [answers, setAnswers] = useState<Record<number, number>>({});
+  const [selectedOption, setSelectedOption] = useState<number | null>(null);
+  const [showFeedback, setShowFeedback] = useState(false);
+  const [result, setResult] = useState<ExamResult | null>(null);
+
+  const en = lang === "en";
+
+  // Shuffle questions once per session
+  const shuffledQuestions = useMemo(
+    () => [...questions].sort(() => Math.random() - 0.5),
+    [questions]
+  );
+
+  const current = shuffledQuestions[currentIndex];
+  const totalQuestions = shuffledQuestions.length;
+  const progress = ((currentIndex) / totalQuestions) * 100;
+
+  // Shuffle options for current question
+  const shuffledOptions = useMemo(() => {
+    if (!current) return [];
+    const indexed = current.options.map((opt, i) => ({ ...opt, originalIndex: i }));
+    return indexed.sort(() => Math.random() - 0.5);
+  }, [current?.id]);
+
+  const handleSelectOption = useCallback(
+    (displayIndex: number) => {
+      if (showFeedback) return;
+      const option = shuffledOptions[displayIndex];
+      setSelectedOption(displayIndex);
+      setAnswers((prev) => ({
+        ...prev,
+        [current.id]: current.options.findIndex((o) => o.text === option.text),
+      }));
+      setShowFeedback(true);
+    },
+    [showFeedback, shuffledOptions, current]
+  );
+
+  const handleNext = useCallback(() => {
+    if (currentIndex < totalQuestions - 1) {
+      setCurrentIndex((i) => i + 1);
+      setSelectedOption(null);
+      setShowFeedback(false);
+    } else {
+      const examResult = calculateExamResult(answers);
+      setResult(examResult);
+      setPhase("results");
+    }
+  }, [currentIndex, totalQuestions, answers]);
+
+  const handleRestart = useCallback(() => {
+    setPhase("intro");
+    setCurrentIndex(0);
+    setAnswers({});
+    setSelectedOption(null);
+    setShowFeedback(false);
+    setResult(null);
+  }, []);
+
+  // ─── Intro Screen ──────────────────────────────────────────────────
+  if (phase === "intro") {
+    return (
+      <div className="max-w-2xl mx-auto text-center space-y-6 py-8">
+        <div className="bg-white rounded-2xl border border-slate-200 p-8 shadow-sm space-y-6">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-amber-100 text-amber-600">
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </div>
+          <h2 className="text-2xl font-bold text-slate-900">
+            {en ? "Ready for the Final Exam?" : "¿Listo para el Examen Final?"}
+          </h2>
+          <div className="text-left space-y-3 text-slate-600">
+            <p>
+              {en
+                ? "This exam tests everything you learned across all 10 units:"
+                : "Este examen evalúa todo lo que aprendiste en las 10 unidades:"}
+            </p>
+            <ul className="space-y-1.5 text-sm">
+              <li className="flex items-start gap-2">
+                <span className="text-amber-500 font-bold mt-0.5">20</span>
+                {en ? "multiple-choice questions" : "preguntas de opción múltiple"}
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-amber-500 font-bold mt-0.5">3</span>
+                {en
+                  ? "categories: vocabulary, grammar, translation"
+                  : "categorías: vocabulario, gramática, traducción"}
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-amber-500 font-bold mt-0.5">{passingScore}%</span>
+                {en ? "to pass" : "para aprobar"}
+              </li>
+            </ul>
+            <p className="text-sm text-slate-500">
+              {en
+                ? "You'll get instant feedback after each question. Take your time — there's no time limit."
+                : "Recibirás retroalimentación instantánea después de cada pregunta. Tómate tu tiempo — no hay límite de tiempo."}
+            </p>
+          </div>
+          <button
+            onClick={() => setPhase("exam")}
+            className="w-full px-6 py-3.5 rounded-xl bg-amber-500 text-white font-semibold hover:bg-amber-400 transition-colors shadow-lg text-lg"
+          >
+            {en ? "Start Exam" : "Comenzar Examen"}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ─── Results Screen ────────────────────────────────────────────────
+  if (phase === "results" && result) {
+    const tier = getScoreTier(result.percentage);
+    const passed = result.percentage >= passingScore;
+    const unitNumbers = Object.keys(result.unitScores)
+      .map(Number)
+      .sort((a, b) => a - b);
+
+    return (
+      <div className="max-w-2xl mx-auto space-y-8 py-8">
+        {/* Score Card */}
+        <div
+          className={`rounded-2xl p-8 text-center space-y-4 ${
+            passed
+              ? "bg-gradient-to-b from-emerald-50 to-white border border-emerald-200"
+              : "bg-gradient-to-b from-rose-50 to-white border border-rose-200"
+          }`}
+        >
+          <div
+            className={`inline-flex items-center justify-center w-24 h-24 rounded-full text-white text-3xl font-bold ${
+              tier.color === "emerald"
+                ? "bg-emerald-500"
+                : tier.color === "amber"
+                ? "bg-amber-500"
+                : "bg-rose-500"
+            }`}
+          >
+            {result.percentage}%
+          </div>
+          <h2 className="text-2xl font-bold text-slate-900">
+            {en ? tier.tier : tier.tierEs}
+          </h2>
+          <p className="text-slate-600 max-w-md mx-auto">
+            {en ? tier.message : tier.messageEs}
+          </p>
+          <p className="text-sm text-slate-500">
+            {result.totalCorrect} / {result.totalQuestions}{" "}
+            {en ? "correct" : "correctas"}
+          </p>
+        </div>
+
+        {/* Category Breakdown */}
+        <div className="bg-white rounded-2xl border border-slate-200 p-6 space-y-4">
+          <h3 className="text-lg font-bold text-slate-900">
+            {en ? "Score by Category" : "Puntuación por Categoría"}
+          </h3>
+          <div className="space-y-3">
+            {Object.entries(result.categoryScores).map(([cat, score]) => {
+              const pct = Math.round((score.correct / score.total) * 100);
+              const catLabel =
+                cat === "vocabulary"
+                  ? en ? "Vocabulary" : "Vocabulario"
+                  : cat === "grammar"
+                  ? en ? "Grammar" : "Gramática"
+                  : en ? "Translation" : "Traducción";
+              return (
+                <div key={cat}>
+                  <div className="flex justify-between text-sm mb-1">
+                    <span className="font-medium text-slate-700">{catLabel}</span>
+                    <span className="text-slate-500">
+                      {score.correct}/{score.total} ({pct}%)
+                    </span>
+                  </div>
+                  <div className="h-2.5 bg-slate-100 rounded-full overflow-hidden">
+                    <div
+                      className={`h-full rounded-full transition-all ${
+                        pct >= 80 ? "bg-emerald-500" : pct >= 60 ? "bg-amber-500" : "bg-rose-500"
+                      }`}
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Unit Breakdown */}
+        <div className="bg-white rounded-2xl border border-slate-200 p-6 space-y-4">
+          <h3 className="text-lg font-bold text-slate-900">
+            {en ? "Score by Unit" : "Puntuación por Unidad"}
+          </h3>
+          <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
+            {unitNumbers.map((unit) => {
+              const s = result.unitScores[unit];
+              const pct = Math.round((s.correct / s.total) * 100);
+              return (
+                <div
+                  key={unit}
+                  className={`rounded-xl p-3 text-center border ${
+                    pct === 100
+                      ? "bg-emerald-50 border-emerald-200"
+                      : pct >= 50
+                      ? "bg-amber-50 border-amber-200"
+                      : "bg-rose-50 border-rose-200"
+                  }`}
+                >
+                  <div className="text-xs text-slate-500 mb-1">
+                    {en ? "Unit" : "Unidad"} {unit}
+                  </div>
+                  <div className="text-lg font-bold text-slate-900">
+                    {s.correct}/{s.total}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Certificate / Celebration (if passed) */}
+        {passed && (
+          <div className="bg-gradient-to-b from-amber-500 to-amber-600 rounded-2xl p-8 text-center text-white space-y-4">
+            <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-white/20">
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+              </svg>
+            </div>
+            <h3 className="text-2xl font-bold">
+              {en ? "Course Complete!" : "¡Curso Completado!"}
+            </h3>
+            <p className="text-amber-100">
+              {en
+                ? "You passed the First Steps Into English final exam. You have a solid foundation in English — 1,500+ words, 11 modal structures, and all three time frames."
+                : "Aprobaste el examen final de Primeros Pasos en Inglés. Tienes una base sólida en inglés — más de 1,500 palabras, 11 estructuras modales y los tres marcos temporales."}
+            </p>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex flex-wrap gap-4 justify-center">
+          <button
+            onClick={handleRestart}
+            className="px-6 py-3 rounded-xl bg-slate-100 text-slate-700 font-medium hover:bg-slate-200 transition-colors"
+          >
+            {en ? "Retake Exam" : "Repetir Examen"}
+          </button>
+          <a
+            href={`${courseBasePath}/`}
+            className="px-6 py-3 rounded-xl bg-slate-700 text-white font-medium hover:bg-slate-600 transition-colors"
+          >
+            {en ? "Review Units" : "Repasar Unidades"}
+          </a>
+          <a
+            href={en ? "/en/contact/" : "/es/contact/"}
+            className="px-6 py-3 rounded-xl bg-amber-500 text-white font-semibold hover:bg-amber-400 transition-colors shadow-lg"
+          >
+            {en ? "Book a Free Consultation" : "Agenda una Consulta Gratuita"}
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  // ─── Exam Screen (Question by Question) ────────────────────────────
+  if (!current) return null;
+
+  const correctDisplayIndex = showFeedback
+    ? shuffledOptions.findIndex((o) => o.correct)
+    : -1;
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6 py-4">
+      {/* Progress */}
+      <div className="space-y-2">
+        <div className="flex justify-between text-sm text-slate-500">
+          <span>
+            {en ? "Question" : "Pregunta"} {currentIndex + 1} / {totalQuestions}
+          </span>
+          <span>
+            {en ? "Unit" : "Unidad"} {current.unit}
+          </span>
+        </div>
+        <div className="h-2 bg-slate-100 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-amber-500 rounded-full transition-all duration-300"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Question Card */}
+      <div className="bg-white rounded-2xl border border-slate-200 p-6 md:p-8 shadow-sm space-y-6">
+        {/* Category badge */}
+        <span
+          className={`inline-block px-3 py-1 rounded-full text-xs font-medium ${
+            current.category === "vocabulary"
+              ? "bg-blue-100 text-blue-700"
+              : current.category === "grammar"
+              ? "bg-purple-100 text-purple-700"
+              : "bg-green-100 text-green-700"
+          }`}
+        >
+          {current.category === "vocabulary"
+            ? en ? "Vocabulary" : "Vocabulario"
+            : current.category === "grammar"
+            ? en ? "Grammar" : "Gramática"
+            : en ? "Translation" : "Traducción"}
+        </span>
+
+        {/* Question text */}
+        <h3 className="text-lg md:text-xl font-semibold text-slate-900 leading-relaxed">
+          {en ? current.prompt : current.promptEs}
+        </h3>
+
+        {/* Options */}
+        <div className="space-y-3">
+          {shuffledOptions.map((option, i) => {
+            const letter = String.fromCharCode(65 + i); // A, B, C, D
+            let borderClass = "border-slate-200 hover:border-amber-300 hover:bg-amber-50";
+            let bgClass = "";
+
+            if (showFeedback) {
+              if (i === correctDisplayIndex) {
+                borderClass = "border-emerald-400";
+                bgClass = "bg-emerald-50";
+              } else if (i === selectedOption && !option.correct) {
+                borderClass = "border-rose-400";
+                bgClass = "bg-rose-50";
+              } else {
+                borderClass = "border-slate-100";
+                bgClass = "opacity-50";
+              }
+            } else if (i === selectedOption) {
+              borderClass = "border-amber-400 bg-amber-50";
+            }
+
+            return (
+              <button
+                key={i}
+                onClick={() => handleSelectOption(i)}
+                disabled={showFeedback}
+                className={`w-full text-left px-4 py-3.5 rounded-xl border-2 transition-all flex items-start gap-3 ${borderClass} ${bgClass} ${
+                  showFeedback ? "cursor-default" : "cursor-pointer"
+                }`}
+              >
+                <span
+                  className={`flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-sm font-semibold ${
+                    showFeedback && i === correctDisplayIndex
+                      ? "bg-emerald-500 text-white"
+                      : showFeedback && i === selectedOption && !option.correct
+                      ? "bg-rose-500 text-white"
+                      : "bg-slate-100 text-slate-600"
+                  }`}
+                >
+                  {showFeedback && i === correctDisplayIndex
+                    ? "\u2713"
+                    : showFeedback && i === selectedOption && !option.correct
+                    ? "\u2717"
+                    : letter}
+                </span>
+                <span className="text-slate-700 leading-relaxed">{option.text}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Feedback */}
+        {showFeedback && (
+          <div
+            className={`rounded-xl p-4 ${
+              shuffledOptions[selectedOption!]?.correct
+                ? "bg-emerald-50 border border-emerald-200"
+                : "bg-rose-50 border border-rose-200"
+            }`}
+          >
+            <p className="text-sm font-medium mb-1">
+              {shuffledOptions[selectedOption!]?.correct
+                ? en ? "Correct!" : "¡Correcto!"
+                : en ? "Not quite." : "No exactamente."}
+            </p>
+            <p className="text-sm text-slate-600">
+              {en ? current.explanation : current.explanationEs}
+            </p>
+          </div>
+        )}
+
+        {/* Next button */}
+        {showFeedback && (
+          <button
+            onClick={handleNext}
+            className="w-full px-6 py-3 rounded-xl bg-amber-500 text-white font-semibold hover:bg-amber-400 transition-colors"
+          >
+            {currentIndex < totalQuestions - 1
+              ? en ? "Next Question" : "Siguiente Pregunta"
+              : en ? "See Results" : "Ver Resultados"}
+          </button>
+        )}
+      </div>
+
+      {/* Running score */}
+      <div className="text-center text-sm text-slate-400">
+        {Object.values(answers).filter((_, idx) => {
+          const qId = Object.keys(answers).map(Number)[idx];
+          const q = shuffledQuestions.find((sq) => sq.id === qId);
+          return q && q.options[answers[qId]]?.correct;
+        }).length}{" "}
+        / {Object.keys(answers).length} {en ? "correct so far" : "correctas hasta ahora"}
+      </div>
+    </div>
+  );
+}

--- a/src/data/course/exam.ts
+++ b/src/data/course/exam.ts
@@ -1,0 +1,444 @@
+// Final Exam: "First Steps Into English" — Comprehensive Assessment
+// 20 multiple-choice questions covering all 10 units
+
+export interface ExamQuestion {
+  id: number;
+  unit: number;
+  category: "vocabulary" | "grammar" | "translation";
+  prompt: string;
+  promptEs: string;
+  options: ExamOption[];
+  explanation: string;
+  explanationEs: string;
+}
+
+export interface ExamOption {
+  text: string;
+  correct: boolean;
+}
+
+export interface ExamResult {
+  totalCorrect: number;
+  totalQuestions: number;
+  percentage: number;
+  unitScores: Record<number, { correct: number; total: number }>;
+  categoryScores: Record<string, { correct: number; total: number }>;
+}
+
+export const examMeta = {
+  title: "Final Exam",
+  titleEs: "Examen Final",
+  subtitle: "First Steps Into English — Comprehensive Assessment",
+  subtitleEs: "Primeros Pasos en Inglés — Evaluación Integral",
+  description:
+    "20 questions covering vocabulary, grammar, and translation from all 10 units. Test everything you've learned and see how far you've come.",
+  descriptionEs:
+    "20 preguntas sobre vocabulario, gramática y traducción de las 10 unidades. Pon a prueba todo lo que has aprendido y mira cuánto has avanzado.",
+  passingScore: 70,
+};
+
+export const examQuestions: ExamQuestion[] = [
+  // ─── Unit 1: Cognates & First Sentences ──────────────────────────────
+  {
+    id: 1,
+    unit: 1,
+    category: "vocabulary",
+    prompt: 'What does "possible" mean in Spanish?',
+    promptEs: '¿Qué significa "possible" en español?',
+    options: [
+      { text: "posible", correct: true },
+      { text: "pasible", correct: false },
+      { text: "potable", correct: false },
+      { text: "portable", correct: false },
+    ],
+    explanation: '"Possible" = posible. The -ible pattern stays nearly identical.',
+    explanationEs: '"Possible" = posible. El patrón -ible se mantiene casi idéntico.',
+  },
+  {
+    id: 2,
+    unit: 1,
+    category: "grammar",
+    prompt: "Which sentence is correct?",
+    promptEs: "¿Cuál oración es correcta?",
+    options: [
+      { text: "I need to know if it is possible.", correct: true },
+      { text: "I need know if it is possible.", correct: false },
+      { text: "I need to know if it possible.", correct: false },
+      { text: "I to need know if it is possible.", correct: false },
+    ],
+    explanation: '"I need TO know" — after "need," use "to" + verb.',
+    explanationEs: '"I need TO know" — después de "need," usa "to" + verbo.',
+  },
+
+  // ─── Unit 2: What You Like ───────────────────────────────────────────
+  {
+    id: 3,
+    unit: 2,
+    category: "translation",
+    prompt: 'How do you say "Me gustaría comer aquí esta noche" in English?',
+    promptEs: 'Traduce: "Me gustaría comer aquí esta noche"',
+    options: [
+      { text: "I would like to eat here tonight.", correct: true },
+      { text: "I like to eat here tonight.", correct: false },
+      { text: "I want like eat here tonight.", correct: false },
+      { text: "I would to like eat here tonight.", correct: false },
+    ],
+    explanation: '"Would like" = gustaría. "I would like TO eat" — always "to" before the verb.',
+    explanationEs: '"Would like" = gustaría. "I would like TO eat" — siempre "to" antes del verbo.',
+  },
+  {
+    id: 4,
+    unit: 2,
+    category: "vocabulary",
+    prompt: 'What does "It was fantastic" mean?',
+    promptEs: '¿Qué significa "It was fantastic"?',
+    options: [
+      { text: "Fue fantástico", correct: true },
+      { text: "Es fantástico", correct: false },
+      { text: "Será fantástico", correct: false },
+      { text: "Sería fantástico", correct: false },
+    ],
+    explanation: '"Was" is past tense of "is." "It was" = fue/era.',
+    explanationEs: '"Was" es el pasado de "is." "It was" = fue/era.',
+  },
+
+  // ─── Unit 3: Talking About Others ────────────────────────────────────
+  {
+    id: 5,
+    unit: 3,
+    category: "grammar",
+    prompt: 'Which is correct for third person?',
+    promptEs: '¿Cuál es correcto para la tercera persona?',
+    options: [
+      { text: "She wants to call me later.", correct: true },
+      { text: "She want to call me later.", correct: false },
+      { text: "She wanting to call me later.", correct: false },
+      { text: "She to wants call me later.", correct: false },
+    ],
+    explanation: 'He/she/it adds -S to the verb: "wants," "has," "knows."',
+    explanationEs: 'He/she/it agrega -S al verbo: "wants," "has," "knows."',
+  },
+
+  // ─── Unit 4: Talking to Someone ──────────────────────────────────────
+  {
+    id: 6,
+    unit: 4,
+    category: "translation",
+    prompt: 'How do you say "Tienes que decirme la verdad" in English?',
+    promptEs: 'Traduce: "Tienes que decirme la verdad"',
+    options: [
+      { text: "You have to tell me the truth.", correct: true },
+      { text: "You have tell me the truth.", correct: false },
+      { text: "You must to tell me the truth.", correct: false },
+      { text: "You have to say me the truth.", correct: false },
+    ],
+    explanation: '"Have to" = tener que. "Tell me" (not "say me") — "tell" needs a person after it.',
+    explanationEs: '"Have to" = tener que. "Tell me" (no "say me") — "tell" necesita una persona después.',
+  },
+  {
+    id: 7,
+    unit: 4,
+    category: "vocabulary",
+    prompt: 'What does "the reason why" mean in Spanish?',
+    promptEs: '¿Qué significa "the reason why" en español?',
+    options: [
+      { text: "el porqué / la razón", correct: true },
+      { text: "la razón dónde", correct: false },
+      { text: "el porque no", correct: false },
+      { text: "la excusa", correct: false },
+    ],
+    explanation: '"The reason why" = el porqué — explains the cause of something.',
+    explanationEs: '"The reason why" = el porqué — explica la causa de algo.',
+  },
+
+  // ─── Unit 5: What Just Happened ──────────────────────────────────────
+  {
+    id: 8,
+    unit: 5,
+    category: "grammar",
+    prompt: 'What does "I just found out" express?',
+    promptEs: '¿Qué expresa "I just found out"?',
+    options: [
+      { text: "Something I discovered very recently", correct: true },
+      { text: "Something I will discover tomorrow", correct: false },
+      { text: "Something I always knew", correct: false },
+      { text: "Something impossible to know", correct: false },
+    ],
+    explanation: '"Just" = acabar de. It means the action happened moments ago.',
+    explanationEs: '"Just" = acabar de. Significa que la acción ocurrió hace momentos.',
+  },
+
+  // ─── Unit 6: Everyone, Someone, No One ───────────────────────────────
+  {
+    id: 9,
+    unit: 6,
+    category: "grammar",
+    prompt: "Which sentence uses correct English (no double negative)?",
+    promptEs: "¿Cuál oración usa inglés correcto (sin doble negación)?",
+    options: [
+      { text: "Nobody wants to go.", correct: true },
+      { text: "Nobody doesn't want to go.", correct: false },
+      { text: "Nobody never wants to go.", correct: false },
+      { text: "Nobody don't want to go.", correct: false },
+    ],
+    explanation: 'In English, "nobody" already contains the negative. Don\'t add another.',
+    explanationEs: 'En inglés, "nobody" ya contiene la negación. No agregues otra.',
+  },
+  {
+    id: 10,
+    unit: 6,
+    category: "translation",
+    prompt: 'How do you say "Deberías poder hacerlo mañana" in English?',
+    promptEs: 'Traduce: "Deberías poder hacerlo mañana"',
+    options: [
+      { text: "You should be able to do it tomorrow.", correct: true },
+      { text: "You should can do it tomorrow.", correct: false },
+      { text: "You should to be able do it tomorrow.", correct: false },
+      { text: "You must be able to do it tomorrow.", correct: false },
+    ],
+    explanation: '"Should be able to" = debería poder. Never "should can" — don\'t stack modals.',
+    explanationEs: '"Should be able to" = debería poder. Nunca "should can" — no apiles modales.',
+  },
+
+  // ─── Unit 7: Together ────────────────────────────────────────────────
+  {
+    id: 11,
+    unit: 7,
+    category: "grammar",
+    prompt: 'What is the difference between "We can\'t go" and "We don\'t have to go"?',
+    promptEs: '¿Cuál es la diferencia entre "We can\'t go" y "We don\'t have to go"?',
+    options: [
+      { text: "Can't = impossible. Don't have to = not necessary (but you can).", correct: true },
+      { text: "They mean the same thing.", correct: false },
+      { text: "Can't = not necessary. Don't have to = impossible.", correct: false },
+      { text: "Can't is formal. Don't have to is informal.", correct: false },
+    ],
+    explanation: '"Can\'t" means it\'s impossible. "Don\'t have to" means it\'s optional — you have a choice.',
+    explanationEs: '"Can\'t" significa que es imposible. "Don\'t have to" significa que es opcional — tienes opción.',
+  },
+  {
+    id: 12,
+    unit: 7,
+    category: "vocabulary",
+    prompt: 'What does "comfortable" mean in Spanish?',
+    promptEs: '¿Qué significa "comfortable" en español?',
+    options: [
+      { text: "cómodo / confortable", correct: true },
+      { text: "comparable", correct: false },
+      { text: "considerable", correct: false },
+      { text: "compacto", correct: false },
+    ],
+    explanation: '"Comfortable" = cómodo/confortable. Part of the massive -able cognate family.',
+    explanationEs: '"Comfortable" = cómodo/confortable. Parte de la enorme familia de cognados -able.',
+  },
+
+  // ─── Unit 8: Feelings and Curiosity ──────────────────────────────────
+  {
+    id: 13,
+    unit: 8,
+    category: "translation",
+    prompt: 'How do you say "Tengo ganas de ir a la playa" in English?',
+    promptEs: 'Traduce: "Tengo ganas de ir a la playa"',
+    options: [
+      { text: "I feel like going to the beach.", correct: true },
+      { text: "I feel going to the beach.", correct: false },
+      { text: "I have feeling to go to the beach.", correct: false },
+      { text: "I am feeling like the beach.", correct: false },
+    ],
+    explanation: '"I feel like" + -ing verb = tengo ganas de. "I feel like GOING."',
+    explanationEs: '"I feel like" + verbo en -ing = tengo ganas de. "I feel like GOING."',
+  },
+  {
+    id: 14,
+    unit: 8,
+    category: "grammar",
+    prompt: 'Which sentence correctly uses "I wonder"?',
+    promptEs: '¿Cuál oración usa "I wonder" correctamente?',
+    options: [
+      { text: "I wonder if they can come tonight.", correct: true },
+      { text: "I wonder do they can come tonight.", correct: false },
+      { text: "I wonder they can come tonight?", correct: false },
+      { text: "I wonder can they come tonight.", correct: false },
+    ],
+    explanation: '"I wonder IF..." uses statement word order (not question order). It\'s not a direct question.',
+    explanationEs: '"I wonder IF..." usa orden de declaración (no de pregunta). No es una pregunta directa.',
+  },
+
+  // ─── Unit 9: Telling Stories ─────────────────────────────────────────
+  {
+    id: 15,
+    unit: 9,
+    category: "grammar",
+    prompt: 'Which sentence correctly uses "used to"?',
+    promptEs: '¿Cuál oración usa "used to" correctamente?',
+    options: [
+      { text: "I used to work here.", correct: true },
+      { text: "I used to working here.", correct: false },
+      { text: "I use to work here.", correct: false },
+      { text: "I used work here.", correct: false },
+    ],
+    explanation: '"Used to" + base verb (no -ing, no extra "to"). Always past tense: "used," not "use."',
+    explanationEs: '"Used to" + verbo base (sin -ing, sin "to" extra). Siempre pasado: "used," no "use."',
+  },
+  {
+    id: 16,
+    unit: 9,
+    category: "grammar",
+    prompt: 'What is the difference between "told" and "said"?',
+    promptEs: '¿Cuál es la diferencia entre "told" y "said"?',
+    options: [
+      { text: '"Told" needs a person (told ME). "Said" doesn\'t (said THAT).', correct: true },
+      { text: "They mean exactly the same thing.", correct: false },
+      { text: '"Said" is formal. "Told" is informal.', correct: false },
+      { text: '"Told" is present tense. "Said" is past tense.', correct: false },
+    ],
+    explanation: '"She told ME the truth" vs. "She said THAT it was true." Told = direct recipient. Said = quoting.',
+    explanationEs: '"She told ME the truth" vs. "She said THAT it was true." Told = destinatario directo. Said = citar.',
+  },
+  {
+    id: 17,
+    unit: 9,
+    category: "vocabulary",
+    prompt: 'What does "suddenly" mean in Spanish?',
+    promptEs: '¿Qué significa "suddenly" en español?',
+    options: [
+      { text: "de repente", correct: true },
+      { text: "lentamente", correct: false },
+      { text: "finalmente", correct: false },
+      { text: "anteriormente", correct: false },
+    ],
+    explanation: '"Suddenly" = de repente. Used to introduce unexpected events in a story.',
+    explanationEs: '"Suddenly" = de repente. Se usa para introducir eventos inesperados en una historia.',
+  },
+
+  // ─── Unit 10: What's Coming Next ─────────────────────────────────────
+  {
+    id: 18,
+    unit: 10,
+    category: "translation",
+    prompt: 'How do you say "Voy a hacerlo mañana" in English?',
+    promptEs: 'Traduce: "Voy a hacerlo mañana"',
+    options: [
+      { text: "I'm going to do it tomorrow.", correct: true },
+      { text: "I going to do it tomorrow.", correct: false },
+      { text: "I go to do it tomorrow.", correct: false },
+      { text: "I'm go to do it tomorrow.", correct: false },
+    ],
+    explanation: '"Going to" needs "am/is/are" before it. "I AM going to" = voy a.',
+    explanationEs: '"Going to" necesita "am/is/are" antes. "I AM going to" = voy a.',
+  },
+  {
+    id: 19,
+    unit: 10,
+    category: "grammar",
+    prompt: 'How do you ask the meaning of a word in English?',
+    promptEs: '¿Cómo preguntas el significado de una palabra en inglés?',
+    options: [
+      { text: "What does it mean?", correct: true },
+      { text: "What it means?", correct: false },
+      { text: "What does it means?", correct: false },
+      { text: "What is it mean?", correct: false },
+    ],
+    explanation: '"What does it MEAN?" — "does" is the helper verb, so "mean" stays in base form (no -s).',
+    explanationEs: '"What does it MEAN?" — "does" es el verbo auxiliar, así que "mean" queda en forma base (sin -s).',
+  },
+  {
+    id: 20,
+    unit: 10,
+    category: "translation",
+    prompt: "Which sentence combines past, present, and future correctly?",
+    promptEs: "¿Cuál oración combina pasado, presente y futuro correctamente?",
+    options: [
+      {
+        text: "I used to think it was impossible, but now I know it's possible and I'm going to do it.",
+        correct: true,
+      },
+      {
+        text: "I use to think it was impossible, but now I know it's possible and I going to do it.",
+        correct: false,
+      },
+      {
+        text: "I used to think it is impossible, but now I knew it's possible and I'm going to do it.",
+        correct: false,
+      },
+      {
+        text: "I used to think it was impossible, but now I know it's possible and I will going to do it.",
+        correct: false,
+      },
+    ],
+    explanation:
+      'Past: "used to" + "was." Present: "know" + "it\'s." Future: "I\'m going to." Three time frames in one sentence.',
+    explanationEs:
+      'Pasado: "used to" + "was." Presente: "know" + "it\'s." Futuro: "I\'m going to." Tres marcos temporales en una oración.',
+  },
+];
+
+export function calculateExamResult(answers: Record<number, number>): ExamResult {
+  const unitScores: Record<number, { correct: number; total: number }> = {};
+  const categoryScores: Record<string, { correct: number; total: number }> = {};
+  let totalCorrect = 0;
+
+  for (const q of examQuestions) {
+    // Initialize trackers
+    if (!unitScores[q.unit]) unitScores[q.unit] = { correct: 0, total: 0 };
+    if (!categoryScores[q.category]) categoryScores[q.category] = { correct: 0, total: 0 };
+
+    unitScores[q.unit].total++;
+    categoryScores[q.category].total++;
+
+    const selectedIndex = answers[q.id];
+    if (selectedIndex !== undefined && q.options[selectedIndex]?.correct) {
+      totalCorrect++;
+      unitScores[q.unit].correct++;
+      categoryScores[q.category].correct++;
+    }
+  }
+
+  return {
+    totalCorrect,
+    totalQuestions: examQuestions.length,
+    percentage: Math.round((totalCorrect / examQuestions.length) * 100),
+    unitScores,
+    categoryScores,
+  };
+}
+
+export function getScoreTier(percentage: number): {
+  tier: string;
+  tierEs: string;
+  color: string;
+  message: string;
+  messageEs: string;
+} {
+  if (percentage >= 90) {
+    return {
+      tier: "Outstanding",
+      tierEs: "Sobresaliente",
+      color: "emerald",
+      message:
+        "Incredible work. You've mastered the foundations of English. You're ready for intermediate-level challenges.",
+      messageEs:
+        "Trabajo increíble. Has dominado las bases del inglés. Estás listo para desafíos de nivel intermedio.",
+    };
+  }
+  if (percentage >= 70) {
+    return {
+      tier: "Passed",
+      tierEs: "Aprobado",
+      color: "amber",
+      message:
+        "Great job! You have a solid foundation. Review the units where you missed questions, then move forward with confidence.",
+      messageEs:
+        "¡Buen trabajo! Tienes una base sólida. Repasa las unidades donde fallaste preguntas, luego avanza con confianza.",
+    };
+  }
+  return {
+    tier: "Keep Practicing",
+    tierEs: "Sigue Practicando",
+    color: "rose",
+    message:
+      "You're making progress, but some areas need more review. Go back to the units where you struggled and try the exam again.",
+    messageEs:
+      "Estás progresando, pero algunas áreas necesitan más repaso. Vuelve a las unidades donde tuviste dificultades e intenta el examen de nuevo.",
+  };
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -84,6 +84,7 @@ export type TKey =
   | "course/beginners/unit-8"
   | "course/beginners/unit-9"
   | "course/beginners/unit-10"
+  | "course/beginners/exam"
   | "course/beginners/pronunciation"
   | "meme-portfolio"
   | "site-index";
@@ -183,6 +184,7 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/beginners/unit-8": "/en/course/beginners/unit-8/",
     "course/beginners/unit-9": "/en/course/beginners/unit-9/",
     "course/beginners/unit-10": "/en/course/beginners/unit-10/",
+    "course/beginners/exam": "/en/course/beginners/exam/",
     "course/beginners/pronunciation": "/en/course/beginners/pronunciation/",
     "meme-portfolio": "/en/meme-portfolio/all/",
     "site-index": "/en/site-index/",
@@ -286,6 +288,7 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/beginners/unit-8": "/es/curso/principiantes/unidad-8/",
     "course/beginners/unit-9": "/es/curso/principiantes/unidad-9/",
     "course/beginners/unit-10": "/es/curso/principiantes/unidad-10/",
+    "course/beginners/exam": "/es/curso/principiantes/examen/",
     "course/beginners/pronunciation": "/es/curso/principiantes/pronunciacion/",
     "meme-portfolio": "/es/meme-portfolio/all/",
     "site-index": "/es/indice-del-sitio/",

--- a/src/pages/en/course/beginners/exam.astro
+++ b/src/pages/en/course/beginners/exam.astro
@@ -1,0 +1,73 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CourseExam from "@components/course/CourseExam";
+import { units } from "@data/course/units";
+import { examQuestions, examMeta } from "@data/course/exam";
+import { ArrowLeft, GraduationCap } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/beginners/exam" as const;
+
+const progressUnits = units.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Final Exam: First Steps Into English | NY English Teacher"
+  description="Take the comprehensive final exam for the First Steps Into English beginner course. 20 questions covering vocabulary, grammar, and translation from all 10 units. Free for Spanish speakers."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={0}
+    basePath="/en/course/beginners"
+    lang="en"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <GraduationCap class="w-4 h-4" />
+          Final Exam
+        </div>
+        <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          First Steps Into English
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          You've completed all 10 units. Now prove what you've learned.
+          20 questions covering vocabulary, grammar, and translation — the complete course in one exam.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <CourseExam
+        client:load
+        questions={examQuestions}
+        lang="en"
+        passingScore={examMeta.passingScore}
+        courseBasePath="/en/course/beginners"
+      />
+    </div>
+  </section>
+
+  <section class="py-8 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4 text-center">
+      <a href="/en/course/beginners/" class="inline-flex items-center gap-2 text-slate-500 hover:text-amber-600 transition-colors text-sm">
+        <ArrowLeft class="w-4 h-4" /> Back to Course Overview
+      </a>
+    </div>
+  </section>
+</Base>

--- a/src/pages/en/course/beginners/unit-10.astro
+++ b/src/pages/en/course/beginners/unit-10.astro
@@ -262,8 +262,8 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
           <a href="/en/course/beginners/unit-9/" class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors">
             <ArrowLeft class="w-4 h-4" /> Review Unit 9
           </a>
-          <a href="/en/contact/" class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-amber-500 text-white font-semibold hover:bg-amber-400 transition-colors shadow-lg">
-            Book a Free Consultation
+          <a href="/en/course/beginners/exam/" class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-amber-500 text-white font-semibold hover:bg-amber-400 transition-colors shadow-lg">
+            Take the Final Exam
           </a>
         </div>
         <div class="flex flex-wrap gap-4 justify-center">

--- a/src/pages/es/curso/principiantes/examen.astro
+++ b/src/pages/es/curso/principiantes/examen.astro
@@ -1,0 +1,73 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CourseExam from "@components/course/CourseExam";
+import { units } from "@data/course/units";
+import { examQuestions, examMeta } from "@data/course/exam";
+import { ArrowLeft, GraduationCap } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/beginners/exam" as const;
+
+const progressUnits = units.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Examen Final: Primeros Pasos en Inglés | NY English Teacher"
+  description="Toma el examen final integral del curso Primeros Pasos en Inglés. 20 preguntas sobre vocabulario, gramática y traducción de las 10 unidades. Gratis para hispanohablantes."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={0}
+    basePath="/es/curso/principiantes"
+    lang="es"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <GraduationCap class="w-4 h-4" />
+          Examen Final
+        </div>
+        <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Primeros Pasos en Inglés
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Has completado las 10 unidades. Ahora demuestra lo que has aprendido.
+          20 preguntas sobre vocabulario, gramática y traducción — el curso completo en un examen.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <CourseExam
+        client:load
+        questions={examQuestions}
+        lang="es"
+        passingScore={examMeta.passingScore}
+        courseBasePath="/es/curso/principiantes"
+      />
+    </div>
+  </section>
+
+  <section class="py-8 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4 text-center">
+      <a href="/es/curso/principiantes/" class="inline-flex items-center gap-2 text-slate-500 hover:text-amber-600 transition-colors text-sm">
+        <ArrowLeft class="w-4 h-4" /> Volver al Curso
+      </a>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/principiantes/unidad-10.astro
+++ b/src/pages/es/curso/principiantes/unidad-10.astro
@@ -262,8 +262,8 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
           <a href="/es/curso/principiantes/unidad-9/" class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors">
             <ArrowLeft class="w-4 h-4" /> Repasar Unidad 9
           </a>
-          <a href="/es/contact/" class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-amber-500 text-white font-semibold hover:bg-amber-400 transition-colors shadow-lg">
-            Agenda una Consulta Gratuita
+          <a href="/es/curso/principiantes/examen/" class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-amber-500 text-white font-semibold hover:bg-amber-400 transition-colors shadow-lg">
+            Tomar el Examen Final
           </a>
         </div>
         <div class="flex flex-wrap gap-4 justify-center">


### PR DESCRIPTION
## Summary
- **20 auto-graded multiple-choice questions** covering all 10 units
- **3 categories**: vocabulary, grammar, translation
- **Instant feedback** after each answer with bilingual explanations
- **Results dashboard**: overall score, category breakdown, unit-by-unit scores
- **Certificate celebration** for passing scores (70%+)
- **Reusable CourseExam component** — ready for intermediate/advanced courses
- Unit 10 completion now links to "Take the Final Exam"
- Full EN + ES bilingual support

## Test plan
- [x] `npm run build` passes (339 pages, 0 errors)
- [x] Sitemap validation passes (214 URLs, 0 warnings)
- [ ] Take exam EN — verify questions render, options clickable, feedback appears
- [ ] Verify scoring: correct answers green, wrong answers red with explanation
- [ ] Complete exam — verify results page shows score, categories, units
- [ ] Verify passing score (70%+) shows certificate celebration
- [ ] Take exam ES — verify all text is in Spanish

🤖 Generated with [Claude Code](https://claude.com/claude-code)