### PR TITLE
feat: advanced course foundation (i18n, types, metadata, 2 of 5 components)

### DIFF
--- a/src/components/course/ErrorSpotter.tsx
+++ b/src/components/course/ErrorSpotter.tsx
@@ -1,0 +1,222 @@
+// ErrorSpotter — reusable component for the advanced course.
+//
+// Shows a sentence with one weak/wrong word inside it. The learner clicks
+// the offending word. If they pick correctly, they see a green checkmark
+// and the improved version. If they pick wrong, the wrong choice flashes
+// red and they can try again.
+//
+// Used in: U2 (word traps), U3 (pronoun errors), U4 (relative pronouns),
+// U5 (article errors), U9 (word order traps).
+
+import { useState } from "react";
+import { CheckCircle2, XCircle, RotateCcw, Sparkles } from "lucide-react";
+import AudioButton from "./AudioButton";
+import type { ErrorSpotterItem } from "@data/advanced/types";
+
+interface Props {
+  items: ErrorSpotterItem[];
+  lang: "en" | "es";
+}
+
+// Tokenize a sentence into clickable word chunks. We split on whitespace
+// but preserve trailing punctuation so the visible text matches the input.
+// Each chunk also gets a "stripped" form (lowercased, punctuation removed)
+// for matching against `errorWord`.
+interface Token {
+  display: string;
+  stripped: string;
+  isWord: boolean;
+}
+
+function tokenize(sentence: string): Token[] {
+  // Split into word vs non-word groups, preserving punctuation/spaces.
+  // Pattern: capture sequences of word chars (incl. apostrophes) OR
+  // sequences of non-word chars.
+  const parts = sentence.match(/[\w'’-]+|[^\w'’-]+/g) ?? [];
+  return parts.map((part) => {
+    const isWord = /[\w'’-]/.test(part);
+    return {
+      display: part,
+      stripped: part
+        .toLowerCase()
+        .replace(/[^a-zà-ÿ' -]/gi, "")
+        .trim(),
+      isWord,
+    };
+  });
+}
+
+export default function ErrorSpotter({ items, lang }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  // null = no choice yet, string = the stripped token the user clicked
+  const [pickedToken, setPickedToken] = useState<string | null>(null);
+  const [wrongAttempts, setWrongAttempts] = useState<Set<string>>(new Set());
+
+  const current = items[currentIndex];
+  const isLast = currentIndex === items.length - 1;
+
+  // Pre-compute the expected (correct) token form for matching
+  const correctToken = current.errorWord.toLowerCase().trim();
+  const tokens = tokenize(current.sentence);
+  const isResolved = pickedToken === correctToken;
+
+  const handleClick = (stripped: string) => {
+    if (isResolved) return;
+    if (stripped === correctToken) {
+      setPickedToken(stripped);
+    } else {
+      setWrongAttempts((prev) => new Set(prev).add(stripped));
+    }
+  };
+
+  const handleNext = () => {
+    if (!isLast) {
+      setCurrentIndex(currentIndex + 1);
+      setPickedToken(null);
+      setWrongAttempts(new Set());
+    }
+  };
+
+  const handleRestart = () => {
+    setCurrentIndex(0);
+    setPickedToken(null);
+    setWrongAttempts(new Set());
+  };
+
+  return (
+    <section className="space-y-6">
+      {/* Progress */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-slate-500">
+          {lang === "es" ? "Oración" : "Sentence"} {currentIndex + 1} / {items.length}
+        </span>
+        <button
+          onClick={handleRestart}
+          className="text-xs text-slate-400 hover:text-amber-600 inline-flex items-center gap-1 transition-colors"
+        >
+          <RotateCcw size={12} />
+          {lang === "es" ? "Reiniciar" : "Restart"}
+        </button>
+      </div>
+
+      <div className="w-full h-1.5 bg-slate-100 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-amber-500 rounded-full transition-all duration-300"
+          style={{ width: `${((currentIndex + 1) / items.length) * 100}%` }}
+        />
+      </div>
+
+      {/* Card */}
+      <div className="bg-white rounded-2xl border-2 border-slate-200 p-6">
+        <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-3">
+          {lang === "es"
+            ? "Toca la palabra que sobra o suena débil:"
+            : "Tap the word that is unnecessary or sounds weak:"}
+        </p>
+
+        {/* Clickable sentence */}
+        <p className="text-lg leading-relaxed text-slate-900">
+          {tokens.map((token, i) => {
+            if (!token.isWord) {
+              return <span key={i}>{token.display}</span>;
+            }
+            const isCorrect = token.stripped === correctToken;
+            const wasWronglyPicked = wrongAttempts.has(token.stripped);
+            const isResolvedAndThis = isResolved && isCorrect;
+
+            let cls = "rounded transition-colors px-0.5";
+            if (isResolvedAndThis) {
+              cls += " bg-emerald-200 text-emerald-900 line-through";
+            } else if (wasWronglyPicked) {
+              cls += " bg-rose-100 text-rose-700";
+            } else if (!isResolved) {
+              cls += " hover:bg-amber-100 cursor-pointer";
+            } else {
+              cls += " text-slate-400";
+            }
+
+            return (
+              <span
+                key={i}
+                onClick={() => handleClick(token.stripped)}
+                className={cls}
+              >
+                {token.display}
+              </span>
+            );
+          })}
+        </p>
+
+        <p className="text-sm text-slate-400 mt-2 italic">{current.sentenceEs}</p>
+
+        {/* Hint state for wrong picks */}
+        {wrongAttempts.size > 0 && !isResolved && (
+          <div className="mt-4 flex items-start gap-2 text-sm text-rose-600">
+            <XCircle size={16} className="shrink-0 mt-0.5" />
+            <p>
+              {lang === "es"
+                ? "Esa no es. Sigue intentando — busca la palabra que no aporta nada."
+                : "Not that one. Keep trying — look for the word that doesn't add anything."}
+            </p>
+          </div>
+        )}
+
+        {/* Resolved state */}
+        {isResolved && (
+          <div className="mt-5 space-y-3">
+            <div className="flex items-start gap-2 text-sm text-emerald-700">
+              <CheckCircle2 size={16} className="shrink-0 mt-0.5" />
+              <p className="font-medium">
+                {lang === "es" ? "¡Correcto!" : "Correct!"}
+              </p>
+            </div>
+
+            <div className="bg-gradient-to-br from-emerald-50 to-emerald-100 border-2 border-emerald-300 rounded-xl p-4">
+              <p className="text-xs font-semibold uppercase tracking-wider text-emerald-700 mb-2">
+                {lang === "es" ? "Versión mejorada:" : "Improved version:"}
+              </p>
+              <div className="flex items-start justify-between gap-3">
+                <p className="text-base text-slate-900 font-medium flex-1 leading-relaxed">
+                  "{current.improved}"
+                </p>
+                <div className="shrink-0 mt-0.5">
+                  <AudioButton text={current.improved} size="sm" />
+                </div>
+              </div>
+              <p className="text-sm text-slate-500 mt-2">{current.improvedEs}</p>
+            </div>
+
+            <div className="flex items-start gap-2">
+              <Sparkles size={12} className="text-amber-500 shrink-0 mt-1" />
+              <p className="text-xs text-slate-600 leading-relaxed">
+                {lang === "es" ? current.explanationEs : current.explanation}
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Next button */}
+      {isResolved && !isLast && (
+        <div className="flex justify-end">
+          <button
+            onClick={handleNext}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-500 text-white font-medium hover:bg-amber-400 transition-colors shadow-sm"
+          >
+            {lang === "es" ? "Siguiente oración" : "Next sentence"}
+          </button>
+        </div>
+      )}
+
+      {isResolved && isLast && (
+        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 text-center">
+          <p className="text-emerald-800 font-medium text-sm">
+            {lang === "es"
+              ? "¡Excelente! Has detectado todos los errores."
+              : "Excellent! You've spotted all the errors."}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/course/WordPairLab.tsx
+++ b/src/components/course/WordPairLab.tsx
@@ -1,0 +1,186 @@
+// WordPairLab — reusable component for the advanced course.
+//
+// Shows a "weak" version of a phrase next to its "strong" upgrade. The
+// learner reveals the strong version with a tap, sees the highlighted word
+// difference, and gets a short explanation of WHY the strong version is
+// better.
+//
+// Used in: U1 (weak verbs vs strong verbs), U2 (word traps), U3 (pronoun
+// corrections), U10 (collocations).
+
+import { useState } from "react";
+import { ArrowDown, RotateCcw, Sparkles, TrendingUp } from "lucide-react";
+import AudioButton from "./AudioButton";
+import type { WordPair } from "@data/advanced/types";
+
+interface Props {
+  pairs: WordPair[];
+  lang: "en" | "es";
+}
+
+// Render a sentence with the highlight word visually emphasized. We split on
+// the first occurrence of `highlight` so we don't accidentally bold every
+// instance of a common word.
+function renderHighlighted(
+  text: string,
+  highlight: string,
+  flavor: "weak" | "strong",
+): React.ReactNode {
+  if (!highlight || !text.includes(highlight)) {
+    return text;
+  }
+  const idx = text.indexOf(highlight);
+  const before = text.slice(0, idx);
+  const after = text.slice(idx + highlight.length);
+  const cls =
+    flavor === "weak"
+      ? "font-bold text-slate-500 line-through decoration-rose-400 decoration-2"
+      : "font-bold text-amber-700 bg-amber-100 px-1 rounded";
+  return (
+    <>
+      {before}
+      <span className={cls}>{highlight}</span>
+      {after}
+    </>
+  );
+}
+
+export default function WordPairLab({ pairs, lang }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isRevealed, setIsRevealed] = useState(false);
+
+  const current = pairs[currentIndex];
+  const isLast = currentIndex === pairs.length - 1;
+
+  const handleReveal = () => setIsRevealed(true);
+
+  const handleNext = () => {
+    if (!isLast) {
+      setCurrentIndex(currentIndex + 1);
+      setIsRevealed(false);
+    }
+  };
+
+  const handleRestart = () => {
+    setCurrentIndex(0);
+    setIsRevealed(false);
+  };
+
+  return (
+    <section className="space-y-6">
+      {/* Progress */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-slate-500">
+          {lang === "es" ? "Par" : "Pair"} {currentIndex + 1} / {pairs.length}
+        </span>
+        <button
+          onClick={handleRestart}
+          className="text-xs text-slate-400 hover:text-amber-600 inline-flex items-center gap-1 transition-colors"
+        >
+          <RotateCcw size={12} />
+          {lang === "es" ? "Reiniciar" : "Restart"}
+        </button>
+      </div>
+
+      <div className="w-full h-1.5 bg-slate-100 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-amber-500 rounded-full transition-all duration-300"
+          style={{ width: `${((currentIndex + 1) / pairs.length) * 100}%` }}
+        />
+      </div>
+
+      {/* Card */}
+      <div className="bg-white rounded-2xl border-2 border-slate-200 overflow-hidden">
+        {/* Optional category badge */}
+        {current.category && (
+          <div className="px-6 pt-6">
+            <span className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+              {lang === "es" && current.categoryEs
+                ? current.categoryEs
+                : current.category}
+            </span>
+          </div>
+        )}
+
+        {/* Weak version */}
+        <div className={`px-6 ${current.category ? "pt-3" : "pt-6"}`}>
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-2">
+            {lang === "es" ? "Lo que muchos dicen:" : "What many people say:"}
+          </p>
+          <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
+            <p className="text-base text-slate-700 italic leading-relaxed">
+              "{renderHighlighted(current.weak, current.weakHighlight, "weak")}"
+            </p>
+            <p className="text-sm text-slate-400 mt-1">{current.weakEs}</p>
+          </div>
+        </div>
+
+        {/* Arrow */}
+        <div className="flex justify-center py-3">
+          <ArrowDown className="w-5 h-5 text-slate-300" />
+        </div>
+
+        {/* Strong version */}
+        <div className="px-6 pb-6">
+          <p className="text-xs font-semibold uppercase tracking-wider text-amber-600 mb-2 flex items-center gap-1">
+            <TrendingUp size={12} />
+            {lang === "es" ? "Lo que dicen los nativos:" : "What native speakers say:"}
+          </p>
+
+          {!isRevealed ? (
+            <button
+              onClick={handleReveal}
+              className="w-full py-4 rounded-xl border-2 border-dashed border-amber-300 text-amber-600 font-medium hover:bg-amber-50 transition-colors"
+            >
+              {lang === "es"
+                ? "Toca para revelar la versión fuerte"
+                : "Tap to reveal the strong version"}
+            </button>
+          ) : (
+            <div className="space-y-3">
+              <div className="bg-gradient-to-br from-amber-50 to-amber-100 border-2 border-amber-300 rounded-xl p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <p className="text-base text-slate-900 font-medium leading-relaxed flex-1">
+                    "{renderHighlighted(current.strong, current.strongHighlight, "strong")}"
+                  </p>
+                  <div className="shrink-0 mt-1">
+                    <AudioButton text={current.strong} size="sm" />
+                  </div>
+                </div>
+                <p className="text-sm text-slate-500 mt-2">{current.strongEs}</p>
+                <div className="mt-3 pt-3 border-t border-amber-200 flex items-start gap-2">
+                  <Sparkles size={12} className="text-amber-500 shrink-0 mt-0.5" />
+                  <p className="text-xs text-slate-600 leading-relaxed">
+                    {lang === "es" ? current.whyEs : current.why}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Next button */}
+      {isRevealed && !isLast && (
+        <div className="flex justify-end">
+          <button
+            onClick={handleNext}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-500 text-white font-medium hover:bg-amber-400 transition-colors shadow-sm"
+          >
+            {lang === "es" ? "Siguiente par" : "Next pair"}
+          </button>
+        </div>
+      )}
+
+      {isRevealed && isLast && (
+        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 text-center">
+          <p className="text-emerald-800 font-medium text-sm">
+            {lang === "es"
+              ? "¡Bien hecho! Ya conoces los pares fuertes de esta sección."
+              : "Well done! You know the strong pairs from this section."}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/data/advanced/types.ts
+++ b/src/data/advanced/types.ts
@@ -1,0 +1,136 @@
+// Type definitions shared across the advanced course data files.
+//
+// Per docs/ADVANCED-COURSE-PLAN.md, the advanced course is structured as
+// 10 units × 3 sections each, using 5 reusable React components. Each unit
+// data file imports types from here so the React components can rely on a
+// stable shape.
+//
+// The types are intentionally pure data — no functions — so they survive
+// the Astro→React island JSON serialization boundary. (See the
+// INTERMEDIATE-COURSE-RETROSPECTIVE.md for the post-mortem on why this
+// matters.)
+
+// ─── WordPairLab ───────────────────────────────────────────────────────────
+// Compares a "weak" version of a phrase with a "strong" upgrade. Used for:
+// U1 (weak verbs vs strong verbs), U2 (word traps), U3 (pronoun corrections),
+// U10 (collocations).
+export interface WordPair {
+  /** The weaker / less precise version */
+  weak: string;
+  weakEs: string;
+  /** The stronger / more precise version */
+  strong: string;
+  strongEs: string;
+  /** The exact substring inside `weak` to highlight (must appear verbatim) */
+  weakHighlight: string;
+  /** The exact substring inside `strong` to highlight */
+  strongHighlight: string;
+  /** Why the strong version is better */
+  why: string;
+  whyEs: string;
+  /** Optional category label shown as a small badge */
+  category?: string;
+  categoryEs?: string;
+}
+
+// ─── ErrorSpotter ──────────────────────────────────────────────────────────
+// A sentence with a single weak/wrong word. The learner clicks the offending
+// word, then sees the upgraded version. Used for adverb removal, misused
+// pronouns, wrong relative pronouns, missing/wrong articles, etc.
+export interface ErrorSpotterItem {
+  /** The full sentence with the problem word inside it */
+  sentence: string;
+  /** The exact word/phrase the learner is supposed to identify */
+  errorWord: string;
+  /** The improved sentence after fixing the error */
+  improved: string;
+  /** Spanish translation of the original (or closest equivalent) */
+  sentenceEs: string;
+  /** Spanish translation of the improved version */
+  improvedEs: string;
+  /** Why the original was wrong / weak */
+  explanation: string;
+  explanationEs: string;
+}
+
+// ─── SentenceTransformer ───────────────────────────────────────────────────
+// Given a flat / weak / verbose sentence, the learner reveals the strong
+// upgraded version. Used for sentence-level rewrites in U1, U7, U9, U10.
+export interface SentenceTransform {
+  /** The original flat / weak sentence */
+  flat: string;
+  flatEs: string;
+  /** The strong upgraded version */
+  strong: string;
+  strongEs: string;
+  /** Short label for the technique used (verb upgrade, consolidation, etc.) */
+  technique: string;
+  techniqueEs: string;
+  /** Longer explanation of why the upgrade works */
+  why: string;
+  whyEs: string;
+}
+
+// ─── MinimalPairDrill (Unit 6 only) ────────────────────────────────────────
+// Two words that differ by a single sound (ship/sheep, walk/work). The
+// learner sees both and uses TTS to compare. Built later when we get to U6.
+export interface MinimalPair {
+  wordA: string;
+  wordB: string;
+  /** What sound distinction this pair illustrates */
+  distinction: string;
+  distinctionEs: string;
+  /** A short example sentence using each word */
+  exampleA: string;
+  exampleAEs: string;
+  exampleB: string;
+  exampleBEs: string;
+  /** Pronunciation tip for the distinction */
+  tip: string;
+  tipEs: string;
+}
+
+// ─── WordBuilder (Unit 8 only) ─────────────────────────────────────────────
+// Decompose a word into prefix + root + suffix and explain each part. Used
+// only in Unit 8 for prefix/suffix decoding.
+export interface WordBreakdown {
+  /** The whole word */
+  word: string;
+  /** Each meaningful piece in order */
+  parts: Array<{
+    text: string;
+    role: "prefix" | "root" | "suffix";
+    meaning: string;
+    meaningEs: string;
+  }>;
+  /** What the assembled word means */
+  fullMeaning: string;
+  fullMeaningEs: string;
+  /** A second example using a different word that shares one of the parts */
+  relatedExample?: string;
+  relatedExampleEs?: string;
+}
+
+// ─── Section header ────────────────────────────────────────────────────────
+// Every unit has 3 sections. Each section has a title, a short hint, and
+// some content (one of the types above). The page file decides which
+// component to render based on the section's `mechanic` field.
+export type SectionMechanic =
+  | "word-pair"
+  | "error-spotter"
+  | "sentence-transformer"
+  | "minimal-pair"
+  | "word-builder";
+
+export interface UnitSection {
+  /** Section number — always 1, 2, or 3 */
+  number: 1 | 2 | 3;
+  /** Section title shown in the page heading */
+  title: string;
+  titleEs: string;
+  /** Short hint shown under the title */
+  hint: string;
+  hintEs: string;
+  /** Which component to render */
+  mechanic: SectionMechanic;
+}

--- a/src/data/advanced/units.ts
+++ b/src/data/advanced/units.ts
@@ -1,0 +1,203 @@
+// Advanced course unit metadata — "Speak with Confidence" (B2-C1)
+//
+// 10 units, 3 sections each. See docs/ADVANCED-COURSE-PLAN.md for the full
+// pedagogical rationale and section pattern.
+
+export interface AdvancedUnit {
+  id: number;
+  slug: string;
+  slugEs: string;
+  title: string;
+  titleEs: string;
+  subtitle: string;
+  subtitleEs: string;
+  description: string;
+  descriptionEs: string;
+  /** What learners will be able to do after this unit */
+  outcome: string;
+  outcomeEs: string;
+  /** Lucide icon name for the unit card */
+  icon: string;
+}
+
+export const advancedInfo = {
+  title: "Speak with Confidence",
+  titleEs: "Habla con Confianza",
+  tagline: "The polish that turns 'fluent' into 'polished'.",
+  taglineEs: "El pulido que convierte 'fluido' en 'pulido'.",
+  description:
+    "A free 10-unit advanced course for high B2 to C1 Spanish speakers. Skill-based drills that fix the granular errors and pronunciation tells that mark a non-native speaker — even at advanced levels. No more themes. No more vocabulary memorization. Just precision.",
+  descriptionEs:
+    "Un curso avanzado gratuito de 10 unidades para hispanohablantes de nivel B2 alto a C1. Ejercicios basados en habilidades que corrigen los errores granulares y los detalles de pronunciación que delatan a un hablante no nativo — incluso en niveles avanzados. Sin más temas. Sin memorización de vocabulario. Solo precisión.",
+  basePath: {
+    en: "/en/course/advanced",
+    es: "/es/curso/avanzado",
+  },
+};
+
+export const advancedUnits: AdvancedUnit[] = [
+  {
+    id: 1,
+    slug: "unit-1",
+    slugEs: "unidad-1",
+    title: "Weak Phrasing → Strong Phrasing",
+    titleEs: "Frases Débiles → Frases Fuertes",
+    subtitle: "Trade 'got', 'made', and 'did' for 'earned', 'built', and 'delivered'.",
+    subtitleEs: "Cambia 'got', 'made' y 'did' por 'earned', 'built' y 'delivered'.",
+    description:
+      "Advanced learners use a small set of weak verbs and adverbs that signal non-native English. This unit replaces those with the precise, strong language that native professionals reach for.",
+    descriptionEs:
+      "Los hablantes avanzados usan un conjunto pequeño de verbos y adverbios débiles que delatan al inglés no nativo. Esta unidad los reemplaza con el lenguaje preciso y fuerte al que recurren los profesionales nativos.",
+    outcome:
+      "You'll spot weak verbs and adverbs in your own speech and replace them with strong, specific language.",
+    outcomeEs:
+      "Identificarás verbos y adverbios débiles en tu propio discurso y los reemplazarás con un lenguaje fuerte y específico.",
+    icon: "Sparkles",
+  },
+  {
+    id: 2,
+    slug: "unit-2",
+    slugEs: "unidad-2",
+    title: "Word Traps That Trip Up Advanced Speakers",
+    titleEs: "Trampas de Palabras que Confunden a Hablantes Avanzados",
+    subtitle: "Fewer/less, say/tell, make/do — the errors that haunt every advanced learner.",
+    subtitleEs: "Fewer/less, say/tell, make/do — los errores que persiguen a cada estudiante avanzado.",
+    description:
+      "There's a short list of word pairs that even C1 speakers get wrong. This unit forces you to choose correctly under pressure so the right one becomes automatic.",
+    descriptionEs:
+      "Hay una lista corta de pares de palabras que incluso los hablantes C1 confunden. Esta unidad te obliga a elegir correctamente bajo presión para que la opción correcta se vuelva automática.",
+    outcome:
+      "You'll never confuse fewer/less, say/tell, or make/do again.",
+    outcomeEs:
+      "Nunca volverás a confundir fewer/less, say/tell ni make/do.",
+    icon: "AlertTriangle",
+  },
+  {
+    id: 3,
+    slug: "unit-3",
+    slugEs: "unidad-3",
+    title: "Pronouns Done Right",
+    titleEs: "Pronombres Bien Usados",
+    subtitle: "Subject vs object, reflexive traps, direct vs indirect — clean it all up.",
+    subtitleEs: "Sujeto vs objeto, trampas reflexivas, directo vs indirecto — limpia todo.",
+    description:
+      "Pronoun errors are subtle but they're one of the fastest tells. This unit fixes them at the sentence level: he vs him, myself vs me, who vs whom in real contexts.",
+    descriptionEs:
+      "Los errores de pronombres son sutiles pero son una de las señales más rápidas. Esta unidad los corrige a nivel de oración: he vs him, myself vs me, who vs whom en contextos reales.",
+    outcome: "You'll stop misplacing pronouns in fast speech.",
+    outcomeEs: "Dejarás de colocar mal los pronombres en el habla rápida.",
+    icon: "Users",
+  },
+  {
+    id: 4,
+    slug: "unit-4",
+    slugEs: "unidad-4",
+    title: "Which, That, Who, When",
+    titleEs: "Which, That, Who, When",
+    subtitle: "Relative clauses without the confusion.",
+    subtitleEs: "Cláusulas relativas sin la confusión.",
+    description:
+      "Defining vs non-defining clauses, who vs whom, when, where, whose. The grammar of relative clauses, drilled until you stop hesitating mid-sentence.",
+    descriptionEs:
+      "Cláusulas definitorias vs no definitorias, who vs whom, when, where, whose. La gramática de las cláusulas relativas, practicada hasta que dejes de dudar a mitad de una oración.",
+    outcome: "You'll choose the right relative pronoun without thinking.",
+    outcomeEs: "Elegirás el pronombre relativo correcto sin pensarlo.",
+    icon: "Link",
+  },
+  {
+    id: 5,
+    slug: "unit-5",
+    slugEs: "unidad-5",
+    title: "Articles: A, An, The, or Nothing",
+    titleEs: "Artículos: A, An, The, o Nada",
+    subtitle: "The lifelong Spanish-speaker error, finally fixed.",
+    subtitleEs: "El error eterno de los hispanohablantes, finalmente corregido.",
+    description:
+      "Articles are the single most persistent error for Spanish speakers — they appear in nearly every sentence and even C2 speakers get them wrong. This unit drills the patterns until article use becomes intuitive.",
+    descriptionEs:
+      "Los artículos son el error más persistente para los hispanohablantes — aparecen en casi cada oración e incluso los hablantes C2 los confunden. Esta unidad practica los patrones hasta que el uso de los artículos se vuelva intuitivo.",
+    outcome: "You'll use 'a', 'the', and zero articles correctly in real speech.",
+    outcomeEs: "Usarás 'a', 'the' y los artículos cero correctamente en el habla real.",
+    icon: "Type",
+  },
+  {
+    id: 6,
+    slug: "unit-6",
+    slugEs: "unidad-6",
+    title: "Pronunciation: Hitting the Hard Sounds",
+    titleEs: "Pronunciación: Acertando los Sonidos Difíciles",
+    subtitle: "S endings, -en endings, TH, R — the sounds that give you away.",
+    subtitleEs: "Terminaciones en S, terminaciones en -en, TH, R — los sonidos que te delatan.",
+    description:
+      "Even fluent speakers carry pronunciation tells that signal non-native English. This unit targets the specific sounds that mark Spanish-speaker English: the dropped S, the missed -en, the soft TH, and the elusive R.",
+    descriptionEs:
+      "Incluso los hablantes fluidos llevan detalles de pronunciación que señalan el inglés no nativo. Esta unidad se enfoca en los sonidos específicos que marcan el inglés del hispanohablante.",
+    outcome: "You'll hit the sounds that matter most for sounding native.",
+    outcomeEs: "Acertarás los sonidos más importantes para sonar nativo.",
+    icon: "Mic",
+  },
+  {
+    id: 7,
+    slug: "unit-7",
+    slugEs: "unidad-7",
+    title: "Contractions, Flipped",
+    titleEs: "Contracciones, Invertidas",
+    subtitle: "I'd've, shouldn't've — and when NOT to contract.",
+    subtitleEs: "I'd've, shouldn't've — y cuándo NO contraer.",
+    description:
+      "Advanced contractions like 'I'd've' and 'shouldn't've' are how natives actually speak. This unit teaches them — plus the equally important question of when contractions sound wrong.",
+    descriptionEs:
+      "Las contracciones avanzadas como 'I'd've' y 'shouldn't've' son como hablan realmente los nativos. Esta unidad las enseña — además de la pregunta igualmente importante de cuándo las contracciones suenan mal.",
+    outcome: "You'll match the contraction level of any conversation.",
+    outcomeEs: "Igualarás el nivel de contracción de cualquier conversación.",
+    icon: "Zap",
+  },
+  {
+    id: 8,
+    slug: "unit-8",
+    slugEs: "unidad-8",
+    title: "Prefixes & Suffixes",
+    titleEs: "Prefijos y Sufijos",
+    subtitle: "Decode any English word by its parts.",
+    subtitleEs: "Decodifica cualquier palabra en inglés por sus partes.",
+    description:
+      "Most English words can be decoded if you know what un-, dis-, mis-, over-, -tion, -ment, and -ness actually mean. This unit gives you the toolkit to expand your vocabulary by recognition, not memorization.",
+    descriptionEs:
+      "La mayoría de las palabras en inglés se pueden decodificar si sabes qué significan realmente un-, dis-, mis-, over-, -tion, -ment y -ness. Esta unidad te da las herramientas para expandir tu vocabulario por reconocimiento, no por memorización.",
+    outcome: "You'll understand new words without looking them up.",
+    outcomeEs: "Entenderás palabras nuevas sin buscarlas.",
+    icon: "Puzzle",
+  },
+  {
+    id: 9,
+    slug: "unit-9",
+    slugEs: "unidad-9",
+    title: "Sentence Construction & Flow",
+    titleEs: "Construcción de Oraciones y Flujo",
+    subtitle: "Vary your sentences without sounding robotic.",
+    subtitleEs: "Varía tus oraciones sin sonar robótico.",
+    description:
+      "Simple, compound, complex — and how to weave them together so your spoken English flows like a native's. Plus the word-order traps that make non-native sentences sound off.",
+    descriptionEs:
+      "Simple, compuesto, complejo — y cómo entrelazarlos para que tu inglés hablado fluya como el de un nativo. Además, las trampas de orden de palabras que hacen que las oraciones no nativas suenen mal.",
+    outcome: "Your spoken English will flow with native-like rhythm and variety.",
+    outcomeEs: "Tu inglés hablado fluirá con el ritmo y la variedad de un nativo.",
+    icon: "Layers",
+  },
+  {
+    id: 10,
+    slug: "unit-10",
+    slugEs: "unidad-10",
+    title: "Sounding Natural, Not Translated",
+    titleEs: "Sonando Natural, No Traducido",
+    subtitle: "Stop translating from Spanish. Start thinking in English.",
+    subtitleEs: "Deja de traducir del español. Empieza a pensar en inglés.",
+    description:
+      "The capstone. Collocations native speakers expect, the rhythm of spoken English, and the mental shift from translating to thinking. The graduation moment of advanced English.",
+    descriptionEs:
+      "La unidad final. Las colocaciones que esperan los nativos, el ritmo del inglés hablado y el cambio mental de traducir a pensar. El momento de graduación del inglés avanzado.",
+    outcome: "You'll think in English instead of translating from Spanish.",
+    outcomeEs: "Pensarás en inglés en lugar de traducir del español.",
+    icon: "Sparkle",
+  },
+];

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -99,6 +99,18 @@ export type TKey =
   | "course/intermediate/unit-9"
   | "course/intermediate/unit-10"
   | "course/intermediate/exam"
+  | "course/advanced"
+  | "course/advanced/unit-1"
+  | "course/advanced/unit-2"
+  | "course/advanced/unit-3"
+  | "course/advanced/unit-4"
+  | "course/advanced/unit-5"
+  | "course/advanced/unit-6"
+  | "course/advanced/unit-7"
+  | "course/advanced/unit-8"
+  | "course/advanced/unit-9"
+  | "course/advanced/unit-10"
+  | "course/advanced/exam"
   | "meme-portfolio"
   | "site-index";
 
@@ -212,6 +224,18 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/intermediate/unit-9": "/en/course/intermediate/unit-9/",
     "course/intermediate/unit-10": "/en/course/intermediate/unit-10/",
     "course/intermediate/exam": "/en/course/intermediate/exam/",
+    "course/advanced": "/en/course/advanced/",
+    "course/advanced/unit-1": "/en/course/advanced/unit-1/",
+    "course/advanced/unit-2": "/en/course/advanced/unit-2/",
+    "course/advanced/unit-3": "/en/course/advanced/unit-3/",
+    "course/advanced/unit-4": "/en/course/advanced/unit-4/",
+    "course/advanced/unit-5": "/en/course/advanced/unit-5/",
+    "course/advanced/unit-6": "/en/course/advanced/unit-6/",
+    "course/advanced/unit-7": "/en/course/advanced/unit-7/",
+    "course/advanced/unit-8": "/en/course/advanced/unit-8/",
+    "course/advanced/unit-9": "/en/course/advanced/unit-9/",
+    "course/advanced/unit-10": "/en/course/advanced/unit-10/",
+    "course/advanced/exam": "/en/course/advanced/exam/",
     "meme-portfolio": "/en/meme-portfolio/all/",
     "site-index": "/en/site-index/",
   },
@@ -329,6 +353,18 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/intermediate/unit-9": "/es/curso/intermedio/unidad-9/",
     "course/intermediate/unit-10": "/es/curso/intermedio/unidad-10/",
     "course/intermediate/exam": "/es/curso/intermedio/examen/",
+    "course/advanced": "/es/curso/avanzado/",
+    "course/advanced/unit-1": "/es/curso/avanzado/unidad-1/",
+    "course/advanced/unit-2": "/es/curso/avanzado/unidad-2/",
+    "course/advanced/unit-3": "/es/curso/avanzado/unidad-3/",
+    "course/advanced/unit-4": "/es/curso/avanzado/unidad-4/",
+    "course/advanced/unit-5": "/es/curso/avanzado/unidad-5/",
+    "course/advanced/unit-6": "/es/curso/avanzado/unidad-6/",
+    "course/advanced/unit-7": "/es/curso/avanzado/unidad-7/",
+    "course/advanced/unit-8": "/es/curso/avanzado/unidad-8/",
+    "course/advanced/unit-9": "/es/curso/avanzado/unidad-9/",
+    "course/advanced/unit-10": "/es/curso/avanzado/unidad-10/",
+    "course/advanced/exam": "/es/curso/avanzado/examen/",
     "meme-portfolio": "/es/meme-portfolio/all/",
     "site-index": "/es/indice-del-sitio/",
   },


### PR DESCRIPTION
## Summary
Foundation work for the upcoming \"Speak with Confidence\" advanced course (B2-C1). **No user-visible pages yet** — that lands in the next PR. This PR sets up everything the unit pages will import.

### What's in this PR

#### i18n routes
12 new TKey entries for the advanced course (landing, 10 units, exam) with EN + ES routes ready for hreflang.

#### \`src/data/advanced/types.ts\`
Type definitions for \`WordPair\`, \`ErrorSpotterItem\`, \`SentenceTransform\`, \`MinimalPair\`, \`WordBreakdown\`, plus a \`UnitSection\` type. **All pure data — no functions** — to survive the Astro→React island JSON serialization boundary (per the lesson documented in [INTERMEDIATE-COURSE-RETROSPECTIVE.md](docs/INTERMEDIATE-COURSE-RETROSPECTIVE.md)).

#### \`src/data/advanced/units.ts\`
Full metadata for **all 10 units** (titles, slugs, subtitles, descriptions, outcomes, icons). The course content itself ships unit by unit in subsequent PRs, but the metadata is locked in now so the landing page can render.

#### \`src/components/course/WordPairLab.tsx\` (Component 1 of 5)
Shows a weak phrase, reveals the strong upgrade with highlighted word difference and explanation. Mechanic powers U1 (weak verbs), U2 (word traps), U3 (pronouns), U10 (collocations).

#### \`src/components/course/ErrorSpotter.tsx\` (Component 2 of 5)
Shows a sentence with one weak/wrong word inside. Learner clicks the offending word; correct picks reveal the improved version, wrong picks flash red and let the learner try again. Powers U2-U5 and U9.

### Still to come for Unit 1 (next PR)
- \`SentenceTransformer\` component (Section 3 mechanic)
- \`unit-1.ts\` data file with the three sections
- Landing page (EN + ES)
- Unit 1 pages (EN + ES)
- Courses hub card update

### Test plan
- [x] \`npm run build\` passes (240 URLs — no new pages yet, foundation files exist but aren't rendered)
- [x] No regressions to existing courses
- [ ] Next PR will add the actual Unit 1 pages and bring the URL count to 244

🤖 Generated with [Claude Code](https://claude.com/claude-code)