### PR TITLE
docs: advanced + executive course plans, intermediate retrospective

### DIFF
--- a/docs/ADVANCED-COURSE-PLAN.md
+++ b/docs/ADVANCED-COURSE-PLAN.md
@@ -1,0 +1,187 @@
+# Advanced Course Plan — "Speak with Confidence" (B2 → C1)
+
+**Status:** Planned, ready to build
+**Target audience:** High B2 to C1 Spanish speakers — professionals who can already hold conversations comfortably but plateau on the precision and naturalness that separates "fluent" from "polished"
+**Tagline:** *Speak with Confidence*
+**Pricing:** **Free** (no email gate). Strong "Book a Strategy Session" CTA at end of every unit and after the final exam.
+
+---
+
+## The thesis
+
+After the beginner ("First Steps Into English") and intermediate ("Building Fluency") courses, the learner can:
+- Recognize the 1,500 cognates Spanish and English share
+- Hold a conversation in present, past, future, and conditionals
+- Use modals correctly for politeness, hypotheticals, and deduction
+- Navigate workplace, travel, social, and emotional contexts
+
+What they CANNOT yet do:
+- Choose **strong** words over weak ones (got/made/did → earned/built/delivered)
+- Avoid the word traps that haunt advanced learners forever (fewer/less, say/tell, who/whom)
+- Use articles like a native (the single most lifelong Spanish-speaker error)
+- Sound natural instead of translated
+- Decode their own pronunciation tells (S endings, -en endings, TH, R)
+
+**Advanced is not "more themes."** It's a skill-based bootcamp that fixes the exact issues that mark a non-native speaker even at C1.
+
+---
+
+## What's CUT from this course (deliberate)
+
+Per Robert's pedagogical direction:
+
+| Cut | Why |
+|---|---|
+| **Writing drills** | Anyone who needs polished writing has Claude/ChatGPT in 2026. Spoken English is the irreplaceable skill. |
+| **Verb tense drills** | Intermediate covered all the major tenses. Advanced learners don't need more tense exercises. |
+| **Phrasal verbs as a unit** | Same reasoning as intermediate — phrasal verbs are oversold. They appear naturally in dialogues but never get a unit. |
+| **Modals as a unit** | Intermediate made modals the spine. Advanced uses them correctly without re-teaching them. |
+
+---
+
+## 10-unit outline (3 sections per unit)
+
+| # | Title | Section 1 | Section 2 | Section 3 |
+|---|---|---|---|---|
+| 1 | **Weak Phrasing → Strong Phrasing** | Weak verbs vs strong verbs (got, made, did → earned, built, delivered) | Killing weak adverbs (very, really, quite, just) | Rewriting flat sentences into sentences with impact |
+| 2 | **Word Traps That Trip Up Advanced Speakers** | Much vs many, few vs little, fewer vs less | Loan vs borrow, bring vs take, lend vs let | Say vs tell, make vs do, win vs earn vs beat |
+| 3 | **Pronouns Done Right** | Subject vs object pronouns (he/him, she/her, they/them) | Reflexive pronouns (myself, yourself, themselves) — when they're wrong | Direct vs indirect object pronouns in real sentences |
+| 4 | **Which, That, Who, When** | Which vs that — defining vs non-defining | Who vs whom (and why nobody says "whom" anymore) | When, where, whose — relative clauses without the confusion |
+| 5 | **Articles: A, An, The, or Nothing** | When to use "a/an" vs "the" | When to use no article (zero article) | The traps — institutions, places, abstract nouns |
+| 6 | **Pronunciation: Hitting the Hard Sounds** | The S sound — plurals, possessives, third-person verbs | -en endings — strengthen, tighten, written, spoken, frighten | TH, R, and the vowels that give you away |
+| 7 | **Contractions, Flipped** | Advanced contractions in declaratives (I'd've, shouldn't've) | Negative contractions and double negatives to avoid | When NOT to use contractions — register and emphasis |
+| 8 | **Prefixes & Suffixes** | Common prefixes and what they actually mean (un-, dis-, mis-, over-) | Suffixes that change word class (-tion, -ment, -ness, -en) | Building vocabulary by decoding word parts |
+| 9 | **Sentence Construction & Flow** | Sentence variety — simple, compound, complex | Word order traps (adverb placement, adjective stacking) | Linking ideas without sounding robotic |
+| 10 | **Sounding Natural, Not Translated** | Collocations native speakers expect (strong coffee, heavy rain) | The rhythm of spoken English — stress and pause | Thinking in English instead of translating |
+
+**Final exam:** Comprehensive assessment covering all 10 units. Multiple-choice format like beginner/intermediate. No real-time speaking task in v1 — see "Recorded speaking task" below.
+
+---
+
+## Section pattern: teach → recognize → produce
+
+Every unit's 3 sections follow the same cognitive progression:
+
+| Section | Cognitive load | Purpose | What it looks like |
+|---|---|---|---|
+| **1: Concept** | Receive | Introduce the rule with clear examples | Read + side-by-side comparisons + audio + reveals |
+| **2: Recognition** | Detect | Spot the issue in real sentences | Multiple-choice or "find the error" |
+| **3: Production** | Create | Build the right version yourself | Sentence transformation, fill-in, pick the upgrade |
+
+This is the **teach → recognize → produce** progression that drives long-term retention. Recognition before production. Concept before recognition.
+
+The 3 sections will FEEL different from beginner/intermediate (which had 6 sections per unit). This is intentional: advanced learners want efficiency, not 20-minute units. Each unit should be ~10 minutes of focused drilling.
+
+---
+
+## Component library (5 reusable components)
+
+Building 30 unique React components for 30 mini-exercises is unrealistic and wasteful. Instead, build 5 reusable components that get reused across units with different content. Each unit feels distinct because the **content** is different, not the widget.
+
+| Component | Purpose | Used in units |
+|---|---|---|
+| **`WordPairLab`** | Compare 2 words/phrases side by side, reveal which is right and why | U1 (weak/strong), U2 (word traps), U3 (pronouns), U10 (collocations) |
+| **`ErrorSpotter`** | Show a sentence, click the error or pick the wrong one from 4 sentences | U2, U3, U4, U5, U9 |
+| **`SentenceTransformer`** | Given a flat/wrong sentence, build the upgraded version (multi-step or pick-the-upgrade) | U1, U7, U9, U10 |
+| **`MinimalPairDrill`** | Audio-driven pronunciation pairs (ship/sheep, walk/work, then/than) | U6 |
+| **`WordBuilder`** | Combine prefix + root + suffix to build/decode words; click parts to see their meaning | U8 |
+
+**Trade-off acknowledged:** This is less varied than intermediate's "unique component per unit" approach. The justification: 30 sections is too many to give each its own widget, AND the skill-based nature of advanced (vs the theme-based nature of intermediate) means the same widget mechanic genuinely fits multiple units. The course feels distinct because the content is sharp and different.
+
+---
+
+## Final exam — and the speaking task strategy
+
+**v1 (now):** 20 multiple-choice questions covering all 10 units, using the existing `CourseExam` React component (the one we just refactored after the prop-passing crash). The exam will:
+
+- Use the same `examQuestions` / `examTiers` data pattern as intermediate
+- Have its own scoring tiers tuned for advanced ("Outstanding" / "Passed" / "Keep Practicing" with C1-appropriate feedback)
+- Cover roughly 2 questions per unit
+- Use the same 3 categories (vocabulary, grammar, translation) for the score breakdown
+
+**Recorded speaking task:** Robert's outline mentions "a recorded speaking task — graded with feedback." We do not yet have audio recording infrastructure on the site, and building it (browser MediaRecorder + Vercel Blob storage + grading flow) is a separate ~1-3 day project.
+
+**v1 strategy: stub it as a coaching funnel.** After the multiple-choice exam, show:
+
+> *"Want a real speaking evaluation? The most reliable way to know if your spoken English has reached C1 is to be heard. Book a free 30-minute strategy session with Robert and submit a 60-second recording. He'll listen personally and give you honest, actionable feedback."*
+> *[Book Strategy Session →]*
+
+This turns a feature limitation into the **most powerful conversion CTA in the entire course**. Don't build the speaking task as a tool — build it as a coaching trial.
+
+**v2 (later):** If demand justifies it, build the in-browser recording flow with manual or AI-assisted grading. Until then, the strategy session IS the speaking task.
+
+---
+
+## Files to be created (estimated)
+
+### React components (5)
+- `src/components/course/WordPairLab.tsx`
+- `src/components/course/ErrorSpotter.tsx`
+- `src/components/course/SentenceTransformer.tsx`
+- `src/components/course/MinimalPairDrill.tsx`
+- `src/components/course/WordBuilder.tsx`
+
+### Data files (12)
+- `src/data/advanced/types.ts`
+- `src/data/advanced/units.ts` (course metadata + 10-unit array)
+- `src/data/advanced/unit-1.ts` through `unit-10.ts`
+- `src/data/advanced/exam.ts`
+
+### Page files (24)
+- `src/pages/en/course/advanced/index.astro` + 10 unit pages + exam page (12 EN)
+- `src/pages/es/curso/avanzado/index.astro` + 10 unit pages + exam page (12 ES)
+
+### Modified files
+- `src/lib/i18n.ts` — add 12 new TKey entries (course/advanced + 10 units + exam) + EN/ES routes
+- `src/pages/en/courses/index.astro` and `src/pages/es/cursos/index.astro` — add Advanced course card
+- `docs/BEGINNER-COURSE-PLAN.md` — update future-phases section to point here
+
+**Total: 41 new files, 4 modified.** Roughly the same scope as intermediate.
+
+---
+
+## Build order (recommended PR cadence)
+
+To keep PRs reviewable, ship in chunks:
+
+| PR | Contents |
+|---|---|
+| **PR 1** | Foundation — i18n routes, types, units metadata, landing page (EN+ES), all 5 React components built as empty/stub forms |
+| **PR 2** | Units 1, 2, 3 — full data files + EN/ES pages + activate components |
+| **PR 3** | Units 4, 5, 6 |
+| **PR 4** | Units 7, 8, 9 |
+| **PR 5** | Unit 10 + final exam + speaking task funnel CTA + courses hub card |
+
+5 PRs is the same cadence we used for intermediate. Each PR builds on the last, none ships broken intermediate states, and Robert can review/correct content as we go.
+
+---
+
+## URL structure
+
+- EN landing: `/en/course/advanced/`
+- EN unit: `/en/course/advanced/unit-1/` through `/unit-10/`
+- EN exam: `/en/course/advanced/exam/`
+- ES landing: `/es/curso/avanzado/`
+- ES unit: `/es/curso/avanzado/unidad-1/` through `/unidad-10/`
+- ES exam: `/es/curso/avanzado/examen/`
+
+These will be added to `src/lib/i18n.ts` as 12 new TKey entries with EN/ES routes for hreflang.
+
+---
+
+## Key principles inherited from intermediate
+
+1. **JSON-serializable props always** when passing data to React islands. Functions never. (See [INTERMEDIATE-COURSE-RETROSPECTIVE.md](./INTERMEDIATE-COURSE-RETROSPECTIVE.md) for the post-mortem on the exam crash bug.)
+2. **No slang, no fads.** Sophisticated, timeless English only.
+3. **No focus on writing.** Spoken-fluency first.
+4. **Manual content audit before launch.** Robert reviews every question, every translation, every category label.
+5. **Strong CTAs to coaching at strategic points.** End of every unit page + after final exam.
+6. **Bilingual mirror pages with hreflang on day one.** Never ship monolingual.
+
+---
+
+## Open questions / decisions for later
+
+- Whether to add a "completion certificate" download (beginner doesn't have one, intermediate doesn't either). May be worth doing for advanced as a CTA-magnet — a downloadable PDF the learner can put on LinkedIn could drive shares and SEO.
+- Whether to record native-speaker audio for Unit 6 (Pronunciation) instead of relying on TTS. Robert's voice would dramatically increase the pedagogical value of the minimal pair drills, but requires his time.
+- Whether to add a "Review Mode" for previously-completed units (not in scope for v1).

