### PR TITLE
feat: courses hub page (EN + ES) with header nav

### DIFF
--- a/rag-chatbot/en/about.txt
+++ b/rag-chatbot/en/about.txt
@@ -1,0 +1,43 @@
+Page: /en/about/
+
+About Robert Cushman | Executive Communication Coach
+
+Robert Cushman spent 20 years in IT — 17 at a Fortune 500. Now he coaches international professionals to sound like the leaders they already are, in English.
+
+Robert Cushman — Executive Communication Coach
+
+I spent 20 years in IT—17 of them at a Fortune 500, climbing from developer to Senior Manager. I've led global teams, presented to boardrooms, and navigated the politics of corporate leadership at scale.
+
+Now I coach international professionals to do the same—in English.
+
+I live in Guadalajara. I married into Mexico. I get what it feels like to operate in a language and culture that isn't your first. That perspective shapes every session I design.
+
+CTA: Book Your Free Session — /en/book/
+
+Why I Coach Differently
+
+Most English teachers teach English.
+
+I teach professionals how to sound like the leaders they already are—in a second language.
+
+The difference matters. I've sat in the meetings you're preparing for. I know what a VP sounds like when they're losing the room... and what it takes to hold it. That's not textbook stuff or grammar drills.
+
+Every session starts from your reality—your next presentation, negotiation, or calendar crunch. Board meeting Thursday? We work it Wednesday.
+
+Authority, not apology. That's the standard.
+
+How It Works
+
+1. We talk first. A short intro call. Your role, goals, fit—no pressure, no pitch.
+2. I build your plan. From your level, industry, and pressure moments. Custom sessions, not off-the-shelf.
+3. You practice under pressure. Pitches, negotiations, client calls. Feedback on tone, pronunciation, those tiny signals that make "fluent" turn commanding. Mess up with me, not when it counts.
+4. I refine as you grow. Communication sharpens? I adjust—new challenges, scenarios, targets. Evolves with your career.
+
+Who I Work With
+COOs prepping cross-border boards. Founders pitching US investors. Tech leads explaining architecture to non-tech folks. Lawyers, doctors—where one word flips everything.
+
+If you're killing it in your field but feel off, less commanding in English? That's the gap I close.
+
+Footer: You already lead. Now sound like it — in English.
+Book a private strategy session. 30 minutes: I'll spot the gaps between your English and the executive presence your role demands.
+CTA: Book My Strategy Session — /en/book/

--- a/rag-chatbot/en/book.txt
+++ b/rag-chatbot/en/book.txt
@@ -1,0 +1,16 @@
+Page: /en/book/
+
+Book Your Free Strategy Session | NY English
+
+Schedule a free 15-minute strategy session. No sales scripts — just a direct conversation about where your English is costing you opportunities and how to fix it.
+
+Book Your Free Strategy Session
+
+In 15 minutes, I'll pinpoint exactly where your English is costing you opportunities — and map a clear path to fix it. No sales scripts. No obligation.
+
+The booking page presents a 3-step booking wizard:
+1. Pick a date
+2. Pick a time slot
+3. Enter your contact info and confirm
+
+Sessions are conducted online via Google Meet. Time zone is Guadalajara, Mexico (UTC–6).

--- a/rag-chatbot/en/contact.txt
+++ b/rag-chatbot/en/contact.txt
@@ -1,0 +1,15 @@
+Page: /en/contact/
+
+Contact | Business English Coaching in New York
+
+Reach out via form or WhatsApp to discuss personalized executive English coaching. I respond within 24 hours and work with professionals worldwide.
+
+Let's Talk About Your English Goals
+Whether you have a question or you're ready to start — I respond within 24 hours.
+
+Contact Information
+Reach me via this form or WhatsApp.
+
+- WhatsApp: https://wa.me/523315590572
+- Time Zone: Guadalajara, Mexico (UTC–6)
+- Reserve Free Consultation: /en/book/

