### PR TITLE
fix: resolve React #418 hydration mismatches

### DIFF
--- a/src/components/course/CourseExam.tsx
+++ b/src/components/course/CourseExam.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import type { ExamQuestion, ExamResult } from "@data/course/exam";
 import { calculateExamResult, getScoreTier } from "@data/course/exam";
 
@@ -19,21 +19,22 @@ export default function CourseExam({ questions, lang, passingScore, courseBasePa
 
   const en = lang === "en";
 
-  // Shuffle questions once per session
-  const shuffledQuestions = useMemo(
-    () => [...questions].sort(() => Math.random() - 0.5),
-    [questions]
-  );
+  // Shuffle questions after hydration to avoid server/client mismatch
+  const [shuffledQuestions, setShuffledQuestions] = useState(questions);
+  useEffect(() => {
+    setShuffledQuestions([...questions].sort(() => Math.random() - 0.5));
+  }, []);
 
   const current = shuffledQuestions[currentIndex];
   const totalQuestions = shuffledQuestions.length;
   const progress = ((currentIndex) / totalQuestions) * 100;
 
-  // Shuffle options for current question
-  const shuffledOptions = useMemo(() => {
-    if (!current) return [];
+  // Shuffle options after hydration — re-shuffle when question changes
+  const [shuffledOptions, setShuffledOptions] = useState<Array<{ text: string; correct: boolean; originalIndex: number }>>([]);
+  useEffect(() => {
+    if (!current) return;
     const indexed = current.options.map((opt, i) => ({ ...opt, originalIndex: i }));
-    return indexed.sort(() => Math.random() - 0.5);
+    setShuffledOptions(indexed.sort(() => Math.random() - 0.5));
   }, [current?.id]);
 
   const handleSelectOption = useCallback(

--- a/src/components/course/SelfTest.tsx
+++ b/src/components/course/SelfTest.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import {
   RotateCcw,
   Eye,
@@ -23,11 +23,11 @@ export default function SelfTest({ vocabulary, lang }: Props) {
   const [score, setScore] = useState({ correct: 0, total: 0 });
   const [isFinished, setIsFinished] = useState(false);
 
-  // Shuffle vocabulary
-  const shuffled = useMemo(
-    () => [...vocabulary].sort(() => Math.random() - 0.5),
-    [],
-  );
+  // Shuffle vocabulary after hydration to avoid server/client mismatch
+  const [shuffled, setShuffled] = useState(vocabulary);
+  useEffect(() => {
+    setShuffled([...vocabulary].sort(() => Math.random() - 0.5));
+  }, []);
 
   const current = shuffled[currentIndex];
 

--- a/src/pages/en/quiz/[quizType]/report.astro
+++ b/src/pages/en/quiz/[quizType]/report.astro
@@ -47,7 +47,7 @@ const description =
   hideLanguageSwitcher={true}
 >
   <div class="quiz-report-wrapper">
-    <QuizReport client:load />
+    <QuizReport client:only="react" />
   </div>
 </Base>
 

--- a/src/pages/es/quiz/[quizType]/report.astro
+++ b/src/pages/es/quiz/[quizType]/report.astro
@@ -47,7 +47,7 @@ const description =
   hideLanguageSwitcher={true}
 >
   <div class="quiz-report-wrapper">
-    <QuizReport client:load />
+    <QuizReport client:only="react" />
   </div>
 </Base>
 


### PR DESCRIPTION
## Summary
- **QuizReport.tsx**: Switched from `client:load` to `client:only="react"` — component is 100% sessionStorage-dependent with zero SSR value, eliminating server/client HTML divergence
- **SelfTest.tsx**: Moved `Math.random()` vocabulary shuffle from `useMemo` to `useEffect` so it runs after hydration
- **CourseExam.tsx**: Moved both question shuffle and option shuffle from `useMemo` to `useEffect` for same reason
- **CourseProgress.tsx**: Investigated — already correctly defers `localStorage` read to `useEffect`, no fix needed

## Test plan
- [ ] Visit `/en/quiz/it-services/report/` — confirm no React #418 console error
- [ ] Visit any course unit page — confirm SelfTest flashcards load without hydration error
- [ ] Visit course exam page — confirm questions render and shuffle properly
- [ ] Verify no console errors on any page with React islands

🤖 Generated with [Claude Code](https://claude.com/claude-code)