--- a/docs/BEGINNER-COURSE-PLAN.md
+++ b/docs/BEGINNER-COURSE-PLAN.md
@@ -954,30 +954,24 @@ Each unit page targets specific long-tail keywords:
 
 ---
 
-## Future Phases
+## The Course Roadmap (Status as of April 2026)
 
-### Phase 2: Intermediate Course — "Building Fluency"
-- Past tenses in depth
-- Phrasal verbs (the Spanish speaker's nemesis)
-- Conditional structures
-- Travel, shopping, social English
-- More complex pronunciation (connected speech, weak forms)
+The original Phase 2/3/4 sketch in this document has evolved into three full course plans with detailed curricula. See the linked plans for specifics.
 
-### Phase 3: Advanced Course — "Professional English"
-- Business vocabulary beyond cognates
-- Meeting participation
-- Email writing
-- Phone and video calls
-- Presentation basics
-- Cultural communication differences
+### ✅ Phase 2: Intermediate Course — "Building Fluency" (B1-B2) — **SHIPPED**
+Live at [/en/course/intermediate/](https://www.nyenglishteacher.com/en/course/intermediate/) and [/es/curso/intermedio/](https://www.nyenglishteacher.com/es/curso/intermedio/). 10 units + final exam, modal-driven curriculum, 7 unique React components built specifically for the course.
 
-### Phase 4: Executive Communication Course
-- High-stakes presentations
-- Negotiation in English
-- Leadership communication
-- Boardroom English
-- C-suite language and register
-- This is essentially a gateway to Robert's 1-on-1 coaching
+📄 **Retrospective:** [INTERMEDIATE-COURSE-RETROSPECTIVE.md](./INTERMEDIATE-COURSE-RETROSPECTIVE.md) — what we shipped, the principles we discovered (modal-driven, no cookie-cutter Section A, no phrasal verb fixation, no slang), and the post-mortem on the Astro island prop crash bug.
+
+### ⏳ Phase 3: Advanced Course — "Speak with Confidence" (B2-C1) — **PLANNED, READY TO BUILD**
+Skill-based bootcamp focused on the granular errors that mark a non-native speaker even at C1: weak vs strong phrasing, word traps (fewer/less, say/tell), pronouns, articles, pronunciation tells, contractions, prefixes/suffixes, sentence flow, sounding natural instead of translated. 10 units × 3 sections each, free, 5 reusable components, multiple-choice final exam with a strategy-session funnel as the speaking-task replacement.
+
+📄 **Full plan:** [ADVANCED-COURSE-PLAN.md](./ADVANCED-COURSE-PLAN.md)
+
+### ⏳ Phase 4: Executive Communication — "Communicate Like a Leader" (C1-C2) — **PLANNED, BUILD DEFERRED UNTIL ADVANCED SHIPS**
+The funnel into Robert's 1-on-1 coaching. 10 units covering executive presence, meetings, presentations, negotiation, small talk, difficult conversations, storytelling, cross-cultural communication, leadership vocabulary, and a personal-brand capstone. Capstone is a recorded executive presentation submitted directly to Robert for personal feedback — the ultimate coaching funnel hook. Free during launch (Phase 1), Stripe paywall in Phase 2.
+
+📄 **Full plan:** [EXECUTIVE-COURSE-PLAN.md](./EXECUTIVE-COURSE-PLAN.md)
 
 ### Platform Enhancements (Any Phase)
 - **User accounts** — save progress across devices

--- a/docs/EXECUTIVE-COURSE-PLAN.md
+++ b/docs/EXECUTIVE-COURSE-PLAN.md
@@ -1,0 +1,182 @@
+# Executive Communication Course Plan — "Communicate Like a Leader" (C1 → C2)
+
+**Status:** Planned, build deferred until Advanced course ships
+**Target audience:** Founders, executives, senior professionals — people who already communicate competently in English but want to **lead** in English
+**Tagline:** *Communicate Like a Leader*
+**Pricing:** **Paid** (with free preview units, paywall added in Phase 2). Strong funnel into Robert's 1-on-1 coaching.
+
+---
+
+## The thesis
+
+This course is fundamentally different from the first three. **It is essentially a productized version of Robert's 1-on-1 executive coaching.** The conversion play is:
+
+1. **The course gets executives in the door** — they pay a small amount or commit an email for premium content
+2. **The course makes 1-on-1 coaching feel inevitable** — every unit reminds the learner that personalized coaching will accelerate them faster
+3. **Strong, well-placed CTAs convert course completers into coaching clients**
+
+Robert IS the differentiator. His Bronx-born background, his Fortune 500 client roster, his personality — none of that can be copied by AI or generic course platforms. The course should feel like an extended seminar with Robert, not a textbook.
+
+---
+
+## What's CUT from this course (deliberate)
+
+| Cut | Why |
+|---|---|
+| **The written email unit** | Same reasoning as advanced — anyone who needs polished writing has Claude/ChatGPT. Spoken executive communication is the irreplaceable skill. |
+| **Verb tense drills** | Assumed mastered by C1+. |
+| **Phrasal verbs** | Same as before. |
+| **Modal drills** | Same as before. |
+| **Vocabulary memorization** | C1 learners build vocabulary by reading and listening, not by memorizing flashcards. |
+
+---
+
+## 10-unit outline (3 sections per unit)
+
+| # | Title | Section 1 | Section 2 | Section 3 |
+|---|---|---|---|---|
+| 1 | **Executive Presence in English** | How leaders speak — pace, pause, and presence | Eliminating filler and hedging language | Sounding decisive without sounding aggressive |
+| 2 | **Meetings That Move Forward** | Opening, steering, and closing a meeting | Interrupting politely and holding the floor | Disagreeing professionally — the diplomatic toolkit |
+| 3 | **Presentations & Public Speaking** | Structuring a talk for English-speaking audiences | Signposting language that keeps listeners engaged | Handling Q&A, including hostile questions |
+| 4 | **Negotiation Language** | Positioning, anchoring, and concession language | Diplomatic "no" — refusing without damaging the relationship | Closing the deal in English |
+| 5 | **Small Talk & Relationship Building** | Opening conversations with clients and colleagues | Networking events — what to say beyond "what do you do?" | Building rapport across the meeting, the meal, and the follow-up |
+| 6 | **Difficult Conversations** | Giving feedback without offending | Receiving feedback with poise | Conflict, apology, and repair language |
+| 7 | **Storytelling for Business** | The narrative arc in pitches and proposals | Data storytelling — making numbers memorable | Personal anecdotes that build credibility |
+| 8 | **Cross-Cultural Communication** | American business culture — directness, small talk, hierarchy | Meeting and call norms across cultures | Avoiding misunderstandings with international teams |
+| 9 | **Leadership Vocabulary & Register** | The language of strategy, vision, and execution | Business idioms that signal seniority | Avoiding jargon that makes you sound junior |
+| 10 | **Your Executive Voice** | Personal brand in English — how you want to be heard | Building a long-term communication practice | **Capstone: a recorded executive presentation with coaching feedback** |
+
+**Final Assessment:** Different from the multiple-choice exams in the other courses. See "The capstone strategy" below.
+
+---
+
+## Component reuse from advanced
+
+The 5 reusable components built for advanced will work here too:
+- `WordPairLab` for U9 (vocabulary register comparisons)
+- `SentenceTransformer` for U1 (eliminating hedging) and U7 (data storytelling)
+- `ErrorSpotter` for U6 (feedback phrasing pitfalls)
+
+Most executive sections will use **less interactivity, more analysis**. Each unit will lean on:
+- **Case studies** — real examples of executive communication (public-domain speeches, leaked memos, famous interviews) with analytical reveals
+- **Frameworks** — SCQA, BLUF, Pyramid Principle, Aristotle's ethos/pathos/logos
+- **Robert's voice** in the prose — opinionated, specific, premium-feeling
+
+This means the executive course will need at most **1-2 new components**:
+
+| Component | Purpose |
+|---|---|
+| `CaseStudyLab` | Show an executive example (text + context), analytical reveal explaining why it worked |
+| `RhetoricalPatternLab` (optional) | Show a rhetorical pattern (rule of three, contrast pair, callback), give examples, learner identifies the pattern in new examples |
+
+---
+
+## The capstone strategy — Unit 10 + Final Assessment
+
+Robert's outline says Unit 10 ends with "a recorded executive presentation with coaching feedback." This is the **single most important conversion moment in the entire course**.
+
+We will NOT build in-browser audio recording for v1 (same reason as advanced — it's a 1-3 day side project that distracts from shipping content). Instead, the capstone will be:
+
+1. **A clear prompt** — "Record a 90-second executive update on a project you're leading. Use the SCQA framework. Submit it via email or book a strategy session."
+2. **A submission CTA** — Two paths:
+    - **Path A:** Email the recording to a dedicated address (e.g., `capstone@nyenglishteacher.com`). Robert listens and replies personally with feedback within 48 hours.
+    - **Path B:** Book a free 30-minute strategy session and present it live to Robert.
+3. **The funnel hook** — Either path puts the executive into direct contact with Robert. The strategy session converts at a high rate. Path A nurtures the email list and creates a personalized touch point.
+
+This is **the entire point of the executive course.** The capstone IS the conversion event.
+
+---
+
+## Pricing & Phase 1 vs Phase 2
+
+### Phase 1 (build now, ship after Advanced)
+
+**Free during launch.** Frame it as "Early Access — free for the first wave of executives." This:
+- Removes friction during the period when we're still learning what content lands
+- Builds testimonials and case studies before charging
+- Lets us gather feedback before locking in a price point
+- Aligns with "free with strategy session booking" — the real conversion is the coaching
+
+### Phase 2 (after we know the content works)
+
+Add a Stripe paywall. Three pricing options to consider when we get there:
+
+| Option | Price | Notes |
+|---|---|---|
+| **A) Standalone course** | $99–$149 one-time | Self-serve, lower commitment |
+| **B) Course + strategy session** | $299 bundle | Includes one 30-minute session with Robert. The session is the value driver. |
+| **C) Course free, coaching paid** | Free / $499 per coaching package | Course as lead magnet only. Highest funnel volume, lowest course revenue. |
+
+**Recommendation when we get to Phase 2:** Option B. Bundles the course with a touch point with Robert, captures actual revenue, and the strategy session anchors the value perception.
+
+**Why we're deferring this:** Building Stripe checkout, payment tracking, course access gating (per-user paid status), and refund handling is a substantial system — probably 2-3 days on its own. We don't want to spend that time before we know the product is good. Free during launch reduces risk.
+
+---
+
+## Files to be created (estimated)
+
+### React components (1-2 new)
+- `src/components/course/CaseStudyLab.tsx`
+- `src/components/course/RhetoricalPatternLab.tsx` (optional)
+
+### Data files (12)
+- `src/data/executive/types.ts`
+- `src/data/executive/units.ts`
+- `src/data/executive/unit-1.ts` through `unit-10.ts`
+- `src/data/executive/assessment.ts` (smaller than a full exam — capstone-focused)
+
+### Page files (24)
+- `src/pages/en/course/executive/index.astro` + 10 unit pages + assessment page (12 EN)
+- `src/pages/es/curso/ejecutivo/index.astro` + 10 unit pages + assessment page (12 ES)
+
+### Modified files
+- `src/lib/i18n.ts` — add 12 new TKey entries + routes
+- `src/pages/en/courses/index.astro` and `src/pages/es/cursos/index.astro` — add Executive course card
+
+**Total: ~38 new files, 3 modified.** Slightly less than advanced because the components are mostly reused.
+
+---
+
+## Build order (recommended PR cadence)
+
+| PR | Contents |
+|---|---|
+| **PR 1** | Foundation — i18n routes, types, units metadata, landing page (EN+ES), CaseStudyLab component |
+| **PR 2** | Units 1, 2, 3 |
+| **PR 3** | Units 4, 5, 6 |
+| **PR 4** | Units 7, 8, 9 |
+| **PR 5** | Unit 10 + Capstone funnel + courses hub card |
+
+Same cadence as advanced. Defer the Stripe paywall to a Phase 2 PR after we ship and validate.
+
+---
+
+## URL structure
+
+- EN landing: `/en/course/executive/`
+- EN unit: `/en/course/executive/unit-1/` through `/unit-10/`
+- EN assessment: `/en/course/executive/assessment/`
+- ES landing: `/es/curso/ejecutivo/`
+- ES unit: `/es/curso/ejecutivo/unidad-1/` through `/unidad-10/`
+- ES assessment: `/es/curso/ejecutivo/evaluacion/`
+
+---
+
+## What this course does NOT try to be
+
+- A grammar refresher (intermediate handled that)
+- A cultural exchange program
+- A networking platform
+- A self-paced certification program
+- A replacement for 1-on-1 coaching
+
+It is **a focused, premium-positioned series of leadership communication lessons designed to convert qualified executives into Robert's coaching clients.** Every unit serves that goal.
+
+---
+
+## Open questions / decisions for later
+
+- **Robert recording video intros for each unit** — flagged in the original alignment discussion. Robert declined for now ("not ready to record a video right now"). If/when he changes his mind, even 2-3 minute video intros per unit would dramatically increase perceived value and conversion. Worth revisiting after Phase 1 ships.
+- **Whether to write a separate Spanish version of the case studies** — most executive content references American business culture and English-language sources. Translation may be straightforward, but some cultural context will need adaptation.
+- **Whether to bundle the course with Robert's existing executive training products** (the Cushlabs offerings, etc.). Worth a strategic conversation when we get to Phase 2 paywall.
+- **Whether to create a private Slack/Discord community for executive course enrollees** — could be a high-value add but creates ongoing moderation work.

