### PR TITLE
feat: intermediate Units 5 + 6 with two new Section A components

### DIFF
--- a/src/components/course/NarrativeTimeline.tsx
+++ b/src/components/course/NarrativeTimeline.tsx
@@ -1,0 +1,210 @@
+import { useState } from "react";
+import { Eye, RotateCcw, Clock, ArrowDown } from "lucide-react";
+import AudioButton from "./AudioButton";
+
+export interface TimelineEvent {
+  /** Order in the story (1 = earliest in time) */
+  order: number;
+  /** When this is told in the narrative (e.g., "First", "Then", "Earlier...") */
+  timeMarker: string;
+  timeMarkerEs: string;
+  /** The English sentence */
+  english: string;
+  /** Spanish translation */
+  spanish: string;
+  /** Which tense is used and why */
+  tense:
+    | "past-simple"
+    | "past-perfect"
+    | "would-habitual"
+    | "reported-speech"
+    | "past-continuous";
+  /** Short explanation of why this tense */
+  whyTense: string;
+  whyTenseEs: string;
+}
+
+export interface NarrativeStory {
+  title: string;
+  titleEs: string;
+  intro: string;
+  introEs: string;
+  events: TimelineEvent[];
+}
+
+interface Props {
+  stories: NarrativeStory[];
+  lang: "en" | "es";
+}
+
+const tenseColors: Record<TimelineEvent["tense"], string> = {
+  "past-simple": "bg-blue-100 text-blue-700 border-blue-200",
+  "past-perfect": "bg-violet-100 text-violet-700 border-violet-200",
+  "would-habitual": "bg-amber-100 text-amber-700 border-amber-200",
+  "reported-speech": "bg-emerald-100 text-emerald-700 border-emerald-200",
+  "past-continuous": "bg-rose-100 text-rose-700 border-rose-200",
+};
+
+const tenseLabels: Record<TimelineEvent["tense"], { en: string; es: string }> = {
+  "past-simple": { en: "past simple", es: "pasado simple" },
+  "past-perfect": { en: "past perfect", es: "pasado perfecto" },
+  "would-habitual": { en: "would (habitual)", es: "would (habitual)" },
+  "reported-speech": { en: "reported speech", es: "discurso indirecto" },
+  "past-continuous": { en: "past continuous", es: "pasado continuo" },
+};
+
+export default function NarrativeTimeline({ stories, lang }: Props) {
+  const [activeStory, setActiveStory] = useState(0);
+  const [revealedEvents, setRevealedEvents] = useState<Set<number>>(new Set());
+
+  const story = stories[activeStory];
+
+  const toggleEvent = (idx: number) => {
+    const next = new Set(revealedEvents);
+    if (next.has(idx)) {
+      next.delete(idx);
+    } else {
+      next.add(idx);
+    }
+    setRevealedEvents(next);
+  };
+
+  const revealAll = () => {
+    setRevealedEvents(new Set(story.events.map((_, i) => i)));
+  };
+
+  const reset = () => {
+    setRevealedEvents(new Set());
+  };
+
+  const switchStory = (idx: number) => {
+    setActiveStory(idx);
+    setRevealedEvents(new Set());
+  };
+
+  return (
+    <section className="space-y-6">
+      {/* Story selector (if more than one) */}
+      {stories.length > 1 && (
+        <div className="flex flex-wrap gap-2">
+          {stories.map((s, i) => (
+            <button
+              key={i}
+              onClick={() => switchStory(i)}
+              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                i === activeStory
+                  ? "bg-amber-500 text-white"
+                  : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+              }`}
+            >
+              {lang === "es" ? s.titleEs : s.title}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Story intro */}
+      <div className="bg-slate-50 border border-slate-200 rounded-xl p-5">
+        <div className="flex items-start gap-3">
+          <Clock className="w-5 h-5 text-slate-400 shrink-0 mt-0.5" />
+          <div>
+            <h3 className="font-bold text-slate-900 mb-1">
+              {lang === "es" ? story.titleEs : story.title}
+            </h3>
+            <p className="text-sm text-slate-600 leading-relaxed">
+              {lang === "es" ? story.introEs : story.intro}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Controls */}
+      <div className="flex items-center justify-between">
+        <button
+          onClick={revealAll}
+          className="text-xs text-slate-500 hover:text-amber-600 inline-flex items-center gap-1 transition-colors font-medium"
+        >
+          <Eye size={12} />
+          {lang === "es" ? "Mostrar todo" : "Reveal all"}
+        </button>
+        <button
+          onClick={reset}
+          className="text-xs text-slate-400 hover:text-amber-600 inline-flex items-center gap-1 transition-colors"
+        >
+          <RotateCcw size={12} />
+          {lang === "es" ? "Reiniciar" : "Reset"}
+        </button>
+      </div>
+
+      {/* Timeline */}
+      <div className="relative">
+        {/* Vertical line */}
+        <div className="absolute left-6 top-2 bottom-2 w-0.5 bg-slate-200" />
+
+        <ol className="space-y-5">
+          {story.events.map((event, idx) => {
+            const isRevealed = revealedEvents.has(idx);
+            return (
+              <li key={idx} className="relative pl-16">
+                {/* Dot on timeline */}
+                <div
+                  className={`absolute left-4 top-3 w-5 h-5 rounded-full border-4 border-white shadow ${
+                    isRevealed ? "bg-amber-500" : "bg-slate-300"
+                  }`}
+                />
+
+                {/* Time marker */}
+                <div className="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-1">
+                  {lang === "es" ? event.timeMarkerEs : event.timeMarker}
+                </div>
+
+                {!isRevealed ? (
+                  <button
+                    onClick={() => toggleEvent(idx)}
+                    className="w-full text-left p-4 rounded-xl border-2 border-dashed border-slate-200 text-slate-400 hover:border-amber-300 hover:text-amber-600 transition-colors"
+                  >
+                    {lang === "es"
+                      ? "Toca para revelar este momento"
+                      : "Tap to reveal this moment"}
+                  </button>
+                ) : (
+                  <div className="bg-white border-2 border-slate-200 rounded-xl p-4 space-y-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <p className="text-base text-slate-900 font-medium leading-relaxed flex-1">
+                        {event.english}
+                      </p>
+                      <div className="shrink-0">
+                        <AudioButton text={event.english} size="sm" />
+                      </div>
+                    </div>
+                    <p className="text-sm text-slate-500">{event.spanish}</p>
+                    <div className="flex items-start gap-2 pt-2 border-t border-slate-100">
+                      <span
+                        className={`text-xs font-mono px-2 py-0.5 rounded-full border shrink-0 ${tenseColors[event.tense]}`}
+                      >
+                        {tenseLabels[event.tense][lang]}
+                      </span>
+                      <p className="text-xs text-slate-500 leading-relaxed">
+                        {lang === "es" ? event.whyTenseEs : event.whyTense}
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+
+      {revealedEvents.size === story.events.length && (
+        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 text-center">
+          <p className="text-emerald-800 font-medium text-sm">
+            {lang === "es"
+              ? "¡Bien hecho! Has visto cómo los tiempos pasados se conectan en una narración."
+              : "Well done! You've seen how past tenses connect in a narrative."}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/course/OpinionStems.tsx
+++ b/src/components/course/OpinionStems.tsx
@@ -1,0 +1,163 @@
+import { useState } from "react";
+import { ChevronRight, MessageSquareQuote } from "lucide-react";
+import AudioButton from "./AudioButton";
+
+export interface OpinionStem {
+  /** The sentence starter / frame */
+  stem: string;
+  stemEs: string;
+  /** A complete example using the stem */
+  example: string;
+  exampleEs: string;
+  /** Tone/register hint */
+  register: "neutral" | "soft" | "strong" | "academic";
+}
+
+export interface OpinionCategory {
+  /** Category label like "State your opinion", "Soften disagreement", etc. */
+  label: string;
+  labelEs: string;
+  /** What this category is for, in plain language */
+  description: string;
+  descriptionEs: string;
+  /** Icon hint (passed to the parent for rendering) */
+  intent: "state" | "soften" | "agree" | "disagree" | "concede" | "challenge";
+  /** The frames in this category */
+  stems: OpinionStem[];
+}
+
+interface Props {
+  categories: OpinionCategory[];
+  lang: "en" | "es";
+}
+
+const intentColors: Record<OpinionCategory["intent"], string> = {
+  state: "from-blue-500 to-blue-600",
+  soften: "from-violet-500 to-violet-600",
+  agree: "from-emerald-500 to-emerald-600",
+  disagree: "from-rose-500 to-rose-600",
+  concede: "from-amber-500 to-amber-600",
+  challenge: "from-slate-600 to-slate-700",
+};
+
+const registerLabels: Record<OpinionStem["register"], { en: string; es: string }> = {
+  neutral: { en: "neutral", es: "neutral" },
+  soft: { en: "soft", es: "suave" },
+  strong: { en: "strong", es: "fuerte" },
+  academic: { en: "academic", es: "académico" },
+};
+
+const registerColors: Record<OpinionStem["register"], string> = {
+  neutral: "bg-slate-100 text-slate-600 border-slate-200",
+  soft: "bg-violet-100 text-violet-700 border-violet-200",
+  strong: "bg-rose-100 text-rose-700 border-rose-200",
+  academic: "bg-blue-100 text-blue-700 border-blue-200",
+};
+
+export default function OpinionStems({ categories, lang }: Props) {
+  const [activeCategory, setActiveCategory] = useState(0);
+  const [expandedExamples, setExpandedExamples] = useState<Set<string>>(new Set());
+
+  const current = categories[activeCategory];
+
+  const toggleExample = (key: string) => {
+    const next = new Set(expandedExamples);
+    if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    setExpandedExamples(next);
+  };
+
+  return (
+    <section className="space-y-6">
+      {/* Category tabs */}
+      <div className="flex flex-wrap gap-2">
+        {categories.map((cat, i) => (
+          <button
+            key={i}
+            onClick={() => setActiveCategory(i)}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+              i === activeCategory
+                ? `bg-gradient-to-r ${intentColors[cat.intent]} text-white shadow-sm`
+                : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+            }`}
+          >
+            {lang === "es" ? cat.labelEs : cat.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Category description */}
+      <div
+        className={`bg-gradient-to-br ${intentColors[current.intent]} rounded-2xl p-5 text-white`}
+      >
+        <div className="flex items-start gap-3">
+          <MessageSquareQuote className="w-5 h-5 shrink-0 mt-0.5 opacity-80" />
+          <div>
+            <h3 className="font-bold mb-1">
+              {lang === "es" ? current.labelEs : current.label}
+            </h3>
+            <p className="text-sm opacity-90 leading-relaxed">
+              {lang === "es" ? current.descriptionEs : current.description}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Stems list */}
+      <div className="space-y-3">
+        {current.stems.map((stem, i) => {
+          const key = `${activeCategory}-${i}`;
+          const isExpanded = expandedExamples.has(key);
+          return (
+            <div
+              key={key}
+              className="bg-white border-2 border-slate-200 rounded-xl overflow-hidden hover:border-amber-300 transition-colors"
+            >
+              <button
+                onClick={() => toggleExample(key)}
+                className="w-full flex items-start justify-between gap-3 p-4 text-left"
+              >
+                <div className="flex-1">
+                  <p className="text-base font-medium text-slate-900 leading-relaxed">
+                    "{stem.stem}..."
+                  </p>
+                  <p className="text-sm text-slate-500 mt-0.5">{stem.stemEs}</p>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <span
+                    className={`text-xs font-mono px-2 py-0.5 rounded-full border ${registerColors[stem.register]}`}
+                  >
+                    {registerLabels[stem.register][lang]}
+                  </span>
+                  <ChevronRight
+                    size={18}
+                    className={`text-slate-300 transition-transform ${isExpanded ? "rotate-90" : ""}`}
+                  />
+                </div>
+              </button>
+              {isExpanded && (
+                <div className="border-t border-slate-100 bg-slate-50 p-4 space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                    {lang === "es" ? "Ejemplo completo:" : "Full example:"}
+                  </p>
+                  <div className="flex items-start justify-between gap-3">
+                    <p className="text-base text-slate-900 italic flex-1">
+                      "{stem.example}"
+                    </p>
+                    <div className="shrink-0 mt-0.5">
+                      <AudioButton text={stem.example} size="sm" />
+                    </div>
+                  </div>
+                  <p className="text-sm text-slate-500">{stem.exampleEs}</p>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/data/intermediate/unit-5.ts
+++ b/src/data/intermediate/unit-5.ts
@@ -1,0 +1,486 @@
+// Unit 5: "Telling Stories" — Full course content
+// Theme: Narrating events, retelling what people said
+// Grammar: Past perfect + reported speech + 'would' (habitual past)
+// Pronunciation: Connected speech in past narratives
+// Section A: NarrativeTimeline (visual past-tense relationships)
+
+import type {
+  Dialogue,
+  ErrorCorrectionSet,
+  IntermediateVocabItem,
+} from "./types";
+import type { NarrativeStory } from "../../components/course/NarrativeTimeline";
+import type { SentenceBlock, PronunciationDrill } from "../course/unit-1";
+
+// ─── Section A: Narrative Timeline ───────────────────────────────────────────
+
+export const stories: NarrativeStory[] = [
+  {
+    title: "The Job Interview",
+    titleEs: "La Entrevista de Trabajo",
+    intro:
+      "A story about Carlos's interview that didn't go as planned. Notice how past simple, past perfect, and 'would' (for habits) work together to build a clear timeline.",
+    introEs:
+      "Una historia sobre la entrevista de Carlos que no salió como planeado. Nota cómo el pasado simple, el pasado perfecto y 'would' (para hábitos) trabajan juntos para construir una línea de tiempo clara.",
+    events: [
+      {
+        order: 1,
+        timeMarker: "Months earlier",
+        timeMarkerEs: "Meses antes",
+        english: "Carlos would spend every weekend studying English.",
+        spanish: "Carlos pasaba cada fin de semana estudiando inglés.",
+        tense: "would-habitual",
+        whyTense:
+          "'Would' here describes a repeated past habit — exactly like 'used to'. It's more elegant than 'always studied' and very common in storytelling.",
+        whyTenseEs:
+          "'Would' aquí describe un hábito repetido del pasado — exactamente como 'used to'. Es más elegante que 'always studied' y muy común al contar historias.",
+      },
+      {
+        order: 2,
+        timeMarker: "The week before",
+        timeMarkerEs: "La semana anterior",
+        english: "He had prepared answers for every question he could think of.",
+        spanish: "Había preparado respuestas para cada pregunta que se le ocurría.",
+        tense: "past-perfect",
+        whyTense:
+          "Past perfect ('had prepared') because this action was COMPLETED before the main story event (the interview). It sets up what was already done.",
+        whyTenseEs:
+          "Pasado perfecto ('had prepared') porque esta acción YA HABÍA TERMINADO antes del evento principal (la entrevista). Establece lo que ya estaba hecho.",
+      },
+      {
+        order: 3,
+        timeMarker: "On the morning of",
+        timeMarkerEs: "La mañana del día",
+        english: "He woke up early, put on his best suit, and left the house.",
+        spanish: "Se levantó temprano, se puso su mejor traje y salió de la casa.",
+        tense: "past-simple",
+        whyTense:
+          "Past simple — these are sequential actions in the main story timeline. No 'before' relationship to anything else, just one thing after another.",
+        whyTenseEs:
+          "Pasado simple — estas son acciones secuenciales en la línea de tiempo principal. Sin relación de 'antes' con nada, solo una cosa tras otra.",
+      },
+      {
+        order: 4,
+        timeMarker: "At the office",
+        timeMarkerEs: "En la oficina",
+        english: "When he arrived, the receptionist told him the interview had been moved to the next day.",
+        spanish: "Cuando llegó, la recepcionista le dijo que la entrevista se había movido al día siguiente.",
+        tense: "past-perfect",
+        whyTense:
+          "Two pasts in one sentence: 'arrived' and 'told' are simple past, but 'had been moved' is past perfect because the rescheduling happened EARLIER than the moment she told him.",
+        whyTenseEs:
+          "Dos pasados en una oración: 'arrived' y 'told' son pasado simple, pero 'had been moved' es pasado perfecto porque el cambio sucedió ANTES del momento en que ella le dijo.",
+      },
+      {
+        order: 5,
+        timeMarker: "Her exact words",
+        timeMarkerEs: "Sus palabras exactas",
+        english: "She said that no one had called him because the system was down.",
+        spanish: "Dijo que nadie lo había llamado porque el sistema estaba caído.",
+        tense: "reported-speech",
+        whyTense:
+          "This is reported speech: when 'said' is in the past, the verbs that follow shift back one tense. Direct speech 'no one has called' becomes 'no one had called'.",
+        whyTenseEs:
+          "Esto es discurso indirecto: cuando 'said' está en pasado, los verbos que siguen retroceden un tiempo. El discurso directo 'no one has called' se vuelve 'no one had called'.",
+      },
+      {
+        order: 6,
+        timeMarker: "The next day",
+        timeMarkerEs: "Al día siguiente",
+        english: "The interview went well, and he got the job.",
+        spanish: "La entrevista salió bien, y consiguió el trabajo.",
+        tense: "past-simple",
+        whyTense:
+          "Back to past simple for the main timeline — straightforward sequential events. Notice how the story flows naturally between tenses.",
+        whyTenseEs:
+          "De vuelta al pasado simple para la línea de tiempo principal — eventos secuenciales directos. Nota cómo la historia fluye naturalmente entre tiempos.",
+      },
+    ],
+  },
+];
+
+// ─── Section B: Dialogue Practice ────────────────────────────────────────────
+
+export const dialogues: Dialogue[] = [
+  {
+    title: "Telling a Friend What Happened",
+    titleEs: "Contándole a un Amigo lo que Pasó",
+    setting: "Two friends meeting for coffee — one shares a story about a recent trip",
+    settingEs: "Dos amigos se encuentran para tomar café — uno comparte una historia sobre un viaje reciente",
+    lines: [
+      {
+        speaker: "A",
+        speakerLabel: "Sofia",
+        speakerLabelEs: "Sofía",
+        english: "You won't believe what happened to me last weekend.",
+        spanish: "No vas a creer lo que me pasó el fin de semana pasado.",
+        highlight: "what happened",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Daniel",
+        speakerLabelEs: "Daniel",
+        english: "Oh? Tell me everything.",
+        spanish: "¿Ah sí? Cuéntame todo.",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Sofia",
+        speakerLabelEs: "Sofía",
+        english: "So I had booked a hotel in Boston weeks ago. When I arrived, they told me my reservation had been cancelled.",
+        spanish: "Reservé un hotel en Boston hace semanas. Cuando llegué, me dijeron que mi reservación había sido cancelada.",
+        highlight: "had booked / had been cancelled",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Daniel",
+        speakerLabelEs: "Daniel",
+        english: "What? Did they say why?",
+        spanish: "¿Qué? ¿Te dijeron por qué?",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Sofia",
+        speakerLabelEs: "Sofía",
+        english: "They said the system had made a mistake and that they would refund me.",
+        spanish: "Dijeron que el sistema había cometido un error y que me reembolsarían.",
+        highlight: "said... had made... would refund",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Daniel",
+        speakerLabelEs: "Daniel",
+        english: "Wow. So where did you stay?",
+        spanish: "Wow. ¿Y dónde te quedaste?",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Sofia",
+        speakerLabelEs: "Sofía",
+        english: "Luckily, my cousin lives nearby. When I was in college, I would visit her every summer, so she insisted I stay with her.",
+        spanish: "Por suerte, mi prima vive cerca. Cuando estaba en la universidad, la visitaba cada verano, así que insistió en que me quedara con ella.",
+        highlight: "I would visit her",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Daniel",
+        speakerLabelEs: "Daniel",
+        english: "That's actually a pretty happy ending. Did the hotel ever refund you?",
+        spanish: "Eso es un final bastante feliz. ¿El hotel te devolvió el dinero?",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Sofia",
+        speakerLabelEs: "Sofía",
+        english: "Yes — they said they would credit my account within 48 hours, and they actually did.",
+        spanish: "Sí — dijeron que abonarían a mi cuenta dentro de 48 horas, y de hecho lo hicieron.",
+        highlight: "they would credit",
+      },
+    ],
+    keyPhrases: [
+      {
+        english: "You won't believe what happened.",
+        spanish: "No vas a creer lo que pasó.",
+        note: "The classic story-opener. Hooks the listener immediately.",
+        noteEs: "El clásico inicio de historia. Engancha al oyente inmediatamente.",
+      },
+      {
+        english: "They said that... had been...",
+        spanish: "Dijeron que... había sido...",
+        note: "Reported speech with past perfect — the formula for retelling what people told you.",
+        noteEs: "Discurso indirecto con pasado perfecto — la fórmula para contar lo que la gente te dijo.",
+      },
+      {
+        english: "I would visit her every summer.",
+        spanish: "La visitaba cada verano.",
+        note: "'Would' for past habits — more elegant than 'I always visited' or 'I used to visit'.",
+        noteEs: "'Would' para hábitos pasados — más elegante que 'I always visited' o 'I used to visit'.",
+      },
+    ],
+  },
+];
+
+// ─── Section C: Structure Builder ────────────────────────────────────────────
+
+export const structureBlocks: SentenceBlock[] = [
+  {
+    label: "Past perfect: the past before the past",
+    labelEs: "Pasado perfecto: el pasado antes del pasado",
+    description:
+      "Structure: had + past participle. Use it when you need to show one past event happened BEFORE another past event.",
+    descriptionEs:
+      "Estructura: had + participio pasado. Úsalo cuando necesitas mostrar que un evento pasado sucedió ANTES de otro evento pasado.",
+    sentences: [
+      {
+        english: "By the time I arrived, the meeting had already started.",
+        spanish: "Para cuando llegué, la junta ya había empezado.",
+        highlight: "had already started",
+      },
+      {
+        english: "She had never seen the ocean before that trip.",
+        spanish: "Ella nunca había visto el océano antes de ese viaje.",
+        highlight: "had never seen",
+      },
+      {
+        english: "We had finished dinner when they finally arrived.",
+        spanish: "Habíamos terminado de cenar cuando por fin llegaron.",
+        highlight: "had finished",
+      },
+      {
+        english: "He realized he had left his keys at home.",
+        spanish: "Se dio cuenta de que había dejado las llaves en casa.",
+        highlight: "had left",
+      },
+    ],
+  },
+  {
+    label: "Reported speech: tense shifts",
+    labelEs: "Discurso indirecto: cambios de tiempo",
+    description:
+      "When the reporting verb (said, told) is in the past, the verbs that follow shift back one tense: present → past, past → past perfect, will → would.",
+    descriptionEs:
+      "Cuando el verbo que reporta (said, told) está en pasado, los verbos que siguen retroceden un tiempo: presente → pasado, pasado → pasado perfecto, will → would.",
+    sentences: [
+      {
+        english: 'Direct: She said, "I am tired." → She said she was tired.',
+        spanish: 'Directo: Ella dijo, "Estoy cansada." → Ella dijo que estaba cansada.',
+        highlight: "was tired",
+      },
+      {
+        english: 'Direct: He said, "I will help you." → He said he would help me.',
+        spanish: 'Directo: Él dijo, "Te ayudaré." → Él dijo que me ayudaría.',
+        highlight: "would help",
+      },
+      {
+        english: 'Direct: They said, "We have finished." → They said they had finished.',
+        spanish: 'Directo: Ellos dijeron, "Hemos terminado." → Dijeron que habían terminado.',
+        highlight: "had finished",
+      },
+      {
+        english: 'Direct: She said, "I went to Paris." → She said she had gone to Paris.',
+        spanish: 'Directo: Ella dijo, "Fui a París." → Dijo que había ido a París.',
+        highlight: "had gone",
+      },
+    ],
+  },
+  {
+    label: "'Would' for past habits",
+    labelEs: "'Would' para hábitos pasados",
+    description:
+      "Use 'would' to describe repeated past habits — actions that happened many times in the past but don't happen anymore. It's the elegant alternative to 'used to'.",
+    descriptionEs:
+      "Usa 'would' para describir hábitos pasados repetidos — acciones que sucedieron muchas veces en el pasado pero ya no suceden. Es la alternativa elegante a 'used to'.",
+    sentences: [
+      {
+        english: "When I was young, my grandfather would tell me stories every night.",
+        spanish: "Cuando era joven, mi abuelo me contaba historias cada noche.",
+        highlight: "would tell",
+      },
+      {
+        english: "Every summer we would visit the lake and stay for a week.",
+        spanish: "Cada verano visitábamos el lago y nos quedábamos una semana.",
+        highlight: "would visit",
+      },
+      {
+        english: "She would always wake up at 5 AM to go running.",
+        spanish: "Ella siempre se levantaba a las 5 AM para ir a correr.",
+        highlight: "would always wake up",
+      },
+      {
+        english: "On Sundays, my father would cook breakfast for the whole family.",
+        spanish: "Los domingos, mi padre hacía el desayuno para toda la familia.",
+        highlight: "would cook",
+      },
+    ],
+  },
+  {
+    label: "Putting it all together",
+    labelEs: "Uniéndolo todo",
+    description:
+      "Real narratives mix all three: past simple for the main timeline, past perfect for what came before, 'would' for habits, reported speech for what people said.",
+    descriptionEs:
+      "Las narrativas reales mezclan los tres: pasado simple para la línea principal, pasado perfecto para lo que vino antes, 'would' para hábitos, discurso indirecto para lo que la gente dijo.",
+    sentences: [
+      {
+        english: "I told her I had already eaten.",
+        spanish: "Le dije que ya había comido.",
+        highlight: "told... had already eaten",
+      },
+      {
+        english: "When we were kids, we would play in that park every day, but it had been demolished by the time I returned.",
+        spanish: "Cuando éramos niños, jugábamos en ese parque todos los días, pero había sido demolido para cuando regresé.",
+        highlight: "would play... had been demolished",
+      },
+      {
+        english: "He explained that he had lost the file but that he would send it the next day.",
+        spanish: "Explicó que había perdido el archivo pero que lo enviaría al día siguiente.",
+        highlight: "had lost... would send",
+      },
+      {
+        english: "She mentioned she had been working there for years before she finally quit.",
+        spanish: "Mencionó que había estado trabajando allí durante años antes de finalmente renunciar.",
+        highlight: "had been working",
+      },
+    ],
+  },
+];
+
+// ─── Section D: Error Correction ─────────────────────────────────────────────
+
+export const errorCorrections: ErrorCorrectionSet = {
+  title: "Common Mistakes with Past Narratives",
+  titleEs: "Errores Comunes con Narrativas Pasadas",
+  description:
+    "These are the exact errors that make B1 storytelling sound flat or confusing. Spot them, fix them.",
+  descriptionEs:
+    "Estos son los errores exactos que hacen que las historias B1 suenen planas o confusas. Detéctalos, corrígelos.",
+  items: [
+    {
+      incorrect: "When I arrived, the meeting already started.",
+      correct: "When I arrived, the meeting had already started.",
+      incorrectHighlight: "already started",
+      correctHighlight: "had already started",
+      explanation:
+        "When two past events happen, use past perfect ('had started') for the EARLIER one. The meeting started BEFORE you arrived, so it needs the past perfect form to make the time relationship clear.",
+      explanationEs:
+        "Cuando suceden dos eventos pasados, usa el pasado perfecto ('had started') para el ANTERIOR. La junta empezó ANTES de que llegaras, así que necesita la forma del pasado perfecto.",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "She told me she will call me later.",
+      correct: "She told me she would call me later.",
+      incorrectHighlight: "she will call",
+      correctHighlight: "she would call",
+      explanation:
+        "In reported speech, when the reporting verb ('told') is in the past, 'will' shifts to 'would'. Direct: 'I will call you' → Reported: 'She said she would call me'. The whole sentence shifts back in time.",
+      explanationEs:
+        "En el discurso indirecto, cuando el verbo que reporta ('told') está en pasado, 'will' cambia a 'would'. Directo: 'I will call you' → Indirecto: 'She said she would call me'.",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "He said me that he was tired.",
+      correct: "He told me that he was tired.",
+      incorrectHighlight: "said me",
+      correctHighlight: "told me",
+      explanation:
+        "'Said' and 'told' are not interchangeable. 'Tell' takes a direct object (tell ME, tell HIM). 'Say' does not — you can't 'say someone' something. Use 'said TO me' or just 'told me'.",
+      explanationEs:
+        "'Said' y 'told' no son intercambiables. 'Tell' toma un objeto directo (tell ME, tell HIM). 'Say' no — no puedes 'say someone' algo. Usa 'said TO me' o simplemente 'told me'.",
+      errorType: "literal-translation",
+    },
+    {
+      incorrect: "When I was a child, I was playing soccer every weekend.",
+      correct: "When I was a child, I would play soccer every weekend.",
+      incorrectHighlight: "I was playing",
+      correctHighlight: "I would play",
+      explanation:
+        "Past continuous ('was playing') describes an action in progress at a SPECIFIC moment. For repeated past habits, use 'would + base verb' or 'used to + base verb'. Spanish imperfect ('jugaba') maps to BOTH, which causes confusion.",
+      explanationEs:
+        "El pasado continuo ('was playing') describe una acción en progreso en un momento ESPECÍFICO. Para hábitos pasados repetidos, usa 'would + verbo base' o 'used to + verbo base'. El imperfecto en español ('jugaba') corresponde a AMBOS, lo que causa confusión.",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "After I had finished my work, I had gone home.",
+      correct: "After I had finished my work, I went home.",
+      incorrectHighlight: "I had gone home",
+      correctHighlight: "I went home",
+      explanation:
+        "You only need ONE past perfect to establish the time order. Once 'had finished' tells the listener which event came first, the second event uses simple past. Don't double up on past perfects — it's redundant.",
+      explanationEs:
+        "Solo necesitas UN pasado perfecto para establecer el orden temporal. Una vez que 'had finished' le dice al oyente cuál evento fue primero, el segundo evento usa pasado simple. No dupliques los pasados perfectos — es redundante.",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "He asked me where do I live.",
+      correct: "He asked me where I lived.",
+      incorrectHighlight: "where do I live",
+      correctHighlight: "where I lived",
+      explanation:
+        "Two errors. First: in reported questions, use STATEMENT order (subject + verb), not question order. Second: 'asked' is past, so 'live' shifts to 'lived'. Reported questions never have 'do/does/did' as auxiliaries.",
+      explanationEs:
+        "Dos errores. Primero: en preguntas indirectas, usa el orden de DECLARACIÓN (sujeto + verbo), no el de pregunta. Segundo: 'asked' es pasado, así que 'live' cambia a 'lived'. Las preguntas indirectas nunca tienen 'do/does/did' como auxiliares.",
+      errorType: "tense-confusion",
+    },
+  ],
+};
+
+// ─── Section E: Pronunciation Lab ────────────────────────────────────────────
+
+export const pronunciationDrills: PronunciationDrill[] = [
+  {
+    word: "had been",
+    spanishStress: "HAD BEEN",
+    englishStress: "həd bin (weak)",
+    tip: "In past perfect, 'had been' is reduced to /həd bin/ — both words unstressed. 'I had been waiting' = 'aid-bin-WAY-ting' (with 'I had' contracted to 'I'd').",
+    tipEs:
+      "En pasado perfecto, 'had been' se reduce a /həd bin/ — ambas palabras sin acento. 'I had been waiting' = 'aid-bin-WAY-ting' (con 'I had' contraído a 'I'd').",
+  },
+  {
+    word: "I'd",
+    spanishStress: "I HAD",
+    englishStress: "aid (one syllable)",
+    tip: "'I'd' contracts BOTH 'I would' and 'I had'. Context tells you which. 'I'd already eaten' = 'I had already eaten'. 'I'd love to' = 'I would love to'. Same sound, different meanings.",
+    tipEs:
+      "'I'd' contrae TANTO 'I would' como 'I had'. El contexto te dice cuál. 'I'd already eaten' = 'I had already eaten'. 'I'd love to' = 'I would love to'. Mismo sonido, significados diferentes.",
+  },
+  {
+    word: "she'd",
+    spanishStress: "SHE HAD",
+    englishStress: "shid (one syllable)",
+    tip: "'She'd' rhymes with 'need'. 'She'd told me' = 'shid-told-mi' — fast and connected. Same contraction works for 'she would' and 'she had'.",
+    tipEs:
+      "'She'd' rima con 'need'. 'She'd told me' = 'shid-told-mi' — rápido y conectado. La misma contracción funciona para 'she would' y 'she had'.",
+  },
+  {
+    word: "would've",
+    spanishStress: "WOULD HAVE",
+    englishStress: "wʊdəv",
+    tip: "'Would've' = 'would have'. The 'have' becomes /əv/ — never 'OF', even though some people misspell it that way. 'I would've told you' = 'aid-əv-TOLD-yu'.",
+    tipEs:
+      "'Would've' = 'would have'. El 'have' se vuelve /əv/ — nunca 'OF', aunque algunos lo escriben mal así. 'I would've told you' = 'aid-əv-TOLD-yu'.",
+  },
+  {
+    word: "told you",
+    spanishStress: "TOLD YOU",
+    englishStress: "TOLD-jə (linked)",
+    tip: "'Told you' links into 'TOLD-jə'. The 'd' + 'y' merges into a 'j' sound, just like 'would you'. 'I told you so' = 'ai-TOLD-jə-so'.",
+    tipEs:
+      "'Told you' se enlaza en 'TOLD-jə'. La 'd' + 'y' se fusiona en un sonido 'j', igual que 'would you'. 'I told you so' = 'ai-TOLD-jə-so'.",
+  },
+];
+
+// ─── Section F: Self-Test Vocabulary ─────────────────────────────────────────
+
+export const vocabularyList: IntermediateVocabItem[] = [
+  // Narrative connectors
+  { english: "by the time", spanish: "para cuando", type: "expression" },
+  { english: "as soon as", spanish: "tan pronto como", type: "expression" },
+  { english: "before that", spanish: "antes de eso", type: "expression" },
+  { english: "after that", spanish: "después de eso", type: "expression" },
+  { english: "earlier that day", spanish: "más temprano ese día", type: "expression" },
+  // Reported speech verbs
+  { english: "She said that...", spanish: "Ella dijo que...", type: "expression" },
+  { english: "He told me that...", spanish: "Él me dijo que...", type: "expression" },
+  { english: "They mentioned that...", spanish: "Mencionaron que...", type: "expression" },
+  { english: "He explained that...", spanish: "Explicó que...", type: "expression" },
+  { english: "She admitted that...", spanish: "Ella admitió que...", type: "expression" },
+  // Past perfect chunks
+  { english: "had already...", spanish: "ya había...", type: "expression" },
+  { english: "had never... before", spanish: "nunca había... antes", type: "expression" },
+  { english: "had just...", spanish: "acababa de...", type: "expression" },
+  // 'Would' for habits
+  { english: "I would always...", spanish: "Yo siempre...", type: "expression" },
+  { english: "We would often...", spanish: "Frecuentemente...", type: "expression" },
+  // Story-opener phrases
+  { english: "You won't believe what happened.", spanish: "No vas a creer lo que pasó.", type: "expression" },
+  { english: "Let me tell you what happened.", spanish: "Déjame contarte lo que pasó.", type: "expression" },
+  { english: "It all started when...", spanish: "Todo empezó cuando...", type: "expression" },
+  // Storytelling verbs
+  { english: "to mention", spanish: "mencionar", type: "verb" },
+  { english: "to admit", spanish: "admitir", type: "verb" },
+  { english: "to explain", spanish: "explicar", type: "verb" },
+  { english: "to insist", spanish: "insistir", type: "verb" },
+  { english: "to realize", spanish: "darse cuenta", type: "verb" },
+  { english: "to notice", spanish: "notar", type: "verb" },
+  { english: "to remind", spanish: "recordar (a alguien)", type: "verb" },
+];

--- a/src/data/intermediate/unit-6.ts
+++ b/src/data/intermediate/unit-6.ts
@@ -1,0 +1,648 @@
+// Unit 6: "Expressing Opinions" — Full course content
+// Theme: Debate, persuasion, professional disagreement
+// Grammar: Third conditional + softening modals (might, may, could)
+// Pronunciation: Agreement/disagreement intonation
+// Section A: OpinionStems (categorized sentence frames for opinions)
+
+import type {
+  Dialogue,
+  ErrorCorrectionSet,
+  IntermediateVocabItem,
+} from "./types";
+import type { OpinionCategory } from "../../components/course/OpinionStems";
+import type { SentenceBlock, PronunciationDrill } from "../course/unit-1";
+
+// ─── Section A: Opinion Stems ────────────────────────────────────────────────
+
+export const opinionCategories: OpinionCategory[] = [
+  {
+    label: "State your opinion",
+    labelEs: "Expresa tu opinión",
+    intent: "state",
+    description:
+      "Sentence starters that introduce your view clearly without sounding aggressive. The first three are everyday-natural; the last two are more formal.",
+    descriptionEs:
+      "Frases iniciales que introducen tu punto de vista claramente sin sonar agresivo. Las primeras tres son cotidianas y naturales; las últimas dos son más formales.",
+    stems: [
+      {
+        stem: "In my opinion",
+        stemEs: "En mi opinión",
+        example:
+          "In my opinion, remote work has made teams more productive, not less.",
+        exampleEs:
+          "En mi opinión, el trabajo remoto ha hecho a los equipos más productivos, no menos.",
+        register: "neutral",
+      },
+      {
+        stem: "I think",
+        stemEs: "Creo que",
+        example: "I think we should look at this from a different angle.",
+        exampleEs: "Creo que deberíamos ver esto desde un ángulo diferente.",
+        register: "neutral",
+      },
+      {
+        stem: "The way I see it",
+        stemEs: "La forma en que lo veo",
+        example:
+          "The way I see it, both options have value — we just need to choose carefully.",
+        exampleEs:
+          "La forma en que lo veo, ambas opciones tienen valor — solo tenemos que elegir con cuidado.",
+        register: "neutral",
+      },
+      {
+        stem: "From my perspective",
+        stemEs: "Desde mi perspectiva",
+        example:
+          "From my perspective, the data clearly supports the second proposal.",
+        exampleEs:
+          "Desde mi perspectiva, los datos claramente apoyan la segunda propuesta.",
+        register: "academic",
+      },
+      {
+        stem: "It seems to me that",
+        stemEs: "Me parece que",
+        example:
+          "It seems to me that we're focusing too much on short-term gains.",
+        exampleEs:
+          "Me parece que nos estamos enfocando demasiado en ganancias a corto plazo.",
+        register: "academic",
+      },
+    ],
+  },
+  {
+    label: "Soften your opinion",
+    labelEs: "Suaviza tu opinión",
+    intent: "soften",
+    description:
+      "These frames let you share strong views without sounding arrogant. The trick: use 'might', 'may', or 'could' to present your opinion as one possibility, not the only truth.",
+    descriptionEs:
+      "Estas frases te permiten compartir opiniones fuertes sin sonar arrogante. El truco: usa 'might', 'may' o 'could' para presentar tu opinión como una posibilidad, no como la única verdad.",
+    stems: [
+      {
+        stem: "I might be wrong, but",
+        stemEs: "Podría estar equivocado, pero",
+        example:
+          "I might be wrong, but I think we're underestimating the timeline.",
+        exampleEs:
+          "Podría estar equivocado, pero creo que estamos subestimando el cronograma.",
+        register: "soft",
+      },
+      {
+        stem: "It could be argued that",
+        stemEs: "Se podría argumentar que",
+        example:
+          "It could be argued that the original plan was actually more effective.",
+        exampleEs:
+          "Se podría argumentar que el plan original era de hecho más efectivo.",
+        register: "academic",
+      },
+      {
+        stem: "I tend to think that",
+        stemEs: "Tiendo a pensar que",
+        example:
+          "I tend to think that simplicity wins over complexity in most cases.",
+        exampleEs:
+          "Tiendo a pensar que la simplicidad gana sobre la complejidad en la mayoría de los casos.",
+        register: "soft",
+      },
+      {
+        stem: "There may be some truth to",
+        stemEs: "Puede haber algo de verdad en",
+        example:
+          "There may be some truth to what they're saying, but I'd want to see the numbers.",
+        exampleEs:
+          "Puede haber algo de verdad en lo que dicen, pero querría ver los números.",
+        register: "soft",
+      },
+    ],
+  },
+  {
+    label: "Agree politely",
+    labelEs: "Mostrar acuerdo cortésmente",
+    intent: "agree",
+    description:
+      "Don't just say 'yes' — show you've actually thought about what the other person said. These frames acknowledge their point and add to it.",
+    descriptionEs:
+      "No solo digas 'yes' — muestra que realmente has pensado en lo que la otra persona dijo. Estas frases reconocen su punto y le agregan algo.",
+    stems: [
+      {
+        stem: "That's a good point",
+        stemEs: "Ese es un buen punto",
+        example:
+          "That's a good point. I hadn't considered the impact on the customer side.",
+        exampleEs:
+          "Ese es un buen punto. No había considerado el impacto en el lado del cliente.",
+        register: "neutral",
+      },
+      {
+        stem: "I couldn't agree more",
+        stemEs: "No podría estar más de acuerdo",
+        example:
+          "I couldn't agree more. We've been ignoring this issue for too long.",
+        exampleEs:
+          "No podría estar más de acuerdo. Hemos estado ignorando este problema por demasiado tiempo.",
+        register: "strong",
+      },
+      {
+        stem: "You make a fair point about",
+        stemEs: "Haces un buen punto sobre",
+        example:
+          "You make a fair point about the cost — that's something we'll need to address.",
+        exampleEs:
+          "Haces un buen punto sobre el costo — eso es algo que necesitaremos abordar.",
+        register: "neutral",
+      },
+      {
+        stem: "That's exactly what I was thinking",
+        stemEs: "Eso es exactamente lo que estaba pensando",
+        example:
+          "That's exactly what I was thinking. We're on the same page.",
+        exampleEs:
+          "Eso es exactamente lo que estaba pensando. Estamos en la misma página.",
+        register: "neutral",
+      },
+    ],
+  },
+  {
+    label: "Disagree without offending",
+    labelEs: "Discrepar sin ofender",
+    intent: "disagree",
+    description:
+      "Disagreement is dangerous in English — direct disagreement can damage relationships fast. These frames let you push back while preserving the connection.",
+    descriptionEs:
+      "El desacuerdo es peligroso en inglés — el desacuerdo directo puede dañar relaciones rápido. Estas frases te permiten objetar sin romper la conexión.",
+    stems: [
+      {
+        stem: "I see your point, but",
+        stemEs: "Entiendo tu punto, pero",
+        example:
+          "I see your point, but I think we should also consider the long-term cost.",
+        exampleEs:
+          "Entiendo tu punto, pero creo que también deberíamos considerar el costo a largo plazo.",
+        register: "neutral",
+      },
+      {
+        stem: "I'm not sure I agree with",
+        stemEs: "No estoy seguro de estar de acuerdo con",
+        example:
+          "I'm not sure I agree with that assessment. The data tells a different story.",
+        exampleEs:
+          "No estoy seguro de estar de acuerdo con esa evaluación. Los datos cuentan una historia diferente.",
+        register: "soft",
+      },
+      {
+        stem: "With respect, I'd have to disagree",
+        stemEs: "Con todo respeto, tendría que discrepar",
+        example:
+          "With respect, I'd have to disagree. The team needs more time, not less.",
+        exampleEs:
+          "Con todo respeto, tendría que discrepar. El equipo necesita más tiempo, no menos.",
+        register: "academic",
+      },
+      {
+        stem: "I'm afraid I see it differently",
+        stemEs: "Me temo que lo veo diferente",
+        example:
+          "I'm afraid I see it differently — I think the original approach was the right one.",
+        exampleEs:
+          "Me temo que lo veo diferente — creo que el enfoque original era el correcto.",
+        register: "soft",
+      },
+    ],
+  },
+  {
+    label: "Concede a point",
+    labelEs: "Conceder un punto",
+    intent: "concede",
+    description:
+      "Strong speakers know how to give ground gracefully. Conceding part of the other person's argument actually makes YOUR position stronger — it shows you're being fair.",
+    descriptionEs:
+      "Los hablantes fuertes saben cómo ceder con elegancia. Conceder parte del argumento de la otra persona en realidad fortalece TU posición — muestra que estás siendo justo.",
+    stems: [
+      {
+        stem: "You may be right about",
+        stemEs: "Puede que tengas razón sobre",
+        example:
+          "You may be right about the budget, but the timeline still concerns me.",
+        exampleEs:
+          "Puede que tengas razón sobre el presupuesto, pero el cronograma aún me preocupa.",
+        register: "soft",
+      },
+      {
+        stem: "Fair enough, but",
+        stemEs: "Es justo, pero",
+        example:
+          "Fair enough, but I still think we need a backup plan.",
+        exampleEs:
+          "Es justo, pero todavía creo que necesitamos un plan de respaldo.",
+        register: "neutral",
+      },
+      {
+        stem: "I'll grant you that",
+        stemEs: "Te concedo eso",
+        example:
+          "I'll grant you that the launch was successful — but we got lucky with the timing.",
+        exampleEs:
+          "Te concedo que el lanzamiento fue exitoso — pero tuvimos suerte con el momento.",
+        register: "academic",
+      },
+      {
+        stem: "There's something to that, although",
+        stemEs: "Hay algo en eso, aunque",
+        example:
+          "There's something to that, although I'd want to verify with the team first.",
+        exampleEs:
+          "Hay algo en eso, aunque querría verificarlo con el equipo primero.",
+        register: "soft",
+      },
+    ],
+  },
+];
+
+// ─── Section B: Dialogue Practice ────────────────────────────────────────────
+
+export const dialogues: Dialogue[] = [
+  {
+    title: "A Productive Disagreement",
+    titleEs: "Un Desacuerdo Productivo",
+    setting: "A planning meeting where two team members disagree about strategy",
+    settingEs: "Una junta de planeación donde dos miembros del equipo no están de acuerdo sobre la estrategia",
+    lines: [
+      {
+        speaker: "A",
+        speakerLabel: "Ana",
+        speakerLabelEs: "Ana",
+        english:
+          "From my perspective, we should launch the product in March. The market is ready.",
+        spanish:
+          "Desde mi perspectiva, deberíamos lanzar el producto en marzo. El mercado está listo.",
+        highlight: "From my perspective",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Roberto",
+        speakerLabelEs: "Roberto",
+        english:
+          "I see your point, Ana, but I'm not sure I agree with the timing. If we had launched the previous version sooner, we might have lost users to bugs.",
+        spanish:
+          "Entiendo tu punto, Ana, pero no estoy seguro de estar de acuerdo con el tiempo. Si hubiéramos lanzado la versión anterior antes, podríamos haber perdido usuarios por los errores.",
+        highlight: "I see your point... I'm not sure I agree",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Ana",
+        speakerLabelEs: "Ana",
+        english:
+          "That's a fair point. But this version has been tested thoroughly. I might be wrong, but I think waiting longer just gives competitors more room.",
+        spanish:
+          "Ese es un punto justo. Pero esta versión ha sido probada a fondo. Podría estar equivocada, pero creo que esperar más solo le da más espacio a los competidores.",
+        highlight: "That's a fair point / I might be wrong",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Roberto",
+        speakerLabelEs: "Roberto",
+        english:
+          "You may be right about the competitors. Still, if we had a soft launch first, we could catch any remaining issues without risking the whole brand.",
+        spanish:
+          "Puede que tengas razón sobre los competidores. Aún así, si tuviéramos un lanzamiento suave primero, podríamos detectar cualquier problema restante sin arriesgar toda la marca.",
+        highlight: "You may be right / If we had... we could",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Ana",
+        speakerLabelEs: "Ana",
+        english:
+          "Hmm. I hadn't thought of it that way. A soft launch could give us the data we need without the risk.",
+        spanish:
+          "Hmm. No lo había pensado de esa manera. Un lanzamiento suave podría darnos los datos que necesitamos sin el riesgo.",
+        highlight: "I hadn't thought of it that way",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Roberto",
+        speakerLabelEs: "Roberto",
+        english:
+          "Exactly. And if it goes well, we could move to a full launch in April with much more confidence.",
+        spanish:
+          "Exactamente. Y si va bien, podríamos pasar a un lanzamiento completo en abril con mucha más confianza.",
+        highlight: "we could move",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Ana",
+        speakerLabelEs: "Ana",
+        english:
+          "I couldn't agree more. Let's bring this proposal to the team tomorrow.",
+        spanish:
+          "No podría estar más de acuerdo. Llevemos esta propuesta al equipo mañana.",
+        highlight: "I couldn't agree more",
+      },
+    ],
+    keyPhrases: [
+      {
+        english: "I see your point, but...",
+        spanish: "Entiendo tu punto, pero...",
+        note: "The diplomatic way to push back. Always acknowledges before disagreeing.",
+        noteEs: "La forma diplomática de objetar. Siempre reconoce antes de discrepar.",
+      },
+      {
+        english: "You may be right about X.",
+        spanish: "Puede que tengas razón sobre X.",
+        note: "Concede a specific point — strengthens your overall position by showing fairness.",
+        noteEs: "Concede un punto específico — fortalece tu posición general al mostrar imparcialidad.",
+      },
+      {
+        english: "I hadn't thought of it that way.",
+        spanish: "No lo había pensado de esa manera.",
+        note: "The most professional way to admit you've been persuaded.",
+        noteEs: "La forma más profesional de admitir que has sido persuadido.",
+      },
+    ],
+  },
+];
+
+// ─── Section C: Structure Builder ────────────────────────────────────────────
+
+export const structureBlocks: SentenceBlock[] = [
+  {
+    label: "Third conditional: imagining a different past",
+    labelEs: "Tercer condicional: imaginando un pasado diferente",
+    description:
+      "Structure: If + had + past participle, would have + past participle. Use it to talk about past situations that did NOT happen — and imagine the result.",
+    descriptionEs:
+      "Estructura: If + had + participio, would have + participio. Úsalo para hablar de situaciones pasadas que NO sucedieron — e imaginar el resultado.",
+    sentences: [
+      {
+        english: "If we had launched earlier, we would have caught the bugs sooner.",
+        spanish: "Si hubiéramos lanzado antes, habríamos detectado los errores más pronto.",
+        highlight: "If we had launched, we would have caught",
+      },
+      {
+        english: "If she had told me, I would have helped.",
+        spanish: "Si ella me hubiera dicho, le habría ayudado.",
+        highlight: "If she had told, I would have helped",
+      },
+      {
+        english: "We would have won the contract if we had submitted the bid on time.",
+        spanish: "Habríamos ganado el contrato si hubiéramos enviado la oferta a tiempo.",
+        highlight: "would have won, had submitted",
+      },
+      {
+        english: "I wouldn't have made that mistake if I had known the rules.",
+        spanish: "No habría cometido ese error si hubiera conocido las reglas.",
+        highlight: "wouldn't have made, had known",
+      },
+    ],
+  },
+  {
+    label: "Softening modals: might, may, could",
+    labelEs: "Modales suavizadores: might, may, could",
+    description:
+      "These three modals turn strong statements into possibilities. They're how educated speakers share opinions without sounding arrogant or absolute.",
+    descriptionEs:
+      "Estos tres modales convierten declaraciones fuertes en posibilidades. Son cómo los hablantes educados comparten opiniones sin sonar arrogantes o absolutos.",
+    sentences: [
+      {
+        english: "This might be the wrong approach.",
+        spanish: "Este podría ser el enfoque equivocado.",
+        highlight: "might be",
+      },
+      {
+        english: "There may be a simpler solution we haven't considered.",
+        spanish: "Puede haber una solución más simple que no hemos considerado.",
+        highlight: "may be",
+      },
+      {
+        english: "We could be looking at this the wrong way.",
+        spanish: "Podríamos estar viendo esto de la manera equivocada.",
+        highlight: "could be",
+      },
+      {
+        english: "It might make sense to wait until next quarter.",
+        spanish: "Podría tener sentido esperar hasta el próximo trimestre.",
+        highlight: "might make sense",
+      },
+    ],
+  },
+  {
+    label: "Combining third conditional with softening modals",
+    labelEs: "Combinando tercer condicional con modales suavizadores",
+    description:
+      "Replace 'would have' with 'might have' or 'could have' to soften the third conditional. The result is even more diplomatic — you're imagining a possible past, not stating a definite one.",
+    descriptionEs:
+      "Reemplaza 'would have' con 'might have' o 'could have' para suavizar el tercer condicional. El resultado es aún más diplomático — estás imaginando un pasado posible, no declarando uno definitivo.",
+    sentences: [
+      {
+        english: "If we had acted faster, we might have avoided the issue.",
+        spanish: "Si hubiéramos actuado más rápido, podríamos haber evitado el problema.",
+        highlight: "might have avoided",
+      },
+      {
+        english: "She could have been promoted if she had spoken up.",
+        spanish: "Ella podría haber sido promovida si hubiera hablado.",
+        highlight: "could have been",
+      },
+      {
+        english: "We may have missed an important detail in the contract.",
+        spanish: "Puede que hayamos pasado por alto un detalle importante en el contrato.",
+        highlight: "may have missed",
+      },
+      {
+        english: "Things might have turned out differently if I had known earlier.",
+        spanish: "Las cosas podrían haber resultado diferentes si yo hubiera sabido antes.",
+        highlight: "might have turned out",
+      },
+    ],
+  },
+  {
+    label: "Three conditionals — side by side",
+    labelEs: "Los tres condicionales — lado a lado",
+    description:
+      "First = real future. Second = hypothetical present/future. Third = imagined past. Same structure, different time and reality level.",
+    descriptionEs:
+      "Primero = futuro real. Segundo = presente/futuro hipotético. Tercero = pasado imaginado. Misma estructura, diferente tiempo y nivel de realidad.",
+    sentences: [
+      {
+        english: "If it rains, I will stay home. (1st — real future)",
+        spanish: "Si llueve, me quedaré en casa. (1ro — futuro real)",
+        highlight: "will stay",
+      },
+      {
+        english: "If it rained more often here, I would buy an umbrella. (2nd — hypothetical)",
+        spanish: "Si lloviera más a menudo aquí, compraría un paraguas. (2do — hipotético)",
+        highlight: "would buy",
+      },
+      {
+        english: "If it had rained yesterday, we would have stayed home. (3rd — imagined past)",
+        spanish: "Si hubiera llovido ayer, nos habríamos quedado en casa. (3ro — pasado imaginado)",
+        highlight: "would have stayed",
+      },
+      {
+        english: "If I had studied harder, I might have a better job today. (mixed — past affecting present)",
+        spanish: "Si hubiera estudiado más, podría tener un mejor trabajo hoy. (mixto — pasado afectando presente)",
+        highlight: "had studied, might have",
+      },
+    ],
+  },
+];
+
+// ─── Section D: Error Correction ─────────────────────────────────────────────
+
+export const errorCorrections: ErrorCorrectionSet = {
+  title: "Common Mistakes with Conditionals & Opinions",
+  titleEs: "Errores Comunes con Condicionales y Opiniones",
+  description:
+    "These are the errors that make B1 speakers sound either too blunt or grammatically wrong when discussing ideas.",
+  descriptionEs:
+    "Estos son los errores que hacen que los hablantes B1 suenen demasiado directos o gramaticalmente incorrectos al discutir ideas.",
+  items: [
+    {
+      incorrect: "If I would have known, I would have called you.",
+      correct: "If I had known, I would have called you.",
+      incorrectHighlight: "If I would have known",
+      correctHighlight: "If I had known",
+      explanation:
+        "Same rule as the second conditional: NEVER use 'would' in the 'if' clause. The third conditional uses 'had + past participle' in the if-clause: 'If I HAD known'. This is the most stubborn error in advanced English.",
+      explanationEs:
+        "Misma regla que el segundo condicional: NUNCA uses 'would' en la cláusula 'if'. El tercer condicional usa 'had + participio' en la cláusula if: 'If I HAD known'. Este es el error más persistente en inglés avanzado.",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "I am not agree with you.",
+      correct: "I don't agree with you.",
+      incorrectHighlight: "I am not agree",
+      correctHighlight: "I don't agree",
+      explanation:
+        "'Agree' is a regular verb in English, not an adjective. Spanish 'estar de acuerdo' uses 'estar' (to be), which tempts learners to say 'I am agree'. In English, you conjugate it directly: 'I agree', 'I don't agree', 'I agreed'.",
+      explanationEs:
+        "'Agree' es un verbo regular en inglés, no un adjetivo. 'Estar de acuerdo' usa 'estar', lo que tienta a los estudiantes a decir 'I am agree'. En inglés, lo conjugas directamente: 'I agree', 'I don't agree', 'I agreed'.",
+      errorType: "literal-translation",
+    },
+    {
+      incorrect: "I am totally agree with that idea.",
+      correct: "I totally agree with that idea.",
+      incorrectHighlight: "I am totally agree",
+      correctHighlight: "I totally agree",
+      explanation:
+        "Same root issue. 'Agree' takes adverbs directly: 'I totally agree', 'I completely agree', 'I strongly agree'. Never combine 'I am' with 'agree' — they're different parts of speech.",
+      explanationEs:
+        "Misma raíz del problema. 'Agree' toma adverbios directamente: 'I totally agree', 'I completely agree', 'I strongly agree'. Nunca combines 'I am' con 'agree' — son diferentes partes del habla.",
+      errorType: "literal-translation",
+    },
+    {
+      incorrect: "In my opinion, the project will be finished if we would have more time.",
+      correct: "In my opinion, the project would be finished if we had more time.",
+      incorrectHighlight: "will be finished... we would have",
+      correctHighlight: "would be finished... we had",
+      explanation:
+        "This sentence mixes two structures incorrectly. It's a hypothetical (we don't have more time), so it needs the second conditional: 'would be finished... if we had more time'. Don't put 'would' in the 'if' clause.",
+      explanationEs:
+        "Esta oración mezcla dos estructuras incorrectamente. Es hipotético (no tenemos más tiempo), así que necesita el segundo condicional: 'would be finished... if we had more time'. No pongas 'would' en la cláusula 'if'.",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "You don't have reason about this.",
+      correct: "You're not right about this.",
+      incorrectHighlight: "don't have reason",
+      correctHighlight: "are not right",
+      explanation:
+        "Spanish 'tener razón' translates literally as 'to have reason', but in English we say 'to BE right'. The polite negative is 'I'm not sure that's right' or 'I don't think that's quite right' — 'you're wrong' is too direct.",
+      explanationEs:
+        "'Tener razón' se traduce literalmente como 'to have reason', pero en inglés decimos 'to BE right'. El negativo cortés es 'I'm not sure that's right' o 'I don't think that's quite right' — 'you're wrong' es demasiado directo.",
+      errorType: "literal-translation",
+    },
+    {
+      incorrect: "I don't agree because it is bad idea.",
+      correct: "I'm not sure I agree — it might not be the best approach.",
+      incorrectHighlight: "I don't agree because it is bad idea",
+      correctHighlight: "I'm not sure I agree — it might not be the best approach",
+      explanation:
+        "Two upgrades. First: 'I don't agree because it is bad' is grammatically OK but socially blunt. Educated speakers soften with 'I'm not sure I agree' and use modals like 'might'. Second: 'a bad idea' needs the article 'a' — count nouns always need articles in English.",
+      explanationEs:
+        "Dos mejoras. Primero: 'I don't agree because it is bad' es gramaticalmente correcto pero socialmente directo. Los hablantes educados suavizan con 'I'm not sure I agree' y usan modales como 'might'. Segundo: 'a bad idea' necesita el artículo 'a' — los sustantivos contables siempre necesitan artículos.",
+      errorType: "literal-translation",
+    },
+  ],
+};
+
+// ─── Section E: Pronunciation Lab ────────────────────────────────────────────
+
+export const pronunciationDrills: PronunciationDrill[] = [
+  {
+    word: "I see your point",
+    spanishStress: "I SEE YOUR POINT",
+    englishStress: "I see-yer POINT (rising)",
+    tip: "When you say 'I see your point', the intonation rises slightly on 'point'. This signals that more is coming — your 'but' is on the way. Flat intonation here sounds dismissive.",
+    tipEs:
+      "Cuando dices 'I see your point', la entonación sube ligeramente en 'point'. Esto señala que viene más — tu 'but' está en camino. Una entonación plana aquí suena despectiva.",
+  },
+  {
+    word: "you may be right",
+    spanishStress: "YOU MAY BE RIGHT",
+    englishStress: "yu may-bi RIGHT",
+    tip: "'You may be' flows together as one unit: /yu mei bi/. The stress falls on 'right' at the end. This is the rhythm of professional concession — calm, deliberate, never rushed.",
+    tipEs:
+      "'You may be' fluye junto como una unidad: /yu mei bi/. El acento cae en 'right' al final. Este es el ritmo de la concesión profesional — calmado, deliberado, nunca apresurado.",
+  },
+  {
+    word: "really?",
+    spanishStress: "REALLY",
+    englishStress: "REE-li (rising = surprise, falling = sarcasm)",
+    tip: "Same word, two completely different meanings depending on intonation. Rising 'really?' = genuine surprise. Falling 'really.' = skepticism or sarcasm. Watch native speakers' faces — both are common.",
+    tipEs:
+      "Misma palabra, dos significados completamente diferentes según la entonación. 'Really?' subiendo = sorpresa genuina. 'Really.' bajando = escepticismo o sarcasmo. Observa las caras de los nativos — ambos son comunes.",
+  },
+  {
+    word: "I'm afraid",
+    spanishStress: "I AM AFRAID",
+    englishStress: "aim-ə-FRAID (one breath)",
+    tip: "'I'm afraid' as a softener (not literal fear) is said quickly, almost as one word: /aim ə FRAID/. It's the warning shot before bad news or disagreement. Slow it down only for emphasis.",
+    tipEs:
+      "'I'm afraid' como suavizador (no miedo literal) se dice rápidamente, casi como una palabra: /aim ə FRAID/. Es el aviso antes de malas noticias o desacuerdo. Solo se dice despacio para énfasis.",
+  },
+  {
+    word: "I couldn't agree more",
+    spanishStress: "I COULDN'T AGREE MORE",
+    englishStress: "ai KUDN-ə-gree MORE",
+    tip: "Counterintuitively, 'I couldn't agree more' = 'I agree completely'. The stress falls on 'more', and 'couldn't' is reduced to /KUDN/. Native speakers say this fast — it's idiomatic.",
+    tipEs:
+      "Contraintuitivamente, 'I couldn't agree more' = 'estoy completamente de acuerdo'. El acento cae en 'more', y 'couldn't' se reduce a /KUDN/. Los nativos lo dicen rápido — es idiomático.",
+  },
+];
+
+// ─── Section F: Self-Test Vocabulary ─────────────────────────────────────────
+
+export const vocabularyList: IntermediateVocabItem[] = [
+  // Opinion stems (the heart of the unit)
+  { english: "In my opinion...", spanish: "En mi opinión...", type: "expression" },
+  { english: "From my perspective...", spanish: "Desde mi perspectiva...", type: "expression" },
+  { english: "The way I see it...", spanish: "La forma en que lo veo...", type: "expression" },
+  { english: "It seems to me that...", spanish: "Me parece que...", type: "expression" },
+  { english: "I might be wrong, but...", spanish: "Podría estar equivocado, pero...", type: "expression" },
+  { english: "I tend to think that...", spanish: "Tiendo a pensar que...", type: "expression" },
+  // Agreement
+  { english: "That's a good point.", spanish: "Ese es un buen punto.", type: "expression" },
+  { english: "I couldn't agree more.", spanish: "No podría estar más de acuerdo.", type: "expression" },
+  { english: "You make a fair point.", spanish: "Haces un buen punto.", type: "expression" },
+  // Polite disagreement
+  { english: "I see your point, but...", spanish: "Entiendo tu punto, pero...", type: "expression" },
+  { english: "I'm not sure I agree.", spanish: "No estoy seguro de estar de acuerdo.", type: "expression" },
+  { english: "With respect, I'd have to disagree.", spanish: "Con respeto, tendría que discrepar.", type: "expression" },
+  { english: "I'm afraid I see it differently.", spanish: "Me temo que lo veo diferente.", type: "expression" },
+  // Conceding
+  { english: "You may be right about...", spanish: "Puede que tengas razón sobre...", type: "expression" },
+  { english: "Fair enough, but...", spanish: "Es justo, pero...", type: "expression" },
+  { english: "I hadn't thought of it that way.", spanish: "No lo había pensado de esa manera.", type: "expression" },
+  // Modals for softening
+  { english: "It might be...", spanish: "Podría ser...", type: "expression" },
+  { english: "There may be...", spanish: "Puede haber...", type: "expression" },
+  { english: "We could be...", spanish: "Podríamos estar...", type: "expression" },
+  // Discussion verbs
+  { english: "to consider", spanish: "considerar", type: "verb" },
+  { english: "to argue", spanish: "argumentar", type: "verb" },
+  { english: "to challenge", spanish: "cuestionar / desafiar", type: "verb" },
+  { english: "to acknowledge", spanish: "reconocer", type: "verb" },
+  { english: "to clarify", spanish: "aclarar", type: "verb" },
+  { english: "to elaborate", spanish: "elaborar / desarrollar", type: "verb" },
+];

--- a/src/pages/en/course/intermediate/index.astro
+++ b/src/pages/en/course/intermediate/index.astro
@@ -133,7 +133,7 @@ const iconMap: Record<string, any> = {
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
         {intermediateUnits.map((unit) => {
           const Icon = iconMap[unit.icon];
-          const isAvailable = unit.id < 5;
+          const isAvailable = unit.id < 7;
           return (
             <a
               href={isAvailable ? `/en/course/intermediate/${unit.slug}/` : undefined}

--- a/src/pages/en/course/intermediate/unit-5.astro
+++ b/src/pages/en/course/intermediate/unit-5.astro
@@ -1,0 +1,191 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import NarrativeTimeline from "@components/course/NarrativeTimeline";
+import DialoguePractice from "@components/course/DialoguePractice";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import ErrorCorrection from "@components/course/ErrorCorrection";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import SelfTest from "@components/course/SelfTest";
+import { intermediateUnits } from "@data/intermediate/units";
+import {
+  stories,
+  dialogues,
+  structureBlocks,
+  errorCorrections,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/intermediate/unit-5";
+import { ArrowRight, MessageSquare, Layers, Volume2, Clock } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/intermediate/unit-5" as const;
+
+const progressUnits = intermediateUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unit 5: Telling Stories | Building Fluency | NY English Teacher"
+  description="Narrate events like a native speaker. Master past perfect, reported speech, and 'would' for past habits. Free interactive lesson for B1-B2 Spanish speakers."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={5}
+    basePath="/en/course/intermediate"
+    lang="en"
+    courseId="intermediate"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <MessageSquare class="w-4 h-4" />
+          Unit 5
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Telling Stories
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Storytelling is where fluency really shows. This unit gives you the three
+          tools native speakers use to narrate events: <strong class="text-white">past perfect</strong>
+          for what happened before, <strong class="text-white">reported speech</strong> for what
+          people said, and <strong class="text-white">'would'</strong> for what you used to do.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Clock class="w-3.5 h-3.5" /> Past Perfect
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Layers class="w-3.5 h-3.5" /> Reported Speech
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Volume2 class="w-3.5 h-3.5" /> 'Would' (Habitual Past)
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-a">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">A</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Narrative Timeline</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Tap each moment in this story to reveal it. Watch how past simple, past perfect,
+          and 'would' connect to build a clear timeline.
+        </p>
+        <NarrativeTimeline client:visible stories={stories} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-b">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">B</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Dialogue Practice</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          A real story being told between friends. Notice every tense shift.
+        </p>
+        <DialoguePractice client:visible dialogues={dialogues} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-c">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">C</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Structure Builder</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Past perfect, reported speech, and 'would' for habits — built one block at a time.
+        </p>
+        <SentenceBuilder client:visible blocks={structureBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-d">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">D</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Error Correction</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Six errors that flatten storytelling. Spot them, fix them.
+        </p>
+        <ErrorCorrection client:visible data={errorCorrections} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-e">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">E</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Pronunciation Lab</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Connected speech in past narratives — the contractions and linkings native speakers use.
+        </p>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-f">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">F</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Self-Test</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Test yourself on storytelling vocabulary, reported speech phrases, and narrative connectors.
+        </p>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/en/course/intermediate/unit-4/"
+          class="text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          &larr; Unit 4
+        </a>
+        <Button href="/en/course/intermediate/unit-6/" variant="primary" size="md">
+          Unit 6: Expressing Opinions
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/en/course/intermediate/unit-6.astro
+++ b/src/pages/en/course/intermediate/unit-6.astro
@@ -1,0 +1,190 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import OpinionStems from "@components/course/OpinionStems";
+import DialoguePractice from "@components/course/DialoguePractice";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import ErrorCorrection from "@components/course/ErrorCorrection";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import SelfTest from "@components/course/SelfTest";
+import { intermediateUnits } from "@data/intermediate/units";
+import {
+  opinionCategories,
+  dialogues,
+  structureBlocks,
+  errorCorrections,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/intermediate/unit-6";
+import { ArrowRight, Scale, Layers, Volume2, MessageSquareQuote } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/intermediate/unit-6" as const;
+
+const progressUnits = intermediateUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unit 6: Expressing Opinions | Building Fluency | NY English Teacher"
+  description="The language of debate, persuasion, and professional disagreement. Master the third conditional and softening modals (might, may, could). Free B1-B2 lesson for Spanish speakers."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={6}
+    basePath="/en/course/intermediate"
+    lang="en"
+    courseId="intermediate"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Scale class="w-4 h-4" />
+          Unit 6
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Expressing Opinions
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          The most dangerous skill in English is disagreement. Done badly, it damages
+          relationships in seconds. Done well, it earns respect. This unit teaches you
+          to share opinions, push back, and concede points — all without offending anyone.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <MessageSquareQuote class="w-3.5 h-3.5" /> Opinion Frames
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Layers class="w-3.5 h-3.5" /> Third Conditional
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Volume2 class="w-3.5 h-3.5" /> Softening Modals
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-a">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">A</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Opinion Stems</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Sentence frames organized by purpose — state, soften, agree, disagree, concede.
+          Tap any stem to see a full example in context.
+        </p>
+        <OpinionStems client:visible categories={opinionCategories} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-b">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">B</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Dialogue Practice</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          A productive disagreement at work — watch how the conversation moves from disagreement to consensus.
+        </p>
+        <DialoguePractice client:visible dialogues={dialogues} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-c">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">C</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Structure Builder</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Third conditional plus softening modals — the diplomatic toolkit for opinions.
+        </p>
+        <SentenceBuilder client:visible blocks={structureBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-d">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">D</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Error Correction</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Six errors that make opinions sound wrong, blunt, or both.
+        </p>
+        <ErrorCorrection client:visible data={errorCorrections} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-e">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">E</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Pronunciation Lab</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Agreement and disagreement intonation — the music of professional debate.
+        </p>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-f">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">F</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Self-Test</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Test yourself on opinion frames, agreement/disagreement phrases, and discussion vocabulary.
+        </p>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/en/course/intermediate/unit-5/"
+          class="text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          &larr; Unit 5
+        </a>
+        <Button href="/en/course/intermediate/" variant="primary" size="md">
+          Course Overview
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/intermedio/index.astro
+++ b/src/pages/es/curso/intermedio/index.astro
@@ -133,7 +133,7 @@ const iconMap: Record<string, any> = {
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
         {intermediateUnits.map((unit) => {
           const Icon = iconMap[unit.icon];
-          const isAvailable = unit.id < 5;
+          const isAvailable = unit.id < 7;
           return (
             <a
               href={isAvailable ? `/es/curso/intermedio/${unit.slugEs}/` : undefined}

--- a/src/pages/es/curso/intermedio/unidad-5.astro
+++ b/src/pages/es/curso/intermedio/unidad-5.astro
@@ -1,0 +1,192 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import NarrativeTimeline from "@components/course/NarrativeTimeline";
+import DialoguePractice from "@components/course/DialoguePractice";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import ErrorCorrection from "@components/course/ErrorCorrection";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import SelfTest from "@components/course/SelfTest";
+import { intermediateUnits } from "@data/intermediate/units";
+import {
+  stories,
+  dialogues,
+  structureBlocks,
+  errorCorrections,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/intermediate/unit-5";
+import { ArrowRight, MessageSquare, Layers, Volume2, Clock } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/intermediate/unit-5" as const;
+
+const progressUnits = intermediateUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unidad 5: Contando Historias | Construyendo Fluidez | NY English Teacher"
+  description="Narra eventos como un hablante nativo. Domina el pasado perfecto, el discurso indirecto y 'would' para hábitos pasados. Lección interactiva gratis para hispanohablantes B1-B2."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={5}
+    basePath="/es/curso/intermedio"
+    lang="es"
+    courseId="intermediate"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <MessageSquare class="w-4 h-4" />
+          Unidad 5
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Contando Historias
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Contar historias es donde la fluidez realmente se nota. Esta unidad te da las
+          tres herramientas que los nativos usan para narrar eventos:
+          <strong class="text-white">pasado perfecto</strong> para lo que pasó antes,
+          <strong class="text-white">discurso indirecto</strong> para lo que la gente dijo,
+          y <strong class="text-white">'would'</strong> para lo que solías hacer.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Clock class="w-3.5 h-3.5" /> Pasado Perfecto
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Layers class="w-3.5 h-3.5" /> Discurso Indirecto
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Volume2 class="w-3.5 h-3.5" /> 'Would' (Pasado Habitual)
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-a">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">A</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Línea de Tiempo Narrativa</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Toca cada momento de esta historia para revelarlo. Observa cómo el pasado simple,
+          el pasado perfecto y 'would' se conectan para construir una línea de tiempo clara.
+        </p>
+        <NarrativeTimeline client:visible stories={stories} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-b">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">B</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Práctica de Diálogo</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Una historia real contada entre amigos. Nota cada cambio de tiempo verbal.
+        </p>
+        <DialoguePractice client:visible dialogues={dialogues} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-c">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">C</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Constructor de Estructuras</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Pasado perfecto, discurso indirecto y 'would' para hábitos — construido bloque por bloque.
+        </p>
+        <SentenceBuilder client:visible blocks={structureBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-d">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">D</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Corrección de Errores</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Seis errores que aplanan las historias. Detéctalos, corrígelos.
+        </p>
+        <ErrorCorrection client:visible data={errorCorrections} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-e">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">E</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Laboratorio de Pronunciación</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Habla conectada en narrativas pasadas — las contracciones y enlaces que usan los nativos.
+        </p>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-f">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">F</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Auto-Evaluación</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Ponte a prueba con vocabulario de narración, frases de discurso indirecto y conectores narrativos.
+        </p>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/es/curso/intermedio/unidad-4/"
+          class="text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          &larr; Unidad 4
+        </a>
+        <Button href="/es/curso/intermedio/unidad-6/" variant="primary" size="md">
+          Unidad 6: Expresando Opiniones
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/intermedio/unidad-6.astro
+++ b/src/pages/es/curso/intermedio/unidad-6.astro
@@ -1,0 +1,190 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import OpinionStems from "@components/course/OpinionStems";
+import DialoguePractice from "@components/course/DialoguePractice";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import ErrorCorrection from "@components/course/ErrorCorrection";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import SelfTest from "@components/course/SelfTest";
+import { intermediateUnits } from "@data/intermediate/units";
+import {
+  opinionCategories,
+  dialogues,
+  structureBlocks,
+  errorCorrections,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/intermediate/unit-6";
+import { ArrowRight, Scale, Layers, Volume2, MessageSquareQuote } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/intermediate/unit-6" as const;
+
+const progressUnits = intermediateUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unidad 6: Expresando Opiniones | Construyendo Fluidez | NY English Teacher"
+  description="El lenguaje del debate, la persuasión y el desacuerdo profesional. Domina el tercer condicional y los modales suavizadores (might, may, could). Lección B1-B2 gratis para hispanohablantes."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={6}
+    basePath="/es/curso/intermedio"
+    lang="es"
+    courseId="intermediate"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Scale class="w-4 h-4" />
+          Unidad 6
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Expresando Opiniones
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          La habilidad más peligrosa en inglés es el desacuerdo. Mal hecho, daña relaciones
+          en segundos. Bien hecho, gana respeto. Esta unidad te enseña a compartir opiniones,
+          objetar y conceder puntos — todo sin ofender a nadie.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <MessageSquareQuote class="w-3.5 h-3.5" /> Frases de Opinión
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Layers class="w-3.5 h-3.5" /> Tercer Condicional
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Volume2 class="w-3.5 h-3.5" /> Modales Suavizadores
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-a">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">A</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Frases de Opinión</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Frases organizadas por propósito — afirmar, suavizar, estar de acuerdo, discrepar, conceder.
+          Toca cualquier frase para ver un ejemplo completo en contexto.
+        </p>
+        <OpinionStems client:visible categories={opinionCategories} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-b">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">B</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Práctica de Diálogo</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Un desacuerdo productivo en el trabajo — observa cómo la conversación pasa del desacuerdo al consenso.
+        </p>
+        <DialoguePractice client:visible dialogues={dialogues} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-c">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">C</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Constructor de Estructuras</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Tercer condicional más modales suavizadores — el kit diplomático para opiniones.
+        </p>
+        <SentenceBuilder client:visible blocks={structureBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-d">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">D</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Corrección de Errores</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Seis errores que hacen que las opiniones suenen incorrectas, directas o ambas.
+        </p>
+        <ErrorCorrection client:visible data={errorCorrections} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-e">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">E</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Laboratorio de Pronunciación</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Entonación de acuerdo y desacuerdo — la música del debate profesional.
+        </p>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-f">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">F</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Auto-Evaluación</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Ponte a prueba con frases de opinión, expresiones de acuerdo/desacuerdo y vocabulario de discusión.
+        </p>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/es/curso/intermedio/unidad-5/"
+          class="text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          &larr; Unidad 5
+        </a>
+        <Button href="/es/curso/intermedio/" variant="primary" size="md">
+          Resumen del Curso
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary
Two units, two brand-new Section A components — keeping the curriculum varied per Robert's "no cookie-cutter" feedback.

### Unit 5 — Telling Stories
- **NarrativeTimeline** component: vertical timeline of story events, reveal-on-tap, color-coded tense badges
- Grammar: past perfect + reported speech + 'would' habitual past
- 6 narrative tense error corrections
- Workplace story dialogue
- Pronunciation: connected speech (had been, I'd, she'd, would've, told you)

### Unit 6 — Expressing Opinions
- **OpinionStems** component: tabbed categories (state/soften/agree/disagree/concede), register-coded (neutral/soft/strong/academic), expandable examples
- Grammar: third conditional + softening modals (might, may, could)
- 6 opinion errors (including the classic "I am agree" trap)
- Productive-disagreement workplace dialogue
- Pronunciation: intonation patterns for agreement/disagreement

### Curriculum direction
- Phrasal verbs: zero in both units. Storytelling vocabulary and opinion frames take their place.
- Each unit has a distinct Section A — the course no longer feels templated.
- Modal thread continues: 'would' (Unit 5 habits), might/may/could (Unit 6 softening).

## Test plan
- [x] \`npm run build\` passes (230 sitemap URLs)
- [ ] Visit \`/en/course/intermediate/unit-5/\` — narrative timeline reveals work
- [ ] Visit \`/en/course/intermediate/unit-6/\` — opinion stems tabs and examples work
- [ ] Verify ES mirrors at \`/es/curso/intermedio/unidad-5/\` and \`/es/curso/intermedio/unidad-6/\`
- [ ] Confirm both units unlocked on landing pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)