### PR TITLE
feat: intermediate finale — Units 9, 10, and final exam

### DIFF
--- a/src/components/course/CourseExam.tsx
+++ b/src/components/course/CourseExam.tsx
@@ -1,15 +1,24 @@
 import { useState, useMemo, useCallback, useEffect } from "react";
 import type { ExamQuestion, ExamResult } from "@data/course/exam";
-import { calculateExamResult, getScoreTier } from "@data/course/exam";
+
+export type ScoreTier = {
+  tier: string;
+  tierEs: string;
+  color: string;
+  message: string;
+  messageEs: string;
+};
 
 interface Props {
   questions: ExamQuestion[];
   lang: "en" | "es";
   passingScore: number;
   courseBasePath: string;
+  calculateExamResult: (answers: Record<number, number>) => ExamResult;
+  getScoreTier: (percentage: number) => ScoreTier;
 }
 
-export default function CourseExam({ questions, lang, passingScore, courseBasePath }: Props) {
+export default function CourseExam({ questions, lang, passingScore, courseBasePath, calculateExamResult, getScoreTier }: Props) {
   const [phase, setPhase] = useState<"intro" | "exam" | "results">("intro");
   const [currentIndex, setCurrentIndex] = useState(0);
   const [answers, setAnswers] = useState<Record<number, number>>({});

--- a/src/components/course/DeductionLab.tsx
+++ b/src/components/course/DeductionLab.tsx
@@ -1,0 +1,197 @@
+import { useState } from "react";
+import { Search, RotateCcw, Sparkles, CheckCircle2, XCircle } from "lucide-react";
+import AudioButton from "./AudioButton";
+
+export interface DeductionScenario {
+  /** The observation/clue */
+  clue: string;
+  clueEs: string;
+  /** Possible deductions, each using a different modal */
+  deductions: {
+    text: string;
+    textEs: string;
+    modal: "must" | "can't" | "might" | "could" | "must have" | "can't have" | "might have";
+    isMostLikely: boolean;
+    why: string;
+    whyEs: string;
+  }[];
+}
+
+interface Props {
+  scenarios: DeductionScenario[];
+  lang: "en" | "es";
+}
+
+const modalColors: Record<DeductionScenario["deductions"][number]["modal"], string> = {
+  must: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  "can't": "bg-rose-100 text-rose-700 border-rose-200",
+  might: "bg-amber-100 text-amber-700 border-amber-200",
+  could: "bg-blue-100 text-blue-700 border-blue-200",
+  "must have": "bg-emerald-100 text-emerald-700 border-emerald-200",
+  "can't have": "bg-rose-100 text-rose-700 border-rose-200",
+  "might have": "bg-amber-100 text-amber-700 border-amber-200",
+};
+
+export default function DeductionLab({ scenarios, lang }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [selectedDeduction, setSelectedDeduction] = useState<number | null>(null);
+  const [showResult, setShowResult] = useState(false);
+
+  const current = scenarios[currentIndex];
+  const isLast = currentIndex === scenarios.length - 1;
+
+  const handleSelect = (i: number) => {
+    if (showResult) return;
+    setSelectedDeduction(i);
+    setShowResult(true);
+  };
+
+  const handleNext = () => {
+    if (!isLast) {
+      setCurrentIndex(currentIndex + 1);
+      setSelectedDeduction(null);
+      setShowResult(false);
+    }
+  };
+
+  const handleRestart = () => {
+    setCurrentIndex(0);
+    setSelectedDeduction(null);
+    setShowResult(false);
+  };
+
+  return (
+    <section className="space-y-6">
+      {/* Progress */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-slate-500">
+          {lang === "es" ? "Escenario" : "Scenario"} {currentIndex + 1} /{" "}
+          {scenarios.length}
+        </span>
+        <button
+          onClick={handleRestart}
+          className="text-xs text-slate-400 hover:text-amber-600 inline-flex items-center gap-1 transition-colors"
+        >
+          <RotateCcw size={12} />
+          {lang === "es" ? "Reiniciar" : "Restart"}
+        </button>
+      </div>
+
+      <div className="w-full h-1.5 bg-slate-100 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-amber-500 rounded-full transition-all duration-300"
+          style={{ width: `${((currentIndex + 1) / scenarios.length) * 100}%` }}
+        />
+      </div>
+
+      {/* Clue card */}
+      <div className="bg-gradient-to-br from-slate-900 to-slate-800 rounded-2xl p-6 text-white">
+        <div className="flex items-start gap-3">
+          <Search className="w-5 h-5 text-amber-400 shrink-0 mt-1" />
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-amber-400 mb-2">
+              {lang === "es" ? "La pista:" : "The clue:"}
+            </p>
+            <p className="text-base leading-relaxed">
+              {lang === "es" ? current.clueEs : current.clue}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Question */}
+      <p className="text-sm font-semibold text-slate-700 text-center">
+        {lang === "es"
+          ? "¿Qué deducción es la más probable?"
+          : "Which deduction is most likely?"}
+      </p>
+
+      {/* Deduction options */}
+      <div className="space-y-3">
+        {current.deductions.map((d, i) => {
+          const isSelected = selectedDeduction === i;
+          const isCorrect = d.isMostLikely;
+          const showCorrectness = showResult;
+
+          return (
+            <button
+              key={i}
+              onClick={() => handleSelect(i)}
+              disabled={showResult}
+              className={`w-full text-left p-4 rounded-xl border-2 transition-all ${
+                showCorrectness
+                  ? isCorrect
+                    ? "border-emerald-400 bg-emerald-50"
+                    : isSelected
+                      ? "border-rose-400 bg-rose-50"
+                      : "border-slate-200 bg-white opacity-60"
+                  : "border-slate-200 bg-white hover:border-amber-300 hover:bg-amber-50"
+              }`}
+            >
+              <div className="flex items-start gap-3">
+                <span
+                  className={`text-xs font-mono px-2 py-0.5 rounded-full border shrink-0 ${modalColors[d.modal]}`}
+                >
+                  {d.modal}
+                </span>
+                <div className="flex-1">
+                  <p className="text-base text-slate-900 leading-relaxed">"{d.text}"</p>
+                  <p className="text-sm text-slate-500 mt-1">{d.textEs}</p>
+                </div>
+                {showCorrectness && isCorrect && (
+                  <CheckCircle2 className="w-5 h-5 text-emerald-500 shrink-0" />
+                )}
+                {showCorrectness && isSelected && !isCorrect && (
+                  <XCircle className="w-5 h-5 text-rose-500 shrink-0" />
+                )}
+              </div>
+              {showCorrectness && (isSelected || isCorrect) && (
+                <div className="mt-3 pt-3 border-t border-slate-200 flex items-start gap-2">
+                  <Sparkles size={12} className="text-amber-500 shrink-0 mt-0.5" />
+                  <p className="text-xs text-slate-600 leading-relaxed">
+                    {lang === "es" ? d.whyEs : d.why}
+                  </p>
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Audio for the most likely deduction */}
+      {showResult && (
+        <div className="bg-amber-50 border border-amber-200 rounded-xl p-3 flex items-center justify-between">
+          <p className="text-sm text-slate-700">
+            {lang === "es" ? "Escucha la deducción correcta:" : "Hear the correct deduction:"}
+          </p>
+          <AudioButton
+            text={current.deductions.find((d) => d.isMostLikely)?.text || ""}
+            size="sm"
+          />
+        </div>
+      )}
+
+      {/* Next button */}
+      {showResult && !isLast && (
+        <div className="flex justify-end">
+          <button
+            onClick={handleNext}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-500 text-white font-medium hover:bg-amber-400 transition-colors shadow-sm"
+          >
+            {lang === "es" ? "Siguiente escenario" : "Next scenario"}
+          </button>
+        </div>
+      )}
+
+      {showResult && isLast && (
+        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 text-center">
+          <p className="text-emerald-800 font-medium text-sm">
+            {lang === "es"
+              ? "¡Has terminado! Ahora puedes razonar en voz alta como un nativo."
+              : "You've finished! You can now reason out loud like a native speaker."}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/course/WishTransformer.tsx
+++ b/src/components/course/WishTransformer.tsx
@@ -1,0 +1,183 @@
+import { useState } from "react";
+import { ArrowDown, RotateCcw, Heart, Sparkles } from "lucide-react";
+import AudioButton from "./AudioButton";
+
+export interface WishTransformation {
+  /** Reality — what is true */
+  reality: string;
+  realityEs: string;
+  /** Wish/regret — how to express the unrealized version */
+  wish: string;
+  wishEs: string;
+  /** Type of wish */
+  wishType: "present" | "past" | "future" | "regret";
+  /** Why this transformation */
+  whyTransform: string;
+  whyTransformEs: string;
+  /** Emotional context — what feeling this captures */
+  feeling: string;
+  feelingEs: string;
+}
+
+interface Props {
+  transformations: WishTransformation[];
+  lang: "en" | "es";
+}
+
+const wishTypeColors: Record<WishTransformation["wishType"], string> = {
+  present: "bg-blue-100 text-blue-700 border-blue-200",
+  past: "bg-violet-100 text-violet-700 border-violet-200",
+  future: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  regret: "bg-rose-100 text-rose-700 border-rose-200",
+};
+
+const wishTypeLabels: Record<WishTransformation["wishType"], { en: string; es: string }> = {
+  present: { en: "wish about present", es: "deseo sobre el presente" },
+  past: { en: "wish about past", es: "deseo sobre el pasado" },
+  future: { en: "wish for future", es: "deseo para el futuro" },
+  regret: { en: "regret", es: "arrepentimiento" },
+};
+
+export default function WishTransformer({ transformations, lang }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isRevealed, setIsRevealed] = useState(false);
+
+  const current = transformations[currentIndex];
+  const isLast = currentIndex === transformations.length - 1;
+
+  const handleReveal = () => setIsRevealed(true);
+
+  const handleNext = () => {
+    if (!isLast) {
+      setCurrentIndex(currentIndex + 1);
+      setIsRevealed(false);
+    }
+  };
+
+  const handleRestart = () => {
+    setCurrentIndex(0);
+    setIsRevealed(false);
+  };
+
+  return (
+    <section className="space-y-6">
+      {/* Progress */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-slate-500">
+          {lang === "es" ? "Transformación" : "Transformation"} {currentIndex + 1} /{" "}
+          {transformations.length}
+        </span>
+        <button
+          onClick={handleRestart}
+          className="text-xs text-slate-400 hover:text-rose-500 inline-flex items-center gap-1 transition-colors"
+        >
+          <RotateCcw size={12} />
+          {lang === "es" ? "Reiniciar" : "Restart"}
+        </button>
+      </div>
+
+      <div className="w-full h-1.5 bg-slate-100 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-rose-400 rounded-full transition-all duration-300"
+          style={{ width: `${((currentIndex + 1) / transformations.length) * 100}%` }}
+        />
+      </div>
+
+      {/* Card */}
+      <div className="bg-white rounded-2xl border-2 border-slate-200 overflow-hidden">
+        {/* Feeling badge */}
+        <div className="px-6 pt-6 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Heart size={14} className="text-rose-400" />
+            <span className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+              {lang === "es" ? current.feelingEs : current.feeling}
+            </span>
+          </div>
+          <span
+            className={`text-xs font-mono px-2 py-0.5 rounded-full border ${wishTypeColors[current.wishType]}`}
+          >
+            {wishTypeLabels[current.wishType][lang]}
+          </span>
+        </div>
+
+        {/* Reality */}
+        <div className="px-6 pt-4">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-2">
+            {lang === "es" ? "La realidad:" : "The reality:"}
+          </p>
+          <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
+            <p className="text-base text-slate-700">{current.reality}</p>
+            <p className="text-sm text-slate-400 mt-1">{current.realityEs}</p>
+          </div>
+        </div>
+
+        {/* Arrow */}
+        <div className="flex justify-center py-3">
+          <ArrowDown className="w-5 h-5 text-slate-300" />
+        </div>
+
+        {/* Wish/regret */}
+        <div className="px-6 pb-6">
+          <p className="text-xs font-semibold uppercase tracking-wider text-rose-500 mb-2 flex items-center gap-1">
+            <Sparkles size={12} />
+            {lang === "es" ? "Cómo expresarlo:" : "How to express it:"}
+          </p>
+
+          {!isRevealed ? (
+            <button
+              onClick={handleReveal}
+              className="w-full py-4 rounded-xl border-2 border-dashed border-rose-300 text-rose-500 font-medium hover:bg-rose-50 transition-colors"
+            >
+              {lang === "es"
+                ? "Toca para ver la transformación"
+                : "Tap to see the transformation"}
+            </button>
+          ) : (
+            <div className="space-y-3">
+              <div className="bg-gradient-to-br from-rose-50 to-rose-100 border-2 border-rose-300 rounded-xl p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex-1">
+                    <p className="text-base text-slate-900 font-medium leading-relaxed">
+                      "{current.wish}"
+                    </p>
+                    <p className="text-sm text-slate-500 mt-2">{current.wishEs}</p>
+                  </div>
+                  <div className="shrink-0 mt-1">
+                    <AudioButton text={current.wish} size="sm" />
+                  </div>
+                </div>
+                <div className="mt-3 pt-3 border-t border-rose-200">
+                  <p className="text-xs text-slate-600 leading-relaxed">
+                    {lang === "es" ? current.whyTransformEs : current.whyTransform}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Next button */}
+      {isRevealed && !isLast && (
+        <div className="flex justify-end">
+          <button
+            onClick={handleNext}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-rose-500 text-white font-medium hover:bg-rose-400 transition-colors shadow-sm"
+          >
+            {lang === "es" ? "Siguiente" : "Next"}
+          </button>
+        </div>
+      )}
+
+      {isRevealed && isLast && (
+        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 text-center">
+          <p className="text-emerald-800 font-medium text-sm">
+            {lang === "es"
+              ? "¡Bien hecho! Has visto cómo expresar deseos y arrepentimientos en inglés."
+              : "Well done! You've seen how to express wishes and regrets in English."}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/data/intermediate/exam.ts
+++ b/src/data/intermediate/exam.ts
@@ -1,0 +1,446 @@
+// Final Exam: "Building Fluency" — Intermediate Course Comprehensive Assessment
+// 20 multiple-choice questions covering all 10 intermediate units
+// Reuses ExamQuestion / ExamOption / ExamResult types from the beginner exam module
+
+import type { ExamQuestion, ExamResult } from "../course/exam";
+import type { ScoreTier } from "../../components/course/CourseExam";
+
+export const examMeta = {
+  title: "Final Exam",
+  titleEs: "Examen Final",
+  subtitle: "Building Fluency — Comprehensive Assessment",
+  subtitleEs: "Construyendo Fluidez — Evaluación Integral",
+  description:
+    "20 questions covering modals, conditionals, narrative tenses, opinions, deductions, and the rest of the intermediate curriculum. Test what you've learned across all 10 units.",
+  descriptionEs:
+    "20 preguntas sobre modales, condicionales, tiempos narrativos, opiniones, deducciones y el resto del currículo intermedio. Evalúa lo que has aprendido en las 10 unidades.",
+  passingScore: 70,
+};
+
+export const examQuestions: ExamQuestion[] = [
+  // ─── Unit 1: The Phrasal Verb Problem ──────────────────────────────
+  {
+    id: 1,
+    unit: 1,
+    category: "vocabulary",
+    prompt: 'What does "find out" mean?',
+    promptEs: '¿Qué significa "find out"?',
+    options: [
+      { text: "to discover information", correct: true },
+      { text: "to leave a place", correct: false },
+      { text: "to make a list", correct: false },
+      { text: "to forget something", correct: false },
+    ],
+    explanation:
+      '"Find out" means to discover information, often something new or surprising. It is one of the most useful phrasal verbs in everyday English.',
+    explanationEs:
+      '"Find out" significa descubrir información, frecuentemente algo nuevo o sorprendente. Es uno de los phrasal verbs más útiles en inglés cotidiano.',
+  },
+  {
+    id: 2,
+    unit: 1,
+    category: "grammar",
+    prompt: "Which sentence uses the present perfect correctly?",
+    promptEs: "¿Qué oración usa el presente perfecto correctamente?",
+    options: [
+      { text: "I have lived here for five years.", correct: true },
+      { text: "I have lived here since five years.", correct: false },
+      { text: "I am living here for five years.", correct: false },
+      { text: "I live here since five years.", correct: false },
+    ],
+    explanation:
+      "Use 'for' with a duration ('for five years') and the present perfect ('have lived') for an ongoing past situation.",
+    explanationEs:
+      "Usa 'for' con una duración ('for five years') y el presente perfecto ('have lived') para una situación pasada continua.",
+  },
+
+  // ─── Unit 2: At the Office ─────────────────────────────────────────
+  {
+    id: 3,
+    unit: 2,
+    category: "grammar",
+    prompt: "Choose the correct present perfect continuous form:",
+    promptEs: "Elige la forma correcta del presente perfecto continuo:",
+    options: [
+      { text: "She has been working on the project all morning.", correct: true },
+      { text: "She has been work on the project all morning.", correct: false },
+      { text: "She has working on the project all morning.", correct: false },
+      { text: "She is been working on the project all morning.", correct: false },
+    ],
+    explanation:
+      "Present perfect continuous = have/has + been + verb-ing. 'Has been working' is the correct form.",
+    explanationEs:
+      "El presente perfecto continuo = have/has + been + verbo-ing. 'Has been working' es la forma correcta.",
+  },
+  {
+    id: 4,
+    unit: 2,
+    category: "vocabulary",
+    prompt: "What does 'follow up' most commonly mean in business English?",
+    promptEs: "¿Qué significa 'follow up' más comúnmente en inglés de negocios?",
+    options: [
+      { text: "to check on the progress of something", correct: true },
+      { text: "to walk behind someone", correct: false },
+      { text: "to obey a command", correct: false },
+      { text: "to climb upward", correct: false },
+    ],
+    explanation:
+      "'Follow up' means to check on the progress of something or contact someone again about a previous matter. It is one of the most common verbs in business English.",
+    explanationEs:
+      "'Follow up' significa verificar el progreso de algo o contactar a alguien de nuevo sobre un asunto previo. Es uno de los verbos más comunes en inglés de negocios.",
+  },
+
+  // ─── Unit 3: Getting Around ────────────────────────────────────────
+  {
+    id: 5,
+    unit: 3,
+    category: "grammar",
+    prompt: "Choose the correct first conditional sentence:",
+    promptEs: "Elige la oración correcta del primer condicional:",
+    options: [
+      { text: "If it rains, we will stay home.", correct: true },
+      { text: "If it will rain, we will stay home.", correct: false },
+      { text: "If it rains, we stay home.", correct: false },
+      { text: "If it would rain, we will stay home.", correct: false },
+    ],
+    explanation:
+      "First conditional = If + present simple, will + base verb. NEVER use 'will' in the if-clause.",
+    explanationEs:
+      "Primer condicional = If + presente simple, will + verbo base. NUNCA uses 'will' en la cláusula 'if'.",
+  },
+  {
+    id: 6,
+    unit: 3,
+    category: "vocabulary",
+    prompt: "Which sentence uses the correct travel phrasal verb?",
+    promptEs: "¿Qué oración usa el phrasal verb de viaje correcto?",
+    options: [
+      { text: "I need to get on the bus at the next stop.", correct: true },
+      { text: "I need to get in the bus at the next stop.", correct: false },
+      { text: "I need to get up the bus at the next stop.", correct: false },
+      { text: "I need to get into the bus at the next stop.", correct: false },
+    ],
+    explanation:
+      "For buses, trains, planes and bikes, use 'get ON'. Use 'get IN' only for cars and small enclosed vehicles.",
+    explanationEs:
+      "Para autobuses, trenes, aviones y bicicletas, usa 'get ON'. Usa 'get IN' solo para coches y vehículos pequeños cerrados.",
+  },
+
+  // ─── Unit 4: Making Plans ──────────────────────────────────────────
+  {
+    id: 7,
+    unit: 4,
+    category: "translation",
+    prompt: "What is the most polite way to invite someone to dinner?",
+    promptEs: "¿Cuál es la forma más cortés de invitar a alguien a cenar?",
+    options: [
+      { text: "Would you like to join us for dinner?", correct: true },
+      { text: "Do you want to come to dinner?", correct: false },
+      { text: "You come to dinner with us?", correct: false },
+      { text: "Come to dinner with us!", correct: false },
+    ],
+    explanation:
+      "'Would you like to' is the polite, sophisticated form for invitations. 'Do you want' is too direct for most social contexts.",
+    explanationEs:
+      "'Would you like to' es la forma cortés y sofisticada para invitaciones. 'Do you want' es demasiado directo para la mayoría de contextos sociales.",
+  },
+  {
+    id: 8,
+    unit: 4,
+    category: "grammar",
+    prompt: "Choose the correct second conditional:",
+    promptEs: "Elige el segundo condicional correcto:",
+    options: [
+      { text: "If I were you, I would accept the offer.", correct: true },
+      { text: "If I would be you, I would accept the offer.", correct: false },
+      { text: "If I am you, I will accept the offer.", correct: false },
+      { text: "If I was you, I will accept the offer.", correct: false },
+    ],
+    explanation:
+      "Second conditional with 'be' uses 'were' for ALL persons (I, he, she, it) — this is the subjunctive mood. 'Were' is the educated B2+ choice.",
+    explanationEs:
+      "El segundo condicional con 'be' usa 'were' para TODAS las personas (I, he, she, it) — este es el modo subjuntivo. 'Were' es la opción educada B2+.",
+  },
+
+  // ─── Unit 5: Telling Stories ───────────────────────────────────────
+  {
+    id: 9,
+    unit: 5,
+    category: "grammar",
+    prompt: "Which sentence correctly uses the past perfect?",
+    promptEs: "¿Qué oración usa correctamente el pasado perfecto?",
+    options: [
+      { text: "When I arrived, the meeting had already started.", correct: true },
+      { text: "When I arrived, the meeting already started.", correct: false },
+      { text: "When I had arrived, the meeting started.", correct: false },
+      { text: "When I arrived, the meeting was already started.", correct: false },
+    ],
+    explanation:
+      "Use past perfect ('had started') for the EARLIER of two past events. The meeting started before you arrived.",
+    explanationEs:
+      "Usa el pasado perfecto ('had started') para el ANTERIOR de dos eventos pasados. La junta empezó antes de que llegaras.",
+  },
+  {
+    id: 10,
+    unit: 5,
+    category: "translation",
+    prompt: "How do you correctly report what someone said in the past?",
+    promptEs: "¿Cómo reportas correctamente lo que alguien dijo en el pasado?",
+    options: [
+      { text: "She said she would call me later.", correct: true },
+      { text: "She said me she will call me later.", correct: false },
+      { text: "She said that she will call me later.", correct: false },
+      { text: "She told that she would call me later.", correct: false },
+    ],
+    explanation:
+      "In reported speech, 'will' shifts to 'would' when the reporting verb is in the past. Also, 'tell' takes a direct object ('told me'), but 'said' does not ('said that').",
+    explanationEs:
+      "En el discurso indirecto, 'will' cambia a 'would' cuando el verbo que reporta está en pasado. Además, 'tell' toma un objeto directo ('told me'), pero 'said' no ('said that').",
+  },
+
+  // ─── Unit 6: Expressing Opinions ───────────────────────────────────
+  {
+    id: 11,
+    unit: 6,
+    category: "grammar",
+    prompt: "Choose the correct third conditional:",
+    promptEs: "Elige el tercer condicional correcto:",
+    options: [
+      { text: "If I had known, I would have called you.", correct: true },
+      { text: "If I would have known, I would have called you.", correct: false },
+      { text: "If I knew, I would call you.", correct: false },
+      { text: "If I had known, I will have called you.", correct: false },
+    ],
+    explanation:
+      "Third conditional = If + had + past participle, would have + past participle. NEVER use 'would have' in the if-clause.",
+    explanationEs:
+      "Tercer condicional = If + had + participio, would have + participio. NUNCA uses 'would have' en la cláusula 'if'.",
+  },
+  {
+    id: 12,
+    unit: 6,
+    category: "vocabulary",
+    prompt: "Which is the most polite way to disagree with someone?",
+    promptEs: "¿Cuál es la forma más cortés de discrepar con alguien?",
+    options: [
+      { text: "I see your point, but I'm not sure I agree.", correct: true },
+      { text: "You are wrong about that.", correct: false },
+      { text: "I am not agree with you.", correct: false },
+      { text: "No, that is bad idea.", correct: false },
+    ],
+    explanation:
+      "Diplomatic disagreement always acknowledges the other person ('I see your point') before pushing back. Direct contradiction damages relationships in English.",
+    explanationEs:
+      "El desacuerdo diplomático siempre reconoce a la otra persona ('I see your point') antes de objetar. La contradicción directa daña relaciones en inglés.",
+  },
+
+  // ─── Unit 7: Health and Emergencies ────────────────────────────────
+  {
+    id: 13,
+    unit: 7,
+    category: "grammar",
+    prompt: "Choose the correct passive voice with an advice modal:",
+    promptEs: "Elige la voz pasiva correcta con un modal de consejo:",
+    options: [
+      { text: "This medication should be taken with food.", correct: true },
+      { text: "This medication should take with food.", correct: false },
+      { text: "This medication should being taken with food.", correct: false },
+      { text: "This medication should taken with food.", correct: false },
+    ],
+    explanation:
+      "Passive voice = be + past participle. With a modal: modal + be + past participle. 'Should be taken' is the correct form.",
+    explanationEs:
+      "Voz pasiva = be + participio. Con un modal: modal + be + participio. 'Should be taken' es la forma correcta.",
+  },
+  {
+    id: 14,
+    unit: 7,
+    category: "vocabulary",
+    prompt: 'Which English term means "efectos secundarios"?',
+    promptEs: 'Qué término en inglés significa "efectos secundarios"?',
+    options: [
+      { text: "side effects", correct: true },
+      { text: "secondary effects", correct: false },
+      { text: "second effects", correct: false },
+      { text: "after effects", correct: false },
+    ],
+    explanation:
+      "The standard medical term is 'side effects'. 'Secondary effects' is a literal Spanish translation that sounds non-native to doctors and pharmacists.",
+    explanationEs:
+      "El término médico estándar es 'side effects'. 'Secondary effects' es una traducción literal del español que suena no-nativa a doctores y farmacéuticos.",
+  },
+
+  // ─── Unit 8: Money and Shopping ────────────────────────────────────
+  {
+    id: 15,
+    unit: 8,
+    category: "grammar",
+    prompt: "Choose the correct relative pronoun:",
+    promptEs: "Elige el pronombre relativo correcto:",
+    options: [
+      { text: "The woman who lives next door is a doctor.", correct: true },
+      { text: "The woman which lives next door is a doctor.", correct: false },
+      { text: "The woman whose lives next door is a doctor.", correct: false },
+      { text: "The woman where lives next door is a doctor.", correct: false },
+    ],
+    explanation:
+      "Use 'who' for people, 'that/which' for things, 'whose' for possession, 'where' for places. Spanish 'que' covers all of these, which causes confusion.",
+    explanationEs:
+      "Usa 'who' para personas, 'that/which' para cosas, 'whose' para posesión, 'where' para lugares. El 'que' del español los cubre todos, lo que causa confusión.",
+  },
+  {
+    id: 16,
+    unit: 8,
+    category: "grammar",
+    prompt: "Which sentence uses 'would rather' correctly?",
+    promptEs: "¿Qué oración usa 'would rather' correctamente?",
+    options: [
+      { text: "I'd rather pay in cash.", correct: true },
+      { text: "I'd rather to pay in cash.", correct: false },
+      { text: "I'd rather paying in cash.", correct: false },
+      { text: "I would rather to pay in cash.", correct: false },
+    ],
+    explanation:
+      "After 'would rather', use the BASE form of the verb — never 'to + verb'. Compare with 'would prefer to pay' (which DOES take 'to').",
+    explanationEs:
+      "Después de 'would rather', usa la forma BASE del verbo — nunca 'to + verbo'. Compara con 'would prefer to pay' (que SÍ lleva 'to').",
+  },
+
+  // ─── Unit 9: Relationships and Feelings ────────────────────────────
+  {
+    id: 17,
+    unit: 9,
+    category: "grammar",
+    prompt: "Choose the correct wish about the present:",
+    promptEs: "Elige el deseo correcto sobre el presente:",
+    options: [
+      { text: "I wish I had more time.", correct: true },
+      { text: "I wish I have more time.", correct: false },
+      { text: "I wish I will have more time.", correct: false },
+      { text: "I wish I would have more time.", correct: false },
+    ],
+    explanation:
+      "After 'wish' for present situations, use the past simple form ('had'), even though you mean now. The past tense signals the unreality of the wish.",
+    explanationEs:
+      "Después de 'wish' para situaciones presentes, usa el pasado simple ('had'), aunque te refieras a ahora. El pasado señala la irrealidad del deseo.",
+  },
+  {
+    id: 18,
+    unit: 9,
+    category: "translation",
+    prompt: "How do you express regret about a past action?",
+    promptEs: "¿Cómo expresas arrepentimiento sobre una acción pasada?",
+    options: [
+      { text: "I should have called you sooner.", correct: true },
+      { text: "I should called you sooner.", correct: false },
+      { text: "I should be called you sooner.", correct: false },
+      { text: "I should call you sooner.", correct: false },
+    ],
+    explanation:
+      "For past regrets with 'should', use 'should have + past participle'. In speech this contracts to 'should've called' (NOT 'should of').",
+    explanationEs:
+      "Para arrepentimientos del pasado con 'should', usa 'should have + participio'. En el habla se contrae a 'should've called' (NO 'should of').",
+  },
+
+  // ─── Unit 10: Sounding Native ──────────────────────────────────────
+  {
+    id: 19,
+    unit: 10,
+    category: "grammar",
+    prompt: "Choose the correct past deduction:",
+    promptEs: "Elige la deducción pasada correcta:",
+    options: [
+      { text: "She must have left early. Her car isn't here.", correct: true },
+      { text: "She must left early. Her car isn't here.", correct: false },
+      { text: "She must to have left early. Her car isn't here.", correct: false },
+      { text: "She must has left early. Her car isn't here.", correct: false },
+    ],
+    explanation:
+      "For past deductions, use 'must have + past participle'. The structure is always 'modal + have + past participle' for past deductions.",
+    explanationEs:
+      "Para deducciones del pasado, usa 'must have + participio'. La estructura siempre es 'modal + have + participio' para deducciones pasadas.",
+  },
+  {
+    id: 20,
+    unit: 10,
+    category: "vocabulary",
+    prompt: "Which modal expresses the HIGHEST confidence in a deduction?",
+    promptEs: "¿Qué modal expresa la MAYOR confianza en una deducción?",
+    options: [
+      { text: "must", correct: true },
+      { text: "might", correct: false },
+      { text: "could", correct: false },
+      { text: "may", correct: false },
+    ],
+    explanation:
+      "'Must' = ~95% certain. 'Could/might/may' = ~40-50% certain. The certainty scale: must (highest) > could > might > may. 'Can't' is the highest negative certainty.",
+    explanationEs:
+      "'Must' = ~95% seguro. 'Could/might/may' = ~40-50% seguro. La escala de certeza: must (la más alta) > could > might > may. 'Can't' es la mayor certeza negativa.",
+  },
+];
+
+export function calculateExamResult(
+  answers: Record<number, number>,
+): ExamResult {
+  const unitScores: Record<number, { correct: number; total: number }> = {};
+  const categoryScores: Record<string, { correct: number; total: number }> = {};
+  let totalCorrect = 0;
+
+  for (const q of examQuestions) {
+    if (!unitScores[q.unit]) unitScores[q.unit] = { correct: 0, total: 0 };
+    if (!categoryScores[q.category])
+      categoryScores[q.category] = { correct: 0, total: 0 };
+
+    unitScores[q.unit].total++;
+    categoryScores[q.category].total++;
+
+    const selectedIndex = answers[q.id];
+    if (selectedIndex !== undefined && q.options[selectedIndex]?.correct) {
+      totalCorrect++;
+      unitScores[q.unit].correct++;
+      categoryScores[q.category].correct++;
+    }
+  }
+
+  return {
+    totalCorrect,
+    totalQuestions: examQuestions.length,
+    percentage: Math.round((totalCorrect / examQuestions.length) * 100),
+    unitScores,
+    categoryScores,
+  };
+}
+
+export function getScoreTier(percentage: number): ScoreTier {
+  if (percentage >= 90) {
+    return {
+      tier: "Outstanding",
+      tierEs: "Sobresaliente",
+      color: "emerald",
+      message:
+        "Exceptional work. You've truly built fluency. You're ready for advanced English and real-world situations of any kind.",
+      messageEs:
+        "Trabajo excepcional. Realmente has construido fluidez. Estás listo para inglés avanzado y situaciones del mundo real de cualquier tipo.",
+    };
+  }
+  if (percentage >= 70) {
+    return {
+      tier: "Passed",
+      tierEs: "Aprobado",
+      color: "amber",
+      message:
+        "Solid performance. You've mastered the core of intermediate English. Review the units where you missed questions and keep practicing in real conversations.",
+      messageEs:
+        "Desempeño sólido. Has dominado el núcleo del inglés intermedio. Repasa las unidades donde fallaste preguntas y sigue practicando en conversaciones reales.",
+    };
+  }
+  return {
+    tier: "Keep Practicing",
+    tierEs: "Sigue Practicando",
+    color: "rose",
+    message:
+      "You're making progress, but key structures need more review. Go back to the units where you struggled — especially modals and conditionals — and try again.",
+    messageEs:
+      "Estás progresando, pero las estructuras clave necesitan más repaso. Vuelve a las unidades donde tuviste dificultades — especialmente modales y condicionales — e intenta de nuevo.",
+  };
+}

--- a/src/data/intermediate/unit-10.ts
+++ b/src/data/intermediate/unit-10.ts
@@ -1,0 +1,555 @@
+// Unit 10: "Sounding Native" — Final unit content
+// Theme: Capstone — modals of deduction, reasoning out loud
+// Grammar: Modals of deduction (must, can't, might, could / must have, can't have, might have)
+// Pronunciation: Thought groups and chunking
+// Section A: DeductionLab (multiple-choice deduction practice)
+
+import type {
+  Dialogue,
+  ErrorCorrectionSet,
+  IntermediateVocabItem,
+} from "./types";
+import type { DeductionScenario } from "../../components/course/DeductionLab";
+import type { SentenceBlock, PronunciationDrill } from "../course/unit-1";
+
+// ─── Section A: Deduction Lab ────────────────────────────────────────────────
+
+export const deductionScenarios: DeductionScenario[] = [
+  {
+    clue: "You see your colleague's car in the parking lot at 10 PM. The office building is dark.",
+    clueEs: "Ves el coche de tu colega en el estacionamiento a las 10 PM. El edificio de oficinas está oscuro.",
+    deductions: [
+      {
+        text: "He must be working late tonight.",
+        textEs: "Debe estar trabajando hasta tarde esta noche.",
+        modal: "must",
+        isMostLikely: false,
+        why: "'Must' is too certain here — the dark building is evidence AGAINST him being inside. The car alone isn't proof he's working.",
+        whyEs: "'Must' es demasiado seguro aquí — el edificio oscuro es evidencia EN CONTRA de que esté adentro. El coche solo no es prueba de que esté trabajando.",
+      },
+      {
+        text: "He might have left his car overnight.",
+        textEs: "Podría haber dejado su coche toda la noche.",
+        modal: "might have",
+        isMostLikely: true,
+        why: "'Might have' expresses uncertain possibility about the past — a perfect fit for this evidence. The dark building suggests he's not inside, so leaving the car is the most likely explanation.",
+        whyEs: "'Might have' expresa una posibilidad incierta sobre el pasado — un ajuste perfecto para esta evidencia. El edificio oscuro sugiere que no está adentro, así que dejar el coche es la explicación más probable.",
+      },
+      {
+        text: "He can't be at the office.",
+        textEs: "No puede estar en la oficina.",
+        modal: "can't",
+        isMostLikely: false,
+        why: "'Can't' is too certain in the negative direction. He COULD be in there with the lights off. We don't have enough evidence to be certain he's NOT there.",
+        whyEs: "'Can't' es demasiado seguro en dirección negativa. PODRÍA estar adentro con las luces apagadas. No tenemos suficiente evidencia para estar seguros de que NO está ahí.",
+      },
+    ],
+  },
+  {
+    clue: "Your friend has been quiet all evening, isn't eating much, and keeps checking her phone.",
+    clueEs: "Tu amiga ha estado callada toda la tarde, no come mucho y sigue revisando su teléfono.",
+    deductions: [
+      {
+        text: "Something must be bothering her.",
+        textEs: "Algo debe estar molestándola.",
+        modal: "must",
+        isMostLikely: true,
+        why: "'Must' is the right level of certainty here. The combination of three behaviors (quiet, not eating, checking phone) is strong enough evidence to draw a confident conclusion.",
+        whyEs: "'Must' es el nivel correcto de certeza aquí. La combinación de tres comportamientos (callada, no comiendo, revisando el teléfono) es evidencia suficientemente fuerte para sacar una conclusión confiada.",
+      },
+      {
+        text: "She might just be tired.",
+        textEs: "Quizás solo está cansada.",
+        modal: "might",
+        isMostLikely: false,
+        why: "'Might' is too weak — tiredness doesn't usually explain checking your phone constantly. The phone-checking is the key clue. 'Might' would be valid if she were just quiet.",
+        whyEs: "'Might' es demasiado débil — el cansancio normalmente no explica revisar el teléfono constantemente. El revisar el teléfono es la pista clave. 'Might' sería válido si solo estuviera callada.",
+      },
+      {
+        text: "She can't be enjoying herself.",
+        textEs: "No puede estar disfrutando.",
+        modal: "can't",
+        isMostLikely: false,
+        why: "'Can't' is technically possible here, but it's a negative deduction that doesn't really explain the situation. 'Must be bothered' is more useful — it's positive AND it gives a reason.",
+        whyEs: "'Can't' es técnicamente posible aquí, pero es una deducción negativa que no explica realmente la situación. 'Must be bothered' es más útil — es positiva Y da una razón.",
+      },
+    ],
+  },
+  {
+    clue: "You arrive home and find the front door unlocked, but you remember locking it before leaving.",
+    clueEs: "Llegas a casa y encuentras la puerta principal sin cerrar, pero recuerdas haberla cerrado antes de irte.",
+    deductions: [
+      {
+        text: "Someone must have come in.",
+        textEs: "Alguien debe haber entrado.",
+        modal: "must have",
+        isMostLikely: true,
+        why: "'Must have' is the right structure for confident deduction about the past. Two facts (door now open, you locked it before) lead logically to one conclusion. The past form is critical here.",
+        whyEs: "'Must have' es la estructura correcta para una deducción confiada sobre el pasado. Dos hechos (puerta ahora abierta, tú la cerraste antes) llevan lógicamente a una conclusión. La forma pasada es crítica aquí.",
+      },
+      {
+        text: "I might have forgotten to lock it.",
+        textEs: "Podría haber olvidado cerrarla.",
+        modal: "might have",
+        isMostLikely: false,
+        why: "'Might have' is possible but the clue says you REMEMBER locking it. The clue itself rules out forgetting. 'Might have' would be correct if you were uncertain.",
+        whyEs: "'Might have' es posible pero la pista dice que RECUERDAS haberla cerrado. La pista misma descarta el olvido. 'Might have' sería correcto si no estuvieras seguro.",
+      },
+      {
+        text: "It can't have been the wind.",
+        textEs: "No puede haber sido el viento.",
+        modal: "can't have",
+        isMostLikely: false,
+        why: "True, but this is a NEGATIVE deduction — it tells us what didn't happen, not what did. In real life, you'd want a positive deduction about who came in. 'Can't have' is correct grammar but unhelpful here.",
+        whyEs: "Cierto, pero esta es una deducción NEGATIVA — nos dice qué no pasó, no qué sí pasó. En la vida real, querrías una deducción positiva sobre quién entró. 'Can't have' es gramática correcta pero poco útil aquí.",
+      },
+    ],
+  },
+  {
+    clue: "You're trying to call your sister but it goes straight to voicemail every time. She always answers.",
+    clueEs: "Estás tratando de llamar a tu hermana pero va directo al buzón de voz cada vez. Ella siempre contesta.",
+    deductions: [
+      {
+        text: "Her phone could be off.",
+        textEs: "Su teléfono podría estar apagado.",
+        modal: "could",
+        isMostLikely: true,
+        why: "'Could' offers a reasonable possibility without claiming certainty. Going straight to voicemail is the classic sign of a phone being off or out of battery. 'Could' is the right tentative deduction.",
+        whyEs: "'Could' ofrece una posibilidad razonable sin reclamar certeza. Ir directo al buzón de voz es la señal clásica de un teléfono apagado o sin batería. 'Could' es la deducción tentativa correcta.",
+      },
+      {
+        text: "She must be ignoring me.",
+        textEs: "Debe estar ignorándome.",
+        modal: "must",
+        isMostLikely: false,
+        why: "Too strong a conclusion. The clue mentions she 'always answers' — that's normal behavior, not evidence of ignoring. 'Must' would be appropriate if you had reason to believe she was upset.",
+        whyEs: "Conclusión demasiado fuerte. La pista menciona que 'siempre contesta' — eso es comportamiento normal, no evidencia de estar ignorándote. 'Must' sería apropiado si tuvieras razón para creer que está molesta.",
+      },
+      {
+        text: "She can't be home.",
+        textEs: "No puede estar en casa.",
+        modal: "can't",
+        isMostLikely: false,
+        why: "Whether she's home or not isn't connected to her phone going to voicemail. People answer their phones from anywhere. This deduction doesn't follow logically from the clue.",
+        whyEs: "Si está en casa o no, no está conectado con que su teléfono vaya al buzón de voz. La gente contesta su teléfono desde cualquier lugar. Esta deducción no se sigue lógicamente de la pista.",
+      },
+    ],
+  },
+  {
+    clue: "You see a man wearing a heavy winter coat and gloves walking down the street. It's 80°F (27°C) outside.",
+    clueEs: "Ves a un hombre con un abrigo de invierno pesado y guantes caminando por la calle. Hace 27°C afuera.",
+    deductions: [
+      {
+        text: "He must not be feeling well.",
+        textEs: "Debe no sentirse bien.",
+        modal: "must",
+        isMostLikely: true,
+        why: "Strong contradiction between dress and weather usually indicates illness — fever can cause chills even in heat. 'Must' captures the high confidence of this deduction. Note: 'must not' (negative) is rare in deduction; we'd usually say 'must be sick' or 'must not be feeling well'.",
+        whyEs: "Una contradicción fuerte entre la ropa y el clima usualmente indica enfermedad — la fiebre puede causar escalofríos incluso en el calor. 'Must' captura la alta confianza de esta deducción.",
+      },
+      {
+        text: "He might be coming from a cold place.",
+        textEs: "Podría venir de un lugar frío.",
+        modal: "might",
+        isMostLikely: false,
+        why: "Possible but unusual — most people change clothes when arriving somewhere warm. 'Might' is too tentative for a deduction with such clear evidence (the visible illness signal).",
+        whyEs: "Posible pero inusual — la mayoría de la gente se cambia de ropa al llegar a un lugar cálido. 'Might' es demasiado tentativo para una deducción con evidencia tan clara.",
+      },
+      {
+        text: "He can't be a tourist.",
+        textEs: "No puede ser turista.",
+        modal: "can't",
+        isMostLikely: false,
+        why: "Tourism is unrelated to the clue. The clothing-vs-weather mismatch is the key fact. This deduction misses the point entirely — it's logically valid but not what a native speaker would conclude first.",
+        whyEs: "El turismo no está relacionado con la pista. El desajuste ropa-vs-clima es el hecho clave. Esta deducción pierde el punto completamente.",
+      },
+    ],
+  },
+];
+
+// ─── Section B: Dialogue Practice ────────────────────────────────────────────
+
+export const dialogues: Dialogue[] = [
+  {
+    title: "Solving a Mystery at Work",
+    titleEs: "Resolviendo un Misterio en el Trabajo",
+    setting: "Two coworkers are trying to figure out why their boss canceled an important meeting at the last minute",
+    settingEs: "Dos compañeros tratan de averiguar por qué su jefe canceló una junta importante en el último momento",
+    lines: [
+      {
+        speaker: "A",
+        speakerLabel: "Pablo",
+        speakerLabelEs: "Pablo",
+        english:
+          "Did you hear? The CEO canceled the all-hands meeting twenty minutes before it started.",
+        spanish:
+          "¿Te enteraste? El CEO canceló la junta general veinte minutos antes de que empezara.",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Linda",
+        speakerLabelEs: "Linda",
+        english:
+          "That's strange. He never cancels things last minute. Something must have come up.",
+        spanish:
+          "Qué raro. Él nunca cancela cosas en el último momento. Algo debe haber surgido.",
+        highlight: "Something must have come up",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Pablo",
+        speakerLabelEs: "Pablo",
+        english:
+          "I noticed he was on a long phone call this morning. It might have been with the board.",
+        spanish:
+          "Noté que estuvo en una llamada larga esta mañana. Podría haber sido con la junta directiva.",
+        highlight: "It might have been",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Linda",
+        speakerLabelEs: "Linda",
+        english:
+          "Could be. Or it could have been with a major client. The timing suggests it was urgent.",
+        spanish:
+          "Podría ser. O podría haber sido con un cliente importante. El momento sugiere que era urgente.",
+        highlight: "Could be / could have been",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Pablo",
+        speakerLabelEs: "Pablo",
+        english:
+          "It can't have been good news. He looked stressed when he walked past my desk.",
+        spanish:
+          "No pueden haber sido buenas noticias. Se veía estresado cuando pasó por mi escritorio.",
+        highlight: "It can't have been good news",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "Linda",
+        speakerLabelEs: "Linda",
+        english:
+          "Hmm. Whatever it is, we'll probably hear about it soon. He must be planning to update us tomorrow.",
+        spanish:
+          "Hmm. Sea lo que sea, probablemente lo escucharemos pronto. Debe estar planeando actualizarnos mañana.",
+        highlight: "He must be planning",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Pablo",
+        speakerLabelEs: "Pablo",
+        english:
+          "Yeah. Anyway — we should get back to work. We don't want him to think we're gossiping.",
+        spanish:
+          "Sí. En fin — deberíamos regresar al trabajo. No queremos que piense que estamos chismeando.",
+        highlight: "we should get back to work",
+      },
+    ],
+    keyPhrases: [
+      {
+        english: "Something must have come up.",
+        spanish: "Algo debe haber surgido.",
+        note: "The classic phrase for assuming an unexpected event interrupted plans. Uses past deduction with 'must have'.",
+        noteEs: "La frase clásica para asumir que un evento inesperado interrumpió planes. Usa deducción del pasado con 'must have'.",
+      },
+      {
+        english: "It can't have been...",
+        spanish: "No puede haber sido...",
+        note: "Negative deduction about the past. Use it when something is logically impossible based on the evidence.",
+        noteEs: "Deducción negativa sobre el pasado. Úsalo cuando algo es lógicamente imposible según la evidencia.",
+      },
+      {
+        english: "He must be planning to...",
+        spanish: "Debe estar planeando...",
+        note: "Present deduction about ongoing activity. Combines 'must' with the continuous form 'be planning'.",
+        noteEs: "Deducción presente sobre actividad en curso. Combina 'must' con la forma continua 'be planning'.",
+      },
+    ],
+  },
+];
+
+// ─── Section C: Structure Builder ────────────────────────────────────────────
+
+export const structureBlocks: SentenceBlock[] = [
+  {
+    label: "Modals of deduction: present",
+    labelEs: "Modales de deducción: presente",
+    description:
+      "Use 'must', 'can't', 'might', and 'could' to deduce things happening NOW. The modal you choose shows how confident you are.",
+    descriptionEs:
+      "Usa 'must', 'can't', 'might' y 'could' para deducir cosas que pasan AHORA. El modal que elijas muestra qué tan seguro estás.",
+    sentences: [
+      {
+        english: "She must be exhausted after that flight.",
+        spanish: "Debe estar agotada después de ese vuelo.",
+        highlight: "must be exhausted",
+      },
+      {
+        english: "He can't be telling the truth — the story doesn't add up.",
+        spanish: "No puede estar diciendo la verdad — la historia no cuadra.",
+        highlight: "can't be telling",
+      },
+      {
+        english: "They might be at the restaurant already.",
+        spanish: "Podrían ya estar en el restaurante.",
+        highlight: "might be",
+      },
+      {
+        english: "It could be raining where they are.",
+        spanish: "Podría estar lloviendo donde están.",
+        highlight: "could be raining",
+      },
+    ],
+  },
+  {
+    label: "Modals of deduction: past",
+    labelEs: "Modales de deducción: pasado",
+    description:
+      "For deductions about past events, use 'must have', 'can't have', 'might have', or 'could have' + past participle.",
+    descriptionEs:
+      "Para deducciones sobre eventos pasados, usa 'must have', 'can't have', 'might have' o 'could have' + participio.",
+    sentences: [
+      {
+        english: "She must have left early. Her car isn't in the lot.",
+        spanish: "Debe haberse ido temprano. Su coche no está en el estacionamiento.",
+        highlight: "must have left",
+      },
+      {
+        english: "They can't have arrived yet — the train was delayed.",
+        spanish: "No pueden haber llegado todavía — el tren se retrasó.",
+        highlight: "can't have arrived",
+      },
+      {
+        english: "He might have forgotten about our meeting.",
+        spanish: "Podría haber olvidado nuestra reunión.",
+        highlight: "might have forgotten",
+      },
+      {
+        english: "Someone could have stolen it from your desk.",
+        spanish: "Alguien podría habérselo robado de tu escritorio.",
+        highlight: "could have stolen",
+      },
+    ],
+  },
+  {
+    label: "The certainty scale",
+    labelEs: "La escala de certeza",
+    description:
+      "These modals form a scale from certain to uncertain. Pick the right one for how much evidence you have.",
+    descriptionEs:
+      "Estos modales forman una escala de certeza a incertidumbre. Elige el correcto según cuánta evidencia tienes.",
+    sentences: [
+      {
+        english: "It MUST be him. (95% certain)",
+        spanish: "DEBE ser él. (95% seguro)",
+        highlight: "MUST be",
+      },
+      {
+        english: "It COULD be him. (50% certain)",
+        spanish: "PODRÍA ser él. (50% seguro)",
+        highlight: "COULD be",
+      },
+      {
+        english: "It MIGHT be him. (40% certain)",
+        spanish: "TAL VEZ es él. (40% seguro)",
+        highlight: "MIGHT be",
+      },
+      {
+        english: "It CAN'T be him. (95% certain it's NOT)",
+        spanish: "NO PUEDE ser él. (95% seguro que NO)",
+        highlight: "CAN'T be",
+      },
+    ],
+  },
+  {
+    label: "Combining everything you've learned",
+    labelEs: "Combinando todo lo que has aprendido",
+    description:
+      "These sentences combine modals of deduction with the structures from earlier units — present perfect, conditionals, relative clauses. This is what advanced English really looks like.",
+    descriptionEs:
+      "Estas oraciones combinan modales de deducción con estructuras de unidades anteriores — presente perfecto, condicionales, cláusulas relativas. Así se ve realmente el inglés avanzado.",
+    sentences: [
+      {
+        english: "If she had told me, I would have known the truth — but she must have had a reason for staying quiet.",
+        spanish: "Si me hubiera dicho, habría sabido la verdad — pero debe haber tenido una razón para quedarse callada.",
+        highlight: "must have had",
+      },
+      {
+        english: "The person who called earlier might have been the one I've been trying to reach all week.",
+        spanish: "La persona que llamó antes podría haber sido la que he estado tratando de localizar toda la semana.",
+        highlight: "might have been",
+      },
+      {
+        english: "If you can't find your wallet, you must have left it at the restaurant where we had dinner.",
+        spanish: "Si no puedes encontrar tu cartera, debes haberla dejado en el restaurante donde cenamos.",
+        highlight: "must have left",
+      },
+      {
+        english: "I wish I had asked her directly — by now, she might have moved on.",
+        spanish: "Ojalá le hubiera preguntado directamente — para ahora, podría haber seguido adelante.",
+        highlight: "might have moved on",
+      },
+    ],
+  },
+];
+
+// ─── Section D: Error Correction ─────────────────────────────────────────────
+
+export const errorCorrections: ErrorCorrectionSet = {
+  title: "Common Mistakes with Modals of Deduction",
+  titleEs: "Errores Comunes con Modales de Deducción",
+  description:
+    "These errors mix up confidence levels and time frames — they make your reasoning sound less precise than it is.",
+  descriptionEs:
+    "Estos errores confunden niveles de certeza y marcos temporales — hacen que tu razonamiento suene menos preciso de lo que es.",
+  items: [
+    {
+      incorrect: "He must to be tired. He worked all night.",
+      correct: "He must be tired. He worked all night.",
+      incorrectHighlight: "must to be",
+      correctHighlight: "must be",
+      explanation:
+        "Modal verbs (must, can, might, could, should) NEVER take 'to' before the next verb. The structure is always 'modal + base verb'. 'Must be', 'might go', 'could see' — never 'must to be' or 'might to go'.",
+      explanationEs:
+        "Los verbos modales (must, can, might, could, should) NUNCA toman 'to' antes del siguiente verbo. La estructura siempre es 'modal + verbo base'. Nunca 'must to be' o 'might to go'.",
+      errorType: "literal-translation",
+    },
+    {
+      incorrect: "She must left already. The lights are off.",
+      correct: "She must have left already. The lights are off.",
+      incorrectHighlight: "must left",
+      correctHighlight: "must have left",
+      explanation:
+        "For PAST deductions, use 'must have + past participle' — never just 'must + past tense'. 'Must left' is grammatically impossible. The structure is 'modal + have + past participle': must have left, might have known, can't have seen.",
+      explanationEs:
+        "Para deducciones del PASADO, usa 'must have + participio' — nunca solo 'must + pasado'. 'Must left' es gramaticalmente imposible. La estructura es 'modal + have + participio'.",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "He must be sick — but I'm not sure.",
+      correct: "He might be sick — I'm not sure.",
+      incorrectHighlight: "must be sick — but I'm not sure",
+      correctHighlight: "might be sick — I'm not sure",
+      explanation:
+        "'Must' means you're highly confident. If you're 'not sure', you can't use 'must' — that's a contradiction. Use 'might' or 'could' for uncertainty. Match the modal to your actual confidence level.",
+      explanationEs:
+        "'Must' significa que estás muy seguro. Si 'no estás seguro', no puedes usar 'must' — es una contradicción. Usa 'might' o 'could' para incertidumbre. Combina el modal con tu nivel real de confianza.",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "It can be true — I saw it with my own eyes.",
+      correct: "It must be true — I saw it with my own eyes.",
+      incorrectHighlight: "can be true",
+      correctHighlight: "must be true",
+      explanation:
+        "'Can' is for ability or general possibility, NOT for deduction. For confident conclusions, use 'must'. 'It can be true' sounds like 'this is possible in general'. 'It must be true' means 'I'm confident based on evidence'.",
+      explanationEs:
+        "'Can' es para habilidad o posibilidad general, NO para deducción. Para conclusiones seguras, usa 'must'. 'It can be true' suena a 'esto es posible en general'. 'It must be true' significa 'estoy seguro según la evidencia'.",
+      errorType: "literal-translation",
+    },
+    {
+      incorrect: "They mustn't have heard the news yet.",
+      correct: "They can't have heard the news yet.",
+      incorrectHighlight: "mustn't have heard",
+      correctHighlight: "can't have heard",
+      explanation:
+        "'Mustn't' means 'it's forbidden' (a rule), NOT 'I'm sure it didn't happen'. For negative deductions, use 'can't' (present) or 'can't have' (past). 'They can't have heard' = 'I'm sure they haven't heard'. 'They mustn't have heard' is wrong.",
+      explanationEs:
+        "'Mustn't' significa 'está prohibido' (una regla), NO 'estoy seguro de que no pasó'. Para deducciones negativas, usa 'can't' (presente) o 'can't have' (pasado). 'They mustn't have heard' es incorrecto.",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "He could have went without us.",
+      correct: "He could have gone without us.",
+      incorrectHighlight: "could have went",
+      correctHighlight: "could have gone",
+      explanation:
+        "After 'have' you ALWAYS use the past participle, not the simple past. 'Go' → past simple 'went' / past participle 'gone'. 'Could have gone', 'must have eaten', 'might have seen'. This is the same rule as the present perfect — the participle is needed.",
+      explanationEs:
+        "Después de 'have' SIEMPRE usas el participio pasado, no el pasado simple. 'Go' → pasado simple 'went' / participio 'gone'. 'Could have gone', 'must have eaten', 'might have seen'. Es la misma regla que el presente perfecto.",
+      errorType: "tense-confusion",
+    },
+  ],
+};
+
+// ─── Section E: Pronunciation Lab ────────────────────────────────────────────
+
+export const pronunciationDrills: PronunciationDrill[] = [
+  {
+    word: "must've been",
+    spanishStress: "MUST HAVE BEEN",
+    englishStress: "MUST-əv-bin",
+    tip: "'Must have been' contracts to 'must've been' = /MUST-əv-bin/. Three syllables, all flowing together. Native speakers ALWAYS contract this. Saying 'must have been' as three full words sounds painfully formal.",
+    tipEs:
+      "'Must have been' se contrae a 'must've been' = /MUST-əv-bin/. Tres sílabas, todas fluyendo juntas. Los nativos SIEMPRE contraen esto. Decir 'must have been' como tres palabras completas suena dolorosamente formal.",
+  },
+  {
+    word: "thought groups",
+    spanishStress: "THOUGHT GROUPS",
+    englishStress: "chunks separated by tiny pauses",
+    tip: "Native speakers don't speak word-by-word — they speak in CHUNKS of 3-7 words with tiny pauses between. 'It must have been / a misunderstanding / because she's not / the kind of person / who would lie.' The slashes are the natural pauses.",
+    tipEs:
+      "Los nativos no hablan palabra por palabra — hablan en CHUNKS de 3-7 palabras con pausas mínimas entre ellas. Las pausas naturales son la clave del ritmo nativo.",
+  },
+  {
+    word: "I think...",
+    spanishStress: "I THINK",
+    englishStress: "ai-THINK (then pause)",
+    tip: "When you start a deduction with 'I think...' or 'I guess...', native speakers pause briefly afterward. This pause signals 'I'm processing' — it gives you time to think AND sounds natural. Don't rush past it.",
+    tipEs:
+      "Cuando empiezas una deducción con 'I think...' o 'I guess...', los nativos hacen una pausa breve después. Esta pausa señala 'estoy procesando' — te da tiempo para pensar Y suena natural.",
+  },
+  {
+    word: "you know",
+    spanishStress: "YOU KNOW",
+    englishStress: "yə-NO (filler)",
+    tip: "'You know' is the most common English filler. Reduced to /yə-NO/ in fast speech, it gives you thinking time without breaking the flow. Used moderately, it sounds native; overused, it sounds uncertain.",
+    tipEs:
+      "'You know' es el filler más común en inglés. Reducido a /yə-NO/ en habla rápida, te da tiempo para pensar sin romper el flujo. Usado con moderación, suena nativo; en exceso, suena inseguro.",
+  },
+  {
+    word: "I mean...",
+    spanishStress: "I MEAN",
+    englishStress: "ai-MIN (correction filler)",
+    tip: "'I mean' is what you say when you're about to clarify or correct yourself. It's more elegant than 'sorry, what I wanted to say is'. Native speakers use it constantly when reasoning out loud.",
+    tipEs:
+      "'I mean' es lo que dices cuando vas a aclarar o corregirte. Es más elegante que 'sorry, what I wanted to say is'. Los nativos lo usan constantemente al razonar en voz alta.",
+  },
+];
+
+// ─── Section F: Self-Test Vocabulary ─────────────────────────────────────────
+
+export const vocabularyList: IntermediateVocabItem[] = [
+  // Modal deduction expressions
+  { english: "It must be...", spanish: "Debe ser...", type: "expression" },
+  { english: "It can't be...", spanish: "No puede ser...", type: "expression" },
+  { english: "It might be...", spanish: "Podría ser...", type: "expression" },
+  { english: "It could be...", spanish: "Podría ser...", type: "expression" },
+  { english: "It must have been...", spanish: "Debe haber sido...", type: "expression" },
+  { english: "It can't have been...", spanish: "No puede haber sido...", type: "expression" },
+  { english: "It might have been...", spanish: "Podría haber sido...", type: "expression" },
+  // Reasoning fillers
+  { english: "I think...", spanish: "Creo que...", type: "expression" },
+  { english: "I guess...", spanish: "Supongo que...", type: "expression" },
+  { english: "I mean...", spanish: "Quiero decir...", type: "expression" },
+  { english: "you know...", spanish: "sabes...", type: "expression" },
+  { english: "I suppose...", spanish: "Supongo...", type: "expression" },
+  // Connecting/reasoning phrases
+  { english: "Something must have come up.", spanish: "Algo debe haber surgido.", type: "expression" },
+  { english: "Whatever it is...", spanish: "Sea lo que sea...", type: "expression" },
+  { english: "By now...", spanish: "Para ahora...", type: "expression" },
+  { english: "It doesn't add up.", spanish: "No cuadra.", type: "expression" },
+  { english: "That makes sense.", spanish: "Eso tiene sentido.", type: "expression" },
+  // Reasoning verbs
+  { english: "to assume", spanish: "asumir", type: "verb" },
+  { english: "to suspect", spanish: "sospechar", type: "verb" },
+  { english: "to conclude", spanish: "concluir", type: "verb" },
+  { english: "to figure out", spanish: "deducir / averiguar", type: "phrasal-verb" },
+  { english: "to wonder", spanish: "preguntarse", type: "verb" },
+  // Self-assessment vocabulary (course wrap-up)
+  { english: "fluent", spanish: "fluido", type: "expression" },
+  { english: "confident", spanish: "seguro / con confianza", type: "expression" },
+  { english: "to make progress", spanish: "progresar", type: "expression" },
+  { english: "to keep going", spanish: "seguir adelante", type: "phrasal-verb" },
+];

--- a/src/data/intermediate/unit-9.ts
+++ b/src/data/intermediate/unit-9.ts
@@ -1,0 +1,521 @@
+// Unit 9: "Relationships and Feelings" — Full course content
+// Theme: Family, friends, conflicts, emotions
+// Grammar: Wish/regret structures + 'would' for hypothetical situations
+// Pronunciation: Emotional intonation
+// Section A: WishTransformer (transform realities into wishes/regrets)
+
+import type {
+  Dialogue,
+  ErrorCorrectionSet,
+  IntermediateVocabItem,
+} from "./types";
+import type { WishTransformation } from "../../components/course/WishTransformer";
+import type { SentenceBlock, PronunciationDrill } from "../course/unit-1";
+
+// ─── Section A: Wish Transformer ─────────────────────────────────────────────
+
+export const wishTransformations: WishTransformation[] = [
+  {
+    feeling: "Frustration about a present situation",
+    feelingEs: "Frustración sobre una situación presente",
+    reality: "I don't speak English fluently.",
+    realityEs: "No hablo inglés con fluidez.",
+    wish: "I wish I spoke English fluently.",
+    wishEs: "Ojalá hablara inglés con fluidez.",
+    wishType: "present",
+    whyTransform:
+      "For wishes about the present, use 'wish' + past simple. The past tense form signals that you're talking about something that ISN'T true right now. The Spanish equivalent uses subjunctive ('hablara'), so the leap is the same.",
+    whyTransformEs:
+      "Para deseos sobre el presente, usa 'wish' + pasado simple. El pasado señala que estás hablando de algo que NO es cierto ahora mismo. El español usa subjuntivo ('hablara'), así que el salto es el mismo.",
+  },
+  {
+    feeling: "Regret about a past decision",
+    feelingEs: "Arrepentimiento sobre una decisión pasada",
+    reality: "I didn't study harder for the exam.",
+    realityEs: "No estudié más para el examen.",
+    wish: "I wish I had studied harder for the exam.",
+    wishEs: "Ojalá hubiera estudiado más para el examen.",
+    wishType: "past",
+    whyTransform:
+      "For regrets about the past, use 'wish' + past perfect ('had + past participle'). This is how English expresses the deep regret of 'if only I had done X'. The construction is rare in casual speech but powerful when used.",
+    whyTransformEs:
+      "Para arrepentimientos sobre el pasado, usa 'wish' + pasado perfecto ('had + participio'). Así es como el inglés expresa el arrepentimiento profundo de 'si tan solo hubiera hecho X'.",
+  },
+  {
+    feeling: "Frustration with someone else's behavior",
+    feelingEs: "Frustración con el comportamiento de otra persona",
+    reality: "My brother always interrupts me.",
+    realityEs: "Mi hermano siempre me interrumpe.",
+    wish: "I wish my brother wouldn't interrupt me all the time.",
+    wishEs: "Ojalá mi hermano no me interrumpiera todo el tiempo.",
+    wishType: "present",
+    whyTransform:
+      "When you're complaining about someone's annoying behavior, use 'wish' + 'would/wouldn't'. This specifically expresses irritation with a habit. You can't use this form for yourself — only for others.",
+    whyTransformEs:
+      "Cuando te quejas del comportamiento molesto de alguien, usa 'wish' + 'would/wouldn't'. Esto expresa específicamente irritación con un hábito. No puedes usar esta forma para ti mismo — solo para otros.",
+  },
+  {
+    feeling: "Longing for an impossible past",
+    feelingEs: "Anhelo por un pasado imposible",
+    reality: "I never met my grandfather.",
+    realityEs: "Nunca conocí a mi abuelo.",
+    wish: "If only I had met my grandfather.",
+    wishEs: "Si tan solo hubiera conocido a mi abuelo.",
+    wishType: "regret",
+    whyTransform:
+      "'If only' is a more dramatic alternative to 'I wish'. Use it for the deepest regrets — things that really matter to you. The grammar is the same as 'I wish' (past perfect for past regrets), but the emotional weight is heavier.",
+    whyTransformEs:
+      "'If only' es una alternativa más dramática a 'I wish'. Úsalo para los arrepentimientos más profundos. La gramática es la misma que 'I wish' (pasado perfecto para arrepentimientos del pasado), pero el peso emocional es mayor.",
+  },
+  {
+    feeling: "Imagining a better life",
+    feelingEs: "Imaginando una vida mejor",
+    reality: "I live in a small apartment.",
+    realityEs: "Vivo en un apartamento pequeño.",
+    wish: "I wish I lived in a bigger place.",
+    wishEs: "Ojalá viviera en un lugar más grande.",
+    wishType: "present",
+    whyTransform:
+      "Note the verb form: 'lived', not 'live'. The past tense after 'wish' marks the wish as hypothetical. Spanish does the same thing with the imperfect subjunctive ('viviera').",
+    whyTransformEs:
+      "Nota la forma verbal: 'lived', no 'live'. El pasado después de 'wish' marca el deseo como hipotético. El español hace lo mismo con el imperfecto del subjuntivo ('viviera').",
+  },
+  {
+    feeling: "Hoping for a better future outcome",
+    feelingEs: "Esperando un mejor resultado futuro",
+    reality: "It will probably rain on my wedding day.",
+    realityEs: "Probablemente lloverá el día de mi boda.",
+    wish: "I hope it doesn't rain on my wedding day.",
+    wishEs: "Espero que no llueva el día de mi boda.",
+    wishType: "future",
+    whyTransform:
+      "For future wishes, English uses 'hope', not 'wish'. 'Wish' is for things that are unlikely or impossible. 'Hope' is for things that are still possible. Spanish 'esperar' covers both, which causes confusion.",
+    whyTransformEs:
+      "Para deseos futuros, el inglés usa 'hope', no 'wish'. 'Wish' es para cosas improbables o imposibles. 'Hope' es para cosas todavía posibles. El español 'esperar' cubre ambos, lo que causa confusión.",
+  },
+  {
+    feeling: "Apologizing with regret",
+    feelingEs: "Disculpándose con arrepentimiento",
+    reality: "I shouted at her in anger.",
+    realityEs: "Le grité con enojo.",
+    wish: "I wish I hadn't shouted at her. I should have stayed calm.",
+    wishEs: "Ojalá no le hubiera gritado. Debería haberme mantenido calmado.",
+    wishType: "regret",
+    whyTransform:
+      "Two structures combined: 'wish I hadn't' (past regret) + 'should have' (the polite way to admit a past mistake). 'Should have' literally means 'the right thing would have been to...' — it's how educated speakers acknowledge wrongdoing.",
+    whyTransformEs:
+      "Dos estructuras combinadas: 'wish I hadn't' (arrepentimiento del pasado) + 'should have' (la forma cortés de admitir un error pasado). 'Should have' significa literalmente 'lo correcto habría sido...' — es cómo los hablantes educados reconocen errores.",
+  },
+  {
+    feeling: "Quietly wanting more time with someone",
+    feelingEs: "Queriendo silenciosamente más tiempo con alguien",
+    reality: "We don't see each other often.",
+    realityEs: "No nos vemos a menudo.",
+    wish: "I wish we saw each other more often. I'd love to spend more time with you.",
+    wishEs: "Ojalá nos viéramos más a menudo. Me encantaría pasar más tiempo contigo.",
+    wishType: "present",
+    whyTransform:
+      "This combination — 'wish' for the situation + 'I'd love to' for the desire — is one of the warmest things you can say in English. It expresses real affection without sounding desperate or demanding.",
+    whyTransformEs:
+      "Esta combinación — 'wish' para la situación + 'I'd love to' para el deseo — es una de las cosas más cálidas que puedes decir en inglés. Expresa afecto real sin sonar desesperado o demandante.",
+  },
+];
+
+// ─── Section B: Dialogue Practice ────────────────────────────────────────────
+
+export const dialogues: Dialogue[] = [
+  {
+    title: "An Honest Conversation",
+    titleEs: "Una Conversación Honesta",
+    setting: "Two old friends reconnect after a long time apart and share regrets",
+    settingEs: "Dos viejos amigos se reconectan después de mucho tiempo y comparten arrepentimientos",
+    lines: [
+      {
+        speaker: "A",
+        speakerLabel: "Elena",
+        speakerLabelEs: "Elena",
+        english:
+          "It's been so long. I wish we hadn't lost touch after college.",
+        spanish:
+          "Ha pasado tanto tiempo. Ojalá no hubiéramos perdido el contacto después de la universidad.",
+        highlight: "I wish we hadn't lost touch",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "David",
+        speakerLabelEs: "David",
+        english:
+          "I know. I think about that sometimes. If I had reached out more, things would have been different.",
+        spanish:
+          "Lo sé. Pienso en eso a veces. Si hubiera buscado más contacto, las cosas habrían sido diferentes.",
+        highlight: "If I had reached out / would have been different",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Elena",
+        speakerLabelEs: "Elena",
+        english:
+          "It wasn't your fault. I should have called too. I just got caught up in work and life.",
+        spanish:
+          "No fue tu culpa. Yo también debería haber llamado. Solo me enredé en el trabajo y la vida.",
+        highlight: "I should have called",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "David",
+        speakerLabelEs: "David",
+        english:
+          "Well, we're here now. I hope we can stay in touch from now on.",
+        spanish:
+          "Bueno, estamos aquí ahora. Espero que podamos mantenernos en contacto de ahora en adelante.",
+        highlight: "I hope we can stay in touch",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Elena",
+        speakerLabelEs: "Elena",
+        english:
+          "I'd really like that. You know, I always wished you had come to visit me in Madrid that summer.",
+        spanish:
+          "De verdad me gustaría eso. Sabes, siempre deseé que hubieras venido a visitarme a Madrid ese verano.",
+        highlight: "wished you had come",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "David",
+        speakerLabelEs: "David",
+        english:
+          "I wanted to. If only I'd had the money back then. I was completely broke.",
+        spanish:
+          "Quería ir. Si tan solo hubiera tenido dinero entonces. Estaba completamente quebrado.",
+        highlight: "If only I'd had the money",
+      },
+      {
+        speaker: "A",
+        speakerLabel: "Elena",
+        speakerLabelEs: "Elena",
+        english:
+          "Maybe next year? I'd love to show you around. It would mean a lot to me.",
+        spanish:
+          "¿Quizás el próximo año? Me encantaría mostrarte la ciudad. Significaría mucho para mí.",
+        highlight: "I'd love to / It would mean",
+      },
+      {
+        speaker: "B",
+        speakerLabel: "David",
+        speakerLabelEs: "David",
+        english:
+          "I'll be there. I promise this time I won't let life get in the way.",
+        spanish:
+          "Estaré ahí. Prometo que esta vez no dejaré que la vida se interponga.",
+        highlight: "I won't let life get in the way",
+      },
+    ],
+    keyPhrases: [
+      {
+        english: "I wish we hadn't lost touch.",
+        spanish: "Ojalá no hubiéramos perdido el contacto.",
+        note: "The most common past regret structure in real conversations between old friends.",
+        noteEs: "La estructura de arrepentimiento del pasado más común en conversaciones reales entre viejos amigos.",
+      },
+      {
+        english: "I should have called.",
+        spanish: "Debería haber llamado.",
+        note: "The mature, accountable way to admit a past mistake. Notice 'should have' = 'should've' in speech.",
+        noteEs: "La forma madura y responsable de admitir un error pasado. Nota que 'should have' = 'should've' en el habla.",
+      },
+      {
+        english: "It would mean a lot to me.",
+        spanish: "Significaría mucho para mí.",
+        note: "One of the most emotionally honest phrases in English. Use it sparingly — it's powerful.",
+        noteEs: "Una de las frases emocionalmente más honestas en inglés. Úsala con moderación — es poderosa.",
+      },
+    ],
+  },
+];
+
+// ─── Section C: Structure Builder ────────────────────────────────────────────
+
+export const structureBlocks: SentenceBlock[] = [
+  {
+    label: "Wishes about the present",
+    labelEs: "Deseos sobre el presente",
+    description:
+      "Structure: wish + past simple. Use it for things that are NOT true right now but you wish were. The past tense signals the unreality.",
+    descriptionEs:
+      "Estructura: wish + pasado simple. Úsalo para cosas que NO son ciertas ahora mismo pero desearías que lo fueran. El pasado señala la irrealidad.",
+    sentences: [
+      {
+        english: "I wish I had more free time.",
+        spanish: "Ojalá tuviera más tiempo libre.",
+        highlight: "wish I had",
+      },
+      {
+        english: "She wishes she lived closer to her family.",
+        spanish: "Ella desearía vivir más cerca de su familia.",
+        highlight: "wishes she lived",
+      },
+      {
+        english: "I wish I were taller.",
+        spanish: "Ojalá fuera más alto.",
+        highlight: "wish I were",
+      },
+      {
+        english: "We wish you were here with us.",
+        spanish: "Desearíamos que estuvieras aquí con nosotros.",
+        highlight: "wish you were",
+      },
+    ],
+  },
+  {
+    label: "Wishes/regrets about the past",
+    labelEs: "Deseos/arrepentimientos sobre el pasado",
+    description:
+      "Structure: wish + past perfect ('had + past participle'). For things that already happened (or didn't happen) and can't be changed.",
+    descriptionEs:
+      "Estructura: wish + pasado perfecto ('had + participio'). Para cosas que ya sucedieron (o no sucedieron) y no se pueden cambiar.",
+    sentences: [
+      {
+        english: "I wish I had studied medicine.",
+        spanish: "Ojalá hubiera estudiado medicina.",
+        highlight: "wish I had studied",
+      },
+      {
+        english: "He wishes he hadn't said those words.",
+        spanish: "Él desearía no haber dicho esas palabras.",
+        highlight: "wishes he hadn't said",
+      },
+      {
+        english: "I wish I had told her how I felt before she left.",
+        spanish: "Ojalá le hubiera dicho lo que sentía antes de que se fuera.",
+        highlight: "wish I had told",
+      },
+      {
+        english: "We wish we had bought that house when we had the chance.",
+        spanish: "Desearíamos haber comprado esa casa cuando tuvimos la oportunidad.",
+        highlight: "wish we had bought",
+      },
+    ],
+  },
+  {
+    label: "'Should have' for regret",
+    labelEs: "'Should have' para arrepentimiento",
+    description:
+      "Structure: should have + past participle. The mature, accountable way to acknowledge a past mistake. Often contracted to 'should've'.",
+    descriptionEs:
+      "Estructura: should have + participio. La forma madura y responsable de reconocer un error pasado. Frecuentemente contraído a 'should've'.",
+    sentences: [
+      {
+        english: "I should have called you back sooner. I'm sorry.",
+        spanish: "Debería haberte devuelto la llamada antes. Lo siento.",
+        highlight: "should have called",
+      },
+      {
+        english: "You shouldn't have said that to her.",
+        spanish: "No deberías haberle dicho eso.",
+        highlight: "shouldn't have said",
+      },
+      {
+        english: "We should have left earlier to avoid the traffic.",
+        spanish: "Deberíamos haber salido antes para evitar el tráfico.",
+        highlight: "should have left",
+      },
+      {
+        english: "He should have apologized when he had the chance.",
+        spanish: "Debería haberse disculpado cuando tuvo la oportunidad.",
+        highlight: "should have apologized",
+      },
+    ],
+  },
+  {
+    label: "'Wish' + would for annoying habits",
+    labelEs: "'Wish' + would para hábitos molestos",
+    description:
+      "Structure: wish + subject + would/wouldn't + base verb. ONLY for complaining about someone else's repeated behavior. You cannot use this for yourself.",
+    descriptionEs:
+      "Estructura: wish + sujeto + would/wouldn't + verbo base. SOLO para quejarse del comportamiento repetido de otra persona. No puedes usarlo para ti mismo.",
+    sentences: [
+      {
+        english: "I wish my neighbors wouldn't play music so late at night.",
+        spanish: "Ojalá mis vecinos no pusieran música tan tarde por la noche.",
+        highlight: "wish... wouldn't play",
+      },
+      {
+        english: "She wishes her boss would give her more credit.",
+        spanish: "Ella desearía que su jefe le diera más crédito.",
+        highlight: "wishes... would give",
+      },
+      {
+        english: "I wish you would listen when I'm trying to explain something.",
+        spanish: "Ojalá escucharas cuando estoy tratando de explicar algo.",
+        highlight: "wish you would listen",
+      },
+      {
+        english: "We wish the weather would improve before the weekend.",
+        spanish: "Desearíamos que el clima mejorara antes del fin de semana.",
+        highlight: "wish... would improve",
+      },
+    ],
+  },
+];
+
+// ─── Section D: Error Correction ─────────────────────────────────────────────
+
+export const errorCorrections: ErrorCorrectionSet = {
+  title: "Common Mistakes with Wishes & Regrets",
+  titleEs: "Errores Comunes con Deseos y Arrepentimientos",
+  description:
+    "Wishes and regrets are emotionally important — getting them wrong can change the meaning of what you want to say. Catch these errors before they slip out.",
+  descriptionEs:
+    "Los deseos y arrepentimientos son emocionalmente importantes — equivocarse puede cambiar el significado de lo que quieres decir. Detecta estos errores antes de que se te escapen.",
+  items: [
+    {
+      incorrect: "I wish I have more money.",
+      correct: "I wish I had more money.",
+      incorrectHighlight: "wish I have",
+      correctHighlight: "wish I had",
+      explanation:
+        "After 'wish', use the PAST tense, not the present — even when talking about a present situation. The past form ('had') signals that the wish is hypothetical (you don't actually have more money). This is unintuitive but absolute.",
+      explanationEs:
+        "Después de 'wish', usa el PASADO, no el presente — incluso cuando hablas de una situación presente. La forma pasada ('had') señala que el deseo es hipotético. Esto es contraintuitivo pero absoluto.",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "I wish I would have studied harder.",
+      correct: "I wish I had studied harder.",
+      incorrectHighlight: "wish I would have studied",
+      correctHighlight: "wish I had studied",
+      explanation:
+        "For past regrets, use 'wish + had + past participle' — never 'would have'. This is a famous mistake even native English speakers make. 'Would have' belongs in conditional sentences ('I would have studied IF...'), not after 'wish'.",
+      explanationEs:
+        "Para arrepentimientos del pasado, usa 'wish + had + participio' — nunca 'would have'. Este es un error famoso que incluso los hablantes nativos cometen. 'Would have' pertenece a oraciones condicionales, no después de 'wish'.",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "I hope I had more time yesterday.",
+      correct: "I wish I had had more time yesterday.",
+      incorrectHighlight: "I hope I had",
+      correctHighlight: "I wish I had had",
+      explanation:
+        "'Hope' is for things that are STILL POSSIBLE in the future. For things that already happened, use 'wish + had + past participle'. So 'wish I had had' (not a typo — past perfect of 'have' really is 'had had').",
+      explanationEs:
+        "'Hope' es para cosas que TODAVÍA SON POSIBLES en el futuro. Para cosas que ya sucedieron, usa 'wish + had + participio'. Así que 'wish I had had' (no es un error — el pasado perfecto de 'have' realmente es 'had had').",
+      errorType: "literal-translation",
+    },
+    {
+      incorrect: "I wish you to call me more often.",
+      correct: "I wish you would call me more often.",
+      incorrectHighlight: "wish you to call",
+      correctHighlight: "wish you would call",
+      explanation:
+        "'Wish' doesn't take 'to + verb' like Spanish 'desear' does. For a present complaint about someone's behavior, use 'wish + subject + would'. 'I wish you to' is a literal Spanish translation that sounds wrong in English.",
+      explanationEs:
+        "'Wish' no toma 'to + verbo' como 'desear' en español. Para una queja presente sobre el comportamiento de alguien, usa 'wish + sujeto + would'. 'I wish you to' es una traducción literal que suena mal.",
+      errorType: "literal-translation",
+    },
+    {
+      incorrect: "I should called you yesterday.",
+      correct: "I should have called you yesterday.",
+      incorrectHighlight: "should called",
+      correctHighlight: "should have called",
+      explanation:
+        "For past regrets with 'should', the structure is 'should HAVE + past participle' — never 'should + past tense'. In speech this is contracted to 'should've called' (NOT 'should of', even though it sounds that way).",
+      explanationEs:
+        "Para arrepentimientos del pasado con 'should', la estructura es 'should HAVE + participio' — nunca 'should + pasado'. En el habla se contrae a 'should've called' (NO 'should of', aunque suene así).",
+      errorType: "tense-confusion",
+    },
+    {
+      incorrect: "I wish I was more patient.",
+      correct: "I wish I were more patient.",
+      incorrectHighlight: "wish I was",
+      correctHighlight: "wish I were",
+      explanation:
+        "After 'wish' (and after 'if I'), the verb 'be' uses 'were' for ALL persons — 'I were', 'she were', 'it were'. This is the subjunctive mood. 'Was' is heard in casual speech but 'were' is the educated B2+ choice.",
+      explanationEs:
+        "Después de 'wish' (y después de 'if I'), el verbo 'be' usa 'were' para TODAS las personas — 'I were', 'she were', 'it were'. Este es el modo subjuntivo. 'Was' se escucha en el habla casual pero 'were' es la opción educada B2+.",
+      errorType: "tense-confusion",
+    },
+  ],
+};
+
+// ─── Section E: Pronunciation Lab ────────────────────────────────────────────
+
+export const pronunciationDrills: PronunciationDrill[] = [
+  {
+    word: "I wish",
+    spanishStress: "I WISH",
+    englishStress: "ai-WISH (rising emotion)",
+    tip: "'I wish' carries emotional weight. The pitch rises on 'wish' — it's almost a sigh. Flat 'I wish' sounds robotic. Listen to native speakers express regret: there's always a slight melodic lift.",
+    tipEs:
+      "'I wish' carga peso emocional. El tono sube en 'wish' — es casi un suspiro. 'I wish' plano suena robótico. Escucha a los nativos expresar arrepentimiento: siempre hay una leve elevación melódica.",
+  },
+  {
+    word: "should've",
+    spanishStress: "SHOULD HAVE",
+    englishStress: "SHUD-əv",
+    tip: "'Should have' = 'should've' = /SHUD-əv/. NOT 'should of' (though it sounds like it). Native speakers say this hundreds of times a day. Master this contraction or you'll sound textbook.",
+    tipEs:
+      "'Should have' = 'should've' = /SHUD-əv/. NO 'should of' (aunque suene así). Los nativos lo dicen cientos de veces al día. Domina esta contracción o sonarás como libro de texto.",
+  },
+  {
+    word: "If only...",
+    spanishStress: "IF ONLY",
+    englishStress: "if-ON-li (long, slow)",
+    tip: "'If only' is said slowly and with a heavier voice. The whole phrase carries longing. Compare quick 'I wish' (mild regret) to drawn-out 'If only...' (deep regret) — the rhythm tells the listener how much it matters.",
+    tipEs:
+      "'If only' se dice lentamente y con voz más pesada. Toda la frase carga anhelo. Compara 'I wish' rápido (arrepentimiento leve) con 'If only...' alargado (arrepentimiento profundo) — el ritmo le dice al oyente cuánto importa.",
+  },
+  {
+    word: "would've",
+    spanishStress: "WOULD HAVE",
+    englishStress: "WUD-əv",
+    tip: "Same pattern as 'should've'. 'Would have' = 'would've' = /WUD-əv/. 'I would've come' = 'ai WUD-əv KAM'. The 'have' is always reduced to /əv/ after modals — never fully pronounced.",
+    tipEs:
+      "Mismo patrón que 'should've'. 'Would have' = 'would've' = /WUD-əv/. 'I would've come' = 'ai WUD-əv KAM'. El 'have' siempre se reduce a /əv/ después de modales — nunca se pronuncia completo.",
+  },
+  {
+    word: "I'm sorry",
+    spanishStress: "I AM SORRY",
+    englishStress: "aim-SOR-i (falling)",
+    tip: "'I'm sorry' has a falling intonation that signals sincerity. Rising intonation makes it sound like a question or sarcasm. The drop on 'sorry' is what makes the apology feel real to the listener.",
+    tipEs:
+      "'I'm sorry' tiene una entonación descendente que señala sinceridad. La entonación ascendente lo hace sonar como pregunta o sarcasmo. La caída en 'sorry' es lo que hace que la disculpa se sienta real.",
+  },
+];
+
+// ─── Section F: Self-Test Vocabulary ─────────────────────────────────────────
+
+export const vocabularyList: IntermediateVocabItem[] = [
+  // Wish/regret expressions
+  { english: "I wish I had...", spanish: "Ojalá tuviera...", type: "expression" },
+  { english: "I wish I hadn't...", spanish: "Ojalá no hubiera...", type: "expression" },
+  { english: "I wish I were...", spanish: "Ojalá fuera...", type: "expression" },
+  { english: "If only...", spanish: "Si tan solo...", type: "expression" },
+  { english: "I should have...", spanish: "Debería haber...", type: "expression" },
+  { english: "I shouldn't have...", spanish: "No debería haber...", type: "expression" },
+  { english: "I would have...", spanish: "Habría...", type: "expression" },
+  // Hope (for the future)
+  { english: "I hope you...", spanish: "Espero que...", type: "expression" },
+  { english: "I hope we can...", spanish: "Espero que podamos...", type: "expression" },
+  // Emotional/relational expressions
+  { english: "I'm sorry.", spanish: "Lo siento.", type: "expression" },
+  { english: "It would mean a lot to me.", spanish: "Significaría mucho para mí.", type: "expression" },
+  { english: "I'd love to...", spanish: "Me encantaría...", type: "expression" },
+  { english: "I miss you.", spanish: "Te extraño.", type: "expression" },
+  { english: "It's not your fault.", spanish: "No es tu culpa.", type: "expression" },
+  // Relationship vocabulary
+  { english: "to lose touch", spanish: "perder el contacto", type: "expression" },
+  { english: "to stay in touch", spanish: "mantenerse en contacto", type: "expression" },
+  { english: "to make up", spanish: "reconciliarse", type: "phrasal-verb" },
+  // Feeling words
+  { english: "regret", spanish: "arrepentimiento", type: "noun" },
+  { english: "longing", spanish: "anhelo", type: "noun" },
+  { english: "loneliness", spanish: "soledad", type: "noun" },
+  { english: "gratitude", spanish: "gratitud", type: "noun" },
+  // Relationship verbs
+  { english: "to forgive", spanish: "perdonar", type: "verb" },
+  { english: "to apologize", spanish: "disculparse", type: "verb" },
+  { english: "to reconcile", spanish: "reconciliarse", type: "verb" },
+  { english: "to confide", spanish: "confiar (en alguien)", type: "verb" },
+  { english: "to appreciate", spanish: "apreciar", type: "verb" },
+];

--- a/src/pages/en/course/intermediate/exam.astro
+++ b/src/pages/en/course/intermediate/exam.astro
@@ -4,14 +4,19 @@ export const prerender = true;
 import Base from "@layouts/Base.astro";
 import CourseProgress from "@components/course/CourseProgress";
 import CourseExam from "@components/course/CourseExam";
-import { units } from "@data/course/units";
-import { examQuestions, examMeta, calculateExamResult, getScoreTier } from "@data/course/exam";
+import { intermediateUnits } from "@data/intermediate/units";
+import {
+  examQuestions,
+  examMeta,
+  calculateExamResult,
+  getScoreTier,
+} from "@data/intermediate/exam";
 import { ArrowLeft, GraduationCap } from "lucide-astro";
 
 const lang = "en";
-const tkey = "course/beginners/exam" as const;
+const tkey = "course/intermediate/exam" as const;
 
-const progressUnits = units.map((u) => ({
+const progressUnits = intermediateUnits.map((u) => ({
   id: u.id,
   slug: u.slug,
   title: u.title,
@@ -22,15 +27,16 @@ const progressUnits = units.map((u) => ({
 <Base
   lang={lang}
   tkey={tkey}
-  title="Final Exam: First Steps Into English | NY English Teacher"
-  description="Take the comprehensive final exam for the First Steps Into English beginner course. 20 questions covering vocabulary, grammar, and translation from all 10 units. Free for Spanish speakers."
+  title="Final Exam: Building Fluency | NY English Teacher"
+  description="Take the comprehensive final exam for the Building Fluency intermediate course. 20 questions covering modals, conditionals, narrative tenses, opinions, and deductions from all 10 units. Free for B1-B2 Spanish speakers."
 >
   <CourseProgress
     client:load
     units={progressUnits}
     currentUnit={0}
-    basePath="/en/course/beginners"
+    basePath="/en/course/intermediate"
     lang="en"
+    courseId="intermediate"
   />
 
   <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
@@ -41,11 +47,12 @@ const progressUnits = units.map((u) => ({
           Final Exam
         </div>
         <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
-          First Steps Into English
+          Building Fluency
         </h1>
         <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
-          You've completed all 10 units. Now prove what you've learned.
-          20 questions covering vocabulary, grammar, and translation — the complete course in one exam.
+          You've completed all 10 units of the intermediate course. Now prove it.
+          20 questions covering modals, conditionals, narrative tenses, opinions, and deductions —
+          everything you've built across the entire course.
         </p>
       </div>
     </div>
@@ -58,7 +65,7 @@ const progressUnits = units.map((u) => ({
         questions={examQuestions}
         lang="en"
         passingScore={examMeta.passingScore}
-        courseBasePath="/en/course/beginners"
+        courseBasePath="/en/course/intermediate"
         calculateExamResult={calculateExamResult}
         getScoreTier={getScoreTier}
       />
@@ -67,7 +74,7 @@ const progressUnits = units.map((u) => ({
 
   <section class="py-8 bg-white border-t border-slate-200">
     <div class="site-container mx-auto px-4 text-center">
-      <a href="/en/course/beginners/" class="inline-flex items-center gap-2 text-slate-500 hover:text-amber-600 transition-colors text-sm">
+      <a href="/en/course/intermediate/" class="inline-flex items-center gap-2 text-slate-500 hover:text-amber-600 transition-colors text-sm">
         <ArrowLeft class="w-4 h-4" /> Back to Course Overview
       </a>
     </div>

--- a/src/pages/en/course/intermediate/index.astro
+++ b/src/pages/en/course/intermediate/index.astro
@@ -133,7 +133,7 @@ const iconMap: Record<string, any> = {
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
         {intermediateUnits.map((unit) => {
           const Icon = iconMap[unit.icon];
-          const isAvailable = unit.id < 9;
+          const isAvailable = true;
           return (
             <a
               href={isAvailable ? `/en/course/intermediate/${unit.slug}/` : undefined}

--- a/src/pages/en/course/intermediate/unit-10.astro
+++ b/src/pages/en/course/intermediate/unit-10.astro
@@ -1,0 +1,216 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import DeductionLab from "@components/course/DeductionLab";
+import DialoguePractice from "@components/course/DialoguePractice";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import ErrorCorrection from "@components/course/ErrorCorrection";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import SelfTest from "@components/course/SelfTest";
+import { intermediateUnits } from "@data/intermediate/units";
+import {
+  deductionScenarios,
+  dialogues,
+  structureBlocks,
+  errorCorrections,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/intermediate/unit-10";
+import { ArrowRight, Rocket, Layers, Volume2, Search } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/intermediate/unit-10" as const;
+
+const progressUnits = intermediateUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unit 10: Sounding Native | Building Fluency | NY English Teacher"
+  description="The capstone unit. Master modals of deduction (must be, can't be, might have been) — the structure that lets you reason out loud like a native. Free B1-B2 lesson for Spanish speakers."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={10}
+    basePath="/en/course/intermediate"
+    lang="en"
+    courseId="intermediate"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Rocket class="w-4 h-4" />
+          Unit 10 — Capstone
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Sounding Native
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          The final structure that separates intermediate from advanced English:
+          <strong class="text-white">modals of deduction</strong>. Learn to reason, speculate,
+          and infer out loud — to say "she must have left" or "it can't have been him" with
+          the natural rhythm of a native speaker. After this unit, you'll be ready for the
+          final exam — and for real-world conversations.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Search class="w-3.5 h-3.5" /> Deduction Lab
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Layers class="w-3.5 h-3.5" /> Modals of Deduction
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Volume2 class="w-3.5 h-3.5" /> Thought Groups
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-a">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">A</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Deduction Lab</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Read each clue and pick the most likely deduction. Each scenario teaches you when
+          to use 'must', 'can't', 'might', and 'could' — and why.
+        </p>
+        <DeductionLab client:visible scenarios={deductionScenarios} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-b">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">B</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Dialogue Practice</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Two coworkers reasoning out loud about a workplace mystery. Watch how they layer
+          modal after modal to build a theory.
+        </p>
+        <DialoguePractice client:visible dialogues={dialogues} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-c">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">C</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Structure Builder</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Modals of deduction across present and past — plus the final block combining
+          everything you've learned across all 10 units.
+        </p>
+        <SentenceBuilder client:visible blocks={structureBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-d">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">D</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Error Correction</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Six errors that confuse confidence levels and time frames in deductions.
+        </p>
+        <ErrorCorrection client:visible data={errorCorrections} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-e">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">E</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Pronunciation Lab</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Thought groups, chunking, and the natural fillers ('I think', 'you know', 'I mean') that make reasoning sound native.
+        </p>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-f">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">F</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Self-Test</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Test yourself on modal deduction expressions, reasoning fillers, and self-assessment vocabulary.
+        </p>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Final exam call-to-action -->
+  <section class="py-16 md:py-20 bg-gradient-to-br from-amber-500 to-amber-600 text-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-2xl mx-auto text-center">
+        <Rocket class="w-12 h-12 mx-auto mb-4" />
+        <h2 class="text-2xl md:text-3xl font-bold mb-3" style="font-family: 'Noto Sans KR', sans-serif;">
+          You've Reached the End. Now Prove It.
+        </h2>
+        <p class="text-amber-50 mb-6 leading-relaxed">
+          You've completed all 10 units. Take the final exam to test everything you've learned —
+          modals, conditionals, narratives, opinions, deductions, and more.
+        </p>
+        <Button href="/en/course/intermediate/exam/" variant="secondary" size="lg">
+          Take the Final Exam
+          <ArrowRight class="w-5 h-5 ml-2" />
+        </Button>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/en/course/intermediate/unit-9/"
+          class="text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          &larr; Unit 9
+        </a>
+        <a
+          href="/en/course/intermediate/"
+          class="text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          Course Overview
+        </a>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/en/course/intermediate/unit-9.astro
+++ b/src/pages/en/course/intermediate/unit-9.astro
@@ -1,0 +1,194 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WishTransformer from "@components/course/WishTransformer";
+import DialoguePractice from "@components/course/DialoguePractice";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import ErrorCorrection from "@components/course/ErrorCorrection";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import SelfTest from "@components/course/SelfTest";
+import { intermediateUnits } from "@data/intermediate/units";
+import {
+  wishTransformations,
+  dialogues,
+  structureBlocks,
+  errorCorrections,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/intermediate/unit-9";
+import { ArrowRight, Heart, Layers, Volume2 } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/intermediate/unit-9" as const;
+
+const progressUnits = intermediateUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unit 9: Relationships and Feelings | Building Fluency | NY English Teacher"
+  description="The emotional vocabulary B1 speakers lack. Master wish/regret structures and 'would' for hypotheticals — express feelings, make apologies, and rebuild relationships in English. Free B1-B2 lesson for Spanish speakers."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={9}
+    basePath="/en/course/intermediate"
+    lang="en"
+    courseId="intermediate"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Heart class="w-4 h-4" />
+          Unit 9
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Relationships and Feelings
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          The hardest English to learn is the English of feelings. B1 speakers can talk
+          about facts, but struggle with regret, longing, hope, and apology. This unit
+          gives you the tools to express what's actually in your heart — using
+          <strong class="text-white">wish</strong>,
+          <strong class="text-white">should have</strong>, and
+          <strong class="text-white">would</strong>.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Heart class="w-3.5 h-3.5" /> Wish Transformer
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Layers class="w-3.5 h-3.5" /> Wish/Regret Structures
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Volume2 class="w-3.5 h-3.5" /> Emotional Intonation
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-a">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">A</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Wish Transformer</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Take a real situation and transform it into a wish or regret. Each transformation
+          teaches you which structure to use for which emotion.
+        </p>
+        <WishTransformer client:visible transformations={wishTransformations} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-b">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">B</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Dialogue Practice</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Two old friends reconnect after years apart. Watch how they use wishes and regrets
+          to express what really matters.
+        </p>
+        <DialoguePractice client:visible dialogues={dialogues} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-c">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">C</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Structure Builder</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Wishes about the present, the past, regrets with 'should have', and the special 'wish + would' for complaining about habits.
+        </p>
+        <SentenceBuilder client:visible blocks={structureBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-d">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">D</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Error Correction</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Six errors that change the emotional meaning of what you're trying to say.
+        </p>
+        <ErrorCorrection client:visible data={errorCorrections} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-e">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">E</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Pronunciation Lab</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Emotional intonation — the music of regret, apology, and longing.
+        </p>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-f">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">F</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Self-Test</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Test yourself on wish/regret expressions, emotional phrases, and relationship vocabulary.
+        </p>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/en/course/intermediate/unit-8/"
+          class="text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          &larr; Unit 8
+        </a>
+        <Button href="/en/course/intermediate/unit-10/" variant="primary" size="md">
+          Unit 10: Sounding Native
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/intermedio/examen.astro
+++ b/src/pages/es/curso/intermedio/examen.astro
@@ -4,16 +4,21 @@ export const prerender = true;
 import Base from "@layouts/Base.astro";
 import CourseProgress from "@components/course/CourseProgress";
 import CourseExam from "@components/course/CourseExam";
-import { units } from "@data/course/units";
-import { examQuestions, examMeta, calculateExamResult, getScoreTier } from "@data/course/exam";
+import { intermediateUnits } from "@data/intermediate/units";
+import {
+  examQuestions,
+  examMeta,
+  calculateExamResult,
+  getScoreTier,
+} from "@data/intermediate/exam";
 import { ArrowLeft, GraduationCap } from "lucide-astro";
 
-const lang = "en";
-const tkey = "course/beginners/exam" as const;
+const lang = "es";
+const tkey = "course/intermediate/exam" as const;
 
-const progressUnits = units.map((u) => ({
+const progressUnits = intermediateUnits.map((u) => ({
   id: u.id,
-  slug: u.slug,
+  slug: u.slugEs,
   title: u.title,
   titleEs: u.titleEs,
 }));
@@ -22,15 +27,16 @@ const progressUnits = units.map((u) => ({
 <Base
   lang={lang}
   tkey={tkey}
-  title="Final Exam: First Steps Into English | NY English Teacher"
-  description="Take the comprehensive final exam for the First Steps Into English beginner course. 20 questions covering vocabulary, grammar, and translation from all 10 units. Free for Spanish speakers."
+  title="Examen Final: Construyendo Fluidez | NY English Teacher"
+  description="Toma el examen final integral del curso intermedio Construyendo Fluidez. 20 preguntas sobre modales, condicionales, tiempos narrativos, opiniones y deducciones de las 10 unidades. Gratis para hispanohablantes B1-B2."
 >
   <CourseProgress
     client:load
     units={progressUnits}
     currentUnit={0}
-    basePath="/en/course/beginners"
-    lang="en"
+    basePath="/es/curso/intermedio"
+    lang="es"
+    courseId="intermediate"
   />
 
   <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
@@ -38,14 +44,15 @@ const progressUnits = units.map((u) => ({
       <div class="max-w-3xl">
         <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
           <GraduationCap class="w-4 h-4" />
-          Final Exam
+          Examen Final
         </div>
         <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
-          First Steps Into English
+          Construyendo Fluidez
         </h1>
         <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
-          You've completed all 10 units. Now prove what you've learned.
-          20 questions covering vocabulary, grammar, and translation — the complete course in one exam.
+          Has completado las 10 unidades del curso intermedio. Ahora demuéstralo.
+          20 preguntas sobre modales, condicionales, tiempos narrativos, opiniones y deducciones —
+          todo lo que has construido a lo largo del curso completo.
         </p>
       </div>
     </div>
@@ -56,9 +63,9 @@ const progressUnits = units.map((u) => ({
       <CourseExam
         client:load
         questions={examQuestions}
-        lang="en"
+        lang="es"
         passingScore={examMeta.passingScore}
-        courseBasePath="/en/course/beginners"
+        courseBasePath="/es/curso/intermedio"
         calculateExamResult={calculateExamResult}
         getScoreTier={getScoreTier}
       />
@@ -67,8 +74,8 @@ const progressUnits = units.map((u) => ({
 
   <section class="py-8 bg-white border-t border-slate-200">
     <div class="site-container mx-auto px-4 text-center">
-      <a href="/en/course/beginners/" class="inline-flex items-center gap-2 text-slate-500 hover:text-amber-600 transition-colors text-sm">
-        <ArrowLeft class="w-4 h-4" /> Back to Course Overview
+      <a href="/es/curso/intermedio/" class="inline-flex items-center gap-2 text-slate-500 hover:text-amber-600 transition-colors text-sm">
+        <ArrowLeft class="w-4 h-4" /> Volver al Resumen del Curso
       </a>
     </div>
   </section>

--- a/src/pages/es/curso/intermedio/index.astro
+++ b/src/pages/es/curso/intermedio/index.astro
@@ -133,7 +133,7 @@ const iconMap: Record<string, any> = {
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
         {intermediateUnits.map((unit) => {
           const Icon = iconMap[unit.icon];
-          const isAvailable = unit.id < 9;
+          const isAvailable = true;
           return (
             <a
               href={isAvailable ? `/es/curso/intermedio/${unit.slugEs}/` : undefined}

--- a/src/pages/es/curso/intermedio/unidad-10.astro
+++ b/src/pages/es/curso/intermedio/unidad-10.astro
@@ -1,0 +1,215 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import DeductionLab from "@components/course/DeductionLab";
+import DialoguePractice from "@components/course/DialoguePractice";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import ErrorCorrection from "@components/course/ErrorCorrection";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import SelfTest from "@components/course/SelfTest";
+import { intermediateUnits } from "@data/intermediate/units";
+import {
+  deductionScenarios,
+  dialogues,
+  structureBlocks,
+  errorCorrections,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/intermediate/unit-10";
+import { ArrowRight, Rocket, Layers, Volume2, Search } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/intermediate/unit-10" as const;
+
+const progressUnits = intermediateUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unidad 10: Sonando como Nativo | Construyendo Fluidez | NY English Teacher"
+  description="La unidad final. Domina los modales de deducción (must be, can't be, might have been) — la estructura que te permite razonar en voz alta como un nativo. Lección B1-B2 gratis para hispanohablantes."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={10}
+    basePath="/es/curso/intermedio"
+    lang="es"
+    courseId="intermediate"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Rocket class="w-4 h-4" />
+          Unidad 10 — Final
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Sonando como Nativo
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          La estructura final que separa el inglés intermedio del avanzado:
+          <strong class="text-white">los modales de deducción</strong>. Aprende a razonar,
+          especular e inferir en voz alta — a decir "she must have left" o "it can't have
+          been him" con el ritmo natural de un hablante nativo. Después de esta unidad,
+          estarás listo para el examen final — y para conversaciones del mundo real.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Search class="w-3.5 h-3.5" /> Laboratorio de Deducción
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Layers class="w-3.5 h-3.5" /> Modales de Deducción
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Volume2 class="w-3.5 h-3.5" /> Grupos de Pensamiento
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-a">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">A</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Laboratorio de Deducción</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Lee cada pista y elige la deducción más probable. Cada escenario te enseña cuándo
+          usar 'must', 'can't', 'might' y 'could' — y por qué.
+        </p>
+        <DeductionLab client:visible scenarios={deductionScenarios} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-b">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">B</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Práctica de Diálogo</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Dos compañeros razonando en voz alta sobre un misterio en el trabajo. Mira cómo
+          combinan modal tras modal para construir una teoría.
+        </p>
+        <DialoguePractice client:visible dialogues={dialogues} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-c">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">C</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Constructor de Estructuras</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Modales de deducción en presente y pasado — más el bloque final que combina todo
+          lo que has aprendido en las 10 unidades.
+        </p>
+        <SentenceBuilder client:visible blocks={structureBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-d">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">D</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Corrección de Errores</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Seis errores que confunden niveles de certeza y marcos temporales en deducciones.
+        </p>
+        <ErrorCorrection client:visible data={errorCorrections} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-e">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">E</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Laboratorio de Pronunciación</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Grupos de pensamiento, segmentación y los fillers naturales ('I think', 'you know', 'I mean') que hacen que el razonamiento suene nativo.
+        </p>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-f">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">F</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Auto-Evaluación</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Ponte a prueba con expresiones de deducción modal, fillers de razonamiento y vocabulario de auto-evaluación.
+        </p>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-gradient-to-br from-amber-500 to-amber-600 text-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-2xl mx-auto text-center">
+        <Rocket class="w-12 h-12 mx-auto mb-4" />
+        <h2 class="text-2xl md:text-3xl font-bold mb-3" style="font-family: 'Noto Sans KR', sans-serif;">
+          Has Llegado al Final. Ahora Demuéstralo.
+        </h2>
+        <p class="text-amber-50 mb-6 leading-relaxed">
+          Has completado las 10 unidades. Toma el examen final para evaluar todo lo que
+          has aprendido — modales, condicionales, narrativas, opiniones, deducciones y más.
+        </p>
+        <Button href="/es/curso/intermedio/examen/" variant="secondary" size="lg">
+          Tomar el Examen Final
+          <ArrowRight class="w-5 h-5 ml-2" />
+        </Button>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/es/curso/intermedio/unidad-9/"
+          class="text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          &larr; Unidad 9
+        </a>
+        <a
+          href="/es/curso/intermedio/"
+          class="text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          Resumen del Curso
+        </a>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/intermedio/unidad-9.astro
+++ b/src/pages/es/curso/intermedio/unidad-9.astro
@@ -1,0 +1,194 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WishTransformer from "@components/course/WishTransformer";
+import DialoguePractice from "@components/course/DialoguePractice";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import ErrorCorrection from "@components/course/ErrorCorrection";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import SelfTest from "@components/course/SelfTest";
+import { intermediateUnits } from "@data/intermediate/units";
+import {
+  wishTransformations,
+  dialogues,
+  structureBlocks,
+  errorCorrections,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/intermediate/unit-9";
+import { ArrowRight, Heart, Layers, Volume2 } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/intermediate/unit-9" as const;
+
+const progressUnits = intermediateUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unidad 9: Relaciones y Sentimientos | Construyendo Fluidez | NY English Teacher"
+  description="El vocabulario emocional que les falta a los hablantes B1. Domina las estructuras de deseo/arrepentimiento y 'would' para hipotéticos — expresa sentimientos, disculpas y reconstruye relaciones en inglés. Lección B1-B2 gratis para hispanohablantes."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={9}
+    basePath="/es/curso/intermedio"
+    lang="es"
+    courseId="intermediate"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Heart class="w-4 h-4" />
+          Unidad 9
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Relaciones y Sentimientos
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          El inglés más difícil de aprender es el inglés de los sentimientos. Los hablantes B1
+          pueden hablar de hechos, pero les cuesta el arrepentimiento, el anhelo, la esperanza
+          y la disculpa. Esta unidad te da las herramientas para expresar lo que está realmente
+          en tu corazón — usando <strong class="text-white">wish</strong>,
+          <strong class="text-white">should have</strong>, y
+          <strong class="text-white">would</strong>.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Heart class="w-3.5 h-3.5" /> Transformador de Deseos
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Layers class="w-3.5 h-3.5" /> Estructuras de Deseo/Arrepentimiento
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-400 text-sm font-medium">
+            <Volume2 class="w-3.5 h-3.5" /> Entonación Emocional
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-a">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">A</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Transformador de Deseos</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Toma una situación real y transfórmala en un deseo o arrepentimiento. Cada
+          transformación te enseña qué estructura usar para qué emoción.
+        </p>
+        <WishTransformer client:visible transformations={wishTransformations} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-b">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">B</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Práctica de Diálogo</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Dos viejos amigos se reconectan después de años. Mira cómo usan deseos y
+          arrepentimientos para expresar lo que realmente importa.
+        </p>
+        <DialoguePractice client:visible dialogues={dialogues} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-c">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">C</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Constructor de Estructuras</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Deseos sobre el presente, sobre el pasado, arrepentimientos con 'should have', y el especial 'wish + would' para quejarse de hábitos.
+        </p>
+        <SentenceBuilder client:visible blocks={structureBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-d">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">D</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Corrección de Errores</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Seis errores que cambian el significado emocional de lo que tratas de decir.
+        </p>
+        <ErrorCorrection client:visible data={errorCorrections} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-e">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">E</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Laboratorio de Pronunciación</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Entonación emocional — la música del arrepentimiento, la disculpa y el anhelo.
+        </p>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-f">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">F</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Auto-Evaluación</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Ponte a prueba con expresiones de deseo/arrepentimiento, frases emocionales y vocabulario de relaciones.
+        </p>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/es/curso/intermedio/unidad-8/"
+          class="text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          &larr; Unidad 8
+        </a>
+        <Button href="/es/curso/intermedio/unidad-10/" variant="primary" size="md">
+          Unidad 10: Sonando como Nativo
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/principiantes/examen.astro
+++ b/src/pages/es/curso/principiantes/examen.astro
@@ -5,7 +5,7 @@ import Base from "@layouts/Base.astro";
 import CourseProgress from "@components/course/CourseProgress";
 import CourseExam from "@components/course/CourseExam";
 import { units } from "@data/course/units";
-import { examQuestions, examMeta } from "@data/course/exam";
+import { examQuestions, examMeta, calculateExamResult, getScoreTier } from "@data/course/exam";
 import { ArrowLeft, GraduationCap } from "lucide-astro";
 
 const lang = "es";
@@ -59,6 +59,8 @@ const progressUnits = units.map((u) => ({
         lang="es"
         passingScore={examMeta.passingScore}
         courseBasePath="/es/curso/principiantes"
+        calculateExamResult={calculateExamResult}
+        getScoreTier={getScoreTier}
       />
     </div>
   </section>


### PR DESCRIPTION
## Summary
The Building Fluency intermediate course is **complete**. This PR ships the last two units, two new Section A components, the final exam, and a small refactor to make CourseExam reusable across courses.

### Unit 9 — Relationships and Feelings
- **WishTransformer** component: reality → wish/regret card-flow with wish type badges (present/past/future/regret) and per-card explanations
- Grammar: wish/regret + 'would' for hypotheticals
- Two-friends-reconnecting dialogue with wishes and apologies
- 6 errors including 'wish I would have' (the famous mistake) and 'wish I was' vs 'wish I were'
- Pronunciation: emotional intonation (I wish, should've, If only)

### Unit 10 — Sounding Native (capstone)
- **DeductionLab** component: pick the most likely deduction from 3 options, color-coded modal badges, explanations of WHY each modal is right or wrong
- Grammar: modals of deduction (must/can't/might/could + must have/can't have/might have)
- Workplace-mystery dialogue showing reasoning out loud
- 6 errors including 'must to be', 'must left' (vs 'must have left'), and 'mustn't have heard'
- Pronunciation: thought groups, chunking, natural fillers (I think, I mean, you know)
- **Final exam CTA section** at the bottom of the unit page

### Final Exam — Building Fluency
- 20 questions, 2 per unit, covering modals, conditionals, narratives, opinions, deductions
- Has its own \`calculateExamResult\` and \`getScoreTier\` with intermediate-level feedback
- Lives at \`/en/course/intermediate/exam/\` and \`/es/curso/intermedio/examen/\`

### Refactor: CourseExam reusability
- \`CourseExam.tsx\` now accepts \`calculateExamResult\` and \`getScoreTier\` as props
- The existing beginner exam pages have been updated to pass them in (zero behavior change)
- This unblocks the intermediate exam (and any future course exam) without duplication

## Test plan
- [x] \`npm run build\` passes (365 pages, 240 sitemap URLs, zero errors)
- [ ] Visit \`/en/course/intermediate/unit-9/\` — wish transformer works
- [ ] Visit \`/en/course/intermediate/unit-10/\` — deduction lab works, exam CTA visible
- [ ] Visit \`/en/course/intermediate/exam/\` — exam runs, scores correctly, shows feedback
- [ ] Verify ES mirrors at \`/es/curso/intermedio/unidad-9/\`, \`/unidad-10/\`, \`/examen/\`
- [ ] Confirm beginner exam still works (refactor regression check)
- [ ] All 10 units unlocked on landing pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)