--- a/docs/INTERMEDIATE-COURSE-RETROSPECTIVE.md
+++ b/docs/INTERMEDIATE-COURSE-RETROSPECTIVE.md
@@ -1,0 +1,153 @@
+# Intermediate Course — "Building Fluency" — Retrospective
+
+**Status:** ✅ Complete and live in production
+**Live at:** [/en/course/intermediate/](https://www.nyenglishteacher.com/en/course/intermediate/) and [/es/curso/intermedio/](https://www.nyenglishteacher.com/es/curso/intermedio/)
+**Built:** April 2026, in collaboration with Robert Cushman III
+
+---
+
+## Scope shipped
+
+- **10 units** covering B1-B2 progression from phrasal verb decoding through modal mastery to native-sounding deduction
+- **Final exam** — 20 questions covering all 10 units, with category breakdown (grammar / vocabulary / translation) and unit-by-unit scoring
+- **Bilingual** — full English + Spanish mirror pages with hreflang
+- **6 unique React components** built specifically for this course (PoliteFramesBuilder, NarrativeTimeline, OpinionStems, SurvivalPhrases, SpecifierBuilder, WishTransformer, DeductionLab) plus the original PhrasalVerbExplorer reused for Units 1-3
+- **Course progress tracking** via localStorage with separate `courseId="intermediate"` namespace
+- **Final exam component** (`CourseExam.tsx`) refactored to be reusable across both beginner and intermediate courses
+
+---
+
+## What we got right
+
+### Modal-driven curriculum
+After Units 1-3 used phrasal verbs as the spine, we pivoted Units 4-10 to make **modals** (would, could, should, might, may, must, can't) the through-line of the course. This was the single most important pedagogical decision. Modals are:
+
+- The politeness layer of English
+- The structure Spanish speakers struggle with most (no clean Spanish equivalent)
+- The thing that separates B1 from B2 in real conversations
+- Universally useful — they age well across decades
+
+Every unit from 4 onward introduces a new dimension of modal usage:
+- U4: would/could for invitations
+- U5: would for habitual past
+- U6: might/may/could for softening opinions
+- U7: should/ought to/had better for advice
+- U8: would rather/would prefer for preferences
+- U9: would in wishes and hypotheticals
+- U10: must/can't/might for deduction
+
+### Sentence construction over phrasal verbs
+Robert's early correction during the build: phrasal verbs are oversold by traditional teaching. Students struggle to memorize them in isolation, and recognition matters more than production. We capped phrasal verbs at 3 per unit after Unit 4 and made `SentenceBuilder` (Section C) the heaviest, most ambitious section in every unit.
+
+### Each unit gets a unique Section A
+The "no cookie-cutter feel" rule. Every unit's first interactive section uses a custom-built React component:
+
+| Unit | Section A component | Mechanic |
+|---|---|---|
+| 1-3 | PhrasalVerbExplorer | Grouped reveal of phrasal verbs by base verb |
+| 4 | PoliteFramesBuilder | Casual sentence → polite B2 upgrade with modal highlighted |
+| 5 | NarrativeTimeline | Vertical timeline of past events with tense badges |
+| 6 | OpinionStems | Tabbed categories (state/soften/agree/disagree/concede) of opinion frames |
+| 7 | SurvivalPhrases | Categorized high-stakes medical phrases with urgency badges |
+| 8 | SpecifierBuilder | Vague → specific transformation with relative clause highlighting |
+| 9 | WishTransformer | Reality → wish/regret transformation with wish-type badges |
+| 10 | DeductionLab | Multiple-choice deduction with modal certainty explanations |
+
+### Sections B-F stayed consistent
+Dialogue Practice, SentenceBuilder, ErrorCorrection, PronunciationDrill, SelfTest reused the same components across all 10 units. The data inside them is unique per unit, so each unit still feels different — but we didn't waste effort building 60 unique components.
+
+### No slang, no fads
+After an early misstep where I drafted social-chunk content like "wanna grab a coffee" and "I'm down for that," Robert killed it. The pivot: timeless, sophisticated English ("Would you like to grab a coffee sometime?"). Slang dates fast and damages credibility with hiring managers and savvy clients. Every unit since has used register-appropriate, ageless English.
+
+### No focus on written English
+Students who need polished written English have ChatGPT/Claude. Spoken English is the irreplaceable skill. The course never wastes time teaching email composition.
+
+### Final exam reuse via prop-passing
+The `CourseExam` React component was generalized to accept `tiers` (array of tier definitions) as a serializable prop, so both beginner and intermediate exams use the same component with different question sets and tier feedback.
+
+---
+
+## What we got wrong (and learned from)
+
+### 🚨 Functions cannot cross Astro island prop boundaries (P0 bug)
+
+**The mistake:** When refactoring `CourseExam.tsx` to be reusable across courses, the first attempt passed `calculateExamResult` and `getScoreTier` as **function props** to the React island. This worked locally during build because Astro's SSR runs the component server-side once, where functions are valid JavaScript. But on the client, **Astro serializes island props as JSON**, and functions don't serialize. The client received `undefined` and the exam crashed at the moment of result computation:
+
+```
+PAGEERROR: calculateExamResult is not a function
+```
+
+**Impact:** Both beginner and intermediate exams (EN + ES, all 4 pages) were broken in production for ~24 hours after the merge. Users could answer all 20 questions but the page crashed at "See Results."
+
+**The fix:** Pass *data* across the island boundary, never functions. Refactored to:
+1. Compute the result inline inside the component using the `questions` prop already passed
+2. Pass tier definitions as a `ScoreTierDefinition[]` array (pure data)
+3. Have the component pick the highest matching tier locally
+
+**Lesson for all future work:** **React island props in Astro must be JSON-serializable.** Test for this rule:
+- ✅ strings, numbers, booleans, plain objects, arrays of plain objects
+- ❌ functions, class instances, Symbols, Maps, Sets, regex objects
+
+This will come up again in the advanced course. Be vigilant.
+
+### My automated test caught the bug, my over-cautious workflow delayed the fix
+
+I found the bug via Playwright testing locally, fixed it, and then **asked permission to merge** instead of merging immediately. A P0 bug where production is broken does not need a confirmation step. The result: production stayed broken for an extra hour while I waited.
+
+**Lesson:** P0 bugs get merged immediately after the fix is verified locally. Confirmation is for high-risk *code*, not high-risk *delay*.
+
+### The exam content audit caught 4 more issues that automated testing couldn't see
+
+After the crash was fixed, Robert manually clicked through the intermediate exam and caught a question with confusing wording (Q6: "I need to get on the bus at the next stop" — "at the next stop" naturally implies you're getting OFF). I then audited every question and found 3 more category mislabels (questions tagged as "translation" that didn't actually translate from Spanish) plus a missing `¿` typo.
+
+**Lesson:** Automated testing verifies the system works. Only a human reading the content can verify the content is *good*. Every future course needs a manual content audit before launch.
+
+---
+
+## Architectural patterns established
+
+### Course data structure
+Every unit uses the same data file structure in `src/data/intermediate/unit-N.ts`:
+
+```typescript
+export const [sectionAData] = [...]   // unique per unit
+export const dialogues = [...]
+export const structureBlocks = [...]
+export const errorCorrections = {...}
+export const pronunciationDrills = [...]
+export const vocabularyList = [...]
+```
+
+The page file imports these and passes them to the corresponding components. This pattern made the build mechanical and reviewable: each unit is one data file plus one Astro page (×2 for EN/ES).
+
+### CourseProgress component
+`courseId` prop allows separate localStorage namespaces per course. When we add the advanced course, it gets `courseId="advanced"` and the user's progress is tracked independently.
+
+### Hub page
+`/en/courses/` and `/es/cursos/` show all courses in one place. Adding a new course just means adding a new card to the hub.
+
+---
+
+## Files of record
+
+| File | Purpose |
+|---|---|
+| `src/lib/i18n.ts` | All TKey routes for the intermediate course (lines 89-100) |
+| `src/data/intermediate/types.ts` | Type definitions shared by all unit data files |
+| `src/data/intermediate/units.ts` | Unit metadata array (titles, slugs, subtitles, grammar focus) |
+| `src/data/intermediate/exam.ts` | Exam questions, examTiers data |
+| `src/components/course/CourseExam.tsx` | Reusable exam component (refactored to be course-agnostic) |
+| `src/components/course/PoliteFramesBuilder.tsx` etc | Section A components |
+
+---
+
+## What the next two courses should inherit from this build
+
+1. **Modal awareness, but not modal-driven.** Intermediate established the modal foundation. Advanced and Executive should *use* modals correctly without needing dedicated units.
+2. **Sentence-level focus.** Construction, precision, register — not vocabulary memorization or theme exploration.
+3. **No phrasal verb fixation.** They appear naturally where useful, never as the spine.
+4. **No slang or trend language.** Timeless sophisticated English only.
+5. **No written English drills.** Spoken English is the only real focus.
+6. **Reusable components for the bulk of interactivity, with one or two unique components per course for differentiation.** Advanced will use a smaller component library than intermediate (5 components for ~30 mini-exercises).
+7. **JSON-serializable props always.** Never pass functions to React islands. The exam crash bug is a one-time lesson.
+8. **Manual content audit before each course launch.** Every question, every translation, every category label. Robert reviews before merge.

--- a/rag-chatbot/en/knowledge-base.en.txt
+++ b/rag-chatbot/en/knowledge-base.en.txt
@@ -207,4 +207,4 @@ SECTION 10 — KEY FACTS THE CHATBOT SHOULD ALWAYS GET RIGHT
 - Cancellation policy: 1 business day notice required
 - Facturas: Available for Mexican corporate clients
 - Specialties: Executive English, Tech English, Logistics English, Medical/Legal English, Interview Prep, Public Speaking, Startup Founders
-- Free self-study courses: Beginner ("First Steps Into English") and Intermediate ("Building Fluency")
+- Free self-study courses: Beginner ("First Steps Into English") and Intermediate ("Building Fluency") and Advanced ("Advanced Fluency") and Business English ("Business Fluency") coming soon


### PR DESCRIPTION
## Summary
Three new docs capturing where we are and where we're going on the course curriculum.

### \`docs/INTERMEDIATE-COURSE-RETROSPECTIVE.md\`
What we shipped in the intermediate course, the pedagogical principles we discovered along the way, and the post-mortem on the Astro island prop serialization bug that crashed both exams in production for ~24 hours.

Key principles documented:
- Modal-driven > phrasal-verb-driven
- Sentence construction is the spine
- Each unit gets a unique Section A (no cookie-cutter feel)
- No slang, no fads, no written drills
- **JSON-serializable props always when passing data to React islands** (the bug lesson)
- Manual content audit before launch is mandatory

### \`docs/ADVANCED-COURSE-PLAN.md\`
Full plan for \"Speak with Confidence\" (B2-C1, free). Robert's outline for 10 units × 3 sections, with the section pattern (teach → recognize → produce), the 5-component reusable library (\`WordPairLab\`, \`ErrorSpotter\`, \`SentenceTransformer\`, \`MinimalPairDrill\`, \`WordBuilder\`), URL structure, build order, and the deliberately-stubbed speaking task as a coaching funnel hook.

### \`docs/EXECUTIVE-COURSE-PLAN.md\`
Full plan for \"Communicate Like a Leader\" (C1-C2, paid). Build deferred until Advanced ships. Documents the Phase 1 (free during launch) → Phase 2 (Stripe paywall) approach and the capstone-as-coaching-funnel strategy.

### \`docs/BEGINNER-COURSE-PLAN.md\` (modified)
Replaced the old Phase 2/3/4 stub bullets with status pointers to the three new docs. The roadmap is now a single source of truth.

## Test plan
- [x] All four files render correctly in markdown
- [x] Cross-links between docs work
- [ ] No code changes — no build verification needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)