### PR TITLE
fix: surface Final Exam card on intermediate landing pages

### DIFF
--- a/PORTFOLIO.md
+++ b/PORTFOLIO.md
@@ -6,7 +6,7 @@ portfolio_featured: true
 
 # === CARD DISPLAY ===
 title: "NY English Teacher"
-tagline: "Lead generation platform replacing 4 roles on $0/month infrastructure"
+tagline: "Lead generation website for an English coaching business — replaced 4 roles, runs for $0/month"
 slug: "ny-english-teacher"
 category: "Client Work"
 tech_stack:

--- a/src/pages/en/course/intermediate/index.astro
+++ b/src/pages/en/course/intermediate/index.astro
@@ -183,6 +183,25 @@ const iconMap: Record<string, any> = {
           );
         })}
       </div>
+
+      <!-- Final Exam Card -->
+      <div class="max-w-4xl mx-auto mt-6">
+        <a
+          href="/en/course/intermediate/exam/"
+          class="group flex items-center gap-4 p-5 rounded-xl border-2 border-dashed border-amber-400 bg-amber-50 hover:bg-amber-100 hover:border-amber-500 transition-all duration-200 cursor-pointer"
+        >
+          <div class="flex items-center justify-center w-12 h-12 rounded-xl shrink-0 bg-amber-500 text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </div>
+          <div>
+            <span class="text-xs font-bold uppercase tracking-wider text-amber-600">After Unit 10</span>
+            <h3 class="text-lg font-bold text-slate-900 mt-0.5">Final Exam</h3>
+            <p class="text-sm text-slate-500 mt-1">20 questions covering all 10 units — modals, conditionals, narratives, opinions, and deductions</p>
+          </div>
+        </a>
+      </div>
     </div>
   </section>
 

--- a/src/pages/es/curso/intermedio/index.astro
+++ b/src/pages/es/curso/intermedio/index.astro
@@ -183,6 +183,25 @@ const iconMap: Record<string, any> = {
           );
         })}
       </div>
+
+      <!-- Final Exam Card -->
+      <div class="max-w-4xl mx-auto mt-6">
+        <a
+          href="/es/curso/intermedio/examen/"
+          class="group flex items-center gap-4 p-5 rounded-xl border-2 border-dashed border-amber-400 bg-amber-50 hover:bg-amber-100 hover:border-amber-500 transition-all duration-200 cursor-pointer"
+        >
+          <div class="flex items-center justify-center w-12 h-12 rounded-xl shrink-0 bg-amber-500 text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </div>
+          <div>
+            <span class="text-xs font-bold uppercase tracking-wider text-amber-600">Después de la Unidad 10</span>
+            <h3 class="text-lg font-bold text-slate-900 mt-0.5">Examen Final</h3>
+            <p class="text-sm text-slate-500 mt-1">20 preguntas sobre las 10 unidades — modales, condicionales, narrativas, opiniones y deducciones</p>
+          </div>
+        </a>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
The intermediate exam was shipped in PR #32 and is fully functional, but the visible Final Exam discovery card was missing from the intermediate landing pages. The beginner course already had it. This adds the same card pattern to both EN and ES intermediate landings.

## Test plan
- [x] \`npm run build\` passes (240 sitemap URLs)
- [ ] Visit \`/en/course/intermediate/\` — Final Exam card visible after Unit 10
- [ ] Visit \`/es/curso/intermedio/\` — Examen Final card visible after Unidad 10
- [ ] Both link correctly to the existing exam pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)