### PR TITLE
feat: Building Fluency intermediate course — Unit 1 + foundation

### DIFF
--- a/src/components/course/CourseProgress.tsx
+++ b/src/components/course/CourseProgress.tsx
@@ -13,28 +13,32 @@ interface Props {
   currentUnit: number;
   basePath: string;
   lang: "en" | "es";
+  courseId?: string;
 }
 
-const STORAGE_KEY = "nye_course_beginners_progress";
+function getStorageKey(courseId: string) {
+  return `nye_course_${courseId}_progress`;
+}
 
-function getCompletedUnits(): number[] {
+function getCompletedUnits(courseId: string = "beginners"): number[] {
   if (typeof window === "undefined") return [];
   try {
-    const data = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
+    const data = JSON.parse(localStorage.getItem(getStorageKey(courseId)) || "{}");
     return data.completedUnits || [];
   } catch {
     return [];
   }
 }
 
-export function markUnitComplete(unitId: number) {
+export function markUnitComplete(unitId: number, courseId: string = "beginners") {
   if (typeof window === "undefined") return;
   try {
-    const data = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
+    const key = getStorageKey(courseId);
+    const data = JSON.parse(localStorage.getItem(key) || "{}");
     const completed = new Set(data.completedUnits || []);
     completed.add(unitId);
     localStorage.setItem(
-      STORAGE_KEY,
+      key,
       JSON.stringify({
         ...data,
         completedUnits: [...completed],
@@ -51,13 +55,14 @@ export default function CourseProgress({
   currentUnit,
   basePath,
   lang,
+  courseId = "beginners",
 }: Props) {
   const [completed, setCompleted] = useState<number[]>([]);
   const [isExpanded, setIsExpanded] = useState(false);
 
   useEffect(() => {
-    setCompleted(getCompletedUnits());
-  }, []);
+    setCompleted(getCompletedUnits(courseId));
+  }, [courseId]);
 
   const progress = Math.round((completed.length / units.length) * 100);
   const currentUnitData = units.find((u) => u.id === currentUnit);

--- a/src/components/course/DialoguePractice.tsx
+++ b/src/components/course/DialoguePractice.tsx
@@ -1,0 +1,191 @@
+import { useState } from "react";
+import { Play, Eye, EyeOff, MapPin } from "lucide-react";
+import AudioButton from "./AudioButton";
+import type { Dialogue } from "@data/intermediate/types";
+
+interface Props {
+  dialogues: Dialogue[];
+  lang: "en" | "es";
+}
+
+export default function DialoguePractice({ dialogues, lang }: Props) {
+  const [activeDialogue, setActiveDialogue] = useState(0);
+  const [revealedLines, setRevealedLines] = useState<Set<number>>(new Set());
+  const [showAllTranslations, setShowAllTranslations] = useState(false);
+
+  const dialogue = dialogues[activeDialogue];
+  if (!dialogue) return null;
+
+  const toggleLine = (index: number) => {
+    if (showAllTranslations) return;
+    setRevealedLines((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+  };
+
+  const toggleAllTranslations = () => {
+    setShowAllTranslations(!showAllTranslations);
+    setRevealedLines(new Set());
+  };
+
+  const isLineRevealed = (index: number) =>
+    showAllTranslations || revealedLines.has(index);
+
+  return (
+    <div className="space-y-6">
+      {/* Dialogue tabs (if multiple) */}
+      {dialogues.length > 1 && (
+        <div className="flex gap-2">
+          {dialogues.map((d, i) => (
+            <button
+              key={i}
+              onClick={() => {
+                setActiveDialogue(i);
+                setRevealedLines(new Set());
+                setShowAllTranslations(false);
+              }}
+              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                activeDialogue === i
+                  ? "bg-amber-500 text-white"
+                  : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+              }`}
+            >
+              {lang === "es" ? d.titleEs : d.title}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Setting badge */}
+      <div className="flex items-center gap-2 text-sm text-slate-500">
+        <MapPin size={14} />
+        <span>{lang === "es" ? dialogue.settingEs : dialogue.setting}</span>
+      </div>
+
+      {/* Translation toggle */}
+      <div className="flex justify-end">
+        <button
+          onClick={toggleAllTranslations}
+          className="flex items-center gap-1.5 text-xs text-slate-500 hover:text-slate-700 transition-colors"
+        >
+          {showAllTranslations ? <EyeOff size={14} /> : <Eye size={14} />}
+          {showAllTranslations
+            ? lang === "es"
+              ? "Ocultar traducciones"
+              : "Hide translations"
+            : lang === "es"
+              ? "Mostrar traducciones"
+              : "Show translations"}
+        </button>
+      </div>
+
+      {/* Dialogue lines */}
+      <div className="space-y-3">
+        {dialogue.lines.map((line, i) => {
+          const isA = line.speaker === "A";
+          const revealed = isLineRevealed(i);
+
+          return (
+            <div
+              key={i}
+              className={`flex ${isA ? "justify-start" : "justify-end"}`}
+            >
+              <div
+                className={`max-w-[80%] ${
+                  isA ? "order-1" : "order-1"
+                }`}
+              >
+                {/* Speaker label */}
+                <p
+                  className={`text-xs font-semibold mb-1 ${
+                    isA ? "text-blue-600" : "text-emerald-600"
+                  } ${isA ? "text-left" : "text-right"}`}
+                >
+                  {lang === "es" ? line.speakerLabelEs : line.speakerLabel}
+                </p>
+
+                {/* Bubble */}
+                <div
+                  onClick={() => toggleLine(i)}
+                  className={`group rounded-2xl px-4 py-3 cursor-pointer transition-colors ${
+                    isA
+                      ? "bg-blue-50 border border-blue-100 rounded-tl-md"
+                      : "bg-emerald-50 border border-emerald-100 rounded-tr-md"
+                  }`}
+                >
+                  <div className="flex items-start gap-2">
+                    <AudioButton text={line.english} size="sm" />
+                    <div className="flex-1">
+                      <p className="text-sm text-slate-800">
+                        {line.highlight ? (
+                          <>
+                            {line.english
+                              .split(line.highlight)
+                              .map((part, pi, arr) => (
+                                <span key={pi}>
+                                  {part}
+                                  {pi < arr.length - 1 && (
+                                    <strong className="text-amber-600">
+                                      {line.highlight}
+                                    </strong>
+                                  )}
+                                </span>
+                              ))}
+                          </>
+                        ) : (
+                          line.english
+                        )}
+                      </p>
+                      {revealed && (
+                        <p className="text-xs text-slate-500 mt-1 italic">
+                          {line.spanish}
+                        </p>
+                      )}
+                      {!revealed && (
+                        <p className="text-xs text-slate-400 mt-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                          {lang === "es"
+                            ? "Toca para traducir"
+                            : "Tap to translate"}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Key phrases */}
+      {dialogue.keyPhrases.length > 0 && (
+        <div className="bg-amber-50 rounded-xl border border-amber-200 p-5">
+          <h4 className="text-sm font-bold text-amber-800 mb-3">
+            {lang === "es" ? "Frases Clave" : "Key Phrases"}
+          </h4>
+          <div className="space-y-2">
+            {dialogue.keyPhrases.map((kp, i) => (
+              <div key={i} className="flex items-start gap-2">
+                <AudioButton text={kp.english} size="sm" />
+                <div>
+                  <p className="text-sm font-medium text-slate-800">
+                    {kp.english}
+                  </p>
+                  <p className="text-xs text-slate-500">{kp.spanish}</p>
+                  {kp.note && (
+                    <p className="text-xs text-amber-600 mt-0.5 italic">
+                      {lang === "es" ? kp.noteEs : kp.note}
+                    </p>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/course/ErrorCorrection.tsx
+++ b/src/components/course/ErrorCorrection.tsx
@@ -1,0 +1,289 @@
+import { useState } from "react";
+import { AlertTriangle, CheckCircle, ArrowRight, RotateCcw } from "lucide-react";
+import AudioButton from "./AudioButton";
+import type { ErrorCorrectionSet } from "@data/intermediate/types";
+
+interface Props {
+  data: ErrorCorrectionSet;
+  lang: "en" | "es";
+}
+
+export default function ErrorCorrection({ data, lang }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [phase, setPhase] = useState<"find" | "revealed">("find");
+  const [score, setScore] = useState({ correct: 0, total: 0 });
+  const [tappedCorrectly, setTappedCorrectly] = useState(false);
+  const [isFinished, setIsFinished] = useState(false);
+
+  const current = data.items[currentIndex];
+
+  const handleTapError = (tappedText: string) => {
+    if (phase !== "find") return;
+
+    const isCorrectTap =
+      tappedText.trim().toLowerCase() ===
+      current.incorrectHighlight.trim().toLowerCase();
+
+    if (isCorrectTap) {
+      setTappedCorrectly(true);
+      setScore((s) => ({ correct: s.correct + 1, total: s.total + 1 }));
+    } else {
+      setTappedCorrectly(false);
+      setScore((s) => ({ ...s, total: s.total + 1 }));
+    }
+    setPhase("revealed");
+  };
+
+  const handleShowAnswer = () => {
+    setTappedCorrectly(false);
+    setScore((s) => ({ ...s, total: s.total + 1 }));
+    setPhase("revealed");
+  };
+
+  const handleNext = () => {
+    if (currentIndex >= data.items.length - 1) {
+      setIsFinished(true);
+    } else {
+      setCurrentIndex(currentIndex + 1);
+      setPhase("find");
+      setTappedCorrectly(false);
+    }
+  };
+
+  const handleRestart = () => {
+    setCurrentIndex(0);
+    setPhase("find");
+    setTappedCorrectly(false);
+    setScore({ correct: 0, total: 0 });
+    setIsFinished(false);
+  };
+
+  // Split sentence into tappable segments around the highlighted error
+  const renderTappableSentence = (sentence: string, highlight: string) => {
+    const parts = sentence.split(highlight);
+    if (parts.length === 1) {
+      // Highlight not found as exact substring — render as one tappable block
+      return (
+        <button
+          onClick={() => handleTapError(sentence)}
+          className="text-lg text-slate-800 hover:bg-rose-50 px-1 py-0.5 rounded transition-colors cursor-pointer"
+        >
+          {sentence}
+        </button>
+      );
+    }
+
+    return (
+      <span className="text-lg leading-relaxed">
+        {parts.map((part, i) => (
+          <span key={i}>
+            {part && (
+              <button
+                onClick={() => handleTapError(part.trim())}
+                className="text-slate-800 hover:bg-slate-100 px-0.5 rounded transition-colors cursor-pointer"
+              >
+                {part}
+              </button>
+            )}
+            {i < parts.length - 1 && (
+              <button
+                onClick={() => handleTapError(highlight)}
+                className="text-slate-800 hover:bg-rose-100 px-0.5 rounded transition-colors cursor-pointer underline decoration-wavy decoration-rose-300 underline-offset-4"
+              >
+                {highlight}
+              </button>
+            )}
+          </span>
+        ))}
+      </span>
+    );
+  };
+
+  if (isFinished) {
+    const pct = Math.round((score.correct / score.total) * 100);
+    return (
+      <div className="text-center py-12 space-y-6">
+        <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-amber-100">
+          <CheckCircle size={36} className="text-amber-500" />
+        </div>
+        <div>
+          <p className="text-4xl font-bold text-slate-900">{pct}%</p>
+          <p className="text-slate-500 mt-1">
+            {score.correct} / {score.total}{" "}
+            {lang === "es" ? "correctas" : "correct"}
+          </p>
+        </div>
+        <p className="text-lg text-slate-700 max-w-md mx-auto">
+          {pct >= 80
+            ? lang === "es"
+              ? "Excelente. Estás reconociendo los errores como un hablante avanzado."
+              : "Excellent! You're spotting errors like an advanced speaker."
+            : pct >= 50
+              ? lang === "es"
+                ? "Buen progreso. Repasa las explicaciones e intenta de nuevo."
+                : "Good progress! Review the explanations and try again."
+              : lang === "es"
+                ? "Sigue practicando. Estos errores son muy comunes para hispanohablantes."
+                : "Keep practicing! These errors are very common for Spanish speakers."}
+        </p>
+        <button
+          onClick={handleRestart}
+          className="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-amber-500 text-white font-semibold hover:bg-amber-400 transition-colors shadow-md"
+        >
+          <RotateCcw size={18} />
+          {lang === "es" ? "Intentar de nuevo" : "Try again"}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Progress */}
+      <div className="flex items-center justify-between text-sm text-slate-400">
+        <span>
+          {currentIndex + 1} / {data.items.length}
+        </span>
+        <span>
+          {score.correct} {lang === "es" ? "correctas" : "correct"}
+        </span>
+      </div>
+
+      <div className="w-full h-2 bg-slate-100 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-amber-500 rounded-full transition-all duration-300"
+          style={{
+            width: `${((currentIndex + 1) / data.items.length) * 100}%`,
+          }}
+        />
+      </div>
+
+      {/* Error card */}
+      <div className="bg-white rounded-2xl border-2 border-slate-200 overflow-hidden">
+        {/* Instruction */}
+        <div className="bg-slate-50 px-5 py-3 border-b border-slate-200">
+          <div className="flex items-center gap-2 text-sm font-medium text-slate-600">
+            <AlertTriangle size={16} className="text-rose-500" />
+            {phase === "find"
+              ? lang === "es"
+                ? "Toca la parte incorrecta de la oración"
+                : "Tap the incorrect part of the sentence"
+              : tappedCorrectly
+                ? lang === "es"
+                  ? "Correcto!"
+                  : "Correct!"
+                : lang === "es"
+                  ? "Veamos la corrección"
+                  : "Let's see the correction"}
+          </div>
+          {/* Error type badge */}
+          <span
+            className={`inline-block mt-1 text-xs px-2 py-0.5 rounded-full ${
+              current.errorType === "literal-translation"
+                ? "bg-rose-100 text-rose-600"
+                : current.errorType === "tense-confusion"
+                  ? "bg-purple-100 text-purple-600"
+                  : current.errorType === "phrasal-verb"
+                    ? "bg-orange-100 text-orange-600"
+                    : current.errorType === "word-order"
+                      ? "bg-blue-100 text-blue-600"
+                      : "bg-teal-100 text-teal-600"
+            }`}
+          >
+            {current.errorType.replace("-", " ")}
+          </span>
+        </div>
+
+        {/* Sentence */}
+        <div className="p-6">
+          {phase === "find" ? (
+            <div className="text-center">
+              {renderTappableSentence(
+                current.incorrect,
+                current.incorrectHighlight
+              )}
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {/* Incorrect with strikethrough */}
+              <div className="text-center">
+                <p className="text-lg text-slate-400 line-through">
+                  {current.incorrect.split(current.incorrectHighlight).map((part, i, arr) => (
+                    <span key={i}>
+                      {part}
+                      {i < arr.length - 1 && (
+                        <span className="text-rose-400 font-semibold">
+                          {current.incorrectHighlight}
+                        </span>
+                      )}
+                    </span>
+                  ))}
+                </p>
+              </div>
+
+              {/* Correct with highlight */}
+              <div className="text-center">
+                <div className="flex items-center justify-center gap-2">
+                  <AudioButton text={current.correct} size="sm" />
+                  <p className="text-lg text-slate-800">
+                    {current.correct.split(current.correctHighlight).map((part, i, arr) => (
+                      <span key={i}>
+                        {part}
+                        {i < arr.length - 1 && (
+                          <span className="text-emerald-600 font-bold">
+                            {current.correctHighlight}
+                          </span>
+                        )}
+                      </span>
+                    ))}
+                  </p>
+                </div>
+              </div>
+
+              {/* Explanation */}
+              <div
+                className={`rounded-xl p-4 ${
+                  tappedCorrectly
+                    ? "bg-emerald-50 border border-emerald-200"
+                    : "bg-amber-50 border border-amber-200"
+                }`}
+              >
+                <p className="text-sm text-slate-700">
+                  {lang === "es"
+                    ? current.explanationEs
+                    : current.explanation}
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="px-6 pb-5">
+          {phase === "find" ? (
+            <button
+              onClick={handleShowAnswer}
+              className="w-full py-3 rounded-xl bg-slate-100 text-slate-600 font-medium hover:bg-slate-200 transition-colors text-sm"
+            >
+              {lang === "es" ? "No lo veo — muéstrame" : "I don't see it — show me"}
+            </button>
+          ) : (
+            <button
+              onClick={handleNext}
+              className="w-full flex items-center justify-center gap-2 py-3 rounded-xl bg-amber-500 text-white font-semibold hover:bg-amber-400 transition-colors"
+            >
+              {currentIndex < data.items.length - 1
+                ? lang === "es"
+                  ? "Siguiente"
+                  : "Next"
+                : lang === "es"
+                  ? "Ver Resultados"
+                  : "See Results"}
+              <ArrowRight size={18} />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/course/PhrasalVerbExplorer.tsx
+++ b/src/components/course/PhrasalVerbExplorer.tsx
@@ -1,0 +1,155 @@
+import { useState } from "react";
+import { ChevronDown, Eye, Volume2 } from "lucide-react";
+import AudioButton from "./AudioButton";
+import type { PhrasalVerbGroup } from "@data/intermediate/types";
+
+interface Props {
+  groups: PhrasalVerbGroup[];
+  lang: "en" | "es";
+}
+
+export default function PhrasalVerbExplorer({ groups, lang }: Props) {
+  const [expandedGroup, setExpandedGroup] = useState<number>(0);
+  const [revealedVerbs, setRevealedVerbs] = useState<Set<string>>(new Set());
+
+  const toggleGroup = (index: number) => {
+    setExpandedGroup(expandedGroup === index ? -1 : index);
+  };
+
+  const revealVerb = (verbKey: string) => {
+    setRevealedVerbs((prev) => new Set([...prev, verbKey]));
+  };
+
+  const revealAll = (groupIndex: number) => {
+    const group = groups[groupIndex];
+    const keys = group.verbs.map((v) => `${groupIndex}-${v.verb}`);
+    setRevealedVerbs((prev) => new Set([...prev, ...keys]));
+  };
+
+  return (
+    <div className="space-y-4">
+      {groups.map((group, gi) => {
+        const isExpanded = expandedGroup === gi;
+        const allRevealed = group.verbs.every((v) =>
+          revealedVerbs.has(`${gi}-${v.verb}`)
+        );
+
+        return (
+          <div
+            key={gi}
+            className="bg-white rounded-2xl border border-slate-200 overflow-hidden"
+          >
+            {/* Group header */}
+            <button
+              onClick={() => toggleGroup(gi)}
+              className="w-full flex items-center justify-between p-5 text-left hover:bg-slate-50 transition-colors"
+            >
+              <div>
+                <div className="flex items-center gap-3">
+                  <span className="text-2xl font-bold text-amber-600">
+                    {group.baseVerb}
+                  </span>
+                  <span className="text-sm text-slate-400">
+                    {group.verbs.length}{" "}
+                    {lang === "es" ? "phrasal verbs" : "phrasal verbs"}
+                  </span>
+                </div>
+                <p className="text-sm text-slate-500 mt-1">
+                  {lang === "es" ? group.descriptionEs : group.description}
+                </p>
+              </div>
+              <ChevronDown
+                size={20}
+                className={`text-slate-400 transition-transform shrink-0 ${
+                  isExpanded ? "rotate-180" : ""
+                }`}
+              />
+            </button>
+
+            {/* Phrasal verb cards */}
+            {isExpanded && (
+              <div className="border-t border-slate-100 p-4 space-y-3">
+                {!allRevealed && (
+                  <button
+                    onClick={() => revealAll(gi)}
+                    className="text-xs text-amber-600 hover:text-amber-700 font-medium"
+                  >
+                    {lang === "es" ? "Revelar todos" : "Reveal all"}
+                  </button>
+                )}
+
+                {group.verbs.map((pv, vi) => {
+                  const key = `${gi}-${pv.verb}`;
+                  const isRevealed = revealedVerbs.has(key);
+
+                  return (
+                    <div
+                      key={vi}
+                      className="rounded-xl border border-slate-200 overflow-hidden"
+                    >
+                      {/* Phrasal verb + particle highlight */}
+                      <div className="flex items-center justify-between p-4 bg-slate-50">
+                        <div className="flex items-center gap-3">
+                          <span className="text-lg font-bold text-slate-900">
+                            {pv.baseVerb}{" "}
+                            <span className="text-amber-600">{pv.particle}</span>
+                          </span>
+                          <AudioButton text={pv.verb} size="sm" />
+                        </div>
+                        {!isRevealed && (
+                          <button
+                            onClick={() => revealVerb(key)}
+                            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-amber-100 text-amber-700 text-sm font-medium hover:bg-amber-200 transition-colors"
+                          >
+                            <Eye size={14} />
+                            {lang === "es" ? "Revelar" : "Reveal"}
+                          </button>
+                        )}
+                      </div>
+
+                      {/* Revealed content */}
+                      {isRevealed && (
+                        <div className="p-4 space-y-3">
+                          <div>
+                            <p className="text-sm font-semibold text-slate-700">
+                              {lang === "es" ? pv.definitionEs : pv.definition}
+                            </p>
+                            <p className="text-sm text-slate-400 mt-0.5">
+                              {pv.verbEs}
+                            </p>
+                          </div>
+
+                          <div className="bg-amber-50 rounded-lg p-3">
+                            <div className="flex items-start gap-2">
+                              <AudioButton text={pv.example} size="sm" />
+                              <div>
+                                <p className="text-sm text-slate-800">
+                                  {pv.example}
+                                </p>
+                                <p className="text-xs text-slate-500 mt-1">
+                                  {pv.exampleEs}
+                                </p>
+                              </div>
+                            </div>
+                          </div>
+
+                          {pv.contextNote && (
+                            <p className="text-xs text-slate-400 italic">
+                              {lang === "es"
+                                ? pv.contextNoteEs
+                                : pv.contextNote}
+                            </p>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/course/SelfTest.tsx
+++ b/src/components/course/SelfTest.tsx
@@ -7,10 +7,14 @@ import {
   Languages,
 } from "lucide-react";
 import AudioButton from "./AudioButton";
-import type { VocabItem } from "@data/course/unit-1";
+interface VocabItemBase {
+  english: string;
+  spanish: string;
+  type: string;
+}
 
 interface Props {
-  vocabulary: VocabItem[];
+  vocabulary: VocabItemBase[];
   lang: "en" | "es";
 }
 
@@ -172,7 +176,11 @@ export default function SelfTest({ vocabulary, lang }: Props) {
                   ? "bg-blue-100 text-blue-700"
                   : current.type === "phrase"
                     ? "bg-green-100 text-green-700"
-                    : "bg-slate-100 text-slate-600"
+                    : current.type === "phrasal-verb"
+                      ? "bg-orange-100 text-orange-700"
+                      : current.type === "expression"
+                        ? "bg-teal-100 text-teal-700"
+                        : "bg-slate-100 text-slate-600"
             }`}
           >
             {current.type}

--- a/src/data/intermediate/types.ts
+++ b/src/data/intermediate/types.ts
@@ -1,0 +1,83 @@
+// Intermediate course type definitions
+// Reuses SentenceBlock and PronunciationDrill from beginner course
+
+import type { SentenceBlock, PronunciationDrill } from "../course/unit-1";
+
+export type { SentenceBlock, PronunciationDrill };
+
+// Extended vocab item supporting phrasal verbs and expressions
+export interface IntermediateVocabItem {
+  english: string;
+  spanish: string;
+  type: "word" | "phrase" | "verb" | "modal" | "phrasal-verb" | "expression";
+}
+
+// Section A: Phrasal Verb Explorer
+export interface PhrasalVerb {
+  verb: string;
+  verbEs: string;
+  particle: string;
+  baseVerb: string;
+  definition: string;
+  definitionEs: string;
+  example: string;
+  exampleEs: string;
+  contextNote?: string;
+  contextNoteEs?: string;
+}
+
+export interface PhrasalVerbGroup {
+  baseVerb: string;
+  baseVerbEs: string;
+  description: string;
+  descriptionEs: string;
+  verbs: PhrasalVerb[];
+}
+
+// Section B: Dialogue Practice
+export interface DialogueLine {
+  speaker: "A" | "B";
+  speakerLabel: string;
+  speakerLabelEs: string;
+  english: string;
+  spanish: string;
+  highlight?: string;
+}
+
+export interface Dialogue {
+  title: string;
+  titleEs: string;
+  setting: string;
+  settingEs: string;
+  lines: DialogueLine[];
+  keyPhrases: {
+    english: string;
+    spanish: string;
+    note?: string;
+    noteEs?: string;
+  }[];
+}
+
+// Section D: Error Correction
+export interface ErrorCorrectionItem {
+  incorrect: string;
+  correct: string;
+  incorrectHighlight: string;
+  correctHighlight: string;
+  explanation: string;
+  explanationEs: string;
+  errorType:
+    | "literal-translation"
+    | "tense-confusion"
+    | "phrasal-verb"
+    | "word-order"
+    | "preposition";
+}
+
+export interface ErrorCorrectionSet {
+  title: string;
+  titleEs: string;
+  description: string;
+  descriptionEs: string;
+  items: ErrorCorrectionItem[];
+}

--- a/src/data/intermediate/unit-1.ts
+++ b/src/data/intermediate/unit-1.ts
@@ -1,0 +1,635 @@
+// Unit 1: "The Phrasal Verb Problem" — Full course content
+// Theme: Understanding why phrasal verbs exist and how to decode them
+// Grammar: Present perfect vs. simple past
+// Pronunciation: Stress in phrasal verbs
+
+import type {
+  PhrasalVerbGroup,
+  Dialogue,
+  ErrorCorrectionSet,
+  IntermediateVocabItem,
+} from "./types";
+import type { SentenceBlock, PronunciationDrill } from "../course/unit-1";
+
+// ─── Section A: Phrasal Verb Explorer ────────────────────────────────────────
+
+export const phrasalVerbGroups: PhrasalVerbGroup[] = [
+  {
+    baseVerb: "find",
+    baseVerbEs: "encontrar",
+    description:
+      "See how 'find' changes meaning completely with different particles.",
+    descriptionEs:
+      "Mira cómo 'find' cambia completamente de significado con diferentes partículas.",
+    verbs: [
+      {
+        verb: "find out",
+        verbEs: "descubrir / enterarse",
+        particle: "out",
+        baseVerb: "find",
+        definition: "To discover information, often something surprising",
+        definitionEs: "Descubrir información, frecuentemente algo sorprendente",
+        example: "I just found out that we're getting a new manager.",
+        exampleEs: "Acabo de enterarme de que vamos a tener un nuevo gerente.",
+        contextNote: "Very common in everyday conversation and workplace gossip",
+        contextNoteEs:
+          "Muy común en conversación diaria y chismes de oficina",
+      },
+    ],
+  },
+  {
+    baseVerb: "figure",
+    baseVerbEs: "figurar",
+    description:
+      "'Figure' alone is rarely used as a verb — but 'figure out' is everywhere.",
+    descriptionEs:
+      "'Figure' solo casi no se usa como verbo — pero 'figure out' está en todas partes.",
+    verbs: [
+      {
+        verb: "figure out",
+        verbEs: "resolver / entender",
+        particle: "out",
+        baseVerb: "figure",
+        definition:
+          "To solve a problem or understand something after thinking about it",
+        definitionEs:
+          "Resolver un problema o entender algo después de pensarlo",
+        example:
+          "I can't figure out why the report isn't working.",
+        exampleEs:
+          "No puedo entender por qué el reporte no funciona.",
+        contextNote: "The go-to verb for problem-solving in English",
+        contextNoteEs: "El verbo preferido para resolver problemas en inglés",
+      },
+    ],
+  },
+  {
+    baseVerb: "come",
+    baseVerbEs: "venir",
+    description:
+      "'Come' combines with many particles. Here's one of the most useful.",
+    descriptionEs:
+      "'Come' se combina con muchas partículas. Aquí está uno de los más útiles.",
+    verbs: [
+      {
+        verb: "come up with",
+        verbEs: "idear / inventar / ocurrírsele a uno",
+        particle: "up with",
+        baseVerb: "come",
+        definition: "To think of an idea, plan, or solution",
+        definitionEs: "Pensar en una idea, plan o solución",
+        example: "She came up with a brilliant solution to the problem.",
+        exampleEs: "A ella se le ocurrió una solución brillante al problema.",
+        contextNote: "Used in brainstorming, meetings, and creative contexts",
+        contextNoteEs:
+          "Se usa en lluvias de ideas, juntas y contextos creativos",
+      },
+    ],
+  },
+  {
+    baseVerb: "look",
+    baseVerbEs: "mirar / ver",
+    description:
+      "'Look' + particles creates some of the most used phrasal verbs in English.",
+    descriptionEs:
+      "'Look' + partículas crea algunos de los phrasal verbs más usados en inglés.",
+    verbs: [
+      {
+        verb: "look up",
+        verbEs: "buscar (información)",
+        particle: "up",
+        baseVerb: "look",
+        definition:
+          "To search for information in a reference source or online",
+        definitionEs:
+          "Buscar información en una fuente de referencia o en línea",
+        example: "Let me look up the address on my phone.",
+        exampleEs: "Déjame buscar la dirección en mi teléfono.",
+      },
+    ],
+  },
+  {
+    baseVerb: "turn",
+    baseVerbEs: "girar / voltear",
+    description:
+      "'Turn' is surprisingly versatile with different particles.",
+    descriptionEs:
+      "'Turn' es sorprendentemente versátil con diferentes partículas.",
+    verbs: [
+      {
+        verb: "turn out",
+        verbEs: "resultar",
+        particle: "out",
+        baseVerb: "turn",
+        definition: "The result was different from what was expected",
+        definitionEs: "El resultado fue diferente de lo esperado",
+        example:
+          "The meeting turned out to be more productive than I expected.",
+        exampleEs:
+          "La junta resultó ser más productiva de lo que esperaba.",
+        contextNote: "Often used to express surprise about outcomes",
+        contextNoteEs:
+          "Se usa frecuentemente para expresar sorpresa sobre resultados",
+      },
+    ],
+  },
+  {
+    baseVerb: "pick",
+    baseVerbEs: "escoger / recoger",
+    description:
+      "'Pick up' is one of the most versatile phrasal verbs — it has many meanings.",
+    descriptionEs:
+      "'Pick up' es uno de los phrasal verbs más versátiles — tiene muchos significados.",
+    verbs: [
+      {
+        verb: "pick up",
+        verbEs: "recoger / aprender rápidamente",
+        particle: "up",
+        baseVerb: "pick",
+        definition:
+          "To collect something/someone, or to learn something quickly and naturally",
+        definitionEs:
+          "Recoger algo/a alguien, o aprender algo rápido y naturalmente",
+        example:
+          "I picked up some Spanish just by living in Mexico for a year.",
+        exampleEs:
+          "Aprendí algo de español solo por vivir en México un año.",
+        contextNote:
+          "For language learning: 'pick up' means to learn naturally, not in a classroom",
+        contextNoteEs:
+          "Para aprendizaje de idiomas: 'pick up' significa aprender naturalmente, no en un salón",
+      },
+    ],
+  },
+  {
+    baseVerb: "go",
+    baseVerbEs: "ir",
+    description:
+      "'Go over' is essential for workplace and study contexts.",
+    descriptionEs:
+      "'Go over' es esencial para contextos de trabajo y estudio.",
+    verbs: [
+      {
+        verb: "go over",
+        verbEs: "repasar / revisar",
+        particle: "over",
+        baseVerb: "go",
+        definition: "To review or examine something carefully",
+        definitionEs: "Revisar o examinar algo cuidadosamente",
+        example:
+          "Can we go over the presentation one more time before the meeting?",
+        exampleEs:
+          "¿Podemos repasar la presentación una vez más antes de la junta?",
+        contextNote:
+          "Extremely common in meetings: 'Let's go over the agenda'",
+        contextNoteEs:
+          "Extremadamente común en juntas: 'Let's go over the agenda'",
+      },
+    ],
+  },
+  {
+    baseVerb: "end",
+    baseVerbEs: "terminar",
+    description:
+      "'End up' describes an unexpected final result — very natural in storytelling.",
+    descriptionEs:
+      "'End up' describe un resultado final inesperado — muy natural al contar historias.",
+    verbs: [
+      {
+        verb: "end up",
+        verbEs: "terminar (haciendo algo) / acabar",
+        particle: "up",
+        baseVerb: "end",
+        definition:
+          "To be in a situation that you didn't plan or expect",
+        definitionEs:
+          "Estar en una situación que no planeaste o esperabas",
+        example:
+          "I went to the store for milk and ended up spending $200.",
+        exampleEs:
+          "Fui a la tienda por leche y terminé gastando $200.",
+        contextNote: "Perfect for telling stories about unexpected outcomes",
+        contextNoteEs:
+          "Perfecto para contar historias sobre resultados inesperados",
+      },
+    ],
+  },
+];
+
+// ─── Section B: Dialogue Practice ────────────────────────────────────────────
+
+export const dialogues: Dialogue[] = [
+  {
+    title: "The New Project",
+    titleEs: "El Proyecto Nuevo",
+    setting: "Two colleagues chatting in the office kitchen",
+    settingEs: "Dos colegas platicando en la cocina de la oficina",
+    lines: [
+      {
+        speaker: "A",
+        speakerLabel: "Maria",
+        speakerLabelEs: "María",
+        english: "Hey, have you found out who's leading the new project?",
+        spanish: "Oye, ¿ya te enteraste quién va a liderar el proyecto nuevo?",
+        highlight: "found out",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "James",
+        speakerLabelEs: "James",
+        english:
+          "Yeah, it turns out it's going to be Sandra. She came up with the original idea.",
+        spanish:
+          "Sí, resulta que va a ser Sandra. A ella se le ocurrió la idea original.",
+        highlight: "turns out",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Maria",
+        speakerLabelEs: "María",
+        english:
+          "Oh really? I've worked with her before. She's great at figuring out complex problems.",
+        spanish:
+          "¿En serio? He trabajado con ella antes. Es excelente para resolver problemas complejos.",
+        highlight: "figuring out",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "James",
+        speakerLabelEs: "James",
+        english:
+          "Same here. I've picked up a lot from her approach to project management.",
+        spanish:
+          "Igual yo. He aprendido mucho de su enfoque en gestión de proyectos.",
+        highlight: "picked up",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Maria",
+        speakerLabelEs: "María",
+        english:
+          "We should go over the project brief together. Are you free after lunch?",
+        spanish:
+          "Deberíamos repasar el brief del proyecto juntos. ¿Estás libre después de comer?",
+        highlight: "go over",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "James",
+        speakerLabelEs: "James",
+        english:
+          "Sure. Let me look up the meeting room availability and I'll send you an invite.",
+        spanish:
+          "Claro. Déjame buscar la disponibilidad de salas y te mando una invitación.",
+        highlight: "look up",
+      },
+    ],
+    keyPhrases: [
+      {
+        english: "Have you found out...?",
+        spanish: "¿Ya te enteraste...?",
+        note: "Present perfect + phrasal verb — asking about recent discoveries",
+        noteEs:
+          "Presente perfecto + phrasal verb — preguntando sobre descubrimientos recientes",
+      },
+      {
+        english: "It turns out...",
+        spanish: "Resulta que...",
+        note: "A natural way to share surprising information",
+        noteEs: "Una forma natural de compartir información sorprendente",
+      },
+      {
+        english: "I've picked up a lot from...",
+        spanish: "He aprendido mucho de...",
+        note: "Present perfect + 'pick up' = learning informally over time",
+        noteEs:
+          "Presente perfecto + 'pick up' = aprender informalmente con el tiempo",
+      },
+    ],
+  },
+];
+
+// ─── Section C: Structure Builder (Present Perfect vs Simple Past) ───────────
+
+export const structureBlocks: SentenceBlock[] = [
+  {
+    label: "Present Perfect: Life Experience",
+    labelEs: "Presente Perfecto: Experiencia de Vida",
+    description:
+      "Use the present perfect to talk about experiences at an unspecified time. The exact time doesn't matter — the experience does.",
+    descriptionEs:
+      "Usa el presente perfecto para hablar de experiencias en un tiempo no especificado. El momento exacto no importa — la experiencia sí.",
+    sentences: [
+      {
+        english: "I have worked in three different countries.",
+        spanish: "He trabajado en tres países diferentes.",
+        highlight: "have worked",
+      },
+      {
+        english: "She has managed teams of over 50 people.",
+        spanish: "Ella ha gestionado equipos de más de 50 personas.",
+        highlight: "has managed",
+      },
+      {
+        english: "We have never had a problem with that client.",
+        spanish: "Nunca hemos tenido un problema con ese cliente.",
+        highlight: "have never had",
+      },
+      {
+        english: "Have you ever given a presentation in English?",
+        spanish: "¿Alguna vez has dado una presentación en inglés?",
+        highlight: "Have you ever given",
+      },
+    ],
+  },
+  {
+    label: "Simple Past: Specific Time",
+    labelEs: "Pasado Simple: Tiempo Específico",
+    description:
+      "Use the simple past when you mention WHEN something happened. The time is specific and finished.",
+    descriptionEs:
+      "Usa el pasado simple cuando mencionas CUÁNDO algo sucedió. El tiempo es específico y terminado.",
+    sentences: [
+      {
+        english: "I worked in London in 2019.",
+        spanish: "Trabajé en Londres en 2019.",
+        highlight: "worked",
+      },
+      {
+        english: "She managed the entire project last quarter.",
+        spanish: "Ella gestionó todo el proyecto el trimestre pasado.",
+        highlight: "managed",
+      },
+      {
+        english: "We didn't have any issues yesterday.",
+        spanish: "No tuvimos ningún problema ayer.",
+        highlight: "didn't have",
+      },
+      {
+        english: "Did you give the presentation last Monday?",
+        spanish: "¿Diste la presentación el lunes pasado?",
+        highlight: "Did you give",
+      },
+    ],
+  },
+  {
+    label: "The Key Difference — Side by Side",
+    labelEs: "La Diferencia Clave — Lado a Lado",
+    description:
+      "Notice: present perfect connects the past to now. Simple past is finished and closed.",
+    descriptionEs:
+      "Nota: el presente perfecto conecta el pasado con el ahora. El pasado simple está terminado y cerrado.",
+    sentences: [
+      {
+        english: "I have lived in Mexico for 5 years. (I still live here)",
+        spanish: "He vivido en México por 5 años. (Todavía vivo aquí)",
+        highlight: "have lived",
+      },
+      {
+        english: "I lived in Mexico for 5 years. (I don't anymore)",
+        spanish: "Viví en México por 5 años. (Ya no vivo ahí)",
+        highlight: "lived",
+      },
+      {
+        english: "She has lost her keys. (They're still missing)",
+        spanish: "Ella ha perdido sus llaves. (Todavía están perdidas)",
+        highlight: "has lost",
+      },
+      {
+        english: "She lost her keys yesterday. (She found them later)",
+        spanish: "Ella perdió sus llaves ayer. (Las encontró después)",
+        highlight: "lost",
+      },
+    ],
+  },
+  {
+    label: "Present Perfect + Phrasal Verbs",
+    labelEs: "Presente Perfecto + Phrasal Verbs",
+    description:
+      "Combine what you learned in Section A with the present perfect — this is how native speakers actually talk.",
+    descriptionEs:
+      "Combina lo que aprendiste en la Sección A con el presente perfecto — así es como realmente hablan los nativos.",
+    sentences: [
+      {
+        english: "I've figured out the problem with the database.",
+        spanish: "He resuelto el problema con la base de datos.",
+        highlight: "I've figured out",
+      },
+      {
+        english: "Have you found out who's coming to the meeting?",
+        spanish: "¿Ya te enteraste quién viene a la junta?",
+        highlight: "Have you found out",
+      },
+      {
+        english:
+          "We've come up with a new strategy for the Q3 launch.",
+        spanish:
+          "Hemos ideado una nueva estrategia para el lanzamiento del Q3.",
+        highlight: "We've come up with",
+      },
+      {
+        english: "He's ended up in a completely different role than he expected.",
+        spanish:
+          "Él terminó en un rol completamente diferente al que esperaba.",
+        highlight: "He's ended up",
+      },
+    ],
+  },
+];
+
+// ─── Section D: Error Correction ─────────────────────────────────────────────
+
+export const errorCorrections: ErrorCorrectionSet = {
+  title: "Common Mistakes with Present Perfect & Phrasal Verbs",
+  titleEs: "Errores Comunes con Presente Perfecto y Phrasal Verbs",
+  description:
+    "Spanish speakers make specific, predictable errors with these structures. Can you spot them?",
+  descriptionEs:
+    "Los hispanohablantes cometen errores específicos y predecibles con estas estructuras. ¿Puedes detectarlos?",
+  items: [
+    {
+      incorrect: "I have worked here since three years.",
+      correct: "I have worked here for three years.",
+      incorrectHighlight: "since three years",
+      correctHighlight: "for three years",
+      explanation:
+        "'Since' needs a specific point in time (since 2021, since Monday). 'For' is used with a duration (for 3 years, for 2 months). Spanish uses 'desde hace' for both, which causes this confusion.",
+      explanationEs:
+        "'Since' necesita un punto específico en el tiempo (since 2021, since Monday). 'For' se usa con una duración (for 3 years, for 2 months). En español usamos 'desde hace' para ambos, lo que causa esta confusión.",
+      errorType: "literal-translation",
+    },
+    {
+      incorrect: "I have went to the meeting yesterday.",
+      correct: "I went to the meeting yesterday.",
+      incorrectHighlight: "have went",
+      correctHighlight: "went",
+      explanation:
+        "When you mention a specific time (yesterday, last week, in 2020), you MUST use simple past, not present perfect. Also, the past participle of 'go' is 'gone', not 'went'.",
+      explanationEs:
+        "Cuando mencionas un tiempo específico (yesterday, last week, in 2020), DEBES usar pasado simple, no presente perfecto. Además, el participio pasado de 'go' es 'gone', no 'went'.",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "She finded out the truth.",
+      correct: "She found out the truth.",
+      incorrectHighlight: "finded out",
+      correctHighlight: "found out",
+      explanation:
+        "'Find' is an irregular verb: find → found → found. Many Spanish speakers add '-ed' to irregular verbs because regular verbs follow that pattern. 'Find out' keeps the irregular past form.",
+      explanationEs:
+        "'Find' es un verbo irregular: find → found → found. Muchos hispanohablantes agregan '-ed' a verbos irregulares porque los regulares siguen ese patrón. 'Find out' mantiene la forma irregular.",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "I looked it up in the Internet.",
+      correct: "I looked it up on the Internet.",
+      incorrectHighlight: "in the Internet",
+      correctHighlight: "on the Internet",
+      explanation:
+        "In English, we say 'on the Internet', 'on a website', 'on my phone'. Spanish uses 'en' for all, but English uses 'on' for digital platforms and surfaces. The phrasal verb 'look up' is correct here.",
+      explanationEs:
+        "En inglés, decimos 'on the Internet', 'on a website', 'on my phone'. En español usamos 'en' para todo, pero en inglés se usa 'on' para plataformas digitales y superficies.",
+      errorType: "preposition",
+    },
+    {
+      incorrect: "I have come up a new idea.",
+      correct: "I have come up with a new idea.",
+      incorrectHighlight: "come up a",
+      correctHighlight: "come up with a",
+      explanation:
+        "'Come up with' is a three-part phrasal verb — you cannot drop the 'with'. The particle combination 'up with' is essential to the meaning. Without 'with', it means something else entirely (to approach/appear).",
+      explanationEs:
+        "'Come up with' es un phrasal verb de tres partes — no puedes quitar el 'with'. La combinación 'up with' es esencial para el significado. Sin 'with', significa algo completamente diferente (acercarse/aparecer).",
+      errorType: "phrasal-verb",
+    },
+    {
+      incorrect: "He has picked up it very quickly.",
+      correct: "He has picked it up very quickly.",
+      incorrectHighlight: "picked up it",
+      correctHighlight: "picked it up",
+      explanation:
+        "When you use a pronoun (it, them, her, him) with a separable phrasal verb, the pronoun MUST go between the verb and particle: 'pick it up', not 'pick up it'. With nouns, both orders work: 'pick up the book' or 'pick the book up'.",
+      explanationEs:
+        "Cuando usas un pronombre (it, them, her, him) con un phrasal verb separable, el pronombre DEBE ir entre el verbo y la partícula: 'pick it up', no 'pick up it'. Con sustantivos, ambos órdenes funcionan: 'pick up the book' o 'pick the book up'.",
+      errorType: "word-order",
+    },
+  ],
+};
+
+// ─── Section E: Pronunciation Lab ────────────────────────────────────────────
+
+export const pronunciationDrills: PronunciationDrill[] = [
+  {
+    word: "find OUT",
+    spanishStress: "FIND out",
+    englishStress: "find OUT",
+    tip: "In most phrasal verbs, the PARTICLE (out, up, over) gets the main stress, not the verb. Say: find OUT, not FIND out.",
+    tipEs:
+      "En la mayoría de phrasal verbs, la PARTÍCULA (out, up, over) lleva el acento principal, no el verbo. Di: find OUT, no FIND out.",
+  },
+  {
+    word: "pick UP",
+    spanishStress: "PICK up",
+    englishStress: "pick UP",
+    tip: "The particle UP is stressed because it carries the meaning. Compare: 'Can you PICK UP the phone?' (phrasal verb) vs. 'PICK-up truck' (compound noun — stress on PICK).",
+    tipEs:
+      "La partícula UP lleva acento porque transmite el significado. Compara: 'Can you pick UP the phone?' (phrasal verb) vs. 'PICK-up truck' (sustantivo compuesto — acento en PICK).",
+  },
+  {
+    word: "figure OUT",
+    spanishStress: "FIG-ure out",
+    englishStress: "figure OUT",
+    tip: "Even though 'figure' has two syllables, the stress falls on OUT. The whole phrase flows as: FIG-ure-OUT.",
+    tipEs:
+      "Aunque 'figure' tiene dos sílabas, el acento cae en OUT. Toda la frase fluye como: FIG-ure-OUT.",
+  },
+  {
+    word: "turn OUT",
+    spanishStress: "TURN out",
+    englishStress: "turn OUT",
+    tip: "When telling a story: 'It turned OUT to be...' — the stress on OUT signals that you're about to reveal the result.",
+    tipEs:
+      "Al contar una historia: 'It turned OUT to be...' — el acento en OUT señala que estás a punto de revelar el resultado.",
+  },
+  {
+    word: "come UP with",
+    spanishStress: "COME up with",
+    englishStress: "come UP with",
+    tip: "In three-part phrasal verbs, the middle particle usually gets stress: come UP with, get ALONG with, look FORWARD to.",
+    tipEs:
+      "En phrasal verbs de tres partes, la partícula del medio generalmente lleva acento: come UP with, get ALONG with, look FORWARD to.",
+  },
+];
+
+// ─── Section F: Self-Test Vocabulary ─────────────────────────────────────────
+
+export const vocabularyList: IntermediateVocabItem[] = [
+  // Phrasal verbs
+  {
+    english: "find out",
+    spanish: "descubrir / enterarse",
+    type: "phrasal-verb",
+  },
+  {
+    english: "figure out",
+    spanish: "resolver / entender",
+    type: "phrasal-verb",
+  },
+  {
+    english: "come up with",
+    spanish: "idear / inventar",
+    type: "phrasal-verb",
+  },
+  {
+    english: "look up",
+    spanish: "buscar (información)",
+    type: "phrasal-verb",
+  },
+  { english: "turn out", spanish: "resultar", type: "phrasal-verb" },
+  {
+    english: "pick up",
+    spanish: "recoger / aprender rápidamente",
+    type: "phrasal-verb",
+  },
+  { english: "go over", spanish: "repasar / revisar", type: "phrasal-verb" },
+  {
+    english: "end up",
+    spanish: "terminar (haciendo algo)",
+    type: "phrasal-verb",
+  },
+  // Present perfect expressions
+  {
+    english: "I have worked",
+    spanish: "He trabajado",
+    type: "expression",
+  },
+  {
+    english: "She has managed",
+    spanish: "Ella ha gestionado",
+    type: "expression",
+  },
+  {
+    english: "Have you ever...?",
+    spanish: "¿Alguna vez has...?",
+    type: "expression",
+  },
+  {
+    english: "We have never had",
+    spanish: "Nunca hemos tenido",
+    type: "expression",
+  },
+  // Key grammar words
+  { english: "since", spanish: "desde (punto en tiempo)", type: "word" },
+  { english: "for", spanish: "por / durante (duración)", type: "word" },
+  { english: "ever", spanish: "alguna vez", type: "word" },
+  { english: "never", spanish: "nunca", type: "word" },
+  { english: "already", spanish: "ya", type: "word" },
+  { english: "yet", spanish: "todavía / aún", type: "word" },
+  { english: "just", spanish: "recién / acabar de", type: "word" },
+  // Useful verbs from the unit
+  { english: "to lead", spanish: "liderar", type: "verb" },
+  { english: "to manage", spanish: "gestionar", type: "verb" },
+  { english: "to discover", spanish: "descubrir", type: "verb" },
+  { english: "to review", spanish: "revisar", type: "verb" },
+  { english: "to solve", spanish: "resolver", type: "verb" },
+];

--- a/src/data/intermediate/units.ts
+++ b/src/data/intermediate/units.ts
@@ -1,0 +1,216 @@
+// Intermediate course unit metadata — "Building Fluency" (B1-B2)
+
+export interface IntermediateUnit {
+  id: number;
+  slug: string;
+  slugEs: string;
+  title: string;
+  titleEs: string;
+  subtitle: string;
+  subtitleEs: string;
+  description: string;
+  descriptionEs: string;
+  grammarFocus: string;
+  grammarFocusEs: string;
+  pronunciationFocus: string;
+  pronunciationFocusEs: string;
+  icon: string;
+}
+
+export const intermediateInfo = {
+  title: "Building Fluency",
+  titleEs: "Construyendo Fluidez",
+  tagline: "Stop Translating. Start Thinking in English.",
+  taglineEs: "Deja de Traducir. Empieza a Pensar en Inglés.",
+  description:
+    "A free 10-unit course for Spanish speakers at the B1-B2 level. Master phrasal verbs, complex tenses, and natural speech patterns through real-world dialogues and interactive exercises.",
+  descriptionEs:
+    "Un curso gratuito de 10 unidades para hispanohablantes de nivel B1-B2. Domina los phrasal verbs, tiempos complejos y patrones de habla natural a través de diálogos reales y ejercicios interactivos.",
+  basePath: {
+    en: "/en/course/intermediate",
+    es: "/es/curso/intermedio",
+  },
+};
+
+export const intermediateUnits: IntermediateUnit[] = [
+  {
+    id: 1,
+    slug: "unit-1",
+    slugEs: "unidad-1",
+    title: "The Phrasal Verb Problem",
+    titleEs: "El Problema de los Phrasal Verbs",
+    subtitle: "Why 'give up' doesn't mean 'dar arriba'",
+    subtitleEs: "Por qué 'give up' no significa 'dar arriba'",
+    description:
+      "Phrasal verbs are the #1 blocker for Spanish speakers. This unit teaches you how to decode them by grouping particles with base verbs — and introduces the present perfect tense.",
+    descriptionEs:
+      "Los phrasal verbs son el obstáculo #1 para hispanohablantes. Esta unidad te enseña a decodificarlos agrupando partículas con verbos base — e introduce el presente perfecto.",
+    grammarFocus: "Present perfect vs. simple past",
+    grammarFocusEs: "Presente perfecto vs. pasado simple",
+    pronunciationFocus: "Stress in phrasal verbs",
+    pronunciationFocusEs: "Acentuación en phrasal verbs",
+    icon: "Puzzle",
+  },
+  {
+    id: 2,
+    slug: "unit-2",
+    slugEs: "unidad-2",
+    title: "At the Office",
+    titleEs: "En la Oficina",
+    subtitle: "Meetings, emails, and status updates",
+    subtitleEs: "Juntas, correos y reportes de estado",
+    description:
+      "Master the language of the modern workplace. Learn to give updates, manage tasks, and communicate professionally using phrasal verbs your colleagues actually use.",
+    descriptionEs:
+      "Domina el lenguaje del lugar de trabajo moderno. Aprende a dar actualizaciones, gestionar tareas y comunicarte profesionalmente con phrasal verbs que tus colegas realmente usan.",
+    grammarFocus: "Present perfect continuous",
+    grammarFocusEs: "Presente perfecto continuo",
+    pronunciationFocus: "Weak forms in function words",
+    pronunciationFocusEs: "Formas débiles en palabras funcionales",
+    icon: "Briefcase",
+  },
+  {
+    id: 3,
+    slug: "unit-3",
+    slugEs: "unidad-3",
+    title: "Getting Around",
+    titleEs: "Moviéndose",
+    subtitle: "Airports, hotels, and taxis — with confidence",
+    subtitleEs: "Aeropuertos, hoteles y taxis — con confianza",
+    description:
+      "Travel English that goes beyond tourist phrases. Handle real situations: delayed flights, hotel problems, getting directions. Plus the first conditional for making plans.",
+    descriptionEs:
+      "Inglés para viajes que va más allá de frases turísticas. Maneja situaciones reales: vuelos retrasados, problemas de hotel, pedir direcciones. Más el primer condicional para hacer planes.",
+    grammarFocus: "First conditional",
+    grammarFocusEs: "Primer condicional",
+    pronunciationFocus: "Contractions in conditionals",
+    pronunciationFocusEs: "Contracciones en condicionales",
+    icon: "Plane",
+  },
+  {
+    id: 4,
+    slug: "unit-4",
+    slugEs: "unidad-4",
+    title: "Making Plans",
+    titleEs: "Haciendo Planes",
+    subtitle: "If I had more time, I would...",
+    subtitleEs: "Si tuviera más tiempo, yo...",
+    description:
+      "Social English for making plans, invitations, and the hypothetical situations that come with them. Master the second conditional — the structure Spanish speakers get wrong most often.",
+    descriptionEs:
+      "Inglés social para hacer planes, invitaciones y las situaciones hipotéticas que vienen con ellos. Domina el segundo condicional — la estructura que los hispanohablantes confunden más.",
+    grammarFocus: "Second conditional",
+    grammarFocusEs: "Segundo condicional",
+    pronunciationFocus: "Would/could/should reductions",
+    pronunciationFocusEs: "Reducciones de would/could/should",
+    icon: "CalendarCheck",
+  },
+  {
+    id: 5,
+    slug: "unit-5",
+    slugEs: "unidad-5",
+    title: "Telling People What Happened",
+    titleEs: "Contando Lo Que Pasó",
+    subtitle: "I had already left when she called",
+    subtitleEs: "Ya me había ido cuando ella llamó",
+    description:
+      "Narrate events like a native speaker. The past perfect lets you order events in time, and reported speech lets you retell what others said — essential skills for workplace storytelling.",
+    descriptionEs:
+      "Narra eventos como un hablante nativo. El pasado perfecto te permite ordenar eventos en el tiempo, y el discurso indirecto te permite contar lo que otros dijeron.",
+    grammarFocus: "Past perfect + reported speech",
+    grammarFocusEs: "Pasado perfecto + discurso indirecto",
+    pronunciationFocus: "Connected speech in past narratives",
+    pronunciationFocusEs: "Habla conectada en narrativas pasadas",
+    icon: "MessageSquare",
+  },
+  {
+    id: 6,
+    slug: "unit-6",
+    slugEs: "unidad-6",
+    title: "Expressing Opinions",
+    titleEs: "Expresando Opiniones",
+    subtitle: "I see your point, but I disagree",
+    subtitleEs: "Entiendo tu punto, pero no estoy de acuerdo",
+    description:
+      "The language of debate, persuasion, and professional disagreement. Complete your conditional system with the third conditional and learn to hold your ground in English.",
+    descriptionEs:
+      "El lenguaje del debate, la persuasión y el desacuerdo profesional. Completa tu sistema condicional con el tercer condicional y aprende a defender tu posición en inglés.",
+    grammarFocus: "Third conditional + mixed conditionals",
+    grammarFocusEs: "Tercer condicional + condicionales mixtos",
+    pronunciationFocus: "Agreement/disagreement intonation",
+    pronunciationFocusEs: "Entonación de acuerdo/desacuerdo",
+    icon: "Scale",
+  },
+  {
+    id: 7,
+    slug: "unit-7",
+    slugEs: "unidad-7",
+    title: "Health and Emergencies",
+    titleEs: "Salud y Emergencias",
+    subtitle: "I've been feeling sick since yesterday",
+    subtitleEs: "Me he sentido mal desde ayer",
+    description:
+      "High-stakes communication for doctor visits, symptoms, and emergencies. The passive voice unlocks the formal English used in medical and bureaucratic settings.",
+    descriptionEs:
+      "Comunicación de alto riesgo para visitas al doctor, síntomas y emergencias. La voz pasiva desbloquea el inglés formal usado en contextos médicos y burocráticos.",
+    grammarFocus: "Passive voice",
+    grammarFocusEs: "Voz pasiva",
+    pronunciationFocus: "Schwa in passive constructions",
+    pronunciationFocusEs: "Schwa en construcciones pasivas",
+    icon: "HeartPulse",
+  },
+  {
+    id: 8,
+    slug: "unit-8",
+    slugEs: "unidad-8",
+    title: "Money and Shopping",
+    titleEs: "Dinero y Compras",
+    subtitle: "The one that I ordered was different",
+    subtitleEs: "El que pedí era diferente",
+    description:
+      "Consumer English for banking, shopping, and complaints. Relative clauses let you describe and specify — the key to making yourself understood when something goes wrong.",
+    descriptionEs:
+      "Inglés de consumo para bancos, compras y quejas. Las cláusulas relativas te permiten describir y especificar — la clave para hacerte entender cuando algo sale mal.",
+    grammarFocus: "Relative clauses",
+    grammarFocusEs: "Cláusulas relativas",
+    pronunciationFocus: "Sentence stress for emphasis",
+    pronunciationFocusEs: "Acento de oración para énfasis",
+    icon: "Wallet",
+  },
+  {
+    id: 9,
+    slug: "unit-9",
+    slugEs: "unidad-9",
+    title: "Relationships and Feelings",
+    titleEs: "Relaciones y Sentimientos",
+    subtitle: "I wish I had told her sooner",
+    subtitleEs: "Ojalá le hubiera dicho antes",
+    description:
+      "The emotional vocabulary that B1 speakers lack. Wish and regret structures let you express the feelings and hypotheticals that make conversations real and human.",
+    descriptionEs:
+      "El vocabulario emocional que les falta a los hablantes B1. Las estructuras de deseo y arrepentimiento te permiten expresar sentimientos e hipotéticos que hacen las conversaciones reales.",
+    grammarFocus: "Wish/regret structures",
+    grammarFocusEs: "Estructuras de deseo/arrepentimiento",
+    pronunciationFocus: "Emotional intonation",
+    pronunciationFocusEs: "Entonación emocional",
+    icon: "Heart",
+  },
+  {
+    id: 10,
+    slug: "unit-10",
+    slugEs: "unidad-10",
+    title: "What's Next for Your English",
+    titleEs: "Lo Que Sigue para Tu Inglés",
+    subtitle: "You must be close to fluent by now",
+    subtitleEs: "Ya debes estar cerca de la fluidez",
+    description:
+      "The grand review. All tenses, all conditionals, all phrasal verbs in context. Plus modals of deduction — the last major B2 structure. A bridge to advanced English and the real world.",
+    descriptionEs:
+      "La gran revisión. Todos los tiempos, todos los condicionales, todos los phrasal verbs en contexto. Más los modales de deducción — la última estructura B2 importante.",
+    grammarFocus: "Review + modals of deduction",
+    grammarFocusEs: "Revisión + modales de deducción",
+    pronunciationFocus: "Thought groups and chunking",
+    pronunciationFocusEs: "Grupos de pensamiento y segmentación",
+    icon: "Rocket",
+  },
+];

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -86,6 +86,18 @@ export type TKey =
   | "course/beginners/unit-10"
   | "course/beginners/exam"
   | "course/beginners/pronunciation"
+  | "course/intermediate"
+  | "course/intermediate/unit-1"
+  | "course/intermediate/unit-2"
+  | "course/intermediate/unit-3"
+  | "course/intermediate/unit-4"
+  | "course/intermediate/unit-5"
+  | "course/intermediate/unit-6"
+  | "course/intermediate/unit-7"
+  | "course/intermediate/unit-8"
+  | "course/intermediate/unit-9"
+  | "course/intermediate/unit-10"
+  | "course/intermediate/exam"
   | "meme-portfolio"
   | "site-index";
 
@@ -186,6 +198,18 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/beginners/unit-10": "/en/course/beginners/unit-10/",
     "course/beginners/exam": "/en/course/beginners/exam/",
     "course/beginners/pronunciation": "/en/course/beginners/pronunciation/",
+    "course/intermediate": "/en/course/intermediate/",
+    "course/intermediate/unit-1": "/en/course/intermediate/unit-1/",
+    "course/intermediate/unit-2": "/en/course/intermediate/unit-2/",
+    "course/intermediate/unit-3": "/en/course/intermediate/unit-3/",
+    "course/intermediate/unit-4": "/en/course/intermediate/unit-4/",
+    "course/intermediate/unit-5": "/en/course/intermediate/unit-5/",
+    "course/intermediate/unit-6": "/en/course/intermediate/unit-6/",
+    "course/intermediate/unit-7": "/en/course/intermediate/unit-7/",
+    "course/intermediate/unit-8": "/en/course/intermediate/unit-8/",
+    "course/intermediate/unit-9": "/en/course/intermediate/unit-9/",
+    "course/intermediate/unit-10": "/en/course/intermediate/unit-10/",
+    "course/intermediate/exam": "/en/course/intermediate/exam/",
     "meme-portfolio": "/en/meme-portfolio/all/",
     "site-index": "/en/site-index/",
   },
@@ -290,6 +314,18 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/beginners/unit-10": "/es/curso/principiantes/unidad-10/",
     "course/beginners/exam": "/es/curso/principiantes/examen/",
     "course/beginners/pronunciation": "/es/curso/principiantes/pronunciacion/",
+    "course/intermediate": "/es/curso/intermedio/",
+    "course/intermediate/unit-1": "/es/curso/intermedio/unidad-1/",
+    "course/intermediate/unit-2": "/es/curso/intermedio/unidad-2/",
+    "course/intermediate/unit-3": "/es/curso/intermedio/unidad-3/",
+    "course/intermediate/unit-4": "/es/curso/intermedio/unidad-4/",
+    "course/intermediate/unit-5": "/es/curso/intermedio/unidad-5/",
+    "course/intermediate/unit-6": "/es/curso/intermedio/unidad-6/",
+    "course/intermediate/unit-7": "/es/curso/intermedio/unidad-7/",
+    "course/intermediate/unit-8": "/es/curso/intermedio/unidad-8/",
+    "course/intermediate/unit-9": "/es/curso/intermedio/unidad-9/",
+    "course/intermediate/unit-10": "/es/curso/intermedio/unidad-10/",
+    "course/intermediate/exam": "/es/curso/intermedio/examen/",
     "meme-portfolio": "/es/meme-portfolio/all/",
     "site-index": "/es/indice-del-sitio/",
   },

--- a/src/pages/en/course/intermediate/index.astro
+++ b/src/pages/en/course/intermediate/index.astro
@@ -1,0 +1,247 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import { intermediateInfo, intermediateUnits } from "@data/intermediate/units";
+import {
+  Puzzle,
+  Briefcase,
+  Plane,
+  CalendarCheck,
+  MessageSquare,
+  Scale,
+  HeartPulse,
+  Wallet,
+  Heart,
+  Rocket,
+  ArrowRight,
+  Sparkles,
+  Zap,
+  MessageCircle,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/intermediate" as const;
+
+const iconMap: Record<string, any> = {
+  Puzzle,
+  Briefcase,
+  Plane,
+  CalendarCheck,
+  MessageSquare,
+  Scale,
+  HeartPulse,
+  Wallet,
+  Heart,
+  Rocket,
+};
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Building Fluency — Free Intermediate English Course for Spanish Speakers | NY English Teacher"
+  description="A free 10-unit intermediate English course for Spanish speakers at the B1-B2 level. Master phrasal verbs, complex tenses, and natural speech patterns through real-world dialogues."
+>
+  <!-- Hero -->
+  <section class="relative w-full overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 pt-32 pb-20 md:pt-40 md:pb-28">
+    <div class="absolute inset-0 opacity-10">
+      <div class="absolute top-20 left-10 w-72 h-72 bg-amber-500 rounded-full blur-3xl"></div>
+      <div class="absolute bottom-10 right-20 w-96 h-96 bg-orange-500 rounded-full blur-3xl"></div>
+    </div>
+    <div class="site-container mx-auto px-4 relative z-10 text-white">
+      <div class="max-w-3xl">
+        <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-semibold mb-6">
+          <Sparkles class="w-4 h-4" />
+          Free Course — 10 Units — B1-B2 Level
+        </div>
+        <h1
+          class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Stop Translating.<br />
+          <span class="text-amber-400">Start Thinking in English.</span>
+        </h1>
+        <p class="text-xl text-slate-300 mb-8 max-w-2xl leading-relaxed">
+          You know the basics. But you still think in Spanish and translate in your head.
+          This course breaks that habit — with <strong class="text-white">phrasal verbs</strong>,
+          <strong class="text-white">real dialogues</strong>, and the grammar structures
+          that separate intermediate from fluent.
+        </p>
+        <div class="flex flex-wrap gap-4">
+          <Button href="/en/course/intermediate/unit-1/" variant="primary" size="lg">
+            Start Unit 1 — Free
+            <ArrowRight class="w-5 h-5 ml-1" />
+          </Button>
+          <a
+            href="/en/course/beginners/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            Need the basics first?
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Value props -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-amber-100 text-amber-600">
+            <Puzzle class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">80+ Phrasal Verbs</h3>
+          <p class="text-slate-600 leading-relaxed">
+            The #1 blocker for Spanish speakers. Learn them grouped by base verb so they finally make sense.
+          </p>
+        </div>
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-amber-100 text-amber-600">
+            <MessageCircle class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">Real-World Dialogues</h3>
+          <p class="text-slate-600 leading-relaxed">
+            Practice with conversations from the office, the airport, the doctor's office, and social situations.
+          </p>
+        </div>
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-amber-100 text-amber-600">
+            <Zap class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">Error Correction</h3>
+          <p class="text-slate-600 leading-relaxed">
+            Spot and fix the specific mistakes Spanish speakers make — before they become habits.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Course Units -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="text-center mb-12">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">10 Units. Intermediate to Fluent.</h2>
+        <p class="text-lg text-slate-600 max-w-2xl mx-auto">
+          Each unit combines a real-world theme with the grammar and phrasal verbs you need for that situation.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
+        {intermediateUnits.map((unit) => {
+          const Icon = iconMap[unit.icon];
+          const isAvailable = unit.id === 1;
+          return (
+            <a
+              href={isAvailable ? `/en/course/intermediate/${unit.slug}/` : undefined}
+              class:list={[
+                "group flex items-start gap-4 p-5 rounded-xl border transition-all duration-200",
+                isAvailable
+                  ? "bg-amber-50 border-amber-300 hover:shadow-md hover:border-amber-400 cursor-pointer"
+                  : "bg-white border-slate-200 opacity-75",
+              ]}
+            >
+              <div
+                class:list={[
+                  "flex items-center justify-center w-12 h-12 rounded-xl shrink-0",
+                  isAvailable ? "bg-amber-500 text-white" : "bg-slate-100 text-slate-400",
+                ]}
+              >
+                {Icon && <Icon class="w-6 h-6" />}
+              </div>
+              <div>
+                <div class="flex items-center gap-2">
+                  <span
+                    class:list={[
+                      "text-xs font-bold uppercase tracking-wider",
+                      isAvailable ? "text-amber-600" : "text-slate-400",
+                    ]}
+                  >
+                    Unit {unit.id}
+                  </span>
+                  {!isAvailable && (
+                    <span class="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-400">
+                      Coming soon
+                    </span>
+                  )}
+                </div>
+                <h3
+                  class:list={[
+                    "text-lg font-bold mt-0.5",
+                    isAvailable ? "text-slate-900" : "text-slate-600",
+                  ]}
+                >
+                  {unit.title}
+                </h3>
+                <p class="text-sm text-slate-500 mt-1">{unit.subtitle}</p>
+                <p class="text-xs text-slate-400 mt-1">{unit.grammarFocus}</p>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <!-- Method explanation -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-6 text-center">
+          Why This Course Works
+        </h2>
+        <div class="space-y-6 text-lg text-slate-700 leading-relaxed">
+          <p>
+            At the B1-B2 level, you know enough English to survive. But you're stuck — you translate everything in your head,
+            you avoid phrasal verbs because they don't make logical sense, and you use the same safe tenses for everything.
+          </p>
+          <p>
+            <strong>Building Fluency</strong> attacks these three problems directly. Each unit pairs a real-world context
+            (the office, the airport, the doctor) with the specific grammar structures and phrasal verbs you need for that situation.
+          </p>
+          <p>
+            And because we know the <em>specific</em> errors Spanish speakers make (like saying "since three years" instead of "for three years"),
+            every unit includes an error correction section that targets your exact pain points.
+          </p>
+        </div>
+        <div class="mt-10 text-center">
+          <Button href="/en/course/intermediate/unit-1/" variant="primary" size="lg">
+            Start Learning — Free
+            <ArrowRight class="w-5 h-5 ml-1" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Prerequisites / Level check -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-2xl font-bold text-slate-900 mb-4">Is This Course Right for You?</h2>
+        <p class="text-lg text-slate-600 leading-relaxed mb-6">
+          This course is designed for Spanish speakers at the <strong>B1-B2 level</strong> — you can have basic conversations,
+          understand most written English, but struggle with natural speech, phrasal verbs, and complex grammar.
+        </p>
+        <div class="flex flex-wrap gap-3 justify-center">
+          <a
+            href="/en/course/beginners/"
+            class="text-amber-600 hover:text-amber-700 font-medium underline underline-offset-2"
+          >
+            Need the basics? Start with First Steps
+          </a>
+          <span class="text-slate-300">|</span>
+          <a
+            href="/en/services/"
+            class="text-amber-600 hover:text-amber-700 font-medium underline underline-offset-2"
+          >
+            Ready for executive coaching?
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/en/course/intermediate/unit-1.astro
+++ b/src/pages/en/course/intermediate/unit-1.astro
@@ -1,0 +1,208 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import PhrasalVerbExplorer from "@components/course/PhrasalVerbExplorer";
+import DialoguePractice from "@components/course/DialoguePractice";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import ErrorCorrection from "@components/course/ErrorCorrection";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import SelfTest from "@components/course/SelfTest";
+import AudioButton from "@components/course/AudioButton";
+import { intermediateUnits, intermediateInfo } from "@data/intermediate/units";
+import {
+  phrasalVerbGroups,
+  dialogues,
+  structureBlocks,
+  errorCorrections,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/intermediate/unit-1";
+import {
+  ArrowRight,
+  Puzzle,
+  MessageCircle,
+  Layers,
+  AlertTriangle,
+  Volume2,
+  ClipboardCheck,
+  BookOpen,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/intermediate/unit-1" as const;
+
+const progressUnits = intermediateUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unit 1: The Phrasal Verb Problem | Building Fluency | NY English Teacher"
+  description="Why 'give up' doesn't mean 'dar arriba'. Master 8 essential phrasal verbs and the present perfect tense. Free interactive lesson for B1-B2 Spanish speakers."
+>
+  <!-- Course progress bar -->
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={1}
+    basePath="/en/course/intermediate"
+    lang="en"
+    courseId="intermediate"
+  />
+
+  <!-- Unit hero -->
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Puzzle class="w-4 h-4" />
+          Unit 1
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          The Phrasal Verb Problem
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Phrasal verbs are the #1 thing that blocks Spanish speakers from sounding natural in English.
+          "Give up" doesn't mean "dar arriba." "Find out" doesn't mean "encontrar afuera."
+          In this unit, you'll learn how to decode them — and stop translating word by word.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Puzzle class="w-3.5 h-3.5" /> 8 Phrasal Verbs
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Layers class="w-3.5 h-3.5" /> Present Perfect
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Volume2 class="w-3.5 h-3.5" /> Phrasal Verb Stress
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section A: Phrasal Verb Explorer -->
+  <section class="py-16 md:py-20 bg-white" id="section-a">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">A</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Phrasal Verb Explorer</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Tap each phrasal verb to reveal its meaning. Try to guess before you look!
+        </p>
+        <PhrasalVerbExplorer client:visible groups={phrasalVerbGroups} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Section B: Dialogue Practice -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-b">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">B</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Dialogue Practice</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          See the phrasal verbs in action. Tap any line to see the Spanish translation.
+        </p>
+        <DialoguePractice client:visible dialogues={dialogues} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Section C: Structure Builder -->
+  <section class="py-16 md:py-20 bg-white" id="section-c">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">C</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Structure Builder</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Present perfect vs. simple past — the difference that changes everything.
+        </p>
+        <SentenceBuilder client:visible blocks={structureBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Section D: Error Correction -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-d">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">D</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Error Correction</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Can you spot the mistakes that Spanish speakers make most often?
+        </p>
+        <ErrorCorrection client:visible data={errorCorrections} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Section E: Pronunciation Lab -->
+  <section class="py-16 md:py-20 bg-white" id="section-e">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">E</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Pronunciation Lab</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Where does the stress go in a phrasal verb? Not where you think.
+        </p>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Section F: Self-Test -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-f">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">F</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Self-Test</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Test yourself on everything from this unit — phrasal verbs, grammar, and key vocabulary.
+        </p>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/en/course/intermediate/"
+          class="text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          &larr; Course Overview
+        </a>
+        <Button href="/en/course/intermediate/unit-2/" variant="primary" size="md">
+          Unit 2: At the Office
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/intermedio/index.astro
+++ b/src/pages/es/curso/intermedio/index.astro
@@ -1,0 +1,247 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import { intermediateInfo, intermediateUnits } from "@data/intermediate/units";
+import {
+  Puzzle,
+  Briefcase,
+  Plane,
+  CalendarCheck,
+  MessageSquare,
+  Scale,
+  HeartPulse,
+  Wallet,
+  Heart,
+  Rocket,
+  ArrowRight,
+  Sparkles,
+  Zap,
+  MessageCircle,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/intermediate" as const;
+
+const iconMap: Record<string, any> = {
+  Puzzle,
+  Briefcase,
+  Plane,
+  CalendarCheck,
+  MessageSquare,
+  Scale,
+  HeartPulse,
+  Wallet,
+  Heart,
+  Rocket,
+};
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Construyendo Fluidez — Curso Intermedio de Inglés Gratis para Hispanohablantes | NY English Teacher"
+  description="Un curso gratuito de 10 unidades de inglés intermedio para hispanohablantes de nivel B1-B2. Domina los phrasal verbs, tiempos complejos y patrones de habla natural."
+>
+  <!-- Hero -->
+  <section class="relative w-full overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 pt-32 pb-20 md:pt-40 md:pb-28">
+    <div class="absolute inset-0 opacity-10">
+      <div class="absolute top-20 left-10 w-72 h-72 bg-amber-500 rounded-full blur-3xl"></div>
+      <div class="absolute bottom-10 right-20 w-96 h-96 bg-orange-500 rounded-full blur-3xl"></div>
+    </div>
+    <div class="site-container mx-auto px-4 relative z-10 text-white">
+      <div class="max-w-3xl">
+        <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-semibold mb-6">
+          <Sparkles class="w-4 h-4" />
+          Curso Gratis — 10 Unidades — Nivel B1-B2
+        </div>
+        <h1
+          class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Deja de Traducir.<br />
+          <span class="text-amber-400">Empieza a Pensar en Inglés.</span>
+        </h1>
+        <p class="text-xl text-slate-300 mb-8 max-w-2xl leading-relaxed">
+          Ya sabes lo básico. Pero todavía piensas en español y traduces en tu cabeza.
+          Este curso rompe ese hábito — con <strong class="text-white">phrasal verbs</strong>,
+          <strong class="text-white">diálogos reales</strong>, y las estructuras gramaticales
+          que separan al intermedio del fluido.
+        </p>
+        <div class="flex flex-wrap gap-4">
+          <Button href="/es/curso/intermedio/unidad-1/" variant="primary" size="lg">
+            Empezar Unidad 1 — Gratis
+            <ArrowRight class="w-5 h-5 ml-1" />
+          </Button>
+          <a
+            href="/es/curso/principiantes/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            ¿Necesitas lo básico primero?
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Value props -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-amber-100 text-amber-600">
+            <Puzzle class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">80+ Phrasal Verbs</h3>
+          <p class="text-slate-600 leading-relaxed">
+            El obstáculo #1 para hispanohablantes. Aprende agrupados por verbo base para que finalmente tengan sentido.
+          </p>
+        </div>
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-amber-100 text-amber-600">
+            <MessageCircle class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">Diálogos del Mundo Real</h3>
+          <p class="text-slate-600 leading-relaxed">
+            Practica con conversaciones de la oficina, el aeropuerto, el consultorio médico y situaciones sociales.
+          </p>
+        </div>
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-amber-100 text-amber-600">
+            <Zap class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">Corrección de Errores</h3>
+          <p class="text-slate-600 leading-relaxed">
+            Detecta y corrige los errores específicos que los hispanohablantes cometen — antes de que se vuelvan hábitos.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Course Units -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="text-center mb-12">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">10 Unidades. De Intermedio a Fluido.</h2>
+        <p class="text-lg text-slate-600 max-w-2xl mx-auto">
+          Cada unidad combina un tema del mundo real con la gramática y phrasal verbs que necesitas para esa situación.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
+        {intermediateUnits.map((unit) => {
+          const Icon = iconMap[unit.icon];
+          const isAvailable = unit.id === 1;
+          return (
+            <a
+              href={isAvailable ? `/es/curso/intermedio/${unit.slugEs}/` : undefined}
+              class:list={[
+                "group flex items-start gap-4 p-5 rounded-xl border transition-all duration-200",
+                isAvailable
+                  ? "bg-amber-50 border-amber-300 hover:shadow-md hover:border-amber-400 cursor-pointer"
+                  : "bg-white border-slate-200 opacity-75",
+              ]}
+            >
+              <div
+                class:list={[
+                  "flex items-center justify-center w-12 h-12 rounded-xl shrink-0",
+                  isAvailable ? "bg-amber-500 text-white" : "bg-slate-100 text-slate-400",
+                ]}
+              >
+                {Icon && <Icon class="w-6 h-6" />}
+              </div>
+              <div>
+                <div class="flex items-center gap-2">
+                  <span
+                    class:list={[
+                      "text-xs font-bold uppercase tracking-wider",
+                      isAvailable ? "text-amber-600" : "text-slate-400",
+                    ]}
+                  >
+                    Unidad {unit.id}
+                  </span>
+                  {!isAvailable && (
+                    <span class="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-400">
+                      Próximamente
+                    </span>
+                  )}
+                </div>
+                <h3
+                  class:list={[
+                    "text-lg font-bold mt-0.5",
+                    isAvailable ? "text-slate-900" : "text-slate-600",
+                  ]}
+                >
+                  {unit.titleEs}
+                </h3>
+                <p class="text-sm text-slate-500 mt-1">{unit.subtitleEs}</p>
+                <p class="text-xs text-slate-400 mt-1">{unit.grammarFocusEs}</p>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <!-- Method explanation -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-6 text-center">
+          Por Qué Este Curso Funciona
+        </h2>
+        <div class="space-y-6 text-lg text-slate-700 leading-relaxed">
+          <p>
+            En el nivel B1-B2, sabes suficiente inglés para sobrevivir. Pero estás estancado — traduces todo en tu cabeza,
+            evitas los phrasal verbs porque no tienen lógica, y usas los mismos tiempos verbales seguros para todo.
+          </p>
+          <p>
+            <strong>Construyendo Fluidez</strong> ataca estos tres problemas directamente. Cada unidad combina un contexto real
+            (la oficina, el aeropuerto, el doctor) con las estructuras gramaticales y phrasal verbs que necesitas para esa situación.
+          </p>
+          <p>
+            Y porque conocemos los errores <em>específicos</em> que cometen los hispanohablantes (como decir "since three years" en vez de "for three years"),
+            cada unidad incluye una sección de corrección de errores que apunta a tus puntos débiles exactos.
+          </p>
+        </div>
+        <div class="mt-10 text-center">
+          <Button href="/es/curso/intermedio/unidad-1/" variant="primary" size="lg">
+            Empezar a Aprender — Gratis
+            <ArrowRight class="w-5 h-5 ml-1" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Prerequisites -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-2xl font-bold text-slate-900 mb-4">¿Es Este Curso Para Ti?</h2>
+        <p class="text-lg text-slate-600 leading-relaxed mb-6">
+          Este curso está diseñado para hispanohablantes de <strong>nivel B1-B2</strong> — puedes tener conversaciones básicas,
+          entiendes la mayoría del inglés escrito, pero tienes dificultades con el habla natural, phrasal verbs y gramática compleja.
+        </p>
+        <div class="flex flex-wrap gap-3 justify-center">
+          <a
+            href="/es/curso/principiantes/"
+            class="text-amber-600 hover:text-amber-700 font-medium underline underline-offset-2"
+          >
+            ¿Necesitas lo básico? Empieza con Primeros Pasos
+          </a>
+          <span class="text-slate-300">|</span>
+          <a
+            href="/es/servicios/"
+            class="text-amber-600 hover:text-amber-700 font-medium underline underline-offset-2"
+          >
+            ¿Listo para coaching ejecutivo?
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/intermedio/unidad-1.astro
+++ b/src/pages/es/curso/intermedio/unidad-1.astro
@@ -1,0 +1,208 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import PhrasalVerbExplorer from "@components/course/PhrasalVerbExplorer";
+import DialoguePractice from "@components/course/DialoguePractice";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import ErrorCorrection from "@components/course/ErrorCorrection";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import SelfTest from "@components/course/SelfTest";
+import AudioButton from "@components/course/AudioButton";
+import { intermediateUnits, intermediateInfo } from "@data/intermediate/units";
+import {
+  phrasalVerbGroups,
+  dialogues,
+  structureBlocks,
+  errorCorrections,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/intermediate/unit-1";
+import {
+  ArrowRight,
+  Puzzle,
+  MessageCircle,
+  Layers,
+  AlertTriangle,
+  Volume2,
+  ClipboardCheck,
+  BookOpen,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/intermediate/unit-1" as const;
+
+const progressUnits = intermediateUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unidad 1: El Problema de los Phrasal Verbs | Construyendo Fluidez | NY English Teacher"
+  description="Por qué 'give up' no significa 'dar arriba'. Domina 8 phrasal verbs esenciales y el presente perfecto. Lección interactiva gratis para hispanohablantes B1-B2."
+>
+  <!-- Course progress bar -->
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={1}
+    basePath="/es/curso/intermedio"
+    lang="es"
+    courseId="intermediate"
+  />
+
+  <!-- Unit hero -->
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Puzzle class="w-4 h-4" />
+          Unidad 1
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          El Problema de los Phrasal Verbs
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Los phrasal verbs son el obstáculo #1 que impide a los hispanohablantes sonar natural en inglés.
+          "Give up" no significa "dar arriba." "Find out" no significa "encontrar afuera."
+          En esta unidad, aprenderás a decodificarlos — y dejarás de traducir palabra por palabra.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Puzzle class="w-3.5 h-3.5" /> 8 Phrasal Verbs
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Layers class="w-3.5 h-3.5" /> Presente Perfecto
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Volume2 class="w-3.5 h-3.5" /> Acento en Phrasal Verbs
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section A: Phrasal Verb Explorer -->
+  <section class="py-16 md:py-20 bg-white" id="section-a">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">A</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Explorador de Phrasal Verbs</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Toca cada phrasal verb para revelar su significado. ¡Intenta adivinar antes de ver!
+        </p>
+        <PhrasalVerbExplorer client:visible groups={phrasalVerbGroups} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Section B: Dialogue Practice -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-b">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">B</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Práctica de Diálogo</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Mira los phrasal verbs en acción. Toca cualquier línea para ver la traducción al español.
+        </p>
+        <DialoguePractice client:visible dialogues={dialogues} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Section C: Structure Builder -->
+  <section class="py-16 md:py-20 bg-white" id="section-c">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">C</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Constructor de Estructuras</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Presente perfecto vs. pasado simple — la diferencia que lo cambia todo.
+        </p>
+        <SentenceBuilder client:visible blocks={structureBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Section D: Error Correction -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-d">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">D</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Corrección de Errores</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          ¿Puedes detectar los errores que los hispanohablantes cometen con más frecuencia?
+        </p>
+        <ErrorCorrection client:visible data={errorCorrections} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Section E: Pronunciation Lab -->
+  <section class="py-16 md:py-20 bg-white" id="section-e">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">E</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Laboratorio de Pronunciación</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          ¿Dónde va el acento en un phrasal verb? No donde crees.
+        </p>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Section F: Self-Test -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-f">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">F</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Auto-Evaluación</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Ponte a prueba con todo lo de esta unidad — phrasal verbs, gramática y vocabulario clave.
+        </p>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/es/curso/intermedio/"
+          class="text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          &larr; Resumen del Curso
+        </a>
+        <Button href="/es/curso/intermedio/unidad-2/" variant="primary" size="md">
+          Unidad 2: En la Oficina
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary
- New **"Building Fluency"** intermediate course (B1-B2) with complete 10-unit curriculum designed and Unit 1 fully implemented
- 3 new React components: PhrasalVerbExplorer, DialoguePractice, ErrorCorrection
- Full bilingual implementation (EN + ES) with i18n routing
- Unit 1 covers 8 phrasal verbs, present perfect vs simple past, and phrasal verb stress patterns
- CourseProgress updated with configurable `courseId` for separate progress tracking per course
- Build passes: 343 pages, 218 sitemap URLs, zero errors

## What's included
- **Landing pages**: `/en/course/intermediate/` + `/es/curso/intermedio/`
- **Unit 1**: `/en/course/intermediate/unit-1/` + `/es/curso/intermedio/unidad-1/`
- **6 interactive sections**: Phrasal Verb Explorer, Dialogue Practice, Structure Builder, Error Correction, Pronunciation Lab, Self-Test
- **Units 2-10**: Metadata defined, pages show "Coming soon"

## Test plan
- [ ] Visit `/en/course/intermediate/` — landing page with 10-unit grid
- [ ] Visit `/en/course/intermediate/unit-1/` — all 6 sections render
- [ ] Visit `/es/curso/intermedio/unidad-1/` — Spanish mirror works
- [ ] PhrasalVerbExplorer: expand groups, reveal verbs, audio plays
- [ ] DialoguePractice: tap lines for translation, audio works
- [ ] ErrorCorrection: tap errors, see corrections with explanations
- [ ] SelfTest: flashcards include phrasal-verb and expression types
- [ ] CourseProgress: shows intermediate course progress (separate from beginners)
- [ ] Beginner course still works correctly (no regression)
- [ ] Hreflang tags present on all new pages
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)