### PR TITLE
fix: exam crash on submit (Astro island props can't be functions)

### DIFF
--- a/src/components/course/CourseExam.tsx
+++ b/src/components/course/CourseExam.tsx
@@ -9,16 +9,70 @@ export type ScoreTier = {
   messageEs: string;
 };
 
+/**
+ * A tier definition is just data: a minimum percentage and the labels/colors
+ * to display when the user scores that high. The component picks the highest
+ * matching tier from the array. Tiers MUST be JSON-serializable because Astro
+ * passes island props as JSON — functions cannot cross the SSR boundary.
+ */
+export type ScoreTierDefinition = ScoreTier & {
+  minPercent: number;
+};
+
 interface Props {
   questions: ExamQuestion[];
   lang: "en" | "es";
   passingScore: number;
   courseBasePath: string;
-  calculateExamResult: (answers: Record<number, number>) => ExamResult;
-  getScoreTier: (percentage: number) => ScoreTier;
+  /** Tier definitions in any order; the component picks the highest matching one. */
+  tiers: ScoreTierDefinition[];
 }
 
-export default function CourseExam({ questions, lang, passingScore, courseBasePath, calculateExamResult, getScoreTier }: Props) {
+function computeResult(
+  questions: ExamQuestion[],
+  answers: Record<number, number>,
+): ExamResult {
+  const unitScores: Record<number, { correct: number; total: number }> = {};
+  const categoryScores: Record<string, { correct: number; total: number }> = {};
+  let totalCorrect = 0;
+
+  for (const q of questions) {
+    if (!unitScores[q.unit]) unitScores[q.unit] = { correct: 0, total: 0 };
+    if (!categoryScores[q.category])
+      categoryScores[q.category] = { correct: 0, total: 0 };
+
+    unitScores[q.unit].total++;
+    categoryScores[q.category].total++;
+
+    const selectedIndex = answers[q.id];
+    if (selectedIndex !== undefined && q.options[selectedIndex]?.correct) {
+      totalCorrect++;
+      unitScores[q.unit].correct++;
+      categoryScores[q.category].correct++;
+    }
+  }
+
+  return {
+    totalCorrect,
+    totalQuestions: questions.length,
+    percentage: Math.round((totalCorrect / questions.length) * 100),
+    unitScores,
+    categoryScores,
+  };
+}
+
+function pickTier(
+  percentage: number,
+  tiers: ScoreTierDefinition[],
+): ScoreTier {
+  // Sort descending by minPercent and pick the first one the user qualifies for.
+  const sorted = [...tiers].sort((a, b) => b.minPercent - a.minPercent);
+  const match = sorted.find((t) => percentage >= t.minPercent) ?? sorted[sorted.length - 1];
+  const { minPercent: _ignored, ...rest } = match;
+  return rest;
+}
+
+export default function CourseExam({ questions, lang, passingScore, courseBasePath, tiers }: Props) {
   const [phase, setPhase] = useState<"intro" | "exam" | "results">("intro");
   const [currentIndex, setCurrentIndex] = useState(0);
   const [answers, setAnswers] = useState<Record<number, number>>({});
@@ -66,11 +120,11 @@ export default function CourseExam({ questions, lang, passingScore, courseBasePa
       setSelectedOption(null);
       setShowFeedback(false);
     } else {
-      const examResult = calculateExamResult(answers);
+      const examResult = computeResult(questions, answers);
       setResult(examResult);
       setPhase("results");
     }
-  }, [currentIndex, totalQuestions, answers]);
+  }, [currentIndex, totalQuestions, answers, questions]);
 
   const handleRestart = useCallback(() => {
     setPhase("intro");
@@ -135,7 +189,7 @@ export default function CourseExam({ questions, lang, passingScore, courseBasePa
 
   // ─── Results Screen ────────────────────────────────────────────────
   if (phase === "results" && result) {
-    const tier = getScoreTier(result.percentage);
+    const tier = pickTier(result.percentage, tiers);
     const passed = result.percentage >= passingScore;
     const unitNumbers = Object.keys(result.unitScores)
       .map(Number)

--- a/src/data/course/exam.ts
+++ b/src/data/course/exam.ts
@@ -403,6 +403,44 @@ export function calculateExamResult(answers: Record<number, number>): ExamResult
   };
 }
 
+/**
+ * Tier definitions for the beginner course exam. Pure data so it can be passed
+ * across the Astro→React island JSON boundary. The component picks the highest
+ * matching tier based on the user's percentage score.
+ */
+export const examTiers = [
+  {
+    minPercent: 90,
+    tier: "Outstanding",
+    tierEs: "Sobresaliente",
+    color: "emerald",
+    message:
+      "Incredible work. You've mastered the foundations of English. You're ready for intermediate-level challenges.",
+    messageEs:
+      "Trabajo increíble. Has dominado las bases del inglés. Estás listo para desafíos de nivel intermedio.",
+  },
+  {
+    minPercent: 70,
+    tier: "Passed",
+    tierEs: "Aprobado",
+    color: "amber",
+    message:
+      "Great job! You have a solid foundation. Review the units where you missed questions, then move forward with confidence.",
+    messageEs:
+      "¡Buen trabajo! Tienes una base sólida. Repasa las unidades donde fallaste preguntas, luego avanza con confianza.",
+  },
+  {
+    minPercent: 0,
+    tier: "Keep Practicing",
+    tierEs: "Sigue Practicando",
+    color: "rose",
+    message:
+      "You're making progress, but some areas need more review. Go back to the units where you struggled and try the exam again.",
+    messageEs:
+      "Estás progresando, pero algunas áreas necesitan más repaso. Vuelve a las unidades donde tuviste dificultades e intenta el examen de nuevo.",
+  },
+] as const;
+
 export function getScoreTier(percentage: number): {
   tier: string;
   tierEs: string;

--- a/src/data/intermediate/exam.ts
+++ b/src/data/intermediate/exam.ts
@@ -115,15 +115,15 @@ export const examQuestions: ExamQuestion[] = [
     prompt: "Which sentence uses the correct travel phrasal verb?",
     promptEs: "¿Qué oración usa el phrasal verb de viaje correcto?",
     options: [
-      { text: "I need to get on the bus at the next stop.", correct: true },
-      { text: "I need to get in the bus at the next stop.", correct: false },
-      { text: "I need to get up the bus at the next stop.", correct: false },
-      { text: "I need to get into the bus at the next stop.", correct: false },
+      { text: "Hurry — we need to get on the train before it leaves.", correct: true },
+      { text: "Hurry — we need to get in the train before it leaves.", correct: false },
+      { text: "Hurry — we need to get up the train before it leaves.", correct: false },
+      { text: "Hurry — we need to get into the train before it leaves.", correct: false },
     ],
     explanation:
-      "For buses, trains, planes and bikes, use 'get ON'. Use 'get IN' only for cars and small enclosed vehicles.",
+      "For buses, trains, planes and bikes, use 'get ON'. Use 'get IN' only for cars, taxis, and small enclosed vehicles. (Note: 'get off at the next stop' is the natural phrase for leaving a bus or train.)",
     explanationEs:
-      "Para autobuses, trenes, aviones y bicicletas, usa 'get ON'. Usa 'get IN' solo para coches y vehículos pequeños cerrados.",
+      "Para autobuses, trenes, aviones y bicicletas, usa 'get ON'. Usa 'get IN' solo para coches, taxis y vehículos pequeños cerrados. (Nota: 'get off at the next stop' es la frase natural para bajarse de un autobús o tren.)",
   },
 
   // ─── Unit 4: Making Plans ──────────────────────────────────────────
@@ -410,6 +410,43 @@ export function calculateExamResult(
     categoryScores,
   };
 }
+
+/**
+ * Tier definitions for the intermediate course exam. Pure data so it can be
+ * passed across the Astro→React island JSON boundary.
+ */
+export const examTiers = [
+  {
+    minPercent: 90,
+    tier: "Outstanding",
+    tierEs: "Sobresaliente",
+    color: "emerald",
+    message:
+      "Exceptional work. You've truly built fluency. You're ready for advanced English and real-world situations of any kind.",
+    messageEs:
+      "Trabajo excepcional. Realmente has construido fluidez. Estás listo para inglés avanzado y situaciones del mundo real de cualquier tipo.",
+  },
+  {
+    minPercent: 70,
+    tier: "Passed",
+    tierEs: "Aprobado",
+    color: "amber",
+    message:
+      "Solid performance. You've mastered the core of intermediate English. Review the units where you missed questions and keep practicing in real conversations.",
+    messageEs:
+      "Desempeño sólido. Has dominado el núcleo del inglés intermedio. Repasa las unidades donde fallaste preguntas y sigue practicando en conversaciones reales.",
+  },
+  {
+    minPercent: 0,
+    tier: "Keep Practicing",
+    tierEs: "Sigue Practicando",
+    color: "rose",
+    message:
+      "You're making progress, but key structures need more review. Go back to the units where you struggled — especially modals and conditionals — and try again.",
+    messageEs:
+      "Estás progresando, pero las estructuras clave necesitan más repaso. Vuelve a las unidades donde tuviste dificultades — especialmente modales y condicionales — e intenta de nuevo.",
+  },
+] as const;
 
 export function getScoreTier(percentage: number): ScoreTier {
   if (percentage >= 90) {

--- a/src/pages/en/course/beginners/exam.astro
+++ b/src/pages/en/course/beginners/exam.astro
@@ -5,7 +5,7 @@ import Base from "@layouts/Base.astro";
 import CourseProgress from "@components/course/CourseProgress";
 import CourseExam from "@components/course/CourseExam";
 import { units } from "@data/course/units";
-import { examQuestions, examMeta, calculateExamResult, getScoreTier } from "@data/course/exam";
+import { examQuestions, examMeta, examTiers } from "@data/course/exam";
 import { ArrowLeft, GraduationCap } from "lucide-astro";
 
 const lang = "en";
@@ -59,8 +59,7 @@ const progressUnits = units.map((u) => ({
         lang="en"
         passingScore={examMeta.passingScore}
         courseBasePath="/en/course/beginners"
-        calculateExamResult={calculateExamResult}
-        getScoreTier={getScoreTier}
+        tiers={examTiers}
       />
     </div>
   </section>

--- a/src/pages/en/course/intermediate/exam.astro
+++ b/src/pages/en/course/intermediate/exam.astro
@@ -5,12 +5,7 @@ import Base from "@layouts/Base.astro";
 import CourseProgress from "@components/course/CourseProgress";
 import CourseExam from "@components/course/CourseExam";
 import { intermediateUnits } from "@data/intermediate/units";
-import {
-  examQuestions,
-  examMeta,
-  calculateExamResult,
-  getScoreTier,
-} from "@data/intermediate/exam";
+import { examQuestions, examMeta, examTiers } from "@data/intermediate/exam";
 import { ArrowLeft, GraduationCap } from "lucide-astro";
 
 const lang = "en";
@@ -66,8 +61,7 @@ const progressUnits = intermediateUnits.map((u) => ({
         lang="en"
         passingScore={examMeta.passingScore}
         courseBasePath="/en/course/intermediate"
-        calculateExamResult={calculateExamResult}
-        getScoreTier={getScoreTier}
+        tiers={examTiers}
       />
     </div>
   </section>

--- a/src/pages/es/curso/intermedio/examen.astro
+++ b/src/pages/es/curso/intermedio/examen.astro
@@ -5,12 +5,7 @@ import Base from "@layouts/Base.astro";
 import CourseProgress from "@components/course/CourseProgress";
 import CourseExam from "@components/course/CourseExam";
 import { intermediateUnits } from "@data/intermediate/units";
-import {
-  examQuestions,
-  examMeta,
-  calculateExamResult,
-  getScoreTier,
-} from "@data/intermediate/exam";
+import { examQuestions, examMeta, examTiers } from "@data/intermediate/exam";
 import { ArrowLeft, GraduationCap } from "lucide-astro";
 
 const lang = "es";
@@ -66,8 +61,7 @@ const progressUnits = intermediateUnits.map((u) => ({
         lang="es"
         passingScore={examMeta.passingScore}
         courseBasePath="/es/curso/intermedio"
-        calculateExamResult={calculateExamResult}
-        getScoreTier={getScoreTier}
+        tiers={examTiers}
       />
     </div>
   </section>

--- a/src/pages/es/curso/principiantes/examen.astro
+++ b/src/pages/es/curso/principiantes/examen.astro
@@ -5,7 +5,7 @@ import Base from "@layouts/Base.astro";
 import CourseProgress from "@components/course/CourseProgress";
 import CourseExam from "@components/course/CourseExam";
 import { units } from "@data/course/units";
-import { examQuestions, examMeta, calculateExamResult, getScoreTier } from "@data/course/exam";
+import { examQuestions, examMeta, examTiers } from "@data/course/exam";
 import { ArrowLeft, GraduationCap } from "lucide-astro";
 
 const lang = "es";
@@ -59,8 +59,7 @@ const progressUnits = units.map((u) => ({
         lang="es"
         passingScore={examMeta.passingScore}
         courseBasePath="/es/curso/principiantes"
-        calculateExamResult={calculateExamResult}
-        getScoreTier={getScoreTier}
+        tiers={examTiers}
       />
     </div>
   </section>


### PR DESCRIPTION
## 🚨 Hotfix — production exams currently broken

PR #25 (originally) and PR #32 (refactor) introduced a regression: **both production exam pages crash when the user clicks "See Results"**. Discovered via Playwright end-to-end testing.

### Root cause
PR #32 refactored CourseExam to accept \`calculateExamResult\` and \`getScoreTier\` as props. **Astro serializes React island props as JSON, and functions don't survive serialization.** The client receives \`undefined\` for both helpers, and the exam crashes at the moment of result computation:

\`\`\`
PAGEERROR: calculateExamResult is not a function
\`\`\`

This means **both** \`/en/course/beginners/exam/\` AND \`/en/course/intermediate/exam/\` (plus ES mirrors) have been broken since PR #32 merged. Users could answer all 20 questions but the page would crash on the very last click.

### Fix
- **CourseExam computes the result internally** using the \`questions\` prop it already has (which IS JSON-serializable)
- **Tier definitions** are now passed as a \`tiers\` array of plain objects (\`ScoreTierDefinition[]\`) — pure data, no functions
- Added \`examTiers\` exports to both \`src/data/course/exam.ts\` and \`src/data/intermediate/exam.ts\`
- Updated all 4 exam pages to pass \`tiers={examTiers}\`

### Bonus content fix (caught during manual testing)
Intermediate exam Q6 was confusingly worded:
- ❌ \"I need to get on the bus at the next stop\" — \"at the next stop\" naturally implies you're getting OFF
- ✅ \"Hurry — we need to get on the train before it leaves\" — unambiguously about boarding

Also added a clarifying note to the explanation about \"get off at the next stop\" being the natural exit phrase.

### Test plan
- [x] \`npm run build\` passes (240 sitemap URLs, zero errors)
- [x] **End-to-end Playwright test on dev server**: beginner exam answers all 20 questions, reaches results screen, renders score (35%), tier (\"Keep Practicing\"), category breakdown, unit breakdown, and retake button
- [x] **Same test on intermediate exam**: 20/20 answered, results render (20%), all UI elements present
- [x] No more \`calculateExamResult is not a function\` errors in console
- [ ] Smoke test on prod after deploy

### Known follow-ups (not blocking)
- React #418 hydration warning still fires on both exam pages on initial load. The exams work end-to-end despite this — likely from a different \`client:load\` component on the page (CourseProgress?). Worth investigating in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)