### PR TITLE
feat: advanced course Unit 1 — Weak Phrasing → Strong Phrasing

### DIFF
--- a/src/components/course/SentenceTransformer.tsx
+++ b/src/components/course/SentenceTransformer.tsx
@@ -1,0 +1,153 @@
+// SentenceTransformer — reusable component for the advanced course.
+//
+// Shows a flat/weak/verbose sentence and reveals the strong upgraded version
+// with a technique badge and explanation. The learner sees the before/after
+// comparison and internalizes the pattern.
+//
+// Used in: U1 (rewriting flat sentences), U7 (contraction register), U9
+// (sentence variety), U10 (natural-sounding rewrites).
+
+import { useState } from "react";
+import { ArrowDown, RotateCcw, Sparkles, Zap } from "lucide-react";
+import AudioButton from "./AudioButton";
+import type { SentenceTransform } from "@data/advanced/types";
+
+interface Props {
+  transforms: SentenceTransform[];
+  lang: "en" | "es";
+}
+
+export default function SentenceTransformer({ transforms, lang }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isRevealed, setIsRevealed] = useState(false);
+
+  const current = transforms[currentIndex];
+  const isLast = currentIndex === transforms.length - 1;
+
+  const handleReveal = () => setIsRevealed(true);
+
+  const handleNext = () => {
+    if (!isLast) {
+      setCurrentIndex(currentIndex + 1);
+      setIsRevealed(false);
+    }
+  };
+
+  const handleRestart = () => {
+    setCurrentIndex(0);
+    setIsRevealed(false);
+  };
+
+  return (
+    <section className="space-y-6">
+      {/* Progress */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-slate-500">
+          {lang === "es" ? "Transformación" : "Transform"} {currentIndex + 1} /{" "}
+          {transforms.length}
+        </span>
+        <button
+          onClick={handleRestart}
+          className="text-xs text-slate-400 hover:text-amber-600 inline-flex items-center gap-1 transition-colors"
+        >
+          <RotateCcw size={12} />
+          {lang === "es" ? "Reiniciar" : "Restart"}
+        </button>
+      </div>
+
+      <div className="w-full h-1.5 bg-slate-100 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-amber-500 rounded-full transition-all duration-300"
+          style={{ width: `${((currentIndex + 1) / transforms.length) * 100}%` }}
+        />
+      </div>
+
+      {/* Card */}
+      <div className="bg-white rounded-2xl border-2 border-slate-200 overflow-hidden">
+        {/* Flat version */}
+        <div className="px-6 pt-6">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-2">
+            {lang === "es" ? "La versión plana:" : "The flat version:"}
+          </p>
+          <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
+            <p className="text-base text-slate-700 italic leading-relaxed">
+              "{current.flat}"
+            </p>
+            <p className="text-sm text-slate-400 mt-1">{current.flatEs}</p>
+          </div>
+        </div>
+
+        {/* Arrow */}
+        <div className="flex justify-center py-3">
+          <ArrowDown className="w-5 h-5 text-slate-300" />
+        </div>
+
+        {/* Strong version */}
+        <div className="px-6 pb-6">
+          <p className="text-xs font-semibold uppercase tracking-wider text-amber-600 mb-2 flex items-center gap-1">
+            <Zap size={12} />
+            {lang === "es" ? "La versión con impacto:" : "The version with impact:"}
+          </p>
+
+          {!isRevealed ? (
+            <button
+              onClick={handleReveal}
+              className="w-full py-4 rounded-xl border-2 border-dashed border-amber-300 text-amber-600 font-medium hover:bg-amber-50 transition-colors"
+            >
+              {lang === "es"
+                ? "Toca para revelar la versión mejorada"
+                : "Tap to reveal the upgraded version"}
+            </button>
+          ) : (
+            <div className="space-y-3">
+              <div className="bg-gradient-to-br from-amber-50 to-amber-100 border-2 border-amber-300 rounded-xl p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <p className="text-base text-slate-900 font-medium leading-relaxed flex-1">
+                    "{current.strong}"
+                  </p>
+                  <div className="shrink-0 mt-1">
+                    <AudioButton text={current.strong} size="sm" />
+                  </div>
+                </div>
+                <p className="text-sm text-slate-500 mt-2">{current.strongEs}</p>
+
+                {/* Technique badge + explanation */}
+                <div className="mt-3 pt-3 border-t border-amber-200 space-y-2">
+                  <span className="inline-flex items-center gap-1 text-xs font-mono px-2 py-0.5 rounded-full border bg-violet-100 text-violet-700 border-violet-200">
+                    {lang === "es" ? current.techniqueEs : current.technique}
+                  </span>
+                  <p className="text-xs text-slate-600 leading-relaxed flex items-start gap-1">
+                    <Sparkles size={11} className="text-amber-500 shrink-0 mt-0.5" />
+                    <span>{lang === "es" ? current.whyEs : current.why}</span>
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Next button */}
+      {isRevealed && !isLast && (
+        <div className="flex justify-end">
+          <button
+            onClick={handleNext}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-500 text-white font-medium hover:bg-amber-400 transition-colors shadow-sm"
+          >
+            {lang === "es" ? "Siguiente" : "Next"}
+          </button>
+        </div>
+      )}
+
+      {isRevealed && isLast && (
+        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 text-center">
+          <p className="text-emerald-800 font-medium text-sm">
+            {lang === "es"
+              ? "¡Excelente! Has visto cómo transformar oraciones planas en oraciones con impacto."
+              : "Excellent! You've seen how to transform flat sentences into sentences with impact."}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/data/advanced/unit-1.ts
+++ b/src/data/advanced/unit-1.ts
@@ -1,0 +1,266 @@
+// Unit 1: "Weak Phrasing → Strong Phrasing" — Full course content
+//
+// Section 1: Weak verbs vs strong verbs (WordPairLab)
+// Section 2: Killing weak adverbs (ErrorSpotter)
+// Section 3: Rewriting flat sentences into sentences with impact (SentenceTransformer)
+
+import type { WordPair, ErrorSpotterItem, SentenceTransform } from "./types";
+
+// ─── Section 1: Weak Verbs → Strong Verbs (WordPairLab) ─────────────────────
+
+export const verbPairs: WordPair[] = [
+  {
+    weak: "I got the promotion after working there for three years.",
+    weakEs: "Obtuve la promoción después de trabajar ahí por tres años.",
+    strong: "I earned the promotion after three years of consistent results.",
+    strongEs: "Me gané la promoción después de tres años de resultados consistentes.",
+    weakHighlight: "got",
+    strongHighlight: "earned",
+    why: "'Got' is passive and vague — it sounds like it happened to you. 'Earned' implies effort, skill, and merit. Hiring managers notice this word choice.",
+    whyEs: "'Got' es pasivo y vago — suena como que te pasó. 'Earned' implica esfuerzo, habilidad y mérito. Los reclutadores notan esta elección de palabras.",
+    category: "Verb upgrade",
+    categoryEs: "Mejora de verbo",
+  },
+  {
+    weak: "We made a new strategy for next quarter.",
+    weakEs: "Hicimos una nueva estrategia para el próximo trimestre.",
+    strong: "We developed a new strategy for next quarter.",
+    strongEs: "Desarrollamos una nueva estrategia para el próximo trimestre.",
+    weakHighlight: "made",
+    strongHighlight: "developed",
+    why: "'Made' is the laziest verb in English — it works for almost anything but says almost nothing. 'Developed' signals thought, process, and expertise.",
+    whyEs: "'Made' es el verbo más perezoso del inglés — funciona para casi todo pero no dice casi nada. 'Developed' señala pensamiento, proceso y experticia.",
+    category: "Verb upgrade",
+    categoryEs: "Mejora de verbo",
+  },
+  {
+    weak: "She did a great presentation yesterday.",
+    weakEs: "Ella hizo una gran presentación ayer.",
+    strong: "She delivered a compelling presentation yesterday.",
+    strongEs: "Ella ofreció una presentación convincente ayer.",
+    weakHighlight: "did",
+    strongHighlight: "delivered",
+    why: "'Did a presentation' is how beginners talk. 'Delivered a presentation' is what professionals say. The verb 'deliver' carries authority and intentionality. 'Compelling' is a bonus — it replaces the overused 'great'.",
+    whyEs: "'Did a presentation' es cómo hablan los principiantes. 'Delivered a presentation' es lo que dicen los profesionales. El verbo 'deliver' lleva autoridad e intencionalidad.",
+    category: "Verb upgrade",
+    categoryEs: "Mejora de verbo",
+  },
+  {
+    weak: "He had a meeting with the client this morning.",
+    weakEs: "Él tuvo una reunión con el cliente esta mañana.",
+    strong: "He met with the client this morning.",
+    strongEs: "Se reunió con el cliente esta mañana.",
+    weakHighlight: "had a meeting with",
+    strongHighlight: "met with",
+    why: "'Had a meeting with' is 4 words. 'Met with' is 2 words and says the same thing. Strong English is shorter. Cut the filler and use the verb directly.",
+    whyEs: "'Had a meeting with' son 4 palabras. 'Met with' son 2 y dicen lo mismo. El inglés fuerte es más corto. Corta el relleno y usa el verbo directamente.",
+    category: "Verb consolidation",
+    categoryEs: "Consolidación de verbo",
+  },
+  {
+    weak: "They got a lot of feedback from the users.",
+    weakEs: "Obtuvieron muchos comentarios de los usuarios.",
+    strong: "They received extensive feedback from the users.",
+    strongEs: "Recibieron retroalimentación extensa de los usuarios.",
+    weakHighlight: "got a lot of",
+    strongHighlight: "received extensive",
+    why: "'Got a lot of' is vague. 'Received extensive' is precise. 'Received' is a clean verb. 'Extensive' tells the listener the volume without resorting to the weak 'a lot of'.",
+    whyEs: "'Got a lot of' es vago. 'Received extensive' es preciso. 'Received' es un verbo limpio. 'Extensive' indica el volumen sin recurrir al débil 'a lot of'.",
+    category: "Verb + adjective upgrade",
+    categoryEs: "Mejora de verbo + adjetivo",
+  },
+  {
+    weak: "I made a decision to leave the company.",
+    weakEs: "Tomé una decisión de dejar la empresa.",
+    strong: "I decided to leave the company.",
+    strongEs: "Decidí dejar la empresa.",
+    weakHighlight: "made a decision to",
+    strongHighlight: "decided to",
+    why: "When a noun hides a perfectly good verb, use the verb. 'Made a decision' = 'decided'. 'Gave an explanation' = 'explained'. 'Did an analysis' = 'analyzed'. Always choose the verb over the noun form.",
+    whyEs: "Cuando un sustantivo esconde un verbo perfectamente bueno, usa el verbo. 'Made a decision' = 'decided'. 'Gave an explanation' = 'explained'. Siempre elige el verbo sobre la forma sustantiva.",
+    category: "Nominalization → verb",
+    categoryEs: "Nominalización → verbo",
+  },
+  {
+    weak: "The team got more efficient over the last year.",
+    weakEs: "El equipo se volvió más eficiente en el último año.",
+    strong: "The team became significantly more efficient over the last year.",
+    strongEs: "El equipo se volvió significativamente más eficiente durante el último año.",
+    weakHighlight: "got",
+    strongHighlight: "became significantly",
+    why: "'Got' is invisible — your ear slides past it. 'Became' is intentional and formal. Adding 'significantly' quantifies the change instead of leaving it vague.",
+    whyEs: "'Got' es invisible — tu oído lo pasa de largo. 'Became' es intencional y formal. Agregar 'significantly' cuantifica el cambio en lugar de dejarlo vago.",
+    category: "Verb + adverb upgrade",
+    categoryEs: "Mejora de verbo + adverbio",
+  },
+  {
+    weak: "We did a study on customer behavior last quarter.",
+    weakEs: "Hicimos un estudio sobre el comportamiento del cliente el trimestre pasado.",
+    strong: "We conducted a study on customer behavior last quarter.",
+    strongEs: "Llevamos a cabo un estudio sobre el comportamiento del cliente el trimestre pasado.",
+    weakHighlight: "did",
+    strongHighlight: "conducted",
+    why: "'Conducted a study' is the standard professional phrasing — it carries scientific weight. 'Did a study' sounds casual and undermines the seriousness of the work.",
+    whyEs: "'Conducted a study' es la frase profesional estándar — lleva peso científico. 'Did a study' suena casual y socava la seriedad del trabajo.",
+    category: "Verb upgrade",
+    categoryEs: "Mejora de verbo",
+  },
+];
+
+// ─── Section 2: Killing Weak Adverbs (ErrorSpotter) ──────────────────────────
+
+export const weakAdverbs: ErrorSpotterItem[] = [
+  {
+    sentence: "The presentation was very important for the team.",
+    errorWord: "very",
+    improved: "The presentation was critical for the team.",
+    sentenceEs: "La presentación fue muy importante para el equipo.",
+    improvedEs: "La presentación fue crítica para el equipo.",
+    explanation:
+      "'Very important' is weak because 'very' is an empty amplifier — it adds no real information. Replace the whole phrase with a single strong adjective: 'critical', 'essential', 'vital'.",
+    explanationEs:
+      "'Very important' es débil porque 'very' es un amplificador vacío — no agrega información real. Reemplaza toda la frase con un solo adjetivo fuerte: 'critical', 'essential', 'vital'.",
+  },
+  {
+    sentence: "She is really good at solving complex problems.",
+    errorWord: "really",
+    improved: "She excels at solving complex problems.",
+    sentenceEs: "Ella es realmente buena resolviendo problemas complejos.",
+    improvedEs: "Ella sobresale en resolver problemas complejos.",
+    explanation:
+      "'Really good' is what children say. Replace the adverb + adjective with a single strong verb: 'excels'. One precise word beats two vague ones.",
+    explanationEs:
+      "'Really good' es lo que dicen los niños. Reemplaza el adverbio + adjetivo con un solo verbo fuerte: 'excels'. Una palabra precisa le gana a dos vagas.",
+  },
+  {
+    sentence: "I am quite concerned about the project timeline.",
+    errorWord: "quite",
+    improved: "I am concerned about the project timeline.",
+    sentenceEs: "Estoy bastante preocupado por el cronograma del proyecto.",
+    improvedEs: "Estoy preocupado por el cronograma del proyecto.",
+    explanation:
+      "'Quite' adds nothing — you're either concerned or you're not. Hedging with 'quite' weakens your statement. Drop it entirely and your sentence is stronger by subtraction.",
+    explanationEs:
+      "'Quite' no agrega nada — estás preocupado o no lo estás. Hedging con 'quite' debilita tu declaración. Elimínalo por completo y tu oración será más fuerte por sustracción.",
+  },
+  {
+    sentence: "The report is just a draft at this point.",
+    errorWord: "just",
+    improved: "The report is a draft at this point.",
+    sentenceEs: "El reporte es solo un borrador en este momento.",
+    improvedEs: "El reporte es un borrador en este momento.",
+    explanation:
+      "'Just' is the most common minimizer in English. Here it apologizes for the draft being a draft. Cut it. The fact that it's a draft IS the information. No apology needed.",
+    explanationEs:
+      "'Just' es el minimizador más común en inglés. Aquí se disculpa porque el borrador es un borrador. Elimínalo. El hecho de que sea un borrador ES la información. No se necesita disculpa.",
+  },
+  {
+    sentence: "He totally understood the problem from the beginning.",
+    errorWord: "totally",
+    improved: "He understood the problem from the beginning.",
+    sentenceEs: "Él totalmente entendió el problema desde el principio.",
+    improvedEs: "Él entendió el problema desde el principio.",
+    explanation:
+      "'Totally' is casual filler that sounds like a teenager texting. In professional English, 'understood' is already complete — it doesn't need amplification. If you need emphasis, say 'fully understood'.",
+    explanationEs:
+      "'Totally' es relleno casual que suena como un adolescente enviando mensajes. En inglés profesional, 'understood' ya está completo — no necesita amplificación. Si necesitas énfasis, di 'fully understood'.",
+  },
+  {
+    sentence: "It was actually a great meeting, to be honest.",
+    errorWord: "actually",
+    improved: "It was a productive meeting.",
+    sentenceEs: "Realmente fue una gran reunión, para ser honesto.",
+    improvedEs: "Fue una reunión productiva.",
+    explanation:
+      "'Actually' signals surprise — it implies you expected it to be bad. Unless you genuinely mean to express surprise, drop it. Also, 'great' is vague: was it productive? Informative? Decisive? Choose the specific word.",
+    explanationEs:
+      "'Actually' señala sorpresa — implica que esperabas que fuera mala. A menos que genuinamente quieras expresar sorpresa, elimínalo. Además, 'great' es vago: ¿fue productiva? ¿Informativa? ¿Decisiva? Elige la palabra específica.",
+  },
+  {
+    sentence: "We definitely need to address this issue before Friday.",
+    errorWord: "definitely",
+    improved: "We need to address this issue before Friday.",
+    sentenceEs: "Definitivamente necesitamos abordar este problema antes del viernes.",
+    improvedEs: "Necesitamos abordar este problema antes del viernes.",
+    explanation:
+      "'Definitely' tries to add certainty, but 'need to' already carries urgency. Stacking 'definitely' on top sounds nervous, not confident. Cut the adverb and let the verb do the work.",
+    explanationEs:
+      "'Definitely' intenta agregar certeza, pero 'need to' ya lleva urgencia. Apilar 'definitely' encima suena nervioso, no confiado. Elimina el adverbio y deja que el verbo haga el trabajo.",
+  },
+  {
+    sentence: "I basically rebuilt the entire system over the weekend.",
+    errorWord: "basically",
+    improved: "I rebuilt the entire system over the weekend.",
+    sentenceEs: "Básicamente reconstruí todo el sistema el fin de semana.",
+    improvedEs: "Reconstruí todo el sistema el fin de semana.",
+    explanation:
+      "'Basically' is a verbal tic. It minimizes your own accomplishment — you REBUILT an entire system, and 'basically' says 'eh, not really.' Own your work. Drop the minimizer.",
+    explanationEs:
+      "'Basically' es un tic verbal. Minimiza tu propio logro — RECONSTRUISTE todo un sistema, y 'basically' dice 'eh, no realmente.' Adueñate de tu trabajo. Elimina el minimizador.",
+  },
+];
+
+// ─── Section 3: Rewriting Flat Sentences (SentenceTransformer) ───────────────
+
+export const sentenceTransforms: SentenceTransform[] = [
+  {
+    flat: "We had a meeting and we talked about the project and we made some decisions.",
+    flatEs: "Tuvimos una reunión y hablamos sobre el proyecto y tomamos algunas decisiones.",
+    strong: "In our project meeting, we reached several key decisions.",
+    strongEs: "En nuestra reunión de proyecto, llegamos a varias decisiones clave.",
+    technique: "consolidation",
+    techniqueEs: "consolidación",
+    why: "Three separate clauses connected by 'and' is the weakest sentence structure in English. Consolidate by making one clause carry the weight. 'Reached decisions' is tighter than 'talked about and made decisions'.",
+    whyEs: "Tres cláusulas separadas conectadas por 'and' es la estructura de oración más débil en inglés. Consolida haciendo que una sola cláusula lleve el peso.",
+  },
+  {
+    flat: "I did a lot of work on this and I think it's really good now.",
+    flatEs: "Trabajé mucho en esto y creo que ya está muy bueno.",
+    strong: "I've refined this thoroughly — I'm confident it's ready.",
+    strongEs: "He refinado esto a fondo — estoy seguro de que está listo.",
+    technique: "verb upgrade + hedging removal",
+    techniqueEs: "mejora de verbo + eliminación de cobertura",
+    why: "'Did a lot of work' is vague. 'Refined thoroughly' is specific. 'I think it's really good' is triple-hedged — drop 'think', 'really', and 'good' for 'I'm confident it's ready.' One decisive statement.",
+    whyEs: "'Did a lot of work' es vago. 'Refined thoroughly' es específico. 'I think it's really good' tiene triple cobertura — elimina 'think', 'really' y 'good' por 'I'm confident it's ready.'",
+  },
+  {
+    flat: "The team got a lot of stuff done last week and I think we can keep going.",
+    flatEs: "El equipo hizo muchas cosas la semana pasada y creo que podemos seguir.",
+    strong: "The team delivered significant results last week and is well-positioned to maintain momentum.",
+    strongEs: "El equipo entregó resultados significativos la semana pasada y está bien posicionado para mantener el impulso.",
+    technique: "precision + formality upgrade",
+    techniqueEs: "precisión + mejora de formalidad",
+    why: "'Got a lot of stuff done' says nothing a manager can measure. 'Delivered significant results' is professional and concrete. 'Keep going' is casual; 'maintain momentum' is boardroom language.",
+    whyEs: "'Got a lot of stuff done' no dice nada que un gerente pueda medir. 'Delivered significant results' es profesional y concreto. 'Keep going' es casual; 'maintain momentum' es lenguaje de sala de juntas.",
+  },
+  {
+    flat: "I'm sorry but I don't think I can do that because I'm too busy right now.",
+    flatEs: "Lo siento pero no creo que pueda hacer eso porque estoy muy ocupado ahorita.",
+    strong: "I appreciate you thinking of me, but my current commitments won't allow me to take this on.",
+    strongEs: "Agradezco que pienses en mí, pero mis compromisos actuales no me permiten tomar esto.",
+    technique: "reframe + gratitude opening",
+    techniqueEs: "reencuadre + apertura de gratitud",
+    why: "Opening with 'I'm sorry but' is defensive. Opening with 'I appreciate...' shows confidence and gratitude. 'Too busy' sounds overwhelmed; 'current commitments' sounds in control. The message is the same — the impact is completely different.",
+    whyEs: "Abrir con 'I'm sorry but' es defensivo. Abrir con 'I appreciate...' muestra confianza y gratitud. 'Too busy' suena abrumado; 'current commitments' suena en control.",
+  },
+  {
+    flat: "It's a really nice place and the people there are very friendly and the food is great.",
+    flatEs: "Es un lugar muy bonito y la gente ahí es muy amigable y la comida es excelente.",
+    strong: "The restaurant has a warm atmosphere, genuinely welcoming staff, and outstanding food.",
+    strongEs: "El restaurante tiene un ambiente cálido, personal genuinamente acogedor y comida sobresaliente.",
+    technique: "list structure + adjective precision",
+    techniqueEs: "estructura de lista + precisión de adjetivos",
+    why: "Three 'and' chains with generic adjectives (nice, friendly, great) = flat. Convert to a list-of-three with SPECIFIC adjectives (warm, welcoming, outstanding). Lists of three are the most persuasive structure in English.",
+    whyEs: "Tres cadenas con 'and' y adjetivos genéricos (nice, friendly, great) = plano. Convierte en una lista de tres con adjetivos ESPECÍFICOS. Las listas de tres son la estructura más persuasiva en inglés.",
+  },
+  {
+    flat: "The problem is that there are many different issues that need to be fixed as soon as possible.",
+    flatEs: "El problema es que hay muchos problemas diferentes que necesitan ser arreglados lo antes posible.",
+    strong: "We're facing several interconnected issues that require immediate attention.",
+    strongEs: "Enfrentamos varios problemas interconectados que requieren atención inmediata.",
+    technique: "active voice + specificity",
+    techniqueEs: "voz activa + especificidad",
+    why: "'The problem is that there are' is a throat-clearing opener — it says nothing. Start with the subject doing something: 'We're facing.' 'Many different issues' is vague; 'several interconnected issues' is precise. 'As soon as possible' is overused; 'immediate attention' is sharper.",
+    whyEs: "'The problem is that there are' es una frase de relleno — no dice nada. Empieza con el sujeto haciendo algo: 'We're facing.' 'Immediate attention' es más afilado que 'as soon as possible'.",
+  },
+];

--- a/src/pages/en/course/advanced/index.astro
+++ b/src/pages/en/course/advanced/index.astro
@@ -1,0 +1,219 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import { advancedInfo, advancedUnits } from "@data/advanced/units";
+import {
+  Sparkles,
+  AlertTriangle,
+  Users,
+  Link,
+  Type,
+  Mic,
+  Zap,
+  Puzzle,
+  Layers,
+  ArrowRight,
+  GraduationCap,
+  Target,
+  CheckCircle2,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/advanced" as const;
+
+const iconMap: Record<string, any> = {
+  Sparkles,
+  AlertTriangle,
+  Users,
+  Link,
+  Type,
+  Mic,
+  Zap,
+  Puzzle,
+  Layers,
+  Sparkle: Sparkles,
+};
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Speak with Confidence — Free Advanced English Course (B2-C1) | NY English Teacher"
+  description="A free 10-unit advanced course for high B2 to C1 Spanish speakers. Fix the granular errors that mark a non-native speaker — weak phrasing, word traps, articles, pronunciation tells. No themes. Just precision."
+>
+  <!-- Hero -->
+  <section class="relative w-full overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 pt-32 pb-20 md:pt-40 md:pb-28">
+    <div class="absolute inset-0 opacity-10">
+      <div class="absolute top-20 left-10 w-72 h-72 bg-violet-500 rounded-full blur-3xl"></div>
+      <div class="absolute bottom-10 right-10 w-96 h-96 bg-amber-500 rounded-full blur-3xl"></div>
+    </div>
+    <div class="site-container mx-auto px-4 relative z-10">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-4">
+          <GraduationCap class="w-4 h-4" />
+          Free Course · B2 → C1
+        </div>
+        <h1
+          class="text-4xl md:text-6xl font-bold text-white mb-6 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          {advancedInfo.title}
+        </h1>
+        <p class="text-xl text-slate-300 max-w-2xl leading-relaxed mb-8">
+          You can hold conversations. You can write emails. You can present.
+          But something still sounds <strong class="text-white">off</strong> — and you can't
+          figure out what. This course fixes the specific, granular errors that mark
+          an advanced speaker as non-native.
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <Button href="#units" variant="primary" size="lg">
+            See the 10 Units
+            <ArrowRight class="w-5 h-5 ml-1" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Value props -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-violet-100 text-violet-600">
+            <Target class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">Precision, Not Volume</h3>
+          <p class="text-slate-600 leading-relaxed">
+            No more vocabulary lists. 3 focused sections per unit that drill the exact
+            skill until it becomes automatic.
+          </p>
+        </div>
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-violet-100 text-violet-600">
+            <Zap class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">Strong Phrasing</h3>
+          <p class="text-slate-600 leading-relaxed">
+            Replace weak verbs, filler adverbs, and flat sentences with the precise,
+            confident language native professionals use.
+          </p>
+        </div>
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-violet-100 text-violet-600">
+            <Mic class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">Pronunciation Tells</h3>
+          <p class="text-slate-600 leading-relaxed">
+            The S endings, TH sounds, and vowel shifts that give away even fluent
+            Spanish speakers. Targeted drills, not generic practice.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Unit grid -->
+  <section class="py-16 md:py-20 bg-slate-50" id="units">
+    <div class="site-container mx-auto px-4">
+      <div class="text-center max-w-2xl mx-auto mb-12">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4" style="font-family: 'Noto Sans KR', sans-serif;">
+          10 Units. 3 Sections Each.
+        </h2>
+        <p class="text-slate-600 leading-relaxed">
+          Each unit targets a specific weakness. 3 focused sections per unit: learn the concept,
+          spot the error, build the fix.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
+        {advancedUnits.map((unit) => {
+          const Icon = iconMap[unit.icon];
+          const isAvailable = unit.id === 1;
+          return (
+            <a
+              href={isAvailable ? `/en/course/advanced/${unit.slug}/` : undefined}
+              class:list={[
+                "group flex items-start gap-4 p-5 rounded-xl border transition-all duration-200",
+                isAvailable
+                  ? "bg-violet-50 border-violet-300 hover:shadow-md hover:border-violet-400 cursor-pointer"
+                  : "bg-white border-slate-200 opacity-75",
+              ]}
+            >
+              <div
+                class:list={[
+                  "flex items-center justify-center w-12 h-12 rounded-xl shrink-0",
+                  isAvailable ? "bg-violet-500 text-white" : "bg-slate-100 text-slate-400",
+                ]}
+              >
+                {Icon && <Icon class="w-6 h-6" />}
+              </div>
+              <div>
+                <div class="flex items-center gap-2">
+                  <span
+                    class:list={[
+                      "text-xs font-bold uppercase tracking-wider",
+                      isAvailable ? "text-violet-600" : "text-slate-400",
+                    ]}
+                  >
+                    Unit {unit.id}
+                  </span>
+                  {!isAvailable && (
+                    <span class="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-400">
+                      Coming soon
+                    </span>
+                  )}
+                </div>
+                <h3
+                  class:list={[
+                    "text-lg font-bold mt-0.5",
+                    isAvailable ? "text-slate-900" : "text-slate-600",
+                  ]}
+                >
+                  {unit.title}
+                </h3>
+                <p class="text-sm text-slate-500 mt-1">{unit.subtitle}</p>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <!-- Who it's for -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6" style="font-family: 'Noto Sans KR', sans-serif;">
+          Is this course for you?
+        </h2>
+        <div class="space-y-4 text-slate-600 leading-relaxed">
+          <p>
+            This course is for you if you can already hold a conversation in English but
+            something still feels off. You use the right grammar, you understand native speakers,
+            you can email and present — but your English doesn't sound <em>polished</em>.
+          </p>
+          <p>
+            The problem isn't vocabulary or grammar. It's <strong>precision</strong>. You use "got"
+            when you could say "earned." You hedge with "very" and "really" when a single strong
+            adjective would hit harder. You hesitate on articles. You overuse "and" to connect ideas.
+          </p>
+          <p>
+            If you've completed the <a href="/en/course/intermediate/" class="text-amber-600 hover:text-amber-500 underline">intermediate course</a> or
+            you're already at B2+, this is your next step. If English is still new to you, start with
+            the <a href="/en/course/beginners/" class="text-amber-600 hover:text-amber-500 underline">beginner course</a> instead.
+          </p>
+        </div>
+        <div class="mt-8">
+          <Button href="/en/services/" variant="secondary" size="md">
+            Or work 1-on-1 with Robert
+            <ArrowRight class="w-4 h-4 ml-1" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/en/course/advanced/unit-1.astro
+++ b/src/pages/en/course/advanced/unit-1.astro
@@ -1,0 +1,143 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WordPairLab from "@components/course/WordPairLab";
+import ErrorSpotter from "@components/course/ErrorSpotter";
+import SentenceTransformer from "@components/course/SentenceTransformer";
+import { advancedUnits } from "@data/advanced/units";
+import { verbPairs, weakAdverbs, sentenceTransforms } from "@data/advanced/unit-1";
+import { ArrowRight, Sparkles, TrendingUp, Search, Zap } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/advanced/unit-1" as const;
+
+const progressUnits = advancedUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unit 1: Weak Phrasing → Strong Phrasing | Speak with Confidence | NY English Teacher"
+  description="Replace 'got', 'made', and 'did' with 'earned', 'built', and 'delivered'. Kill weak adverbs. Rewrite flat sentences into sentences with impact. Free advanced English lesson for B2-C1 Spanish speakers."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={1}
+    basePath="/en/course/advanced"
+    lang="en"
+    courseId="advanced"
+  />
+
+  <!-- Unit hero -->
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-violet-400 text-sm font-semibold mb-3">
+          <Sparkles class="w-4 h-4" />
+          Unit 1
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Weak Phrasing → Strong Phrasing
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Advanced learners lean on a small set of weak verbs — "got", "made", "did" — and
+          pad them with empty adverbs like "very", "really", and "just." Native professionals
+          reach for specific, strong language that carries authority. This unit rewires
+          your word choices at three levels: the verb, the adverb, and the full sentence.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <TrendingUp class="w-3.5 h-3.5" /> Strong Verbs
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <Search class="w-3.5 h-3.5" /> Adverb Removal
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <Zap class="w-3.5 h-3.5" /> Sentence Impact
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 1: Weak verbs → Strong verbs -->
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Weak Verbs → Strong Verbs</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          See the weak version, then reveal the strong upgrade. Notice how one word changes
+          the entire impact of the sentence.
+        </p>
+        <WordPairLab client:visible pairs={verbPairs} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2: Killing Weak Adverbs -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Killing Weak Adverbs</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Each sentence has one word that weakens it. Tap the offending word to remove it
+          and see the upgraded version.
+        </p>
+        <ErrorSpotter client:visible items={weakAdverbs} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3: Rewriting Flat Sentences -->
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Rewriting Flat Sentences</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Flat sentences are the biggest tell of a non-native speaker. See the before and
+          after — and learn the technique behind each transformation.
+        </p>
+        <SentenceTransformer client:visible transforms={sentenceTransforms} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/en/course/advanced/"
+          class="text-sm text-slate-500 hover:text-violet-600 transition-colors"
+        >
+          &larr; Course Overview
+        </a>
+        <Button href="/en/course/advanced/" variant="primary" size="md">
+          Course Overview
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/en/courses/index.astro
+++ b/src/pages/en/courses/index.astro
@@ -5,6 +5,7 @@ import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
 import { courseInfo, units } from "@data/course/units";
 import { intermediateInfo, intermediateUnits } from "@data/intermediate/units";
+import { advancedInfo, advancedUnits } from "@data/advanced/units";
 import {
   Sparkles,
   Puzzle,
@@ -17,7 +18,8 @@ const lang = "en";
 const tkey = "courses" as const;
 
 const beginnerAvailable = units.length;
-const intermediateAvailable = intermediateUnits.filter((u) => u.id < 3).length;
+const intermediateAvailable = intermediateUnits.length;
+const advancedAvailable = advancedUnits.filter((u) => u.id === 1).length;
 ---
 
 <Base
@@ -52,7 +54,7 @@ const intermediateAvailable = intermediateUnits.filter((u) => u.id < 3).length;
   <!-- Course cards -->
   <section class="py-16 md:py-20 bg-slate-50">
     <div class="site-container mx-auto px-4">
-      <div class="max-w-5xl mx-auto grid md:grid-cols-2 gap-6">
+      <div class="max-w-5xl mx-auto grid md:grid-cols-3 gap-6">
 
         <!-- Beginner -->
         <a
@@ -138,9 +140,56 @@ const intermediateAvailable = intermediateUnits.filter((u) => u.id < 3).length;
             </ul>
             <div class="flex items-center justify-between">
               <span class="text-xs font-semibold text-amber-600 uppercase tracking-wider">
-                {intermediateAvailable} units available · more coming
+                {intermediateAvailable} units available
               </span>
               <span class="inline-flex items-center gap-1 text-amber-600 font-semibold text-sm group-hover:gap-2 transition-all">
+                Start course
+                <ArrowRight class="w-4 h-4" />
+              </span>
+            </div>
+          </div>
+        </a>
+
+        <!-- Advanced -->
+        <a
+          href="/en/course/advanced/"
+          class="group block bg-white rounded-2xl border border-slate-200 overflow-hidden hover:shadow-xl hover:border-violet-300 transition-all duration-200"
+        >
+          <div class="bg-gradient-to-br from-violet-500 to-violet-600 p-6 text-white">
+            <div class="flex items-center gap-2 text-violet-100 text-xs font-bold uppercase tracking-wider mb-2">
+              <Sparkles class="w-3.5 h-3.5" />
+              Level B2–C1 — Advanced
+            </div>
+            <h2 class="text-2xl md:text-3xl font-bold mb-2" style="font-family: 'Noto Sans KR', sans-serif;">
+              {advancedInfo.title}
+            </h2>
+            <p class="text-violet-50 text-sm leading-relaxed">
+              {advancedInfo.tagline}
+            </p>
+          </div>
+          <div class="p-6">
+            <p class="text-slate-600 text-sm leading-relaxed mb-4">
+              Fix the granular errors that mark a non-native speaker even at C1. Skill-based drills — no themes, no vocabulary memorization.
+            </p>
+            <ul class="space-y-2 mb-6">
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-violet-500 shrink-0 mt-0.5" />
+                <span>Strong phrasing & precision vocabulary</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-violet-500 shrink-0 mt-0.5" />
+                <span>Articles, pronouns, word traps — the lifelong errors</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-violet-500 shrink-0 mt-0.5" />
+                <span>Pronunciation tells that give you away</span>
+              </li>
+            </ul>
+            <div class="flex items-center justify-between">
+              <span class="text-xs font-semibold text-violet-600 uppercase tracking-wider">
+                {advancedAvailable} unit available · more coming
+              </span>
+              <span class="inline-flex items-center gap-1 text-violet-600 font-semibold text-sm group-hover:gap-2 transition-all">
                 Start course
                 <ArrowRight class="w-4 h-4" />
               </span>

--- a/src/pages/es/curso/avanzado/index.astro
+++ b/src/pages/es/curso/avanzado/index.astro
@@ -1,0 +1,215 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import { advancedInfo, advancedUnits } from "@data/advanced/units";
+import {
+  Sparkles,
+  AlertTriangle,
+  Users,
+  Link,
+  Type,
+  Mic,
+  Zap,
+  Puzzle,
+  Layers,
+  ArrowRight,
+  GraduationCap,
+  Target,
+  CheckCircle2,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/advanced" as const;
+
+const iconMap: Record<string, any> = {
+  Sparkles,
+  AlertTriangle,
+  Users,
+  Link,
+  Type,
+  Mic,
+  Zap,
+  Puzzle,
+  Layers,
+  Sparkle: Sparkles,
+};
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Habla con Confianza — Curso Avanzado Gratis de Inglés (B2-C1) | NY English Teacher"
+  description="Un curso avanzado gratuito de 10 unidades para hispanohablantes de nivel B2 alto a C1. Corrige los errores granulares que delatan al hablante no nativo — frases débiles, trampas de palabras, artículos, detalles de pronunciación."
+>
+  <section class="relative w-full overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 pt-32 pb-20 md:pt-40 md:pb-28">
+    <div class="absolute inset-0 opacity-10">
+      <div class="absolute top-20 left-10 w-72 h-72 bg-violet-500 rounded-full blur-3xl"></div>
+      <div class="absolute bottom-10 right-10 w-96 h-96 bg-amber-500 rounded-full blur-3xl"></div>
+    </div>
+    <div class="site-container mx-auto px-4 relative z-10">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-4">
+          <GraduationCap class="w-4 h-4" />
+          Curso Gratis · B2 → C1
+        </div>
+        <h1
+          class="text-4xl md:text-6xl font-bold text-white mb-6 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          {advancedInfo.titleEs}
+        </h1>
+        <p class="text-xl text-slate-300 max-w-2xl leading-relaxed mb-8">
+          Puedes tener conversaciones. Puedes escribir correos. Puedes presentar.
+          Pero algo todavía suena <strong class="text-white">mal</strong> — y no
+          logras descifrar qué es. Este curso corrige los errores específicos y granulares
+          que delatan a un hablante avanzado como no nativo.
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <Button href="#units" variant="primary" size="lg">
+            Ver las 10 Unidades
+            <ArrowRight class="w-5 h-5 ml-1" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-violet-100 text-violet-600">
+            <Target class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">Precisión, No Volumen</h3>
+          <p class="text-slate-600 leading-relaxed">
+            Sin más listas de vocabulario. 3 secciones enfocadas por unidad que practican
+            la habilidad exacta hasta que se vuelve automática.
+          </p>
+        </div>
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-violet-100 text-violet-600">
+            <Zap class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">Frases Fuertes</h3>
+          <p class="text-slate-600 leading-relaxed">
+            Reemplaza verbos débiles, adverbios de relleno y oraciones planas con
+            el lenguaje preciso y confiado que usan los profesionales nativos.
+          </p>
+        </div>
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-violet-100 text-violet-600">
+            <Mic class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">Detalles de Pronunciación</h3>
+          <p class="text-slate-600 leading-relaxed">
+            Las terminaciones en S, los sonidos TH y los cambios de vocales que delatan
+            incluso a hispanohablantes fluidos. Ejercicios dirigidos, no práctica genérica.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="units">
+    <div class="site-container mx-auto px-4">
+      <div class="text-center max-w-2xl mx-auto mb-12">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4" style="font-family: 'Noto Sans KR', sans-serif;">
+          10 Unidades. 3 Secciones Cada Una.
+        </h2>
+        <p class="text-slate-600 leading-relaxed">
+          Cada unidad se enfoca en una debilidad específica. 3 secciones enfocadas por unidad:
+          aprende el concepto, detecta el error, construye la corrección.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
+        {advancedUnits.map((unit) => {
+          const Icon = iconMap[unit.icon];
+          const isAvailable = unit.id === 1;
+          return (
+            <a
+              href={isAvailable ? `/es/curso/avanzado/${unit.slugEs}/` : undefined}
+              class:list={[
+                "group flex items-start gap-4 p-5 rounded-xl border transition-all duration-200",
+                isAvailable
+                  ? "bg-violet-50 border-violet-300 hover:shadow-md hover:border-violet-400 cursor-pointer"
+                  : "bg-white border-slate-200 opacity-75",
+              ]}
+            >
+              <div
+                class:list={[
+                  "flex items-center justify-center w-12 h-12 rounded-xl shrink-0",
+                  isAvailable ? "bg-violet-500 text-white" : "bg-slate-100 text-slate-400",
+                ]}
+              >
+                {Icon && <Icon class="w-6 h-6" />}
+              </div>
+              <div>
+                <div class="flex items-center gap-2">
+                  <span
+                    class:list={[
+                      "text-xs font-bold uppercase tracking-wider",
+                      isAvailable ? "text-violet-600" : "text-slate-400",
+                    ]}
+                  >
+                    Unidad {unit.id}
+                  </span>
+                  {!isAvailable && (
+                    <span class="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-400">
+                      Próximamente
+                    </span>
+                  )}
+                </div>
+                <h3
+                  class:list={[
+                    "text-lg font-bold mt-0.5",
+                    isAvailable ? "text-slate-900" : "text-slate-600",
+                  ]}
+                >
+                  {unit.titleEs}
+                </h3>
+                <p class="text-sm text-slate-500 mt-1">{unit.subtitleEs}</p>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6" style="font-family: 'Noto Sans KR', sans-serif;">
+          ¿Es este curso para ti?
+        </h2>
+        <div class="space-y-4 text-slate-600 leading-relaxed">
+          <p>
+            Este curso es para ti si ya puedes mantener una conversación en inglés pero algo
+            todavía se siente mal. Usas la gramática correcta, entiendes a los nativos,
+            puedes enviar correos y presentar — pero tu inglés no suena <em>pulido</em>.
+          </p>
+          <p>
+            El problema no es vocabulario ni gramática. Es <strong>precisión</strong>. Usas "got"
+            cuando podrías decir "earned." Hedges con "very" y "really" cuando un solo adjetivo
+            fuerte tendría más impacto. Dudas con los artículos. Usas "and" de más para conectar ideas.
+          </p>
+          <p>
+            Si completaste el <a href="/es/curso/intermedio/" class="text-amber-600 hover:text-amber-500 underline">curso intermedio</a> o
+            ya estás en B2+, este es tu siguiente paso. Si el inglés todavía es nuevo para ti,
+            empieza con el <a href="/es/curso/principiantes/" class="text-amber-600 hover:text-amber-500 underline">curso principiante</a>.
+          </p>
+        </div>
+        <div class="mt-8">
+          <Button href="/es/servicios/" variant="secondary" size="md">
+            O trabaja 1-a-1 con Robert
+            <ArrowRight class="w-4 h-4 ml-1" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/avanzado/unidad-1.astro
+++ b/src/pages/es/curso/avanzado/unidad-1.astro
@@ -1,0 +1,139 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WordPairLab from "@components/course/WordPairLab";
+import ErrorSpotter from "@components/course/ErrorSpotter";
+import SentenceTransformer from "@components/course/SentenceTransformer";
+import { advancedUnits } from "@data/advanced/units";
+import { verbPairs, weakAdverbs, sentenceTransforms } from "@data/advanced/unit-1";
+import { ArrowRight, Sparkles, TrendingUp, Search, Zap } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/advanced/unit-1" as const;
+
+const progressUnits = advancedUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unidad 1: Frases Débiles → Frases Fuertes | Habla con Confianza | NY English Teacher"
+  description="Reemplaza 'got', 'made' y 'did' por 'earned', 'built' y 'delivered'. Elimina adverbios débiles. Transforma oraciones planas en oraciones con impacto. Lección avanzada gratis para hispanohablantes B2-C1."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={1}
+    basePath="/es/curso/avanzado"
+    lang="es"
+    courseId="advanced"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-violet-400 text-sm font-semibold mb-3">
+          <Sparkles class="w-4 h-4" />
+          Unidad 1
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Frases Débiles → Frases Fuertes
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Los hablantes avanzados se apoyan en un conjunto pequeño de verbos débiles — "got",
+          "made", "did" — y los rellenan con adverbios vacíos como "very", "really" y "just."
+          Los profesionales nativos eligen un lenguaje específico y fuerte que transmite autoridad.
+          Esta unidad reprograma tus elecciones de palabras en tres niveles: el verbo, el adverbio
+          y la oración completa.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <TrendingUp class="w-3.5 h-3.5" /> Verbos Fuertes
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <Search class="w-3.5 h-3.5" /> Eliminación de Adverbios
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <Zap class="w-3.5 h-3.5" /> Impacto de Oración
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Verbos Débiles → Verbos Fuertes</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Mira la versión débil, luego revela la versión fuerte. Nota cómo una palabra
+          cambia el impacto completo de la oración.
+        </p>
+        <WordPairLab client:visible pairs={verbPairs} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Eliminando Adverbios Débiles</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Cada oración tiene una palabra que la debilita. Toca la palabra ofensiva para
+          eliminarla y ver la versión mejorada.
+        </p>
+        <ErrorSpotter client:visible items={weakAdverbs} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Reescribiendo Oraciones Planas</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          Las oraciones planas son la mayor señal de un hablante no nativo. Mira el antes y
+          el después — y aprende la técnica detrás de cada transformación.
+        </p>
+        <SentenceTransformer client:visible transforms={sentenceTransforms} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/es/curso/avanzado/"
+          class="text-sm text-slate-500 hover:text-violet-600 transition-colors"
+        >
+          &larr; Resumen del Curso
+        </a>
+        <Button href="/es/curso/avanzado/" variant="primary" size="md">
+          Resumen del Curso
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/cursos/index.astro
+++ b/src/pages/es/cursos/index.astro
@@ -5,6 +5,7 @@ import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
 import { courseInfo, units } from "@data/course/units";
 import { intermediateInfo, intermediateUnits } from "@data/intermediate/units";
+import { advancedInfo, advancedUnits } from "@data/advanced/units";
 import {
   Sparkles,
   Puzzle,
@@ -17,7 +18,8 @@ const lang = "es";
 const tkey = "courses" as const;
 
 const beginnerAvailable = units.length;
-const intermediateAvailable = intermediateUnits.filter((u) => u.id < 3).length;
+const intermediateAvailable = intermediateUnits.length;
+const advancedAvailable = advancedUnits.filter((u) => u.id === 1).length;
 ---
 
 <Base
@@ -50,7 +52,7 @@ const intermediateAvailable = intermediateUnits.filter((u) => u.id < 3).length;
 
   <section class="py-16 md:py-20 bg-slate-50">
     <div class="site-container mx-auto px-4">
-      <div class="max-w-5xl mx-auto grid md:grid-cols-2 gap-6">
+      <div class="max-w-5xl mx-auto grid md:grid-cols-3 gap-6">
 
         <!-- Beginner -->
         <a
@@ -136,9 +138,56 @@ const intermediateAvailable = intermediateUnits.filter((u) => u.id < 3).length;
             </ul>
             <div class="flex items-center justify-between">
               <span class="text-xs font-semibold text-amber-600 uppercase tracking-wider">
-                {intermediateAvailable} unidades disponibles · más en camino
+                {intermediateAvailable} unidades disponibles
               </span>
               <span class="inline-flex items-center gap-1 text-amber-600 font-semibold text-sm group-hover:gap-2 transition-all">
+                Empezar curso
+                <ArrowRight class="w-4 h-4" />
+              </span>
+            </div>
+          </div>
+        </a>
+
+        <!-- Advanced -->
+        <a
+          href="/es/curso/avanzado/"
+          class="group block bg-white rounded-2xl border border-slate-200 overflow-hidden hover:shadow-xl hover:border-violet-300 transition-all duration-200"
+        >
+          <div class="bg-gradient-to-br from-violet-500 to-violet-600 p-6 text-white">
+            <div class="flex items-center gap-2 text-violet-100 text-xs font-bold uppercase tracking-wider mb-2">
+              <Sparkles class="w-3.5 h-3.5" />
+              Nivel B2–C1 — Avanzado
+            </div>
+            <h2 class="text-2xl md:text-3xl font-bold mb-2" style="font-family: 'Noto Sans KR', sans-serif;">
+              {advancedInfo.titleEs}
+            </h2>
+            <p class="text-violet-50 text-sm leading-relaxed">
+              {advancedInfo.taglineEs}
+            </p>
+          </div>
+          <div class="p-6">
+            <p class="text-slate-600 text-sm leading-relaxed mb-4">
+              Corrige los errores granulares que delatan al hablante no nativo incluso a nivel C1. Ejercicios basados en habilidades — sin temas, sin memorización de vocabulario.
+            </p>
+            <ul class="space-y-2 mb-6">
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-violet-500 shrink-0 mt-0.5" />
+                <span>Frases fuertes y vocabulario de precisión</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-violet-500 shrink-0 mt-0.5" />
+                <span>Artículos, pronombres, trampas de palabras — los errores de toda la vida</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-violet-500 shrink-0 mt-0.5" />
+                <span>Detalles de pronunciación que te delatan</span>
+              </li>
+            </ul>
+            <div class="flex items-center justify-between">
+              <span class="text-xs font-semibold text-violet-600 uppercase tracking-wider">
+                {advancedAvailable} unidad disponible · más en camino
+              </span>
+              <span class="inline-flex items-center gap-1 text-violet-600 font-semibold text-sm group-hover:gap-2 transition-all">
                 Empezar curso
                 <ArrowRight class="w-4 h-4" />
               </span>


### PR DESCRIPTION
## Summary
First user-visible unit of the **\"Speak with Confidence\"** advanced course (B2-C1). The advanced course uses a different format than beginner/intermediate: **3 sections per unit** instead of 6, each powered by a reusable component from the advanced component library.

### Unit 1: Weak Phrasing → Strong Phrasing

**Section 1 — Weak Verbs → Strong Verbs** (\`WordPairLab\`)
8 verb pair upgrades: got→earned, made→developed, did→delivered, had a meeting→met with, etc. Each pair highlights the changed word and explains WHY the strong version carries more authority.

**Section 2 — Killing Weak Adverbs** (\`ErrorSpotter\`)
8 sentences with a weak adverb hidden inside. Learner clicks the offending word (very, really, quite, just, totally, actually, definitely, basically). Wrong picks flash red; correct picks reveal the improved version.

**Section 3 — Rewriting Flat Sentences** (\`SentenceTransformer\` — NEW component)
6 flat→strong sentence rewrites with technique badges (consolidation, verb upgrade, reframe, list structure, active voice) and explanations. This is the production exercise — the capstone of the unit.

### Also in this PR
- EN + ES **landing pages** for the advanced course (all 10 units listed, Unit 1 active, rest \"Coming soon\")
- **Courses hub** updated with a third card (violet accent) for the advanced course, grid switched from 2-col to 3-col
- Fixed intermediate hub card unit count (was showing old filtered number)

### Visual identity
Advanced uses **violet accents** to differentiate from beginner (emerald) and intermediate (amber).

## Test plan
- [x] \`npm run build\` passes (244 sitemap URLs)
- [ ] Visit \`/en/course/advanced/\` — landing page renders with 10-unit grid
- [ ] Visit \`/en/course/advanced/unit-1/\` — all 3 sections render and interact correctly
- [ ] Visit \`/es/curso/avanzado/unidad-1/\` — Spanish mirror works
- [ ] Courses hub shows all 3 courses in a 3-column grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)