### PR TITLE
feat: intermediate Units 7 + 8 with two new Section A components

### DIFF
--- a/src/components/course/SpecifierBuilder.tsx
+++ b/src/components/course/SpecifierBuilder.tsx
@@ -1,0 +1,201 @@
+import { useState } from "react";
+import { ArrowDown, RotateCcw, Target, Sparkles } from "lucide-react";
+import AudioButton from "./AudioButton";
+
+export interface SpecifierExample {
+  /** Vague version with too little information */
+  vague: string;
+  vagueEs: string;
+  /** Specific version using a relative clause */
+  specific: string;
+  specificEs: string;
+  /** The relative pronoun being used */
+  relativePronoun: "that" | "which" | "who" | "whose" | "where" | "when";
+  /** Highlight the relative clause portion (just the words to bold) */
+  clauseHighlight: string;
+  /** Why this relative pronoun is the right choice */
+  whyPronoun: string;
+  whyPronounEs: string;
+  /** A real-world situation where this matters */
+  situation: string;
+  situationEs: string;
+}
+
+interface Props {
+  examples: SpecifierExample[];
+  lang: "en" | "es";
+}
+
+const pronounColors: Record<SpecifierExample["relativePronoun"], string> = {
+  that: "bg-amber-100 text-amber-700 border-amber-200",
+  which: "bg-blue-100 text-blue-700 border-blue-200",
+  who: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  whose: "bg-violet-100 text-violet-700 border-violet-200",
+  where: "bg-rose-100 text-rose-700 border-rose-200",
+  when: "bg-teal-100 text-teal-700 border-teal-200",
+};
+
+// Helper to highlight the relative clause portion in a sentence
+function renderHighlighted(sentence: string, highlight: string): React.ReactNode {
+  if (!highlight || !sentence.includes(highlight)) {
+    return sentence;
+  }
+  const parts = sentence.split(highlight);
+  return (
+    <>
+      {parts[0]}
+      <span className="font-bold text-amber-700 bg-amber-100 px-1 rounded">
+        {highlight}
+      </span>
+      {parts[1]}
+    </>
+  );
+}
+
+export default function SpecifierBuilder({ examples, lang }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isRevealed, setIsRevealed] = useState(false);
+
+  const current = examples[currentIndex];
+  const isLast = currentIndex === examples.length - 1;
+
+  const handleReveal = () => setIsRevealed(true);
+
+  const handleNext = () => {
+    if (!isLast) {
+      setCurrentIndex(currentIndex + 1);
+      setIsRevealed(false);
+    }
+  };
+
+  const handleRestart = () => {
+    setCurrentIndex(0);
+    setIsRevealed(false);
+  };
+
+  return (
+    <section className="space-y-6">
+      {/* Progress */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-slate-500">
+          {lang === "es" ? "Ejemplo" : "Example"} {currentIndex + 1} / {examples.length}
+        </span>
+        <button
+          onClick={handleRestart}
+          className="text-xs text-slate-400 hover:text-amber-600 inline-flex items-center gap-1 transition-colors"
+        >
+          <RotateCcw size={12} />
+          {lang === "es" ? "Reiniciar" : "Restart"}
+        </button>
+      </div>
+
+      <div className="w-full h-1.5 bg-slate-100 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-amber-500 rounded-full transition-all duration-300"
+          style={{ width: `${((currentIndex + 1) / examples.length) * 100}%` }}
+        />
+      </div>
+
+      {/* Card */}
+      <div className="bg-white rounded-2xl border-2 border-slate-200 overflow-hidden">
+        {/* Situation */}
+        <div className="px-6 pt-6">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-2">
+            {lang === "es" ? "La situación:" : "The situation:"}
+          </p>
+          <p className="text-sm text-slate-600 leading-relaxed">
+            {lang === "es" ? current.situationEs : current.situation}
+          </p>
+        </div>
+
+        {/* Vague */}
+        <div className="px-6 pt-5">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-2">
+            {lang === "es" ? "Demasiado vago:" : "Too vague:"}
+          </p>
+          <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
+            <div className="flex items-start gap-2">
+              <Target className="w-4 h-4 text-slate-400 shrink-0 mt-1" />
+              <div className="flex-1">
+                <p className="text-base text-slate-700 italic">"{current.vague}"</p>
+                <p className="text-sm text-slate-400 mt-1">{current.vagueEs}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Arrow */}
+        <div className="flex justify-center py-3">
+          <ArrowDown className="w-5 h-5 text-slate-300" />
+        </div>
+
+        {/* Specific (hidden until reveal) */}
+        <div className="px-6 pb-6">
+          <p className="text-xs font-semibold uppercase tracking-wider text-amber-600 mb-2 flex items-center gap-1">
+            <Sparkles size={12} />
+            {lang === "es" ? "Específico (con cláusula relativa):" : "Specific (with relative clause):"}
+          </p>
+
+          {!isRevealed ? (
+            <button
+              onClick={handleReveal}
+              className="w-full py-4 rounded-xl border-2 border-dashed border-amber-300 text-amber-600 font-medium hover:bg-amber-50 transition-colors"
+            >
+              {lang === "es"
+                ? "Toca para revelar la versión específica"
+                : "Tap to reveal the specific version"}
+            </button>
+          ) : (
+            <div className="space-y-3">
+              <div className="bg-gradient-to-br from-amber-50 to-amber-100 border-2 border-amber-300 rounded-xl p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex-1">
+                    <p className="text-base text-slate-900 leading-relaxed">
+                      "{renderHighlighted(current.specific, current.clauseHighlight)}"
+                    </p>
+                    <p className="text-sm text-slate-500 mt-2">{current.specificEs}</p>
+                  </div>
+                  <div className="shrink-0 mt-1">
+                    <AudioButton text={current.specific} size="sm" />
+                  </div>
+                </div>
+                <div className="mt-3 pt-3 border-t border-amber-200 flex items-start gap-2">
+                  <span
+                    className={`text-xs font-mono px-2 py-0.5 rounded-full border shrink-0 ${pronounColors[current.relativePronoun]}`}
+                  >
+                    {current.relativePronoun}
+                  </span>
+                  <p className="text-xs text-slate-600 leading-relaxed">
+                    {lang === "es" ? current.whyPronounEs : current.whyPronoun}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Next button */}
+      {isRevealed && !isLast && (
+        <div className="flex justify-end">
+          <button
+            onClick={handleNext}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-500 text-white font-medium hover:bg-amber-400 transition-colors shadow-sm"
+          >
+            {lang === "es" ? "Siguiente" : "Next"}
+          </button>
+        </div>
+      )}
+
+      {isRevealed && isLast && (
+        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 text-center">
+          <p className="text-emerald-800 font-medium text-sm">
+            {lang === "es"
+              ? "¡Bien hecho! Ya sabes cómo usar cláusulas relativas para ser específico."
+              : "Well done! You now know how to use relative clauses to be specific."}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/course/SurvivalPhrases.tsx
+++ b/src/components/course/SurvivalPhrases.tsx
@@ -1,0 +1,208 @@
+import { useState } from "react";
+import { AlertTriangle, Eye, RotateCcw, Stethoscope, Phone, Pill, Hospital } from "lucide-react";
+import AudioButton from "./AudioButton";
+
+export interface SurvivalPhrase {
+  /** The situation the learner is in (in their language) */
+  situation: string;
+  situationEs: string;
+  /** The exact phrase to say in English */
+  english: string;
+  /** Spanish version of the phrase */
+  spanish: string;
+  /** Why this exact wording matters */
+  whyExact: string;
+  whyExactEs: string;
+  /** Urgency level */
+  urgency: "low" | "medium" | "high";
+}
+
+export interface SurvivalCategory {
+  label: string;
+  labelEs: string;
+  description: string;
+  descriptionEs: string;
+  icon: "stethoscope" | "phone" | "pill" | "hospital";
+  phrases: SurvivalPhrase[];
+}
+
+interface Props {
+  categories: SurvivalCategory[];
+  lang: "en" | "es";
+}
+
+const iconMap = {
+  stethoscope: Stethoscope,
+  phone: Phone,
+  pill: Pill,
+  hospital: Hospital,
+};
+
+const urgencyStyles: Record<SurvivalPhrase["urgency"], string> = {
+  low: "bg-blue-100 text-blue-700 border-blue-200",
+  medium: "bg-amber-100 text-amber-700 border-amber-200",
+  high: "bg-rose-100 text-rose-700 border-rose-200",
+};
+
+const urgencyLabels: Record<SurvivalPhrase["urgency"], { en: string; es: string }> = {
+  low: { en: "routine", es: "rutina" },
+  medium: { en: "important", es: "importante" },
+  high: { en: "urgent", es: "urgente" },
+};
+
+export default function SurvivalPhrases({ categories, lang }: Props) {
+  const [activeCategory, setActiveCategory] = useState(0);
+  const [revealed, setRevealed] = useState<Set<string>>(new Set());
+
+  const current = categories[activeCategory];
+  const Icon = iconMap[current.icon];
+
+  const toggle = (key: string) => {
+    const next = new Set(revealed);
+    if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    setRevealed(next);
+  };
+
+  const revealAll = () => {
+    const all = new Set<string>();
+    current.phrases.forEach((_, i) => all.add(`${activeCategory}-${i}`));
+    setRevealed(all);
+  };
+
+  const reset = () => setRevealed(new Set());
+
+  const switchCategory = (idx: number) => {
+    setActiveCategory(idx);
+    setRevealed(new Set());
+  };
+
+  return (
+    <section className="space-y-6">
+      {/* Category tabs */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+        {categories.map((cat, i) => {
+          const CatIcon = iconMap[cat.icon];
+          const isActive = i === activeCategory;
+          return (
+            <button
+              key={i}
+              onClick={() => switchCategory(i)}
+              className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-all ${
+                isActive
+                  ? "bg-rose-500 text-white shadow-sm"
+                  : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+              }`}
+            >
+              <CatIcon size={16} />
+              <span className="truncate">
+                {lang === "es" ? cat.labelEs : cat.label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Category description */}
+      <div className="bg-rose-50 border border-rose-200 rounded-xl p-4 flex items-start gap-3">
+        <Icon className="w-5 h-5 text-rose-500 shrink-0 mt-0.5" />
+        <div>
+          <h3 className="font-bold text-slate-900 text-sm">
+            {lang === "es" ? current.labelEs : current.label}
+          </h3>
+          <p className="text-sm text-slate-600 leading-relaxed mt-1">
+            {lang === "es" ? current.descriptionEs : current.description}
+          </p>
+        </div>
+      </div>
+
+      {/* Controls */}
+      <div className="flex items-center justify-between">
+        <button
+          onClick={revealAll}
+          className="text-xs text-slate-500 hover:text-rose-600 inline-flex items-center gap-1 transition-colors font-medium"
+        >
+          <Eye size={12} />
+          {lang === "es" ? "Mostrar todo" : "Reveal all"}
+        </button>
+        <button
+          onClick={reset}
+          className="text-xs text-slate-400 hover:text-rose-600 inline-flex items-center gap-1 transition-colors"
+        >
+          <RotateCcw size={12} />
+          {lang === "es" ? "Reiniciar" : "Reset"}
+        </button>
+      </div>
+
+      {/* Phrases */}
+      <div className="space-y-3">
+        {current.phrases.map((phrase, i) => {
+          const key = `${activeCategory}-${i}`;
+          const isRevealed = revealed.has(key);
+          return (
+            <div
+              key={key}
+              className="bg-white border-2 border-slate-200 rounded-xl overflow-hidden"
+            >
+              {/* Situation */}
+              <div className="p-4 bg-slate-50 border-b border-slate-200">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex-1">
+                    <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-1">
+                      {lang === "es" ? "La situación:" : "The situation:"}
+                    </p>
+                    <p className="text-sm text-slate-700 leading-relaxed">
+                      {lang === "es" ? phrase.situationEs : phrase.situation}
+                    </p>
+                  </div>
+                  <span
+                    className={`text-xs font-mono px-2 py-0.5 rounded-full border shrink-0 ${urgencyStyles[phrase.urgency]}`}
+                  >
+                    {urgencyLabels[phrase.urgency][lang]}
+                  </span>
+                </div>
+              </div>
+
+              {/* Phrase reveal */}
+              <div className="p-4">
+                {!isRevealed ? (
+                  <button
+                    onClick={() => toggle(key)}
+                    className="w-full py-3 rounded-lg border-2 border-dashed border-rose-200 text-rose-600 font-medium hover:bg-rose-50 transition-colors text-sm"
+                  >
+                    {lang === "es"
+                      ? "Toca para ver qué decir en inglés"
+                      : "Tap to see what to say in English"}
+                  </button>
+                ) : (
+                  <div className="space-y-3">
+                    <div className="bg-gradient-to-br from-rose-50 to-rose-100 border-2 border-rose-300 rounded-xl p-4">
+                      <div className="flex items-start justify-between gap-3">
+                        <p className="text-base font-bold text-slate-900 flex-1 leading-relaxed">
+                          "{phrase.english}"
+                        </p>
+                        <div className="shrink-0">
+                          <AudioButton text={phrase.english} size="sm" />
+                        </div>
+                      </div>
+                      <p className="text-sm text-slate-500 mt-2">{phrase.spanish}</p>
+                    </div>
+                    <div className="flex items-start gap-2 px-1">
+                      <AlertTriangle className="w-3.5 h-3.5 text-amber-500 shrink-0 mt-0.5" />
+                      <p className="text-xs text-slate-500 leading-relaxed">
+                        {lang === "es" ? phrase.whyExactEs : phrase.whyExact}
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/data/intermediate/unit-7.ts
+++ b/src/data/intermediate/unit-7.ts
@@ -1,0 +1,608 @@
+// Unit 7: "Health and Emergencies" — Full course content
+// Theme: Doctor visits, symptoms, emergencies, pharmacy
+// Grammar: Passive voice + advice modals (should, ought to, had better)
+// Pronunciation: Schwa in passive constructions
+// Section A: SurvivalPhrases (high-stakes English the user might need verbatim)
+
+import type {
+  Dialogue,
+  ErrorCorrectionSet,
+  IntermediateVocabItem,
+} from "./types";
+import type { SurvivalCategory } from "../../components/course/SurvivalPhrases";
+import type { SentenceBlock, PronunciationDrill } from "../course/unit-1";
+
+// ─── Section A: Survival Phrases ─────────────────────────────────────────────
+
+export const survivalCategories: SurvivalCategory[] = [
+  {
+    label: "At the Doctor",
+    labelEs: "Con el Doctor",
+    icon: "stethoscope",
+    description:
+      "Phrases for describing symptoms and asking questions during a doctor's appointment. These are the exact words doctors expect to hear.",
+    descriptionEs:
+      "Frases para describir síntomas y hacer preguntas durante una cita médica. Estas son las palabras exactas que los doctores esperan escuchar.",
+    phrases: [
+      {
+        situation: "You've had a sore throat for 3 days and want to describe it.",
+        situationEs: "Has tenido dolor de garganta por 3 días y quieres describirlo.",
+        english: "I've had a sore throat for three days, and it's been getting worse.",
+        spanish: "He tenido dolor de garganta por tres días, y ha estado empeorando.",
+        whyExact:
+          "'I've had... for' uses present perfect — the tense doctors expect for ongoing symptoms. 'Getting worse' is the standard way to describe progression.",
+        whyExactEs:
+          "'I've had... for' usa el presente perfecto — el tiempo que los doctores esperan para síntomas continuos. 'Getting worse' es la forma estándar de describir la progresión.",
+        urgency: "low",
+      },
+      {
+        situation: "You need to ask about how to take a medication.",
+        situationEs: "Necesitas preguntar cómo tomar un medicamento.",
+        english: "How often should I take this, and should it be taken with food?",
+        spanish: "¿Con qué frecuencia debería tomar esto, y debería tomarse con comida?",
+        whyExact:
+          "'Should I take' is the standard advice modal in medical contexts. 'Should it be taken' uses passive voice — the natural way to ask about a medication's instructions.",
+        whyExactEs:
+          "'Should I take' es el modal de consejo estándar en contextos médicos. 'Should it be taken' usa la voz pasiva — la forma natural de preguntar sobre las instrucciones de un medicamento.",
+        urgency: "low",
+      },
+      {
+        situation: "You're allergic to penicillin and need to make sure the doctor knows.",
+        situationEs: "Eres alérgico a la penicilina y necesitas asegurarte de que el doctor lo sepa.",
+        english: "I'm allergic to penicillin. I just want to make sure that's noted in my file.",
+        spanish: "Soy alérgico a la penicilina. Solo quiero asegurarme de que esté anotado en mi expediente.",
+        whyExact:
+          "'I just want to make sure' is the polite, non-confrontational way to insist on something. 'That's noted' is medical-office English for 'recorded'.",
+        whyExactEs:
+          "'I just want to make sure' es la forma cortés y no confrontacional de insistir en algo. 'That's noted' es el inglés de consultorio médico para 'anotado'.",
+        urgency: "high",
+      },
+      {
+        situation: "You don't understand what the doctor just said.",
+        situationEs: "No entiendes lo que el doctor acaba de decir.",
+        english: "Could you explain that in simpler terms? I want to make sure I understand.",
+        spanish: "¿Podría explicar eso en términos más simples? Quiero asegurarme de entender.",
+        whyExact:
+          "'Could you' is the polite request form. Saying 'I want to make sure I understand' is much better than 'I don't understand' — it shifts the focus from your limitation to your effort to follow.",
+        whyExactEs:
+          "'Could you' es la forma cortés de pedir. Decir 'I want to make sure I understand' es mucho mejor que 'I don't understand' — cambia el enfoque de tu limitación a tu esfuerzo por seguir la conversación.",
+        urgency: "medium",
+      },
+    ],
+  },
+  {
+    label: "Emergency Call",
+    labelEs: "Llamada de Emergencia",
+    icon: "phone",
+    description:
+      "If you ever need to call 911 in the U.S., these are the exact phrases that get help fastest. The dispatcher will ask in this order.",
+    descriptionEs:
+      "Si alguna vez necesitas llamar al 911 en EE.UU., estas son las frases exactas que consiguen ayuda más rápido. El operador preguntará en este orden.",
+    phrases: [
+      {
+        situation: "The 911 operator answers. You need to state the emergency type immediately.",
+        situationEs: "El operador del 911 contesta. Necesitas decir el tipo de emergencia inmediatamente.",
+        english: "I need an ambulance. There's a medical emergency.",
+        spanish: "Necesito una ambulancia. Hay una emergencia médica.",
+        whyExact:
+          "Lead with WHAT you need, not WHY. 'I need an ambulance' is faster than explaining symptoms first. The operator will ask follow-up questions.",
+        whyExactEs:
+          "Empieza con LO QUE necesitas, no con POR QUÉ. 'I need an ambulance' es más rápido que explicar síntomas primero. El operador hará preguntas de seguimiento.",
+        urgency: "high",
+      },
+      {
+        situation: "The operator asks for the address.",
+        situationEs: "El operador pide la dirección.",
+        english: "The address is 142 Main Street, apartment 3B. The cross street is Oak Avenue.",
+        spanish: "La dirección es 142 Main Street, apartamento 3B. La calle perpendicular es Oak Avenue.",
+        whyExact:
+          "Always include the cross street if you can — it helps emergency services find you faster, especially in cities with long streets. 'Apartment' or 'unit' tells them which door.",
+        whyExactEs:
+          "Siempre incluye la calle perpendicular si puedes — ayuda a los servicios de emergencia a encontrarte más rápido, especialmente en ciudades con calles largas. 'Apartment' o 'unit' les dice qué puerta.",
+        urgency: "high",
+      },
+      {
+        situation: "The operator asks what's wrong with the person.",
+        situationEs: "El operador pregunta qué le pasa a la persona.",
+        english: "She's conscious but having trouble breathing. She's about 60 years old.",
+        spanish: "Está consciente pero tiene dificultad para respirar. Tiene unos 60 años.",
+        whyExact:
+          "'Conscious' / 'unconscious' and 'breathing' / 'not breathing' are the two pieces of information that determine how help is dispatched. State them first.",
+        whyExactEs:
+          "'Consciente' / 'inconsciente' y 'respirando' / 'no respirando' son los dos datos que determinan cómo se despacha la ayuda. Decláralos primero.",
+        urgency: "high",
+      },
+      {
+        situation: "The operator tells you to stay on the line.",
+        situationEs: "El operador te dice que te quedes en la línea.",
+        english: "Yes, I'll stay on the line. What should I do until help arrives?",
+        spanish: "Sí, me quedaré en la línea. ¿Qué debería hacer hasta que llegue la ayuda?",
+        whyExact:
+          "Asking 'what should I do' invites the dispatcher to give you instructions. They're trained to walk you through CPR, bleeding control, and other interventions.",
+        whyExactEs:
+          "Preguntar 'what should I do' invita al operador a darte instrucciones. Están entrenados para guiarte a través de CPR, control de sangrado y otras intervenciones.",
+        urgency: "high",
+      },
+    ],
+  },
+  {
+    label: "At the Pharmacy",
+    labelEs: "En la Farmacia",
+    icon: "pill",
+    description:
+      "Filling prescriptions and asking for over-the-counter medication. Pharmacists are a great resource if you know how to ask.",
+    descriptionEs:
+      "Surtir recetas y pedir medicamentos sin receta. Los farmacéuticos son un gran recurso si sabes cómo preguntar.",
+    phrases: [
+      {
+        situation: "You're picking up a prescription that should be ready.",
+        situationEs: "Vas a recoger una receta que debería estar lista.",
+        english: "I'm here to pick up a prescription. The name is Garcia, G-A-R-C-I-A.",
+        spanish: "Vengo a recoger una receta. El nombre es Garcia, G-A-R-C-I-A.",
+        whyExact:
+          "Always spell your last name. Pharmacists deal with hundreds of names daily — spelling avoids mix-ups, especially with names that aren't common in English.",
+        whyExactEs:
+          "Siempre deletrea tu apellido. Los farmacéuticos manejan cientos de nombres diariamente — deletrear evita confusiones, especialmente con nombres no comunes en inglés.",
+        urgency: "low",
+      },
+      {
+        situation: "You have a cold and want to ask the pharmacist for a recommendation.",
+        situationEs: "Tienes un resfriado y quieres pedirle al farmacéutico una recomendación.",
+        english: "I've come down with a cold. What would you recommend for congestion?",
+        spanish: "Me ha dado un resfriado. ¿Qué me recomendaría para la congestión?",
+        whyExact:
+          "'Come down with' is the standard verb for catching a minor illness — much more natural than 'I have a cold'. 'What would you recommend' invites their expertise without demanding it.",
+        whyExactEs:
+          "'Come down with' es el verbo estándar para enfermarse de algo menor — mucho más natural que 'I have a cold'. 'What would you recommend' invita a su experticia sin exigirla.",
+        urgency: "low",
+      },
+      {
+        situation: "You want to know if a medication has side effects.",
+        situationEs: "Quieres saber si un medicamento tiene efectos secundarios.",
+        english: "Are there any side effects I should be aware of?",
+        spanish: "¿Hay efectos secundarios de los que deba estar consciente?",
+        whyExact:
+          "'Side effects' is the universal medical term — never 'secondary effects' (literal Spanish translation). 'I should be aware of' is a polite way to ask without sounding worried.",
+        whyExactEs:
+          "'Side effects' es el término médico universal — nunca 'secondary effects' (traducción literal del español). 'I should be aware of' es una forma cortés de preguntar sin sonar preocupado.",
+        urgency: "medium",
+      },
+    ],
+  },
+  {
+    label: "At the Hospital",
+    labelEs: "En el Hospital",
+    icon: "hospital",
+    description:
+      "Emergency room and hospital admission English — the high-stress moments where every word matters.",
+    descriptionEs:
+      "Inglés de sala de emergencias y admisión hospitalaria — los momentos de alto estrés donde cada palabra importa.",
+    phrases: [
+      {
+        situation: "You arrive at the ER with chest pain.",
+        situationEs: "Llegas a la sala de emergencias con dolor de pecho.",
+        english: "I'm having chest pain that started about an hour ago. I've never felt this before.",
+        spanish: "Tengo dolor de pecho que empezó hace aproximadamente una hora. Nunca había sentido esto antes.",
+        whyExact:
+          "'Chest pain' is the magic phrase in any U.S. ER — it triggers immediate triage. Always include WHEN it started and whether it's NEW (never felt before) or familiar.",
+        whyExactEs:
+          "'Chest pain' es la frase mágica en cualquier sala de emergencias en EE.UU. — activa una clasificación inmediata. Siempre incluye CUÁNDO empezó y si es NUEVO (nunca sentido antes) o familiar.",
+        urgency: "high",
+      },
+      {
+        situation: "You need to give your medical history quickly.",
+        situationEs: "Necesitas dar tu historial médico rápidamente.",
+        english: "I have high blood pressure. I'm taking lisinopril. I have no other conditions.",
+        spanish: "Tengo presión arterial alta. Estoy tomando lisinopril. No tengo otras condiciones.",
+        whyExact:
+          "Three short sentences in this exact order: condition, medication, anything else. Doctors trained on this format process the information instantly.",
+        whyExactEs:
+          "Tres oraciones cortas en este orden exacto: condición, medicamento, cualquier cosa más. Los doctores entrenados en este formato procesan la información instantáneamente.",
+        urgency: "high",
+      },
+      {
+        situation: "You're being asked to sign forms but don't fully understand them.",
+        situationEs: "Te piden que firmes formularios pero no los entiendes completamente.",
+        english: "Before I sign, could someone explain what I'm agreeing to? I want to be sure.",
+        spanish: "Antes de firmar, ¿podría alguien explicar a qué estoy accediendo? Quiero estar seguro.",
+        whyExact:
+          "It is your legal right to understand any document before signing it. 'Before I sign' is firm but polite. Hospital staff are required to explain consent forms.",
+        whyExactEs:
+          "Es tu derecho legal entender cualquier documento antes de firmarlo. 'Before I sign' es firme pero cortés. El personal del hospital está obligado a explicar formularios de consentimiento.",
+        urgency: "medium",
+      },
+    ],
+  },
+];
+
+// ─── Section B: Dialogue Practice ────────────────────────────────────────────
+
+export const dialogues: Dialogue[] = [
+  {
+    title: "A Visit to the Doctor",
+    titleEs: "Una Visita al Doctor",
+    setting: "A patient visits her doctor about persistent back pain",
+    settingEs: "Una paciente visita a su doctora por dolor de espalda persistente",
+    lines: [
+      {
+        speaker: "A",
+        speakerLabel: "Dr. Wilson",
+        speakerLabelEs: "Dra. Wilson",
+        english: "Good morning. So tell me, what brings you in today?",
+        spanish: "Buenos días. Dígame, ¿qué la trae por aquí hoy?",
+        highlight: "what brings you in",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Carmen",
+        speakerLabelEs: "Carmen",
+        english:
+          "I've had lower back pain for about two weeks now. It's been getting worse, especially in the morning.",
+        spanish:
+          "He tenido dolor de espalda baja por aproximadamente dos semanas. Ha estado empeorando, especialmente en la mañana.",
+        highlight: "I've had... for about / been getting worse",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Dr. Wilson",
+        speakerLabelEs: "Dra. Wilson",
+        english: "I see. Have you been doing any heavy lifting recently?",
+        spanish: "Ya veo. ¿Ha estado cargando cosas pesadas recientemente?",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Carmen",
+        speakerLabelEs: "Carmen",
+        english:
+          "Not really. But I should mention that my office chair was replaced last month, and it's not very comfortable.",
+        spanish:
+          "No realmente. Pero debo mencionar que mi silla de oficina fue reemplazada el mes pasado, y no es muy cómoda.",
+        highlight: "I should mention / was replaced",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Dr. Wilson",
+        speakerLabelEs: "Dra. Wilson",
+        english:
+          "That could definitely be the cause. I'd like to examine your back, and then I think you should consider seeing a physical therapist.",
+        spanish:
+          "Eso podría ser definitivamente la causa. Me gustaría examinar su espalda, y luego creo que debería considerar ver a un fisioterapeuta.",
+        highlight: "you should consider",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Carmen",
+        speakerLabelEs: "Carmen",
+        english:
+          "Of course. Could you explain what a physical therapist does? I want to make sure I understand the recommendation.",
+        spanish:
+          "Por supuesto. ¿Podría explicar lo que hace un fisioterapeuta? Quiero asegurarme de entender la recomendación.",
+        highlight: "Could you explain / I want to make sure",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Dr. Wilson",
+        speakerLabelEs: "Dra. Wilson",
+        english:
+          "Of course. They'll teach you exercises that strengthen your back muscles. You ought to see results within a few weeks.",
+        spanish:
+          "Por supuesto. Le enseñarán ejercicios que fortalecen los músculos de la espalda. Debería ver resultados en unas pocas semanas.",
+        highlight: "You ought to see",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Carmen",
+        speakerLabelEs: "Carmen",
+        english:
+          "That sounds like a good plan. Should I take anything for the pain in the meantime?",
+        spanish:
+          "Eso suena como un buen plan. ¿Debería tomar algo para el dolor mientras tanto?",
+        highlight: "Should I take",
+      },
+    ],
+    keyPhrases: [
+      {
+        english: "What brings you in today?",
+        spanish: "¿Qué lo/la trae por aquí hoy?",
+        note: "The standard opening question from any U.S. doctor. Be ready for it.",
+        noteEs: "La pregunta estándar de apertura de cualquier doctor en EE.UU. Prepárate para ella.",
+      },
+      {
+        english: "I've had X for...",
+        spanish: "He tenido X por...",
+        note: "Present perfect — the correct tense for describing how long you've had a symptom.",
+        noteEs: "Presente perfecto — el tiempo correcto para describir cuánto tiempo has tenido un síntoma.",
+      },
+      {
+        english: "I should mention...",
+        spanish: "Debo mencionar...",
+        note: "The polite way to add a relevant detail you almost forgot. Doctors love this phrase.",
+        noteEs: "La forma cortés de agregar un detalle relevante que casi olvidaste. Los doctores aman esta frase.",
+      },
+    ],
+  },
+];
+
+// ─── Section C: Structure Builder ────────────────────────────────────────────
+
+export const structureBlocks: SentenceBlock[] = [
+  {
+    label: "Passive voice: form and use",
+    labelEs: "Voz pasiva: forma y uso",
+    description:
+      "Structure: be + past participle. Use it when the ACTION matters more than WHO did it. Common in medical, scientific, and formal English.",
+    descriptionEs:
+      "Estructura: be + participio pasado. Úsalo cuando la ACCIÓN importa más que QUIÉN la hizo. Común en inglés médico, científico y formal.",
+    sentences: [
+      {
+        english: "The patient was examined by the doctor.",
+        spanish: "El paciente fue examinado por la doctora.",
+        highlight: "was examined",
+      },
+      {
+        english: "Your prescription will be ready in 20 minutes.",
+        spanish: "Su receta estará lista en 20 minutos.",
+        highlight: "will be ready",
+      },
+      {
+        english: "Side effects have been reported, but they're rare.",
+        spanish: "Se han reportado efectos secundarios, pero son raros.",
+        highlight: "have been reported",
+      },
+      {
+        english: "These results need to be reviewed by a specialist.",
+        spanish: "Estos resultados necesitan ser revisados por un especialista.",
+        highlight: "need to be reviewed",
+      },
+    ],
+  },
+  {
+    label: "Should: medical advice",
+    labelEs: "Should: consejo médico",
+    description:
+      "'Should' is the most common modal in medical English — used by both doctors giving advice and patients asking what to do.",
+    descriptionEs:
+      "'Should' es el modal más común en inglés médico — usado tanto por doctores dando consejos como por pacientes preguntando qué hacer.",
+    sentences: [
+      {
+        english: "You should take this medication twice a day.",
+        spanish: "Debería tomar este medicamento dos veces al día.",
+        highlight: "should take",
+      },
+      {
+        english: "Should I be worried about these symptoms?",
+        spanish: "¿Debería preocuparme por estos síntomas?",
+        highlight: "Should I be worried",
+      },
+      {
+        english: "You shouldn't drink alcohol while taking this.",
+        spanish: "No debería tomar alcohol mientras toma esto.",
+        highlight: "shouldn't drink",
+      },
+      {
+        english: "When should I come back for a follow-up?",
+        spanish: "¿Cuándo debería regresar para un seguimiento?",
+        highlight: "should I come back",
+      },
+    ],
+  },
+  {
+    label: "Ought to and had better",
+    labelEs: "Ought to y had better",
+    description:
+      "'Ought to' is a more formal version of 'should'. 'Had better' is stronger — it implies a warning about consequences if you don't follow the advice.",
+    descriptionEs:
+      "'Ought to' es una versión más formal de 'should'. 'Had better' es más fuerte — implica una advertencia sobre las consecuencias si no sigues el consejo.",
+    sentences: [
+      {
+        english: "You ought to see a specialist about that.",
+        spanish: "Debería ver a un especialista sobre eso.",
+        highlight: "ought to see",
+      },
+      {
+        english: "She ought to rest for at least a week.",
+        spanish: "Debería descansar por al menos una semana.",
+        highlight: "ought to rest",
+      },
+      {
+        english: "You'd better get that checked out — it doesn't look good.",
+        spanish: "Más vale que se haga revisar eso — no se ve bien.",
+        highlight: "You'd better get",
+      },
+      {
+        english: "We had better leave for the hospital now.",
+        spanish: "Más vale que salgamos al hospital ahora.",
+        highlight: "had better leave",
+      },
+    ],
+  },
+  {
+    label: "Combining passive voice with advice modals",
+    labelEs: "Combinando voz pasiva con modales de consejo",
+    description:
+      "This combination is the bedrock of medical English. 'Should be taken', 'must be checked', 'ought to be reviewed' — these are everywhere in pharmacy labels and doctor instructions.",
+    descriptionEs:
+      "Esta combinación es la base del inglés médico. 'Should be taken', 'must be checked', 'ought to be reviewed' — están en todas partes en etiquetas de farmacia e instrucciones médicas.",
+    sentences: [
+      {
+        english: "This medication should be taken with food.",
+        spanish: "Este medicamento debería tomarse con comida.",
+        highlight: "should be taken",
+      },
+      {
+        english: "Your blood pressure should be checked monthly.",
+        spanish: "Su presión arterial debería revisarse mensualmente.",
+        highlight: "should be checked",
+      },
+      {
+        english: "These symptoms ought to be evaluated by a professional.",
+        spanish: "Estos síntomas deberían ser evaluados por un profesional.",
+        highlight: "ought to be evaluated",
+      },
+      {
+        english: "The dosage must not be exceeded.",
+        spanish: "La dosis no debe excederse.",
+        highlight: "must not be exceeded",
+      },
+    ],
+  },
+];
+
+// ─── Section D: Error Correction ─────────────────────────────────────────────
+
+export const errorCorrections: ErrorCorrectionSet = {
+  title: "Common Mistakes in Medical English",
+  titleEs: "Errores Comunes en Inglés Médico",
+  description:
+    "These errors can confuse doctors, slow down treatment, or accidentally minimize serious symptoms. Get them right — your health may depend on it.",
+  descriptionEs:
+    "Estos errores pueden confundir a los doctores, retrasar el tratamiento o minimizar accidentalmente síntomas serios. Hazlos bien — tu salud puede depender de ello.",
+  items: [
+    {
+      incorrect: "I have pain in my chest since this morning.",
+      correct: "I've had chest pain since this morning.",
+      incorrectHighlight: "I have pain in my chest since",
+      correctHighlight: "I've had chest pain since",
+      explanation:
+        "Two upgrades. First: with 'since' (a starting point), use present perfect, not present simple. Second: 'chest pain' is the standard medical term — much more direct than 'pain in my chest'. Triage staff process 'chest pain' as a high-priority phrase.",
+      explanationEs:
+        "Dos mejoras. Primero: con 'since' (un punto de inicio), usa el presente perfecto, no el presente simple. Segundo: 'chest pain' es el término médico estándar — mucho más directo que 'pain in my chest'. El personal de triaje procesa 'chest pain' como una frase de alta prioridad.",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "The doctor said me to take this twice a day.",
+      correct: "The doctor told me to take this twice a day.",
+      incorrectHighlight: "said me to take",
+      correctHighlight: "told me to take",
+      explanation:
+        "Same rule from Unit 5: 'tell' takes a direct object (told ME), 'say' does not. Also, after 'tell' use the infinitive 'to take' — never 'that I should take' in this construction.",
+      explanationEs:
+        "Misma regla de la Unidad 5: 'tell' toma un objeto directo (told ME), 'say' no. Además, después de 'tell' usa el infinitivo 'to take' — nunca 'that I should take' en esta construcción.",
+      errorType: "literal-translation",
+    },
+    {
+      incorrect: "I am sick from two days.",
+      correct: "I've been sick for two days.",
+      incorrectHighlight: "am sick from two days",
+      correctHighlight: "have been sick for two days",
+      explanation:
+        "Three errors at once. 'I am sick' should be present perfect ('I've been sick'). 'From' should be 'for' (duration). And the natural medical phrasing uses 'I've been' (continuous condition), not 'I am' (current state). All three matter.",
+      explanationEs:
+        "Tres errores a la vez. 'I am sick' debería ser presente perfecto ('I've been sick'). 'From' debería ser 'for' (duración). Y la frase médica natural usa 'I've been' (condición continua), no 'I am' (estado actual). Los tres importan.",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "This medicine should take with water.",
+      correct: "This medicine should be taken with water.",
+      incorrectHighlight: "should take with",
+      correctHighlight: "should be taken with",
+      explanation:
+        "Passive voice problem. The medicine doesn't take itself — it IS taken by someone. The correct passive form is 'should BE TAKEN'. This is one of the most common errors on pharmacy instruction labels read by Spanish speakers.",
+      explanationEs:
+        "Problema de voz pasiva. El medicamento no se toma a sí mismo — alguien LO toma. La forma pasiva correcta es 'should BE TAKEN'. Este es uno de los errores más comunes al leer etiquetas de farmacia.",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "I am embarrassed because my stomach is hurting.",
+      correct: "I'm uncomfortable because my stomach is hurting.",
+      incorrectHighlight: "embarrassed",
+      correctHighlight: "uncomfortable",
+      explanation:
+        "False cognate alert. 'Embarrassed' does NOT mean 'embarazada' (pregnant in Spanish). It means 'feeling shame'. If you say 'I'm embarrassed' to a doctor about a health issue, they'll think you're ashamed, not in physical discomfort. For pregnancy, say 'I'm pregnant'.",
+      explanationEs:
+        "Alerta de falso cognado. 'Embarrassed' NO significa 'embarazada'. Significa 'sentir vergüenza'. Si le dices 'I'm embarrassed' a un doctor sobre un problema de salud, pensará que estás avergonzado, no incómodo físicamente. Para embarazo, di 'I'm pregnant'.",
+      errorType: "literal-translation",
+    },
+    {
+      incorrect: "Are there any secondary effects of this medicine?",
+      correct: "Are there any side effects of this medicine?",
+      incorrectHighlight: "secondary effects",
+      correctHighlight: "side effects",
+      explanation:
+        "'Secondary effects' is a literal translation of 'efectos secundarios' but it's not standard medical English. The correct term is 'side effects'. Pharmacists and doctors will understand 'secondary effects' but it sounds non-native immediately.",
+      explanationEs:
+        "'Secondary effects' es una traducción literal de 'efectos secundarios' pero no es inglés médico estándar. El término correcto es 'side effects'. Los farmacéuticos y doctores entenderán 'secondary effects' pero suena no-nativo inmediatamente.",
+      errorType: "literal-translation",
+    },
+  ],
+};
+
+// ─── Section E: Pronunciation Lab ────────────────────────────────────────────
+
+export const pronunciationDrills: PronunciationDrill[] = [
+  {
+    word: "be taken",
+    spanishStress: "BE TAKEN",
+    englishStress: "bi TAY-kən",
+    tip: "In passive voice, 'be taken' flows together. The 'be' is short /bi/ and 'taken' has a schwa in the second syllable: TAY-kən, not TAY-ken. 'Should be taken' = 'shʊd-bi-TAY-kən'.",
+    tipEs:
+      "En la voz pasiva, 'be taken' fluye junto. El 'be' es corto /bi/ y 'taken' tiene una schwa en la segunda sílaba: TAY-kən, no TAY-ken. 'Should be taken' = 'shʊd-bi-TAY-kən'.",
+  },
+  {
+    word: "patient",
+    spanishStress: "PA-CIENT-E",
+    englishStress: "PAY-shənt",
+    tip: "'Patient' has just two syllables in English: PAY-shənt. The 'tient' becomes 'shənt' — never the four syllables Spanish speakers tend to give it. The 'a' is a long /ei/ sound.",
+    tipEs:
+      "'Patient' tiene solo dos sílabas en inglés: PAY-shənt. El 'tient' se vuelve 'shənt' — nunca las cuatro sílabas que tienden a darle los hispanohablantes. La 'a' es un sonido largo /ei/.",
+  },
+  {
+    word: "medicine",
+    spanishStress: "ME-DI-CI-NE",
+    englishStress: "MED-sən",
+    tip: "'Medicine' is two syllables in fast American English: MED-sən. The middle 'i' almost disappears. Don't say MED-i-cin (3 syllables) — that sounds non-native.",
+    tipEs:
+      "'Medicine' es dos sílabas en inglés americano rápido: MED-sən. La 'i' del medio casi desaparece. No digas MED-i-cin (3 sílabas) — eso suena no-nativo.",
+  },
+  {
+    word: "comfortable",
+    spanishStress: "COM-FOR-TA-BLE",
+    englishStress: "KUMF-tər-bəl",
+    tip: "Three syllables, not four: KUMF-tər-bəl. The 'comfor' collapses into 'KUMF', and the 'table' becomes 'tər-bəl' with two schwas. This is a notorious word for Spanish speakers.",
+    tipEs:
+      "Tres sílabas, no cuatro: KUMF-tər-bəl. El 'comfor' se colapsa en 'KUMF', y 'table' se vuelve 'tər-bəl' con dos schwas. Esta es una palabra notoria para hispanohablantes.",
+  },
+  {
+    word: "ambulance",
+    spanishStress: "AM-BU-LAN-CIA",
+    englishStress: "AM-byə-ləns",
+    tip: "'Ambulance' has three syllables in English with two schwas: AM-byə-ləns. Stress on the FIRST syllable. Spanish speakers often say AM-bu-LANCE — wrong stress placement.",
+    tipEs:
+      "'Ambulance' tiene tres sílabas en inglés con dos schwas: AM-byə-ləns. Acento en la PRIMERA sílaba. Los hispanohablantes frecuentemente dicen AM-bu-LANCE — colocación de acento incorrecta.",
+  },
+];
+
+// ─── Section F: Self-Test Vocabulary ─────────────────────────────────────────
+
+export const vocabularyList: IntermediateVocabItem[] = [
+  // Symptom expressions
+  { english: "I've had a sore throat for...", spanish: "He tenido dolor de garganta por...", type: "expression" },
+  { english: "It's been getting worse.", spanish: "Ha estado empeorando.", type: "expression" },
+  { english: "I'm having chest pain.", spanish: "Tengo dolor de pecho.", type: "expression" },
+  { english: "I've come down with a cold.", spanish: "Me ha dado un resfriado.", type: "expression" },
+  { english: "I'm allergic to...", spanish: "Soy alérgico a...", type: "expression" },
+  // Question phrases for doctors
+  { english: "Should I take...?", spanish: "¿Debería tomar...?", type: "expression" },
+  { english: "How often should I...?", spanish: "¿Con qué frecuencia debería...?", type: "expression" },
+  { english: "Are there any side effects?", spanish: "¿Hay efectos secundarios?", type: "expression" },
+  { english: "Could you explain that in simpler terms?", spanish: "¿Podría explicar eso en términos más simples?", type: "expression" },
+  // Emergency expressions
+  { english: "I need an ambulance.", spanish: "Necesito una ambulancia.", type: "expression" },
+  { english: "There's a medical emergency.", spanish: "Hay una emergencia médica.", type: "expression" },
+  { english: "She's having trouble breathing.", spanish: "Tiene dificultad para respirar.", type: "expression" },
+  // Body parts and conditions
+  { english: "chest pain", spanish: "dolor de pecho", type: "noun" },
+  { english: "side effects", spanish: "efectos secundarios", type: "noun" },
+  { english: "prescription", spanish: "receta", type: "noun" },
+  { english: "blood pressure", spanish: "presión arterial", type: "noun" },
+  { english: "fever", spanish: "fiebre", type: "noun" },
+  { english: "dizziness", spanish: "mareo", type: "noun" },
+  { english: "nausea", spanish: "náusea", type: "noun" },
+  { english: "swelling", spanish: "hinchazón", type: "noun" },
+  { english: "rash", spanish: "sarpullido / erupción", type: "noun" },
+  // Medical verbs
+  { english: "to examine", spanish: "examinar", type: "verb" },
+  { english: "to prescribe", spanish: "recetar", type: "verb" },
+  { english: "to recover", spanish: "recuperarse", type: "verb" },
+  { english: "to diagnose", spanish: "diagnosticar", type: "verb" },
+];

--- a/src/data/intermediate/unit-8.ts
+++ b/src/data/intermediate/unit-8.ts
@@ -1,0 +1,526 @@
+// Unit 8: "Money and Shopping" — Full course content
+// Theme: Banking, shopping, complaints, returns
+// Grammar: Relative clauses + preference modals (would rather, would prefer)
+// Pronunciation: Sentence stress for emphasis
+// Section A: SpecifierBuilder (relative clauses for precise descriptions)
+
+import type {
+  Dialogue,
+  ErrorCorrectionSet,
+  IntermediateVocabItem,
+} from "./types";
+import type { SpecifierExample } from "../../components/course/SpecifierBuilder";
+import type { SentenceBlock, PronunciationDrill } from "../course/unit-1";
+
+// ─── Section A: Specifier Builder ────────────────────────────────────────────
+
+export const specifierExamples: SpecifierExample[] = [
+  {
+    situation:
+      "You're returning a shirt at a store. The clerk asks which one. You need to identify it precisely.",
+    situationEs:
+      "Estás devolviendo una camisa en una tienda. El empleado pregunta cuál. Necesitas identificarla con precisión.",
+    vague: "I want to return the shirt.",
+    vagueEs: "Quiero devolver la camisa.",
+    specific: "I want to return the shirt that I bought last week — the blue one with the small stain.",
+    specificEs: "Quiero devolver la camisa que compré la semana pasada — la azul con la pequeña mancha.",
+    relativePronoun: "that",
+    clauseHighlight: "that I bought last week",
+    whyPronoun:
+      "Use 'that' for things (objects, ideas). It connects 'the shirt' to identifying information that lets the clerk know exactly which shirt you mean.",
+    whyPronounEs:
+      "Usa 'that' para cosas (objetos, ideas). Conecta 'the shirt' con información identificadora que le permite al empleado saber exactamente cuál camisa.",
+  },
+  {
+    situation:
+      "You're complaining to a manager about an employee. You need to specify which one without sounding rude.",
+    situationEs:
+      "Te quejas con un gerente sobre un empleado. Necesitas especificar cuál sin sonar grosero.",
+    vague: "The cashier was rude to me.",
+    vagueEs: "El cajero fue grosero conmigo.",
+    specific: "The cashier who helped me on Tuesday afternoon was rude when I asked for a refund.",
+    specificEs: "El cajero que me atendió el martes por la tarde fue grosero cuando pedí un reembolso.",
+    relativePronoun: "who",
+    clauseHighlight: "who helped me on Tuesday afternoon",
+    whyPronoun:
+      "Use 'who' for people. This makes your complaint specific and credible — vague complaints get dismissed, specific ones get action.",
+    whyPronounEs:
+      "Usa 'who' para personas. Esto hace tu queja específica y creíble — las quejas vagas se ignoran, las específicas reciben acción.",
+  },
+  {
+    situation:
+      "You want to recommend a restaurant to a friend, but there are several with similar names.",
+    situationEs:
+      "Quieres recomendarle un restaurante a un amigo, pero hay varios con nombres similares.",
+    vague: "There's a great Italian restaurant downtown.",
+    vagueEs: "Hay un excelente restaurante italiano en el centro.",
+    specific: "There's a great Italian restaurant downtown that has a wood-fired oven and homemade pasta.",
+    specificEs: "Hay un excelente restaurante italiano en el centro que tiene un horno de leña y pasta hecha en casa.",
+    relativePronoun: "that",
+    clauseHighlight: "that has a wood-fired oven and homemade pasta",
+    whyPronoun:
+      "'That' restricts which restaurant you mean. Without it, your friend would have no way to find the right one. Specificity prevents confusion.",
+    whyPronounEs:
+      "'That' restringe a qué restaurante te refieres. Sin esto, tu amigo no tendría forma de encontrar el correcto. La especificidad previene confusión.",
+  },
+  {
+    situation:
+      "You're asking the bank about a transaction you don't recognize on your statement.",
+    situationEs:
+      "Le preguntas al banco sobre una transacción que no reconoces en tu estado de cuenta.",
+    vague: "There's a charge I don't recognize.",
+    vagueEs: "Hay un cargo que no reconozco.",
+    specific: "There's a charge from last Saturday for $87.50, which I don't recognize. Could you tell me what it's for?",
+    specificEs: "Hay un cargo del sábado pasado por $87.50, el cual no reconozco. ¿Podría decirme para qué es?",
+    relativePronoun: "which",
+    clauseHighlight: "which I don't recognize",
+    whyPronoun:
+      "'Which' adds extra information separated by a comma — it doesn't restrict the meaning, just adds context. Note the comma before 'which' — that's the rule.",
+    whyPronounEs:
+      "'Which' agrega información adicional separada por una coma — no restringe el significado, solo agrega contexto. Nota la coma antes de 'which' — esa es la regla.",
+  },
+  {
+    situation:
+      "You're describing the apartment you're looking for to a real estate agent.",
+    situationEs:
+      "Le describes a un agente inmobiliario el departamento que buscas.",
+    vague: "I'm looking for an apartment.",
+    vagueEs: "Estoy buscando un departamento.",
+    specific: "I'm looking for an apartment whose monthly rent is under $2,000 and that has at least two bedrooms.",
+    specificEs: "Estoy buscando un departamento cuya renta mensual sea menos de $2,000 y que tenga al menos dos recámaras.",
+    relativePronoun: "whose",
+    clauseHighlight: "whose monthly rent is under $2,000",
+    whyPronoun:
+      "'Whose' shows possession — 'the apartment's rent'. It's the only way to combine these ideas into one sentence. Without 'whose', you'd need two clunky sentences.",
+    whyPronounEs:
+      "'Whose' muestra posesión — 'la renta del departamento'. Es la única forma de combinar estas ideas en una oración. Sin 'whose', necesitarías dos oraciones torpes.",
+  },
+  {
+    situation:
+      "You're trying to remember the name of a coffee shop where you had a great meeting.",
+    situationEs:
+      "Tratas de recordar el nombre de una cafetería donde tuviste una excelente junta.",
+    vague: "We met at a coffee shop.",
+    vagueEs: "Nos reunimos en una cafetería.",
+    specific: "We met at the coffee shop where they have those huge windows facing the park.",
+    specificEs: "Nos reunimos en la cafetería donde tienen esas ventanas enormes que dan al parque.",
+    relativePronoun: "where",
+    clauseHighlight: "where they have those huge windows",
+    whyPronoun:
+      "'Where' is the relative pronoun for places. It connects the location to a memorable detail. More natural than 'in which' (technically correct but stiff).",
+    whyPronounEs:
+      "'Where' es el pronombre relativo para lugares. Conecta la ubicación con un detalle memorable. Más natural que 'in which' (técnicamente correcto pero rígido).",
+  },
+  {
+    situation:
+      "You're describing the moment you realized you'd been overcharged at a store.",
+    situationEs:
+      "Describes el momento en que te diste cuenta de que te habían cobrado de más en una tienda.",
+    vague: "I noticed the mistake later.",
+    vagueEs: "Noté el error después.",
+    specific: "I noticed the mistake the moment when I checked my receipt in the parking lot.",
+    specificEs: "Noté el error en el momento en que revisé mi recibo en el estacionamiento.",
+    relativePronoun: "when",
+    clauseHighlight: "when I checked my receipt",
+    whyPronoun:
+      "'When' is the relative pronoun for time references. It anchors the moment precisely — much clearer than 'later'.",
+    whyPronounEs:
+      "'When' es el pronombre relativo para referencias de tiempo. Ancla el momento con precisión — mucho más claro que 'later'.",
+  },
+];
+
+// ─── Section B: Dialogue Practice ────────────────────────────────────────────
+
+export const dialogues: Dialogue[] = [
+  {
+    title: "Returning a Defective Item",
+    titleEs: "Devolviendo un Artículo Defectuoso",
+    setting: "A customer returns a coffee maker that stopped working after two days",
+    settingEs: "Un cliente devuelve una cafetera que dejó de funcionar después de dos días",
+    lines: [
+      {
+        speaker: "A",
+        speakerLabel: "Marcos",
+        speakerLabelEs: "Marcos",
+        english:
+          "Hi, I'd like to return this coffee maker that I bought on Saturday. It stopped working after two days.",
+        spanish:
+          "Hola, me gustaría devolver esta cafetera que compré el sábado. Dejó de funcionar después de dos días.",
+        highlight: "that I bought on Saturday",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Clerk",
+        speakerLabelEs: "Empleada",
+        english: "I'm sorry to hear that. Do you have the receipt?",
+        spanish: "Lamento escuchar eso. ¿Tiene el recibo?",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Marcos",
+        speakerLabelEs: "Marcos",
+        english:
+          "Yes, here it is. Would you prefer to give me a refund, or would a replacement be possible?",
+        spanish:
+          "Sí, aquí está. ¿Preferiría darme un reembolso, o sería posible un reemplazo?",
+        highlight: "Would you prefer / would a replacement be possible",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Clerk",
+        speakerLabelEs: "Empleada",
+        english:
+          "It's up to you. Most customers who have this problem prefer a replacement, since the model is popular.",
+        spanish:
+          "Depende de usted. La mayoría de los clientes que tienen este problema prefieren un reemplazo, ya que el modelo es popular.",
+        highlight: "customers who have this problem",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Marcos",
+        speakerLabelEs: "Marcos",
+        english:
+          "Actually, I'd rather have my money back. I'd prefer to try a different brand.",
+        spanish:
+          "De hecho, preferiría que me devolvieran mi dinero. Preferiría probar una marca diferente.",
+        highlight: "I'd rather... I'd prefer",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Clerk",
+        speakerLabelEs: "Empleada",
+        english:
+          "Of course. Is there anything specific that we can do better with this product?",
+        spanish:
+          "Por supuesto. ¿Hay algo específico que podamos hacer mejor con este producto?",
+        highlight: "anything specific that",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Marcos",
+        speakerLabelEs: "Marcos",
+        english:
+          "The instructions, which were translated poorly, were really hard to follow. That's not your fault, of course — it's the manufacturer.",
+        spanish:
+          "Las instrucciones, que estaban mal traducidas, fueron muy difíciles de seguir. No es su culpa, claro — es del fabricante.",
+        highlight: "which were translated poorly",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Clerk",
+        speakerLabelEs: "Empleada",
+        english:
+          "I'll pass that feedback on. Your refund will be credited to the card you used, and it should appear in 3 to 5 business days.",
+        spanish:
+          "Pasaré ese comentario. Su reembolso se acreditará a la tarjeta que usó, y debería aparecer en 3 a 5 días hábiles.",
+        highlight: "the card you used",
+      },
+    ],
+    keyPhrases: [
+      {
+        english: "I'd like to return this... that I bought...",
+        spanish: "Me gustaría devolver este... que compré...",
+        note: "The standard return formula. 'Would like' is polite, the relative clause identifies the item.",
+        noteEs: "La fórmula estándar de devolución. 'Would like' es cortés, la cláusula relativa identifica el artículo.",
+      },
+      {
+        english: "I'd rather have...",
+        spanish: "Preferiría tener...",
+        note: "'Would rather' followed by base verb — the polite way to state a preference.",
+        noteEs: "'Would rather' seguido de verbo base — la forma cortés de expresar una preferencia.",
+      },
+      {
+        english: "I'd prefer to...",
+        spanish: "Preferiría...",
+        note: "'Would prefer' followed by 'to + verb'. Slightly more formal than 'would rather'.",
+        noteEs: "'Would prefer' seguido de 'to + verbo'. Ligeramente más formal que 'would rather'.",
+      },
+    ],
+  },
+];
+
+// ─── Section C: Structure Builder ────────────────────────────────────────────
+
+export const structureBlocks: SentenceBlock[] = [
+  {
+    label: "Defining relative clauses",
+    labelEs: "Cláusulas relativas definitorias",
+    description:
+      "Defining relative clauses tell you WHICH one — they're essential for the meaning. Use 'that', 'who', or 'which' with NO comma.",
+    descriptionEs:
+      "Las cláusulas relativas definitorias te dicen CUÁL — son esenciales para el significado. Usa 'that', 'who' o 'which' SIN coma.",
+    sentences: [
+      {
+        english: "The book that I borrowed from you was excellent.",
+        spanish: "El libro que te pedí prestado fue excelente.",
+        highlight: "that I borrowed",
+      },
+      {
+        english: "The woman who lives next door is a doctor.",
+        spanish: "La mujer que vive al lado es doctora.",
+        highlight: "who lives next door",
+      },
+      {
+        english: "The bank that's on the corner has the best rates.",
+        spanish: "El banco que está en la esquina tiene las mejores tasas.",
+        highlight: "that's on the corner",
+      },
+      {
+        english: "The store where I bought this is having a sale.",
+        spanish: "La tienda donde compré esto tiene una venta.",
+        highlight: "where I bought this",
+      },
+    ],
+  },
+  {
+    label: "Non-defining relative clauses",
+    labelEs: "Cláusulas relativas no definitorias",
+    description:
+      "Non-defining clauses add EXTRA information that isn't essential. Use 'which' or 'who', and ALWAYS use commas. 'That' is not allowed here.",
+    descriptionEs:
+      "Las cláusulas no definitorias agregan información EXTRA que no es esencial. Usa 'which' o 'who', y SIEMPRE usa comas. 'That' no se permite aquí.",
+    sentences: [
+      {
+        english: "My new phone, which I bought last month, has already broken.",
+        spanish: "Mi teléfono nuevo, que compré el mes pasado, ya se rompió.",
+        highlight: "which I bought last month",
+      },
+      {
+        english: "Mr. Garcia, who manages the store, is very helpful.",
+        spanish: "El Sr. Garcia, quien dirige la tienda, es muy servicial.",
+        highlight: "who manages the store",
+      },
+      {
+        english: "This jacket, which was a gift from my sister, is my favorite.",
+        spanish: "Esta chaqueta, que fue un regalo de mi hermana, es mi favorita.",
+        highlight: "which was a gift",
+      },
+      {
+        english: "Our manager, whose office is upstairs, will see you now.",
+        spanish: "Nuestro gerente, cuya oficina está arriba, te atenderá ahora.",
+        highlight: "whose office is upstairs",
+      },
+    ],
+  },
+  {
+    label: "Preference modals: would rather and would prefer",
+    labelEs: "Modales de preferencia: would rather y would prefer",
+    description:
+      "Two ways to politely state what you want — both more elegant than 'I want'. The grammar is slightly different: 'would rather' + base verb, 'would prefer' + 'to' + verb.",
+    descriptionEs:
+      "Dos formas de expresar cortésmente lo que quieres — ambas más elegantes que 'I want'. La gramática es ligeramente diferente: 'would rather' + verbo base, 'would prefer' + 'to' + verbo.",
+    sentences: [
+      {
+        english: "I'd rather pay in cash, if that's okay.",
+        spanish: "Preferiría pagar en efectivo, si está bien.",
+        highlight: "I'd rather pay",
+      },
+      {
+        english: "I'd prefer to wait for the manager.",
+        spanish: "Preferiría esperar al gerente.",
+        highlight: "I'd prefer to wait",
+      },
+      {
+        english: "Would you rather have a refund or store credit?",
+        spanish: "¿Preferirías un reembolso o crédito en la tienda?",
+        highlight: "Would you rather have",
+      },
+      {
+        english: "We'd prefer not to wait in line if possible.",
+        spanish: "Preferiríamos no esperar en la fila si es posible.",
+        highlight: "We'd prefer not to wait",
+      },
+    ],
+  },
+  {
+    label: "Combining relative clauses with preferences",
+    labelEs: "Combinando cláusulas relativas con preferencias",
+    description:
+      "When you're shopping or complaining, you often need to specify exactly what you want AND state a preference at the same time. Here's the combination in action.",
+    descriptionEs:
+      "Cuando vas de compras o te quejas, frecuentemente necesitas especificar exactamente lo que quieres Y expresar una preferencia al mismo tiempo. Aquí está la combinación en acción.",
+    sentences: [
+      {
+        english: "I'd rather have the model that comes with the longer warranty.",
+        spanish: "Preferiría el modelo que viene con la garantía más larga.",
+        highlight: "the model that comes with",
+      },
+      {
+        english: "I'd prefer to speak with someone who has more experience.",
+        spanish: "Preferiría hablar con alguien que tenga más experiencia.",
+        highlight: "someone who has more experience",
+      },
+      {
+        english: "The card that I use for online purchases is the one I'd rather not give out.",
+        spanish: "La tarjeta que uso para compras en línea es la que preferiría no dar.",
+        highlight: "the one I'd rather not give out",
+      },
+      {
+        english: "Could I have the room that has a view, if there's one available?",
+        spanish: "¿Podría tener la habitación que tiene vista, si hay alguna disponible?",
+        highlight: "the room that has a view",
+      },
+    ],
+  },
+];
+
+// ─── Section D: Error Correction ─────────────────────────────────────────────
+
+export const errorCorrections: ErrorCorrectionSet = {
+  title: "Common Mistakes with Relative Clauses & Preferences",
+  titleEs: "Errores Comunes con Cláusulas Relativas y Preferencias",
+  description:
+    "These errors make your descriptions either confusing, ungrammatical, or oddly demanding. Fix them before your next return.",
+  descriptionEs:
+    "Estos errores hacen que tus descripciones sean confusas, incorrectas o extrañamente demandantes. Corrígelos antes de tu próxima devolución.",
+  items: [
+    {
+      incorrect: "The man which sold me this is gone.",
+      correct: "The man who sold me this is gone.",
+      incorrectHighlight: "which sold me",
+      correctHighlight: "who sold me",
+      explanation:
+        "Use 'who' for people, not 'which'. 'Which' is for things and 'that' works for both. Spanish uses 'que' for everything, which causes this slip. Quick rule: people = who, things = that or which.",
+      explanationEs:
+        "Usa 'who' para personas, no 'which'. 'Which' es para cosas y 'that' funciona para ambos. El español usa 'que' para todo, lo que causa este desliz. Regla rápida: personas = who, cosas = that o which.",
+      errorType: "literal-translation",
+    },
+    {
+      incorrect: "I'd rather to pay in cash.",
+      correct: "I'd rather pay in cash.",
+      incorrectHighlight: "rather to pay",
+      correctHighlight: "rather pay",
+      explanation:
+        "After 'would rather', use the BASE form of the verb — never 'to + verb'. This is one of the trickiest modal patterns. Compare: 'I'd rather pay' (correct) vs. 'I'd prefer to pay' (also correct, different structure).",
+      explanationEs:
+        "Después de 'would rather', usa la forma BASE del verbo — nunca 'to + verbo'. Este es uno de los patrones modales más complicados. Compara: 'I'd rather pay' (correcto) vs. 'I'd prefer to pay' (también correcto, estructura diferente).",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "The shirt who I bought has a stain.",
+      correct: "The shirt that I bought has a stain.",
+      incorrectHighlight: "who I bought",
+      correctHighlight: "that I bought",
+      explanation:
+        "'Who' is for people only. A shirt is not a person — use 'that' or 'which'. The most common version of this error is using 'who' for animals or objects because Spanish makes no distinction.",
+      explanationEs:
+        "'Who' es solo para personas. Una camisa no es una persona — usa 'that' o 'which'. La versión más común de este error es usar 'who' para animales u objetos porque el español no hace la distinción.",
+      errorType: "literal-translation",
+    },
+    {
+      incorrect: "My phone which I bought last month is broken.",
+      correct: "My phone, which I bought last month, is broken.",
+      incorrectHighlight: "phone which I bought last month is",
+      correctHighlight: "phone, which I bought last month, is",
+      explanation:
+        "When 'which' is used with extra (non-essential) information, you MUST use commas before AND after the clause. Without commas, the meaning becomes unclear. With 'that', no commas are ever used.",
+      explanationEs:
+        "Cuando 'which' se usa con información adicional (no esencial), DEBES usar comas antes Y después de la cláusula. Sin comas, el significado se vuelve poco claro. Con 'that', nunca se usan comas.",
+      errorType: "word-order",
+    },
+    {
+      incorrect: "I want the one is on the second shelf.",
+      correct: "I want the one that is on the second shelf.",
+      incorrectHighlight: "the one is",
+      correctHighlight: "the one that is",
+      explanation:
+        "You can't drop the relative pronoun 'that' here because it's the subject of the relative clause. You CAN drop 'that' when it's the object: 'the book I bought' (object — drop OK). But not when it's the subject: 'the book that is on the table'.",
+      explanationEs:
+        "No puedes omitir el pronombre relativo 'that' aquí porque es el sujeto de la cláusula relativa. PUEDES omitir 'that' cuando es el objeto: 'the book I bought' (objeto — OK). Pero no cuando es el sujeto: 'the book that is on the table'.",
+      errorType: "word-order",
+    },
+    {
+      incorrect: "I prefer paying with credit card more than cash.",
+      correct: "I'd rather pay with a credit card than with cash.",
+      incorrectHighlight: "prefer paying with credit card more than",
+      correctHighlight: "rather pay with a credit card than with",
+      explanation:
+        "Two issues. First: 'prefer X more than Y' is a literal translation that sounds non-native. The natural patterns are 'prefer X to Y' or 'would rather X than Y'. Second: count nouns like 'credit card' need an article ('a credit card'), but 'cash' is uncountable and doesn't.",
+      explanationEs:
+        "Dos problemas. Primero: 'prefer X more than Y' es una traducción literal que suena no-nativa. Los patrones naturales son 'prefer X to Y' o 'would rather X than Y'. Segundo: los sustantivos contables como 'credit card' necesitan un artículo ('a credit card'), pero 'cash' es incontable y no.",
+      errorType: "literal-translation",
+    },
+  ],
+};
+
+// ─── Section E: Pronunciation Lab ────────────────────────────────────────────
+
+export const pronunciationDrills: PronunciationDrill[] = [
+  {
+    word: "I'd RATHER pay cash",
+    spanishStress: "I'D RATHER PAY CASH",
+    englishStress: "aid-RATH-er-pei-KASH",
+    tip: "In 'I'd rather pay cash', stress falls on 'rather' (the choice) and 'cash' (the key noun). 'I'd' and 'pay' are quick. Native speakers compress the unstressed words.",
+    tipEs:
+      "En 'I'd rather pay cash', el acento cae en 'rather' (la elección) y 'cash' (el sustantivo clave). 'I'd' y 'pay' son rápidos. Los nativos comprimen las palabras sin acento.",
+  },
+  {
+    word: "I bought THIS one",
+    spanishStress: "I BOUGHT THIS ONE",
+    englishStress: "ai-baut-THIS-wən",
+    tip: "Sentence stress changes meaning. 'I bought THIS one' (not that one) puts emphasis on 'this'. 'I BOUGHT this one' (didn't steal it) emphasizes the action. Stress = meaning.",
+    tipEs:
+      "El acento de oración cambia el significado. 'I bought THIS one' (no esa) pone énfasis en 'this'. 'I BOUGHT this one' (no la robé) enfatiza la acción. Acento = significado.",
+  },
+  {
+    word: "the one THAT broke",
+    spanishStress: "THE ONE THAT BROKE",
+    englishStress: "thi-wən-thət-BROK",
+    tip: "In relative clauses, 'that' is unstressed and reduced to 'thət'. The main stress falls on the action verb at the end. 'The one that broke' = 'thi-wən-thət-BROK'.",
+    tipEs:
+      "En cláusulas relativas, 'that' no lleva acento y se reduce a 'thət'. El acento principal cae en el verbo de acción al final. 'The one that broke' = 'thi-wən-thət-BROK'.",
+  },
+  {
+    word: "How much DOES it cost?",
+    spanishStress: "HOW MUCH DOES IT COST",
+    englishStress: "hau-MUCH-dəz-it-KOST",
+    tip: "In questions, stress lands on the question word ('much') and the key noun/verb ('cost'). 'Does' and 'it' are weak — almost swallowed. This rhythm signals 'I'm asking for information'.",
+    tipEs:
+      "En preguntas, el acento va en la palabra interrogativa ('much') y el sustantivo/verbo clave ('cost'). 'Does' y 'it' son débiles — casi se tragan. Este ritmo señala 'estoy pidiendo información'.",
+  },
+  {
+    word: "It's TOO expensive",
+    spanishStress: "IT'S TOO EXPENSIVE",
+    englishStress: "its-TU-ek-SPEN-siv",
+    tip: "'Too' means 'more than acceptable' and gets a clear stress. Don't confuse with 'two' or 'to' in pronunciation. 'It's too expensive' is your polite refusal phrase — practice it.",
+    tipEs:
+      "'Too' significa 'más de lo aceptable' y lleva un acento claro. No lo confundas con 'two' o 'to' en pronunciación. 'It's too expensive' es tu frase cortés de rechazo — practícala.",
+  },
+];
+
+// ─── Section F: Self-Test Vocabulary ─────────────────────────────────────────
+
+export const vocabularyList: IntermediateVocabItem[] = [
+  // Relative clause expressions
+  { english: "the one that...", spanish: "el/la que...", type: "expression" },
+  { english: "the kind of thing that...", spanish: "el tipo de cosa que...", type: "expression" },
+  { english: "the person who...", spanish: "la persona que...", type: "expression" },
+  { english: "the place where...", spanish: "el lugar donde...", type: "expression" },
+  { english: "the day when...", spanish: "el día en que...", type: "expression" },
+  // Preference expressions
+  { english: "I'd rather...", spanish: "Preferiría...", type: "expression" },
+  { english: "I'd prefer to...", spanish: "Preferiría...", type: "expression" },
+  { english: "Would you rather...?", spanish: "¿Preferirías...?", type: "expression" },
+  { english: "I'd prefer not to...", spanish: "Preferiría no...", type: "expression" },
+  // Shopping/banking expressions
+  { english: "I'd like to return this.", spanish: "Me gustaría devolver esto.", type: "expression" },
+  { english: "Do you have the receipt?", spanish: "¿Tiene el recibo?", type: "expression" },
+  { english: "It's too expensive.", spanish: "Es demasiado caro.", type: "expression" },
+  { english: "Is there a cheaper option?", spanish: "¿Hay una opción más barata?", type: "expression" },
+  { english: "I'd like a refund.", spanish: "Me gustaría un reembolso.", type: "expression" },
+  // Money/shopping vocabulary
+  { english: "refund", spanish: "reembolso", type: "noun" },
+  { english: "receipt", spanish: "recibo", type: "noun" },
+  { english: "warranty", spanish: "garantía", type: "noun" },
+  { english: "discount", spanish: "descuento", type: "noun" },
+  { english: "tax", spanish: "impuesto", type: "noun" },
+  { english: "exchange rate", spanish: "tipo de cambio", type: "noun" },
+  { english: "credit card", spanish: "tarjeta de crédito", type: "noun" },
+  { english: "checking account", spanish: "cuenta corriente", type: "noun" },
+  // Money/shopping verbs
+  { english: "to charge", spanish: "cobrar", type: "verb" },
+  { english: "to refund", spanish: "reembolsar", type: "verb" },
+  { english: "to exchange", spanish: "cambiar", type: "verb" },
+  { english: "to deposit", spanish: "depositar", type: "verb" },
+  { english: "to withdraw", spanish: "retirar", type: "verb" },
+];

--- a/src/pages/en/course/intermediate/index.astro
+++ b/src/pages/en/course/intermediate/index.astro
@@ -133,7 +133,7 @@ const iconMap: Record<string, any> = {
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
         {intermediateUnits.map((unit) => {
           const Icon = iconMap[unit.icon];
-          const isAvailable = unit.id < 7;
+          const isAvailable = unit.id < 9;
           return (
             <a
               href={isAvailable ? `/en/course/intermediate/${unit.slug}/` : undefined}

--- a/src/pages/en/course/intermediate/unit-7.astro
+++ b/src/pages/en/course/intermediate/unit-7.astro
@@ -1,0 +1,194 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import SurvivalPhrases from "@components/course/SurvivalPhrases";
+import DialoguePractice from "@components/course/DialoguePractice";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import ErrorCorrection from "@components/course/ErrorCorrection";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import SelfTest from "@components/course/SelfTest";
+import { intermediateUnits } from "@data/intermediate/units";
+import {
+  survivalCategories,
+  dialogues,
+  structureBlocks,
+  errorCorrections,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/intermediate/unit-7";
+import { ArrowRight, HeartPulse, Layers, Volume2, Stethoscope } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/intermediate/unit-7" as const;
+
+const progressUnits = intermediateUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unit 7: Health and Emergencies | Building Fluency | NY English Teacher"
+  description="High-stakes medical English. Master passive voice, advice modals (should, ought to), and the exact phrases you need at the doctor, pharmacy, or hospital. Free B1-B2 lesson for Spanish speakers."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={7}
+    basePath="/en/course/intermediate"
+    lang="en"
+    courseId="intermediate"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <HeartPulse class="w-4 h-4" />
+          Unit 7
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Health and Emergencies
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          This is the unit where English stops being a school subject and becomes a real
+          tool. The phrases here can help you describe symptoms, ask for the right medication,
+          and — in the worst case — get an ambulance to your door. Master the passive voice
+          and advice modals: <strong class="text-white">should</strong>,
+          <strong class="text-white">ought to</strong>, and
+          <strong class="text-white">had better</strong>.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Stethoscope class="w-3.5 h-3.5" /> Survival Phrases
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Layers class="w-3.5 h-3.5" /> Passive Voice
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Volume2 class="w-3.5 h-3.5" /> Advice Modals
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-a">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">A</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Survival Phrases</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Real medical situations with the exact English you need. Read the situation,
+          then reveal the phrase. Memorize the high-urgency ones — your safety may depend on them.
+        </p>
+        <SurvivalPhrases client:visible categories={survivalCategories} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-b">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">B</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Dialogue Practice</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          A typical doctor's appointment from start to finish. Notice how every patient question
+          and doctor recommendation uses the structures from this unit.
+        </p>
+        <DialoguePractice client:visible dialogues={dialogues} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-c">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">C</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Structure Builder</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Passive voice and advice modals — the foundation of medical English.
+        </p>
+        <SentenceBuilder client:visible blocks={structureBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-d">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">D</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Error Correction</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Six errors that can confuse doctors or, worse, minimize serious symptoms.
+        </p>
+        <ErrorCorrection client:visible data={errorCorrections} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-e">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">E</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Pronunciation Lab</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Schwa sounds in passive constructions and tricky medical vocabulary.
+        </p>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-f">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">F</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Self-Test</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Test yourself on symptom expressions, doctor question phrases, and emergency vocabulary.
+        </p>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/en/course/intermediate/unit-6/"
+          class="text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          &larr; Unit 6
+        </a>
+        <Button href="/en/course/intermediate/unit-8/" variant="primary" size="md">
+          Unit 8: Money and Shopping
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/en/course/intermediate/unit-8.astro
+++ b/src/pages/en/course/intermediate/unit-8.astro
@@ -1,0 +1,193 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import SpecifierBuilder from "@components/course/SpecifierBuilder";
+import DialoguePractice from "@components/course/DialoguePractice";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import ErrorCorrection from "@components/course/ErrorCorrection";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import SelfTest from "@components/course/SelfTest";
+import { intermediateUnits } from "@data/intermediate/units";
+import {
+  specifierExamples,
+  dialogues,
+  structureBlocks,
+  errorCorrections,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/intermediate/unit-8";
+import { ArrowRight, Wallet, Layers, Volume2, Target } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/intermediate/unit-8" as const;
+
+const progressUnits = intermediateUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unit 8: Money and Shopping | Building Fluency | NY English Teacher"
+  description="Consumer English for shopping, banking, and complaints. Master relative clauses to specify exactly what you want, plus preference modals (would rather, would prefer). Free B1-B2 lesson for Spanish speakers."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={8}
+    basePath="/en/course/intermediate"
+    lang="en"
+    courseId="intermediate"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Wallet class="w-4 h-4" />
+          Unit 8
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Money and Shopping
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          When something goes wrong with a purchase, vague English gets ignored — specific
+          English gets results. This unit teaches you to identify, describe, and complain
+          with precision using <strong class="text-white">relative clauses</strong>, plus
+          state your preferences politely with <strong class="text-white">would rather</strong>
+          and <strong class="text-white">would prefer</strong>.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Target class="w-3.5 h-3.5" /> Specifier Builder
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Layers class="w-3.5 h-3.5" /> Relative Clauses
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Volume2 class="w-3.5 h-3.5" /> Preference Modals
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-a">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">A</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Specifier Builder</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          See how vague sentences become specific with relative clauses. Each example
+          highlights the relative pronoun and explains why it's the right choice.
+        </p>
+        <SpecifierBuilder client:visible examples={specifierExamples} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-b">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">B</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Dialogue Practice</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          A real return at a real store — watch how the customer uses relative clauses to
+          identify the item and preference modals to state what they want.
+        </p>
+        <DialoguePractice client:visible dialogues={dialogues} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-c">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">C</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Structure Builder</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Defining vs. non-defining relative clauses, plus 'would rather' and 'would prefer'.
+        </p>
+        <SentenceBuilder client:visible blocks={structureBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-d">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">D</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Error Correction</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Six errors that confuse store clerks and bank tellers — fix them before your next return.
+        </p>
+        <ErrorCorrection client:visible data={errorCorrections} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-e">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">E</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Pronunciation Lab</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Sentence stress for emphasis — how the same words can mean different things based on which one you stress.
+        </p>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-f">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">F</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Self-Test</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Test yourself on relative clause expressions, preference phrases, and money/shopping vocabulary.
+        </p>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/en/course/intermediate/unit-7/"
+          class="text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          &larr; Unit 7
+        </a>
+        <Button href="/en/course/intermediate/" variant="primary" size="md">
+          Course Overview
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/intermedio/index.astro
+++ b/src/pages/es/curso/intermedio/index.astro
@@ -133,7 +133,7 @@ const iconMap: Record<string, any> = {
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
         {intermediateUnits.map((unit) => {
           const Icon = iconMap[unit.icon];
-          const isAvailable = unit.id < 7;
+          const isAvailable = unit.id < 9;
           return (
             <a
               href={isAvailable ? `/es/curso/intermedio/${unit.slugEs}/` : undefined}

--- a/src/pages/es/curso/intermedio/unidad-7.astro
+++ b/src/pages/es/curso/intermedio/unidad-7.astro
@@ -1,0 +1,195 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import SurvivalPhrases from "@components/course/SurvivalPhrases";
+import DialoguePractice from "@components/course/DialoguePractice";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import ErrorCorrection from "@components/course/ErrorCorrection";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import SelfTest from "@components/course/SelfTest";
+import { intermediateUnits } from "@data/intermediate/units";
+import {
+  survivalCategories,
+  dialogues,
+  structureBlocks,
+  errorCorrections,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/intermediate/unit-7";
+import { ArrowRight, HeartPulse, Layers, Volume2, Stethoscope } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/intermediate/unit-7" as const;
+
+const progressUnits = intermediateUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unidad 7: Salud y Emergencias | Construyendo Fluidez | NY English Teacher"
+  description="Inglés médico de alto riesgo. Domina la voz pasiva, los modales de consejo (should, ought to) y las frases exactas que necesitas en el doctor, la farmacia o el hospital. Lección B1-B2 gratis para hispanohablantes."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={7}
+    basePath="/es/curso/intermedio"
+    lang="es"
+    courseId="intermediate"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <HeartPulse class="w-4 h-4" />
+          Unidad 7
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Salud y Emergencias
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Esta es la unidad donde el inglés deja de ser una materia escolar y se convierte
+          en una herramienta real. Las frases aquí pueden ayudarte a describir síntomas, pedir
+          el medicamento correcto y — en el peor caso — conseguir una ambulancia en tu puerta.
+          Domina la voz pasiva y los modales de consejo:
+          <strong class="text-white">should</strong>,
+          <strong class="text-white">ought to</strong>, y
+          <strong class="text-white">had better</strong>.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Stethoscope class="w-3.5 h-3.5" /> Frases de Supervivencia
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Layers class="w-3.5 h-3.5" /> Voz Pasiva
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Volume2 class="w-3.5 h-3.5" /> Modales de Consejo
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-a">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">A</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Frases de Supervivencia</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Situaciones médicas reales con el inglés exacto que necesitas. Lee la situación,
+          luego revela la frase. Memoriza las de alta urgencia — tu seguridad puede depender de ellas.
+        </p>
+        <SurvivalPhrases client:visible categories={survivalCategories} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-b">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">B</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Práctica de Diálogo</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Una cita médica típica de principio a fin. Nota cómo cada pregunta del paciente
+          y cada recomendación de la doctora usa las estructuras de esta unidad.
+        </p>
+        <DialoguePractice client:visible dialogues={dialogues} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-c">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">C</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Constructor de Estructuras</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Voz pasiva y modales de consejo — la base del inglés médico.
+        </p>
+        <SentenceBuilder client:visible blocks={structureBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-d">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">D</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Corrección de Errores</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Seis errores que pueden confundir a los doctores o, peor, minimizar síntomas serios.
+        </p>
+        <ErrorCorrection client:visible data={errorCorrections} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-e">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">E</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Laboratorio de Pronunciación</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Sonidos schwa en construcciones pasivas y vocabulario médico difícil.
+        </p>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-f">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">F</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Auto-Evaluación</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Ponte a prueba con expresiones de síntomas, frases de preguntas para doctores y vocabulario de emergencia.
+        </p>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/es/curso/intermedio/unidad-6/"
+          class="text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          &larr; Unidad 6
+        </a>
+        <Button href="/es/curso/intermedio/unidad-8/" variant="primary" size="md">
+          Unidad 8: Dinero y Compras
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/intermedio/unidad-8.astro
+++ b/src/pages/es/curso/intermedio/unidad-8.astro
@@ -1,0 +1,194 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import SpecifierBuilder from "@components/course/SpecifierBuilder";
+import DialoguePractice from "@components/course/DialoguePractice";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import ErrorCorrection from "@components/course/ErrorCorrection";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import SelfTest from "@components/course/SelfTest";
+import { intermediateUnits } from "@data/intermediate/units";
+import {
+  specifierExamples,
+  dialogues,
+  structureBlocks,
+  errorCorrections,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/intermediate/unit-8";
+import { ArrowRight, Wallet, Layers, Volume2, Target } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/intermediate/unit-8" as const;
+
+const progressUnits = intermediateUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unidad 8: Dinero y Compras | Construyendo Fluidez | NY English Teacher"
+  description="Inglés de consumidor para compras, banca y quejas. Domina las cláusulas relativas para especificar exactamente lo que quieres, más los modales de preferencia (would rather, would prefer). Lección B1-B2 gratis para hispanohablantes."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={8}
+    basePath="/es/curso/intermedio"
+    lang="es"
+    courseId="intermediate"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Wallet class="w-4 h-4" />
+          Unidad 8
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Dinero y Compras
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Cuando algo sale mal con una compra, el inglés vago se ignora — el inglés
+          específico obtiene resultados. Esta unidad te enseña a identificar, describir
+          y quejarte con precisión usando <strong class="text-white">cláusulas relativas</strong>,
+          además de expresar tus preferencias cortésmente con
+          <strong class="text-white">would rather</strong> y
+          <strong class="text-white">would prefer</strong>.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Target class="w-3.5 h-3.5" /> Constructor de Especificaciones
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Layers class="w-3.5 h-3.5" /> Cláusulas Relativas
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Volume2 class="w-3.5 h-3.5" /> Modales de Preferencia
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-a">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">A</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Constructor de Especificaciones</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Mira cómo las oraciones vagas se vuelven específicas con cláusulas relativas. Cada
+          ejemplo destaca el pronombre relativo y explica por qué es la elección correcta.
+        </p>
+        <SpecifierBuilder client:visible examples={specifierExamples} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-b">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">B</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Práctica de Diálogo</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Una devolución real en una tienda real — observa cómo el cliente usa cláusulas
+          relativas para identificar el artículo y modales de preferencia para expresar lo que quiere.
+        </p>
+        <DialoguePractice client:visible dialogues={dialogues} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-c">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">C</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Constructor de Estructuras</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Cláusulas relativas definitorias vs. no definitorias, más 'would rather' y 'would prefer'.
+        </p>
+        <SentenceBuilder client:visible blocks={structureBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-d">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">D</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Corrección de Errores</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Seis errores que confunden a empleados de tienda y cajeros bancarios — corrígelos antes de tu próxima devolución.
+        </p>
+        <ErrorCorrection client:visible data={errorCorrections} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-e">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">E</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Laboratorio de Pronunciación</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Acento de oración para énfasis — cómo las mismas palabras pueden significar cosas diferentes según cuál acentúes.
+        </p>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-f">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">F</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Auto-Evaluación</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Ponte a prueba con expresiones de cláusulas relativas, frases de preferencia y vocabulario de dinero y compras.
+        </p>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/es/curso/intermedio/unidad-7/"
+          class="text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          &larr; Unidad 7
+        </a>
+        <Button href="/es/curso/intermedio/" variant="primary" size="md">
+          Resumen del Curso
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary
Two more units, two more brand-new Section A components — keeping the curriculum visually and pedagogically distinct per unit.

### Unit 7 — Health and Emergencies
- **SurvivalPhrases** component: 4 categorized situations (Doctor / Emergency Call / Pharmacy / Hospital), reveal-on-tap with urgency badges (low/medium/high) and explanations of why the exact wording matters
- Grammar: passive voice + advice modals (should, ought to, had better)
- Doctor's appointment dialogue
- 6 medical English errors including the famous **'embarrassed' / 'embarazada' false cognate** that could embarrass patients literally
- Pronunciation: schwa in passive constructions, plus tricky medical vocab (patient, medicine, comfortable, ambulance)

### Unit 8 — Money and Shopping
- **SpecifierBuilder** component: vague→specific transformation with relative clauses, color-coded relative pronoun badges, inline highlighting of the clause itself
- Grammar: defining vs non-defining relative clauses + preference modals (would rather, would prefer)
- Store return dialogue
- 6 relative clause errors including 'I'd rather **to** pay' (the modal+to trap) and the comma-with-which rule
- Pronunciation: sentence stress for emphasis (how 'I bought THIS one' vs 'I BOUGHT this one' change meaning)

### Curriculum direction
- Phrasal verbs: zero in both units. Survival phrases and specifier patterns take their place.
- Each unit Section A is now genuinely distinct from the others — no template feel.
- Modal thread continues: should/ought to/had better (Unit 7), would rather/would prefer (Unit 8).

## Test plan
- [x] \`npm run build\` passes (234 sitemap URLs)
- [ ] Visit \`/en/course/intermediate/unit-7/\` — survival phrases categories work
- [ ] Visit \`/en/course/intermediate/unit-8/\` — specifier builder transitions work
- [ ] Verify ES mirrors at \`/es/curso/intermedio/unidad-7/\` and \`/es/curso/intermedio/unidad-8/\`
- [ ] Confirm both units unlocked on landing pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)