--- a/rag-chatbot/en/faqs.txt
+++ b/rag-chatbot/en/faqs.txt
@@ -1,0 +1,77 @@
+Page: /en/faqs/
+
+Your English Coaching Questions Answered | New York English Teacher
+
+DEBUG YOUR COMMUNICATION
+Your English Coaching Questions, Answered
+Everything you need to know about optimizing your English for high-stakes career moments.
+
+Section: Mexico & Latin America
+Questions specific to professionals working from Mexico and Latin America.
+
+Q: Do you understand the specific challenges Mexican professionals face with English?
+A: Yes — this is my specialty. I work primarily with Mexican and Latin American professionals. I understand the false cognates (actualmente ≠ actually), the cultural communication differences (directness vs. formality), and the specific pronunciation patterns that affect credibility with North American clients.
+
+Q: Can you help me prepare for meetings with US headquarters?
+A: Absolutely. Many of my clients report to US-based leadership or work with North American clients. I practice the specific meeting scenarios you face — status updates, escalation calls, quarterly reviews — using the communication style that US executives expect.
+
+Q: I work for a Mexican company expanding into the US market. Can you help our team?
+A: Yes. I offer corporate packages for teams making the leap into US markets. I focus on the communication skills that determine success — client-facing English, partnership negotiations, and the cultural fluency that builds trust with American business partners.
+
+Q: Do you accept payment in Mexican pesos?
+A: Yes. Pricing is available in both MXN and USD. Single sessions are 500 MXN ($25 USD), and 12-session packages are 6,000 MXN ($300 USD). I can also issue Mexican corporate invoices (facturas) for company billing.
+
+Section: Getting Started
+
+Q: How do I get started with coaching?
+A: Book a free discovery call through the website. In 15-20 minutes, I'll discuss your goals, assess your current level, and determine if coaching is the right fit. There's no obligation — it's simply a conversation about where you want to go.
+
+Q: What happens in the first coaching session?
+A: The first session is a diagnostic. I identify your specific communication gaps, understand your professional context, and create a prioritized roadmap. You'll leave with 2-3 immediate action items you can start using that same week.
+
+Q: Do I need to commit to a long-term package, or can I try a single session?
+A: You can absolutely start with a single session at 500 MXN / $25 USD. Many clients try one session and then choose to continue because they see immediate value. There's no pressure to commit — results speak for themselves.
+
+Q: What technology do I need for online sessions?
+A: Just a computer or phone with a camera, microphone, and stable internet connection. Sessions are conducted via Google Meet — no special software needed. A quiet space where you can speak freely is ideal.
+
+Section: Investment & Value
+
+Q: What is the cost of your coaching?
+A: Current Rate: 500 MXN ($25 USD) per session. 12-Session Executive Roadmap: 6,000 MXN / $300 USD. Every session is custom-built around your specific industry, upcoming presentations, and professional goals. I work directly on your real-world challenges: your upcoming board presentation, your salary negotiation, or your client emails. This isn't a curriculum you follow — it's a strategy built around your calendar.
+
+Q: How is this different from a traditional ESL course?
+A: Traditional ESL courses focus on grammar rules and vocabulary lists. I focus on real-time performance under pressure—handling Q&A, negotiating in English, and projecting authority in high-stakes meetings. You won't be memorizing verb tenses; you'll be practicing the exact scenarios you face at work.
+
+Q: What kind of results can a C-level executive expect in 90 days?
+A: Most executives see measurable improvement in 5–8 sessions: faster response times in meetings, more confident negotiation, and the ability to 'own the room' without translating in their head. By 90 days, you should be leading high-stakes conversations with the same authority you have in your native language.
+
+Q: Will this help with my accent, or is it just vocabulary?
+A: Both, but the focus is strategic. I help you identify which pronunciation patterns are actually hurting your credibility (most aren't), and I focus on clarity and confidence, not erasing your accent. The goal is to be understood and respected, not to sound like a native speaker.
+
+Section: Logistics & Scheduling
+
+Q: Do you provide invoices for corporate reimbursement or company expense?
+A: Yes — I provide professional invoices (facturas) for corporate clients. Companies are billed monthly at the end of each month for all sessions completed.
+
+Q: What is your cancellation or rescheduling policy?
+A: Cancellations or rescheduling require at least one business day's notice. Payment is due before each session (individuals) or monthly invoicing for companies. I wait up to 15 minutes after the start time; after that, the session is considered a no-show and the full fee applies.
+
+Q: How many sessions per week do you recommend for optimal results?
+A: For rapid improvement, I recommend 2–3 sessions per week. For maintenance or lighter goals, 1 session per week works. The key is consistency and practice between sessions.
+
+Section: Methodology & Approach
+
+Q: I know the grammar, but I freeze under pressure. How do you fix that?
+A: This is a performance issue, not a knowledge issue. I use high-pressure simulation drills—rapid-fire Q&A, objection handling, and real-time pivoting—to rewire your brain to think directly in English under stress. It's like athletic training for your communication.
+
+Q: What specific skills do you cover (e.g., Negotiation, Q&A, Presentation)?
+A: I cover the exact scenarios you face: boardroom presentations, investor pitches, client negotiations, rapid-fire Q&A, and high-pressure troubleshooting. Each session is customized to your industry and role.
+
+Q: Do you work with a specific industry (e.g., Finance, Technology, Consulting)?
+A: I specialize in IT, professional services (law, medicine, consulting), logistics, and executive leadership. I understand the jargon and high-stakes dynamics of these fields, so you're not wasting time explaining your world to me.
+
+Q: What materials or resources are included in the coaching?
+A: After each session, you receive customized PDF notes with key phrases, pronunciation tips, and practice scenarios tailored to your goals. You also get access to my recommended resources for self-study between sessions.
+
+CTA: Ready to turn fluency into influence? Book Your Free Discovery Call — /en/book/

--- a/rag-chatbot/en/home.txt
+++ b/rag-chatbot/en/home.txt
@@ -1,0 +1,64 @@
+Page: /en/
+
+Professional English Coaching | New York English Teacher
+
+Boost your English fluency and confidence with personalized coaching tailored for professionals, executives, and companies worldwide.
+
+Hero — Private English Coaching for Senior Professionals
+
+You're a leader in Spanish. Sound like one in English.
+
+Lead global meetings with calm authority. Private coaching that makes your English match your expertise.
+
+Trusted by leaders at Fortune 500 companies and global startups.
+
+Call to action: Start My Strategy Session — /en/book/
+
+Is this you?
+If you run boardrooms, close deals, and manage teams in your native language — but feel less precise, less commanding, less yourself when you switch to English — this is built for you.
+
+NY ENGLISH OFFERS — Where does your English cost you the most?
+Each pathway targets a specific career bottleneck. Pick yours — get a personalized score in 90 seconds.
+
+- Executive Leaders — Your strategy is strong. Your English isn't keeping up. Command boardrooms, lead negotiations, and speak with the clarity global leadership expects — without translating in your head.
+- Tech Leaders — Your code is flawless. Your explanation loses the room. Turn technical complexity into clear business value that executives, clients, and stakeholders immediately understand.
+- Professional Services — One wrong word can cost more than your fee. Precision English for medical and legal professionals who must communicate with absolute clarity when the stakes are real.
+- Interviews & Presentations — You get one shot. Sound ready. Targeted preparation for interviews, investor pitches, and the presentations that change careers.
+
+Real Results — Why Top-Level Professionals Choose Coaching with Robert
+Real feedback from real clients.
+
+For professionals who lead in every language but one.
+Start with a complimentary strategy session to identify your communication gaps and map your goals.
+CTA: Book My Strategy Session — /en/book/
+
+My Methodology — Every lesson is built from your next meeting, not a textbook.
+I design each session around your actual role, industry, and upcoming deadlines. If you have a board presentation Thursday, that's what I prepare you for on Wednesday. Nothing generic. Nothing theoretical.
+
+- Your curriculum, not a course catalog — sessions built from your real scenarios, your industry vocabulary, your upcoming pressure moments.
+- Your voice, sharpened — tactical feedback on tone, pronunciation, and the small signals that separate "fluent" from "commanding."
+- Your rehearsal space — simulate the pitch, the negotiation, or the client call before it counts. Make mistakes here, not there.
+
+CTA: Explore The Framework — /en/about/
+
+Common Questions
+Everything you need to know before we talk
+
+Q: What is the investment for coaching?
+A: The current rate is 500 MXN ($25 USD) per session or 6,000 MXN ($300 USD) for a 12-session executive roadmap. Every session is custom-built around your specific industry, upcoming presentations, and professional goals. This isn't a curriculum you follow — it's a strategy built around your calendar.
+
+Q: How long does it take to see results?
+A: You'll feel a shift in confidence and clarity immediately after your first strategy session. For measurable changes in fluency and executive presence, most clients see significant ROI within the 12-session roadmap. I don't aim for 'perfect grammar' in 5 years — I aim for 'effective leadership communication' in 3 months.
+
+Q: Do you work with teams or individuals?
+A: Both. I provide 1-on-1 Executive Coaching for C-Suite leaders and Directors who need confidentiality and precision. I also lead Corporate Training for IT and Engineering teams who need to bridge the gap between technical code and business communication.
+
+Q: How is this different from traditional English classes?
+A: Traditional classes focus on textbooks and grammar rules. I focus on your reality — your actual emails, your slide decks, and your upcoming meeting agendas become the learning materials. I simulate your high-pressure scenarios so you can perform when it counts.
+
+Q: What's included in the complimentary strategy session?
+A: This is a diagnostic call, not a sales pitch. I'll assess your current communication gaps, identify your highest-impact language goals, and outline a 30-day roadmap to address them. You'll leave with a clear plan, whether you decide to work with me or not.
+
+Footer CTA: You already lead. Now sound like it — in English.
+Book a private strategy session. In 30 minutes, I'll identify the specific gaps between your current English and the executive presence your role demands.
+Book My Strategy Session — /en/book/

--- a/src/data/header/en.ts
+++ b/src/data/header/en.ts
@@ -7,7 +7,7 @@ export const headerContent = {
     { name: "Blog", link: routes.en.blog },
     { name: "Testimonials", link: routes.en.testimonials },
     { name: "Resources", link: routes.en.resources },
-    { name: "Courses", link: "/en/course/beginners/" },
+    { name: "Courses", link: "/en/courses/" },
   ],
   cta: { text: "Contact", link: routes.en.contact },
   logoLink: routes.en.home,

--- a/src/data/header/es.ts
+++ b/src/data/header/es.ts
@@ -7,7 +7,7 @@ export const headerContent = {
     { name: "Blog", link: routes.es.blog },
     { name: "Casos de Éxito", link: routes.es.testimonios },
     { name: "Recursos", link: routes.es.recursos },
-    { name: "Cursos", link: "/es/curso/principiantes/" },
+    { name: "Cursos", link: "/es/cursos/" },
   ],
   cta: { text: "Contacto", link: routes.es.contact },
   logoLink: routes.es.home,

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -73,6 +73,7 @@ export type TKey =
   | "quiz/executives"
   | "quiz/professional-services"
   | "quiz/high-stakes"
+  | "courses"
   | "course/beginners"
   | "course/beginners/unit-1"
   | "course/beginners/unit-2"
@@ -185,6 +186,7 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "quiz/executives": "/en/quiz/executives/",
     "quiz/professional-services": "/en/quiz/professional-services/",
     "quiz/high-stakes": "/en/quiz/high-stakes/",
+    courses: "/en/courses/",
     "course/beginners": "/en/course/beginners/",
     "course/beginners/unit-1": "/en/course/beginners/unit-1/",
     "course/beginners/unit-2": "/en/course/beginners/unit-2/",
@@ -301,6 +303,7 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "quiz/executives": "/es/quiz/executives/",
     "quiz/professional-services": "/es/quiz/professional-services/",
     "quiz/high-stakes": "/es/quiz/high-stakes/",
+    courses: "/es/cursos/",
     "course/beginners": "/es/curso/principiantes/",
     "course/beginners/unit-1": "/es/curso/principiantes/unidad-1/",
     "course/beginners/unit-2": "/es/curso/principiantes/unidad-2/",

--- a/src/pages/en/courses/index.astro
+++ b/src/pages/en/courses/index.astro
@@ -1,0 +1,167 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import { courseInfo, units } from "@data/course/units";
+import { intermediateInfo, intermediateUnits } from "@data/intermediate/units";
+import {
+  Sparkles,
+  Puzzle,
+  ArrowRight,
+  CheckCircle2,
+  GraduationCap,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "courses" as const;
+
+const beginnerAvailable = units.length;
+const intermediateAvailable = intermediateUnits.filter((u) => u.id < 3).length;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Free English Courses for Spanish Speakers | NY English Teacher"
+  description="Free, interactive English courses for Spanish speakers — from absolute beginner to upper-intermediate. No sign-up. No paywall. Built by a real NYC English teacher."
+>
+  <!-- Hero -->
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-16 pb-20 md:pt-20 md:pb-24">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <GraduationCap class="w-4 h-4" />
+          Free Courses
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          English Courses That Actually Work for Spanish Speakers
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Two free, interactive courses built specifically for Spanish speakers.
+          No sign-up. No paywall. No textbook drudgery. Just real progress
+          from the first lesson.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Course cards -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-5xl mx-auto grid md:grid-cols-2 gap-6">
+
+        <!-- Beginner -->
+        <a
+          href="/en/course/beginners/"
+          class="group block bg-white rounded-2xl border border-slate-200 overflow-hidden hover:shadow-xl hover:border-amber-300 transition-all duration-200"
+        >
+          <div class="bg-gradient-to-br from-emerald-500 to-emerald-600 p-6 text-white">
+            <div class="flex items-center gap-2 text-emerald-100 text-xs font-bold uppercase tracking-wider mb-2">
+              <Sparkles class="w-3.5 h-3.5" />
+              Level A1 — Beginner
+            </div>
+            <h2 class="text-2xl md:text-3xl font-bold mb-2" style="font-family: 'Noto Sans KR', sans-serif;">
+              {courseInfo.title}
+            </h2>
+            <p class="text-emerald-50 text-sm leading-relaxed">
+              {courseInfo.tagline}
+            </p>
+          </div>
+          <div class="p-6">
+            <p class="text-slate-600 text-sm leading-relaxed mb-4">
+              {courseInfo.description}
+            </p>
+            <ul class="space-y-2 mb-6">
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-emerald-500 shrink-0 mt-0.5" />
+                <span>10 interactive units + final exam</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-emerald-500 shrink-0 mt-0.5" />
+                <span>1,500+ English/Spanish cognates</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-emerald-500 shrink-0 mt-0.5" />
+                <span>Audio for every word and phrase</span>
+              </li>
+            </ul>
+            <div class="flex items-center justify-between">
+              <span class="text-xs font-semibold text-emerald-600 uppercase tracking-wider">
+                {beginnerAvailable} units available
+              </span>
+              <span class="inline-flex items-center gap-1 text-amber-600 font-semibold text-sm group-hover:gap-2 transition-all">
+                Start course
+                <ArrowRight class="w-4 h-4" />
+              </span>
+            </div>
+          </div>
+        </a>
+
+        <!-- Intermediate -->
+        <a
+          href="/en/course/intermediate/"
+          class="group block bg-white rounded-2xl border border-slate-200 overflow-hidden hover:shadow-xl hover:border-amber-300 transition-all duration-200"
+        >
+          <div class="bg-gradient-to-br from-amber-500 to-amber-600 p-6 text-white">
+            <div class="flex items-center gap-2 text-amber-100 text-xs font-bold uppercase tracking-wider mb-2">
+              <Puzzle class="w-3.5 h-3.5" />
+              Level B1–B2 — Intermediate
+            </div>
+            <h2 class="text-2xl md:text-3xl font-bold mb-2" style="font-family: 'Noto Sans KR', sans-serif;">
+              {intermediateInfo.title}
+            </h2>
+            <p class="text-amber-50 text-sm leading-relaxed">
+              {intermediateInfo.tagline}
+            </p>
+          </div>
+          <div class="p-6">
+            <p class="text-slate-600 text-sm leading-relaxed mb-4">
+              {intermediateInfo.description}
+            </p>
+            <ul class="space-y-2 mb-6">
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>80+ phrasal verbs in real context</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>Office, travel, and social English</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>Fixes the exact mistakes Spanish speakers make</span>
+              </li>
+            </ul>
+            <div class="flex items-center justify-between">
+              <span class="text-xs font-semibold text-amber-600 uppercase tracking-wider">
+                {intermediateAvailable} units available · more coming
+              </span>
+              <span class="inline-flex items-center gap-1 text-amber-600 font-semibold text-sm group-hover:gap-2 transition-all">
+                Start course
+                <ArrowRight class="w-4 h-4" />
+              </span>
+            </div>
+          </div>
+        </a>
+      </div>
+
+      <!-- Which one? -->
+      <div class="max-w-3xl mx-auto mt-16 text-center">
+        <h3 class="text-2xl font-bold text-slate-900 mb-3">Not sure which one to start?</h3>
+        <p class="text-slate-600 mb-6">
+          If you can introduce yourself, order food, and read simple signs in English — start with
+          the <strong>intermediate</strong> course. If English still feels brand new, start with
+          the <strong>beginner</strong> course. You can always switch later — your progress is saved separately for each course.
+        </p>
+        <Button href="/en/services/" variant="secondary" size="md">
+          Or work 1-on-1 with Robert
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/cursos/index.astro
+++ b/src/pages/es/cursos/index.astro
@@ -1,0 +1,165 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import { courseInfo, units } from "@data/course/units";
+import { intermediateInfo, intermediateUnits } from "@data/intermediate/units";
+import {
+  Sparkles,
+  Puzzle,
+  ArrowRight,
+  CheckCircle2,
+  GraduationCap,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "courses" as const;
+
+const beginnerAvailable = units.length;
+const intermediateAvailable = intermediateUnits.filter((u) => u.id < 3).length;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Cursos Gratis de Inglés para Hispanohablantes | NY English Teacher"
+  description="Cursos de inglés gratuitos e interactivos para hispanohablantes — desde principiante absoluto hasta intermedio alto. Sin registro. Sin barreras. Hechos por un maestro de inglés de NYC."
+>
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-16 pb-20 md:pt-20 md:pb-24">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <GraduationCap class="w-4 h-4" />
+          Cursos Gratis
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Cursos de Inglés que Realmente Funcionan para Hispanohablantes
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Dos cursos gratuitos e interactivos hechos específicamente para hispanohablantes.
+          Sin registro. Sin barreras. Sin la pesadez de los libros de texto.
+          Solo progreso real desde la primera lección.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-5xl mx-auto grid md:grid-cols-2 gap-6">
+
+        <!-- Beginner -->
+        <a
+          href="/es/curso/principiantes/"
+          class="group block bg-white rounded-2xl border border-slate-200 overflow-hidden hover:shadow-xl hover:border-amber-300 transition-all duration-200"
+        >
+          <div class="bg-gradient-to-br from-emerald-500 to-emerald-600 p-6 text-white">
+            <div class="flex items-center gap-2 text-emerald-100 text-xs font-bold uppercase tracking-wider mb-2">
+              <Sparkles class="w-3.5 h-3.5" />
+              Nivel A1 — Principiante
+            </div>
+            <h2 class="text-2xl md:text-3xl font-bold mb-2" style="font-family: 'Noto Sans KR', sans-serif;">
+              {courseInfo.titleEs}
+            </h2>
+            <p class="text-emerald-50 text-sm leading-relaxed">
+              {courseInfo.taglineEs}
+            </p>
+          </div>
+          <div class="p-6">
+            <p class="text-slate-600 text-sm leading-relaxed mb-4">
+              {courseInfo.descriptionEs}
+            </p>
+            <ul class="space-y-2 mb-6">
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-emerald-500 shrink-0 mt-0.5" />
+                <span>10 unidades interactivas + examen final</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-emerald-500 shrink-0 mt-0.5" />
+                <span>Más de 1,500 cognados inglés/español</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-emerald-500 shrink-0 mt-0.5" />
+                <span>Audio para cada palabra y frase</span>
+              </li>
+            </ul>
+            <div class="flex items-center justify-between">
+              <span class="text-xs font-semibold text-emerald-600 uppercase tracking-wider">
+                {beginnerAvailable} unidades disponibles
+              </span>
+              <span class="inline-flex items-center gap-1 text-amber-600 font-semibold text-sm group-hover:gap-2 transition-all">
+                Empezar curso
+                <ArrowRight class="w-4 h-4" />
+              </span>
+            </div>
+          </div>
+        </a>
+
+        <!-- Intermediate -->
+        <a
+          href="/es/curso/intermedio/"
+          class="group block bg-white rounded-2xl border border-slate-200 overflow-hidden hover:shadow-xl hover:border-amber-300 transition-all duration-200"
+        >
+          <div class="bg-gradient-to-br from-amber-500 to-amber-600 p-6 text-white">
+            <div class="flex items-center gap-2 text-amber-100 text-xs font-bold uppercase tracking-wider mb-2">
+              <Puzzle class="w-3.5 h-3.5" />
+              Nivel B1–B2 — Intermedio
+            </div>
+            <h2 class="text-2xl md:text-3xl font-bold mb-2" style="font-family: 'Noto Sans KR', sans-serif;">
+              {intermediateInfo.titleEs}
+            </h2>
+            <p class="text-amber-50 text-sm leading-relaxed">
+              {intermediateInfo.taglineEs}
+            </p>
+          </div>
+          <div class="p-6">
+            <p class="text-slate-600 text-sm leading-relaxed mb-4">
+              {intermediateInfo.descriptionEs}
+            </p>
+            <ul class="space-y-2 mb-6">
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>Más de 80 phrasal verbs en contexto real</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>Inglés de oficina, viajes y vida social</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>Corrige los errores exactos de los hispanohablantes</span>
+              </li>
+            </ul>
+            <div class="flex items-center justify-between">
+              <span class="text-xs font-semibold text-amber-600 uppercase tracking-wider">
+                {intermediateAvailable} unidades disponibles · más en camino
+              </span>
+              <span class="inline-flex items-center gap-1 text-amber-600 font-semibold text-sm group-hover:gap-2 transition-all">
+                Empezar curso
+                <ArrowRight class="w-4 h-4" />
+              </span>
+            </div>
+          </div>
+        </a>
+      </div>
+
+      <div class="max-w-3xl mx-auto mt-16 text-center">
+        <h3 class="text-2xl font-bold text-slate-900 mb-3">¿No sabes con cuál empezar?</h3>
+        <p class="text-slate-600 mb-6">
+          Si puedes presentarte, pedir comida y leer letreros simples en inglés — empieza con el
+          curso <strong>intermedio</strong>. Si el inglés todavía se siente totalmente nuevo,
+          empieza con el curso <strong>principiante</strong>. Puedes cambiar después — tu
+          progreso se guarda por separado para cada curso.
+        </p>
+        <Button href="/es/servicios/" variant="secondary" size="md">
+          O trabaja 1-a-1 con Robert
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary
- New \`/en/courses/\` and \`/es/cursos/\` hub pages with two course cards (beginner + intermediate)
- Header nav "Courses" / "Cursos" now points at the hub instead of the beginner course
- Adds \`courses\` TKey + EN/ES routes to i18n.ts (proper hreflang)
- Includes a "not sure which one?" guide and a CTA to 1-on-1 services

## Test plan
- [x] \`npm run build\` passes (222 sitemap URLs)
- [ ] Click "Courses" in header → lands on hub
- [ ] Both course cards link correctly
- [ ] Spanish hub mirrors English

🤖 Generated with [Claude Code](https://claude.com/claude-code)