### PR TITLE
chore: add health status to portfolio file

### DIFF
--- a/PORTFOLIO.md
+++ b/PORTFOLIO.md
@@ -85,6 +85,23 @@ tags:
   - "lead-generation"
   - "solopreneur"
 date_completed: "2026-02"
+
+# === REPO HEALTH STATUS ===
+# Last audited: 2026-04-04
+# Standards defined in: operating-system/delivery/repo-health-baseline.md
+health_status:
+  sentry: "-"
+  testing: "-"
+  ci_cd: "Y"
+  health_endpoint: "n/a"
+  security_headers: "-"
+  rate_limiting: "n/a"
+  env_validation: "Y"
+  analytics: "DEFERRED"
+  structured_logging: "-"
+  dependabot: "Y"
+  secret_scanning: "Y"
+  db_backup: "-"
 ---
 
 ## The Architecture of Authority


### PR DESCRIPTION
## Summary
Adds a `health_status` section to the portfolio file tracking all 12 CushLabs repo health standards.

This enables automated auditing — scan portfolio files to get instant health snapshots without running a full audit.

Standards defined in: `operating-system/delivery/repo-health-baseline.md`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>