### PR TITLE
feat: advanced Units 3 + 4 — Pronouns and Relative Clauses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ scripts/seo/.submissions/
 
 # Cloudflare Worker config (contains client IDs)
 wrangler.toml
+
+.vercel
+.env*.local

--- a/src/data/advanced/unit-3.ts
+++ b/src/data/advanced/unit-3.ts
@@ -1,0 +1,220 @@
+// Unit 3: "Pronouns Done Right" — Full course content
+//
+// Section 1: Subject vs object pronouns (he/him, she/her, they/them) — WordPairLab
+// Section 2: Reflexive pronouns — when they're wrong — ErrorSpotter
+// Section 3: Direct vs indirect object pronouns in real sentences — SentenceTransformer
+
+import type { WordPair, ErrorSpotterItem, SentenceTransform } from "./types";
+
+// ─── Section 1: Subject vs Object Pronouns (WordPairLab) ─────────────────────
+
+export const pronounPairs: WordPair[] = [
+  {
+    weak: "Me and him went to the meeting together.",
+    weakEs: "Yo y él fuimos a la junta juntos.",
+    strong: "He and I went to the meeting together.",
+    strongEs: "Él y yo fuimos a la junta juntos.",
+    weakHighlight: "Me and him",
+    strongHighlight: "He and I",
+    why: "Subject position (before the verb) requires subject pronouns: I, he, she, we, they. Quick test: remove the other person. Would you say 'Me went to the meeting'? No — 'I went.' So it's 'He and I.'",
+    whyEs: "La posición de sujeto (antes del verbo) requiere pronombres de sujeto: I, he, she, we, they. Prueba rápida: quita a la otra persona. ¿Dirías 'Me went to the meeting'? No — 'I went.' Entonces es 'He and I.'",
+    category: "Subject pronouns",
+    categoryEs: "Pronombres de sujeto",
+  },
+  {
+    weak: "The manager spoke to he and I about the project.",
+    weakEs: "El gerente habló con él y yo sobre el proyecto.",
+    strong: "The manager spoke to him and me about the project.",
+    strongEs: "El gerente habló con él y conmigo sobre el proyecto.",
+    weakHighlight: "he and I",
+    strongHighlight: "him and me",
+    why: "After a preposition (to, with, for, about) you need OBJECT pronouns: me, him, her, us, them. 'Spoke to I' sounds wrong — 'spoke to me.' Many people overcorrect to 'I' because they were told 'me' is wrong. It's not — it's just wrong in subject position.",
+    whyEs: "Después de una preposición (to, with, for, about) necesitas pronombres de OBJETO: me, him, her, us, them. 'Spoke to I' suena mal — 'spoke to me.' Muchos hipercorrigen a 'I' porque les dijeron que 'me' es incorrecto. No lo es — solo es incorrecto en posición de sujeto.",
+    category: "Hypercorrection trap",
+    categoryEs: "Trampa de hipercorrección",
+  },
+  {
+    weak: "Between you and I, this project is failing.",
+    weakEs: "Entre tú y yo, este proyecto está fallando.",
+    strong: "Between you and me, this project is failing.",
+    strongEs: "Entre tú y yo, este proyecto está fallando.",
+    weakHighlight: "you and I",
+    strongHighlight: "you and me",
+    why: "'Between' is a preposition, so it takes object pronouns: 'between you and ME.' This is the single most common pronoun error among educated English speakers — even native ones get it wrong because 'you and I' sounds 'more correct.' It's not.",
+    whyEs: "'Between' es una preposición, así que lleva pronombres de objeto: 'between you and ME.' Este es el error de pronombres más común entre hablantes educados de inglés — incluso los nativos lo confunden porque 'you and I' suena 'más correcto.' No lo es.",
+    category: "The famous trap",
+    categoryEs: "La trampa famosa",
+  },
+  {
+    weak: "Her and me finished the report early.",
+    weakEs: "Ella y yo terminamos el reporte temprano.",
+    strong: "She and I finished the report early.",
+    strongEs: "Ella y yo terminamos el reporte temprano.",
+    weakHighlight: "Her and me",
+    strongHighlight: "She and I",
+    why: "Both pronouns are subjects (they did the finishing), so both must be subject pronouns: She, I. Remove one: 'Her finished the report'? No. 'Me finished the report'? No. 'She finished' and 'I finished' — both correct.",
+    whyEs: "Ambos pronombres son sujetos (ellos hicieron la acción), así que ambos deben ser pronombres de sujeto: She, I. Quita uno: '¿Her finished the report?' No. '¿Me finished the report?' No. 'She finished' y 'I finished' — ambos correctos.",
+    category: "Double subject error",
+    categoryEs: "Error de doble sujeto",
+  },
+  {
+    weak: "Give the documents to she and he before the deadline.",
+    weakEs: "Dale los documentos a ella y él antes de la fecha límite.",
+    strong: "Give the documents to her and him before the deadline.",
+    strongEs: "Dale los documentos a ella y él antes de la fecha límite.",
+    weakHighlight: "she and he",
+    strongHighlight: "her and him",
+    why: "'To' is a preposition → object pronouns. 'Give the documents to she'? No. 'Give the documents to her.' Same for 'him.' Both are objects of the preposition 'to.'",
+    whyEs: "'To' es una preposición → pronombres de objeto. '¿Give the documents to she?' No. 'Give the documents to her.' Lo mismo para 'him.' Ambos son objetos de la preposición 'to.'",
+    category: "Object pronouns",
+    categoryEs: "Pronombres de objeto",
+  },
+  {
+    weak: "Us developers need better tools.",
+    weakEs: "Nosotros los desarrolladores necesitamos mejores herramientas.",
+    strong: "We developers need better tools.",
+    strongEs: "Nosotros los desarrolladores necesitamos mejores herramientas.",
+    weakHighlight: "Us",
+    strongHighlight: "We",
+    why: "'Developers' is the subject, and 'us/we' modifies it. Subject position → 'We developers.' The test: drop 'developers.' 'Us need better tools'? No. 'We need better tools.' Yes.",
+    whyEs: "'Developers' es el sujeto, y 'us/we' lo modifica. Posición de sujeto → 'We developers.' La prueba: quita 'developers.' '¿Us need better tools?' No. 'We need better tools.' Sí.",
+    category: "Subject pronouns",
+    categoryEs: "Pronombres de sujeto",
+  },
+];
+
+// ─── Section 2: Reflexive Pronoun Traps (ErrorSpotter) ───────────────────────
+
+export const reflexiveErrors: ErrorSpotterItem[] = [
+  {
+    sentence: "If you have any questions, please contact myself or my colleague.",
+    errorWord: "myself",
+    improved: "If you have any questions, please contact me or my colleague.",
+    sentenceEs: "Si tiene alguna pregunta, por favor contácteme a mí o a mi colega.",
+    improvedEs: "Si tiene alguna pregunta, por favor contácteme a mí o a mi colega.",
+    explanation:
+      "'Myself' is a reflexive pronoun — use it only when the subject and object are the SAME person: 'I hurt myself.' Here, 'you' is the subject and 'me' is the object — different people. Use 'me.' The 'myself' habit comes from people thinking it sounds more professional. It doesn't.",
+    explanationEs:
+      "'Myself' es un pronombre reflexivo — úsalo solo cuando el sujeto y el objeto son la MISMA persona: 'I hurt myself.' Aquí, 'you' es el sujeto y 'me' es el objeto — diferentes personas. Usa 'me.' El hábito de 'myself' viene de personas que creen que suena más profesional. No es así.",
+  },
+  {
+    sentence: "The report was written by John and myself.",
+    errorWord: "myself",
+    improved: "The report was written by John and me.",
+    sentenceEs: "El reporte fue escrito por John y yo mismo.",
+    improvedEs: "El reporte fue escrito por John y por mí.",
+    explanation:
+      "After a preposition ('by'), use the object pronoun: 'me', not 'myself.' Reflexive pronouns ONLY reflect back to the subject. The subject here is 'the report', not 'I', so there's nothing to reflect. 'By me' is correct.",
+    explanationEs:
+      "Después de una preposición ('by'), usa el pronombre de objeto: 'me', no 'myself.' Los pronombres reflexivos SOLO reflejan de vuelta al sujeto. El sujeto aquí es 'the report', no 'I', así que no hay nada que reflejar. 'By me' es correcto.",
+  },
+  {
+    sentence: "The children can dress theirselves now.",
+    errorWord: "theirselves",
+    improved: "The children can dress themselves now.",
+    sentenceEs: "Los niños pueden vestirse solos ahora.",
+    improvedEs: "Los niños pueden vestirse solos ahora.",
+    explanation:
+      "'Theirselves' is NOT a word — it doesn't exist in standard English. The correct reflexive for 'they' is 'themselves.' Similarly, 'hisself' doesn't exist — it's 'himself.' These are real errors even native speakers make in informal speech.",
+    explanationEs:
+      "'Theirselves' NO es una palabra — no existe en inglés estándar. El reflexivo correcto para 'they' es 'themselves.' De manera similar, 'hisself' no existe — es 'himself.'",
+  },
+  {
+    sentence: "My wife and myself would like to invite you to dinner.",
+    errorWord: "myself",
+    improved: "My wife and I would like to invite you to dinner.",
+    sentenceEs: "Mi esposa y yo mismo quisiéramos invitarte a cenar.",
+    improvedEs: "Mi esposa y yo quisiéramos invitarte a cenar.",
+    explanation:
+      "Subject position: 'My wife and I' (not 'myself'). The reflexive adds nothing here — it's filler. 'I' is the subject pronoun. Remember: 'myself' appears only when you previously said 'I' in the same clause: 'I did it myself.'",
+    explanationEs:
+      "Posición de sujeto: 'My wife and I' (no 'myself'). El reflexivo no agrega nada aquí — es relleno. 'I' es el pronombre de sujeto. Recuerda: 'myself' aparece solo cuando previamente dijiste 'I' en la misma cláusula: 'I did it myself.'",
+  },
+  {
+    sentence: "Please send the proposal to yourself at your earliest convenience.",
+    errorWord: "yourself",
+    improved: "Please review the proposal at your earliest convenience.",
+    sentenceEs: "Por favor envíe la propuesta a usted mismo a la brevedad posible.",
+    improvedEs: "Por favor revise la propuesta a la brevedad posible.",
+    explanation:
+      "You can't 'send something to yourself' in a business context — it's nonsensical. The writer probably meant 'please review the proposal.' Reflexive pronouns cause confusion when used as fancy-sounding replacements for simple pronouns.",
+    explanationEs:
+      "No puedes 'enviar algo a ti mismo' en un contexto de negocios — no tiene sentido. El escritor probablemente quiso decir 'please review the proposal.' Los pronombres reflexivos causan confusión cuando se usan como reemplazos sofisticados de pronombres simples.",
+  },
+  {
+    sentence: "He gave the award to herself during the ceremony.",
+    errorWord: "herself",
+    improved: "He gave the award to her during the ceremony.",
+    sentenceEs: "Él le dio el premio a ella misma durante la ceremonia.",
+    improvedEs: "Él le dio el premio a ella durante la ceremonia.",
+    explanation:
+      "The subject is 'he' and the recipient is a different person (her). Since they're not the same person, no reflexive. 'Herself' would only be correct if she gave something to her OWN self: 'She gave herself a break.'",
+    explanationEs:
+      "El sujeto es 'he' y la receptora es una persona diferente (her). Como no son la misma persona, no hay reflexivo. 'Herself' solo sería correcto si ella se diera algo a SÍ MISMA: 'She gave herself a break.'",
+  },
+];
+
+// ─── Section 3: Direct vs Indirect Object Pronouns (SentenceTransformer) ─────
+
+export const objectPronounTransforms: SentenceTransform[] = [
+  {
+    flat: "I gave to her the book yesterday.",
+    flatEs: "Le di a ella el libro ayer.",
+    strong: "I gave her the book yesterday.",
+    strongEs: "Le di el libro ayer.",
+    technique: "indirect object placement",
+    techniqueEs: "colocación de objeto indirecto",
+    why: "In English, the indirect object (the person receiving) goes DIRECTLY after the verb, with NO preposition: 'gave HER the book.' The 'to' version also works but in a different order: 'gave the book TO her.' Never 'gave to her the book.'",
+    whyEs: "En inglés, el objeto indirecto (la persona que recibe) va DIRECTAMENTE después del verbo, SIN preposición: 'gave HER the book.' La versión con 'to' también funciona pero en diferente orden: 'gave the book TO her.' Nunca 'gave to her the book.'",
+  },
+  {
+    flat: "Can you explain me the situation?",
+    flatEs: "¿Puedes explicarme la situación?",
+    strong: "Can you explain the situation to me?",
+    strongEs: "¿Puedes explicarme la situación?",
+    technique: "explain + to (no double object)",
+    techniqueEs: "explain + to (sin doble objeto)",
+    why: "'Explain' is special — it does NOT take a double object pattern. You can 'give me the book' but you cannot 'explain me the situation.' It MUST be 'explain X TO me.' Other verbs like this: suggest, describe, mention, announce.",
+    whyEs: "'Explain' es especial — NO toma un patrón de doble objeto. Puedes 'give me the book' pero no puedes 'explain me the situation.' DEBE ser 'explain X TO me.' Otros verbos así: suggest, describe, mention, announce.",
+  },
+  {
+    flat: "She told the news to him and then she told the news to them.",
+    flatEs: "Ella le dio las noticias a él y luego les dio las noticias a ellos.",
+    strong: "She told him the news, then told them.",
+    strongEs: "Le contó la noticia y luego se la contó a ellos.",
+    technique: "pronoun efficiency",
+    techniqueEs: "eficiencia de pronombres",
+    why: "Native speakers avoid repeating nouns when pronouns can carry the meaning. 'Told him the news' (indirect object first) is cleaner than 'told the news to him.' The second clause drops 'the news' entirely because the listener already knows what was told.",
+    whyEs: "Los nativos evitan repetir sustantivos cuando los pronombres pueden llevar el significado. 'Told him the news' es más limpio que 'told the news to him.' La segunda cláusula omite 'the news' porque el oyente ya sabe qué se contó.",
+  },
+  {
+    flat: "He bought for his wife a diamond ring for their anniversary.",
+    flatEs: "Él compró para su esposa un anillo de diamantes para su aniversario.",
+    strong: "He bought his wife a diamond ring for their anniversary.",
+    strongEs: "Le compró a su esposa un anillo de diamantes para su aniversario.",
+    technique: "double object pattern",
+    techniqueEs: "patrón de doble objeto",
+    why: "'Buy' takes the double object pattern naturally: 'bought HER a ring.' No 'for' needed when the indirect object comes right after the verb. The 'for' version: 'bought a ring FOR her' — also fine, but the double object version is more natural.",
+    whyEs: "'Buy' toma el patrón de doble objeto naturalmente: 'bought HER a ring.' No se necesita 'for' cuando el objeto indirecto va justo después del verbo.",
+  },
+  {
+    flat: "They showed to us the new office and they showed to us the parking area.",
+    flatEs: "Nos mostraron a nosotros la nueva oficina y nos mostraron a nosotros el área de estacionamiento.",
+    strong: "They showed us the new office and the parking area.",
+    strongEs: "Nos mostraron la nueva oficina y el área de estacionamiento.",
+    technique: "consolidation + double object",
+    techniqueEs: "consolidación + doble objeto",
+    why: "Two upgrades. First: 'showed US' (double object) is tighter than 'showed TO us.' Second: don't repeat the whole clause — combine the objects: 'the new office AND the parking area.' One sentence does the work of two.",
+    whyEs: "Dos mejoras. Primero: 'showed US' (doble objeto) es más compacto que 'showed TO us.' Segundo: no repitas toda la cláusula — combina los objetos: 'the new office AND the parking area.'",
+  },
+  {
+    flat: "I want to ask to you a question about the schedule.",
+    flatEs: "Quiero preguntarte una pregunta sobre el horario.",
+    strong: "I want to ask you a question about the schedule.",
+    strongEs: "Quiero hacerte una pregunta sobre el horario.",
+    technique: "ask + double object (no 'to')",
+    techniqueEs: "ask + doble objeto (sin 'to')",
+    why: "'Ask' takes the double object pattern with NO preposition: 'ask YOU a question.' Never 'ask TO you.' Spanish 'preguntar a' tempts the 'to' insertion, but English doesn't use it here. Same pattern: 'ask him a favor', 'ask her the time.'",
+    whyEs: "'Ask' toma el patrón de doble objeto SIN preposición: 'ask YOU a question.' Nunca 'ask TO you.' El español 'preguntar a' tienta a insertar 'to', pero el inglés no lo usa aquí.",
+  },
+];

--- a/src/data/advanced/unit-4.ts
+++ b/src/data/advanced/unit-4.ts
@@ -1,0 +1,220 @@
+// Unit 4: "Which, That, Who, When" — Full course content
+//
+// Section 1: Which vs that — defining vs non-defining — WordPairLab
+// Section 2: Who vs whom (and why nobody says "whom" anymore) — ErrorSpotter
+// Section 3: When, where, whose — relative clauses without the confusion — SentenceTransformer
+
+import type { WordPair, ErrorSpotterItem, SentenceTransform } from "./types";
+
+// ─── Section 1: Which vs That (WordPairLab) ──────────────────────────────────
+
+export const whichThatPairs: WordPair[] = [
+  {
+    weak: "The laptop which I bought last week is already broken.",
+    weakEs: "La laptop que compré la semana pasada ya está rota.",
+    strong: "The laptop that I bought last week is already broken.",
+    strongEs: "La laptop que compré la semana pasada ya está rota.",
+    weakHighlight: "which",
+    strongHighlight: "that",
+    why: "This is a DEFINING clause — it tells you WHICH laptop. Use 'that' with no comma. 'Which' is for non-defining clauses (extra info, with commas). Rule: if removing the clause changes the meaning, use 'that'. If you could delete it and the sentence still works, use 'which' with commas.",
+    whyEs: "Esta es una cláusula DEFINITORIA — te dice CUÁL laptop. Usa 'that' sin coma. 'Which' es para cláusulas no definitorias (información extra, con comas). Regla: si quitar la cláusula cambia el significado, usa 'that'. Si pudieras eliminarla y la oración sigue funcionando, usa 'which' con comas.",
+    category: "Defining clause",
+    categoryEs: "Cláusula definitoria",
+  },
+  {
+    weak: "The policy that was updated last month, is now in effect.",
+    weakEs: "La política que fue actualizada el mes pasado, ahora está en efecto.",
+    strong: "The policy that was updated last month is now in effect.",
+    strongEs: "La política que fue actualizada el mes pasado ahora está en efecto.",
+    weakHighlight: "month,",
+    strongHighlight: "month",
+    why: "When you use 'that', NEVER add a comma before or after the clause. The comma signals non-defining information — and 'that' clauses are always defining. The comma here is a common error that muddles the sentence structure.",
+    whyEs: "Cuando usas 'that', NUNCA agregues una coma antes o después de la cláusula. La coma señala información no definitoria — y las cláusulas con 'that' siempre son definitorias. La coma aquí es un error común que confunde la estructura.",
+    category: "Comma rule",
+    categoryEs: "Regla de la coma",
+  },
+  {
+    weak: "My car that is a 2020 model needs new tires.",
+    weakEs: "Mi coche que es modelo 2020 necesita llantas nuevas.",
+    strong: "My car, which is a 2020 model, needs new tires.",
+    strongEs: "Mi coche, que es modelo 2020, necesita llantas nuevas.",
+    weakHighlight: "that",
+    strongHighlight: ", which",
+    why: "You only have ONE car — so 'that is a 2020 model' isn't telling the listener WHICH car. It's adding EXTRA info. Extra info = 'which' + commas. If you had multiple cars and needed to specify which one, 'that' would be correct: 'The car that is a 2020 model' (not the other one).",
+    whyEs: "Solo tienes UN coche — así que 'that is a 2020 model' no le dice al oyente CUÁL coche. Agrega información EXTRA. Información extra = 'which' + comas. Si tuvieras múltiples coches, 'that' sería correcto: 'The car that is a 2020 model' (no el otro).",
+    category: "Non-defining clause",
+    categoryEs: "Cláusula no definitoria",
+  },
+  {
+    weak: "The book, that she recommended, was excellent.",
+    weakEs: "El libro, que ella recomendó, fue excelente.",
+    strong: "The book that she recommended was excellent.",
+    strongEs: "El libro que ella recomendó fue excelente.",
+    weakHighlight: ", that",
+    strongHighlight: "that",
+    why: "If you're using commas, you MUST use 'which', not 'that'. But here, the clause IS defining — it tells you which book. So drop the commas and keep 'that'. Alternatively: 'The book, which she recommended, was excellent' (non-defining — extra info about a book already identified).",
+    whyEs: "Si usas comas, DEBES usar 'which', no 'that'. Pero aquí, la cláusula SÍ es definitoria — te dice cuál libro. Así que quita las comas y conserva 'that'.",
+    category: "Comma conflict",
+    categoryEs: "Conflicto de coma",
+  },
+  {
+    weak: "The meeting that was very productive lasted three hours.",
+    weakEs: "La junta que fue muy productiva duró tres horas.",
+    strong: "The meeting, which was very productive, lasted three hours.",
+    strongEs: "La junta, que fue muy productiva, duró tres horas.",
+    weakHighlight: "that",
+    strongHighlight: ", which",
+    why: "Ask: does the clause identify WHICH meeting? If there was only one meeting that day, 'very productive' is extra info → 'which' + commas. If there were several meetings and you need to specify which one was productive → 'that' with no commas.",
+    whyEs: "Pregunta: ¿la cláusula identifica CUÁL junta? Si solo hubo una junta ese día, 'very productive' es información extra → 'which' + comas. Si hubo varias juntas y necesitas especificar cuál fue productiva → 'that' sin comas.",
+    category: "Context determines choice",
+    categoryEs: "El contexto determina la elección",
+  },
+  {
+    weak: "Everything which happened today was unexpected.",
+    weakEs: "Todo lo que pasó hoy fue inesperado.",
+    strong: "Everything that happened today was unexpected.",
+    strongEs: "Todo lo que pasó hoy fue inesperado.",
+    weakHighlight: "which",
+    strongHighlight: "that",
+    why: "After indefinite pronouns (everything, something, anything, nothing, all), ALWAYS use 'that', never 'which'. This is a hard rule with no exceptions. 'Something that matters.' 'Anything that works.' 'Nothing that we can do.'",
+    whyEs: "Después de pronombres indefinidos (everything, something, anything, nothing, all), SIEMPRE usa 'that', nunca 'which'. Esta es una regla dura sin excepciones. 'Something that matters.' 'Anything that works.'",
+    category: "Hard rule",
+    categoryEs: "Regla absoluta",
+  },
+];
+
+// ─── Section 2: Who vs Whom (ErrorSpotter) ───────────────────────────────────
+
+export const whoWhomErrors: ErrorSpotterItem[] = [
+  {
+    sentence: "The candidate whom arrived late was not considered for the position.",
+    errorWord: "whom",
+    improved: "The candidate who arrived late was not considered for the position.",
+    sentenceEs: "El candidato quien llegó tarde no fue considerado para el puesto.",
+    improvedEs: "El candidato que llegó tarde no fue considerado para el puesto.",
+    explanation:
+      "'Who' is the SUBJECT form (like he/she). 'Whom' is the OBJECT form (like him/her). Here, the candidate ARRIVED (subject) → 'who'. Quick test: replace with he/him. 'He arrived late' works. 'Him arrived late' doesn't. So: 'who.'",
+    explanationEs:
+      "'Who' es la forma de SUJETO (como he/she). 'Whom' es la forma de OBJETO (como him/her). Aquí, el candidato LLEGÓ (sujeto) → 'who'. Prueba rápida: reemplaza con he/him. 'He arrived late' funciona. 'Him arrived late' no. Entonces: 'who.'",
+  },
+  {
+    sentence: "I need to know who the package was sent to.",
+    errorWord: "who",
+    improved: "I need to know whom the package was sent to.",
+    sentenceEs: "Necesito saber a quién se envió el paquete.",
+    improvedEs: "Necesito saber a quién se envió el paquete.",
+    explanation:
+      "The package was sent TO someone — that someone is the OBJECT of the preposition 'to.' Object position → 'whom.' Test: 'The package was sent to HIM' (works). 'The package was sent to HE' (doesn't). So: 'whom.' In practice, most speakers say 'who' here and nobody blinks — but 'whom' is technically correct.",
+    explanationEs:
+      "El paquete fue enviado A alguien — ese alguien es el OBJETO de la preposición 'to.' Posición de objeto → 'whom.' Prueba: 'The package was sent to HIM' (funciona). En la práctica, la mayoría dice 'who' aquí y nadie reacciona — pero 'whom' es técnicamente correcto.",
+  },
+  {
+    sentence: "She is the manager whom I believe is the most qualified.",
+    errorWord: "whom",
+    improved: "She is the manager who I believe is the most qualified.",
+    sentenceEs: "Ella es la gerente quien yo creo que es la más calificada.",
+    improvedEs: "Ella es la gerente que yo creo que es la más calificada.",
+    explanation:
+      "This is a TRAP. 'I believe' is a parenthetical — remove it and the sentence is 'the manager IS the most qualified.' The manager is the SUBJECT of 'is', so use 'who.' The insertion of 'I believe' tricks people into thinking 'whom' is correct because it LOOKS like an object. It's not.",
+    explanationEs:
+      "Esta es una TRAMPA. 'I believe' es un paréntesis — quítalo y la oración es 'the manager IS the most qualified.' La gerente es el SUJETO de 'is', así que usa 'who.' La inserción de 'I believe' engaña a la gente.",
+  },
+  {
+    sentence: "Whom is responsible for this mistake?",
+    errorWord: "Whom",
+    improved: "Who is responsible for this mistake?",
+    sentenceEs: "¿Quién es responsable de este error?",
+    improvedEs: "¿Quién es responsable de este error?",
+    explanation:
+      "'Is responsible' needs a SUBJECT. 'Whom' is never a subject — only 'who' can be. 'Whom' is reserved for objects. Using 'whom' in subject position is a common overcorrection by people trying to sound formal.",
+    explanationEs:
+      "'Is responsible' necesita un SUJETO. 'Whom' nunca es sujeto — solo 'who' puede serlo. 'Whom' está reservado para objetos. Usar 'whom' en posición de sujeto es una hipercorrección común de personas tratando de sonar formales.",
+  },
+  {
+    sentence: "The people who we interviewed yesterday were all very strong candidates.",
+    errorWord: "who",
+    improved: "The people whom we interviewed yesterday were all very strong candidates.",
+    sentenceEs: "Las personas a quienes entrevistamos ayer fueron candidatos muy fuertes.",
+    improvedEs: "Las personas a quienes entrevistamos ayer fueron candidatos muy fuertes.",
+    explanation:
+      "WE interviewed THEM — 'them' is the object of 'interviewed.' Object → 'whom.' But here's the reality: in 2026 spoken English, 'who we interviewed' is universally accepted. 'Whom' is technically correct but increasingly rare outside legal and academic writing. Know the rule, then choose your register.",
+    explanationEs:
+      "NOSOTROS los entrevistamos — 'them' es el objeto de 'interviewed.' Objeto → 'whom.' Pero la realidad: en inglés hablado 2026, 'who we interviewed' es universalmente aceptado. 'Whom' es técnicamente correcto pero cada vez más raro fuera de escritura legal y académica.",
+  },
+  {
+    sentence: "The person which called you is waiting in the lobby.",
+    errorWord: "which",
+    improved: "The person who called you is waiting in the lobby.",
+    sentenceEs: "La persona que te llamó está esperando en el lobby.",
+    improvedEs: "La persona que te llamó está esperando en el lobby.",
+    explanation:
+      "'Which' is NEVER used for people — only 'who' or 'that.' This is a hard rule with no exceptions. Spanish 'que' covers both people and things, which causes this error. People = 'who.' Things = 'which' or 'that.'",
+    explanationEs:
+      "'Which' NUNCA se usa para personas — solo 'who' o 'that.' Esta es una regla dura sin excepciones. El 'que' del español cubre tanto personas como cosas, lo que causa este error. Personas = 'who.' Cosas = 'which' o 'that.'",
+  },
+];
+
+// ─── Section 3: When, Where, Whose (SentenceTransformer) ─────────────────────
+
+export const relativeClauseTransforms: SentenceTransform[] = [
+  {
+    flat: "I remember the day. I started this job on that day.",
+    flatEs: "Recuerdo el día. Empecé este trabajo en ese día.",
+    strong: "I remember the day when I started this job.",
+    strongEs: "Recuerdo el día en que empecé este trabajo.",
+    technique: "when (time reference)",
+    techniqueEs: "when (referencia de tiempo)",
+    why: "'When' replaces 'on that day' / 'at that time' / 'in that year.' It joins two sentences about the same time point into one fluid sentence. 'The day when', 'the moment when', 'the year when' — all standard patterns.",
+    whyEs: "'When' reemplaza 'on that day' / 'at that time' / 'in that year.' Une dos oraciones sobre el mismo punto en el tiempo en una sola oración fluida.",
+  },
+  {
+    flat: "This is the restaurant. We had our first meeting there.",
+    flatEs: "Este es el restaurante. Tuvimos nuestra primera junta ahí.",
+    strong: "This is the restaurant where we had our first meeting.",
+    strongEs: "Este es el restaurante donde tuvimos nuestra primera junta.",
+    technique: "where (place reference)",
+    techniqueEs: "where (referencia de lugar)",
+    why: "'Where' replaces 'there' / 'at that place' / 'in that building.' It's the relative pronoun for locations. Never use 'which' for places when 'where' fits — 'the office where I work' is more natural than 'the office in which I work.'",
+    whyEs: "'Where' reemplaza 'there' / 'at that place' / 'in that building.' Es el pronombre relativo para lugares. Nunca uses 'which' para lugares cuando 'where' funciona — 'the office where I work' es más natural que 'the office in which I work.'",
+  },
+  {
+    flat: "The manager has a reputation. His leadership style is very collaborative.",
+    flatEs: "El gerente tiene una reputación. Su estilo de liderazgo es muy colaborativo.",
+    strong: "The manager, whose leadership style is very collaborative, has an excellent reputation.",
+    strongEs: "El gerente, cuyo estilo de liderazgo es muy colaborativo, tiene una excelente reputación.",
+    technique: "whose (possession)",
+    techniqueEs: "whose (posesión)",
+    why: "'Whose' shows that something BELONGS to the person or thing mentioned. It replaces 'his/her/its/their.' 'The manager whose style...' = 'the manager — his style...' It's the only way to combine these two ideas cleanly.",
+    whyEs: "'Whose' muestra que algo PERTENECE a la persona o cosa mencionada. Reemplaza 'his/her/its/their.' 'The manager whose style...' = 'the manager — his style...' Es la única forma de combinar estas dos ideas limpiamente.",
+  },
+  {
+    flat: "The client called us. His contract expires next month.",
+    flatEs: "El cliente nos llamó. Su contrato expira el próximo mes.",
+    strong: "The client whose contract expires next month called us.",
+    strongEs: "El cliente cuyo contrato expira el próximo mes nos llamó.",
+    technique: "whose (mid-sentence placement)",
+    techniqueEs: "whose (colocación a mitad de oración)",
+    why: "Notice the 'whose' clause sits between the subject ('the client') and the verb ('called'). This mid-sentence placement is natural in English and avoids the need for two choppy sentences. Spanish speakers often avoid 'whose' because 'cuyo' is also rarely used in spoken Spanish.",
+    whyEs: "Nota que la cláusula con 'whose' se sitúa entre el sujeto ('the client') y el verbo ('called'). Esta colocación a mitad de oración es natural en inglés. Los hispanohablantes frecuentemente evitan 'whose' porque 'cuyo' también se usa poco en español hablado.",
+  },
+  {
+    flat: "I grew up in a small town. There wasn't much to do in that town. The town had only one school.",
+    flatEs: "Crecí en un pueblo pequeño. No había mucho que hacer en ese pueblo. El pueblo tenía solo una escuela.",
+    strong: "I grew up in a small town where there wasn't much to do and whose only school closed years ago.",
+    strongEs: "Crecí en un pueblo pequeño donde no había mucho que hacer y cuya única escuela cerró hace años.",
+    technique: "where + whose (combined)",
+    techniqueEs: "where + whose (combinados)",
+    why: "Advanced writers chain relative clauses using different pronouns in the same sentence. 'Where' for the location fact, 'whose' for the possession fact. Three choppy sentences become one fluid, sophisticated sentence. This is C1-level construction.",
+    whyEs: "Los escritores avanzados encadenan cláusulas relativas usando diferentes pronombres en la misma oración. 'Where' para el dato de ubicación, 'whose' para el dato de posesión. Tres oraciones cortas se vuelven una oración fluida y sofisticada. Esta es construcción nivel C1.",
+  },
+  {
+    flat: "There was a time. People wrote letters to communicate at that time.",
+    flatEs: "Hubo un tiempo. La gente escribía cartas para comunicarse en ese tiempo.",
+    strong: "There was a time when people wrote letters to communicate.",
+    strongEs: "Hubo un tiempo en que la gente escribía cartas para comunicarse.",
+    technique: "when (nostalgic reference)",
+    techniqueEs: "when (referencia nostálgica)",
+    why: "'There was a time when...' is one of the most powerful storytelling openings in English. It immediately signals nostalgia or reflection. The 'when' clause completes the thought in a single breath.",
+    whyEs: "'There was a time when...' es una de las aperturas narrativas más poderosas en inglés. Señala inmediatamente nostalgia o reflexión. La cláusula con 'when' completa el pensamiento en un solo respiro.",
+  },
+];

--- a/src/pages/en/course/advanced/index.astro
+++ b/src/pages/en/course/advanced/index.astro
@@ -131,7 +131,7 @@ const iconMap: Record<string, any> = {
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
         {advancedUnits.map((unit) => {
           const Icon = iconMap[unit.icon];
-          const isAvailable = unit.id < 3;
+          const isAvailable = unit.id < 5;
           return (
             <a
               href={isAvailable ? `/en/course/advanced/${unit.slug}/` : undefined}

--- a/src/pages/en/course/advanced/unit-3.astro
+++ b/src/pages/en/course/advanced/unit-3.astro
@@ -1,0 +1,115 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WordPairLab from "@components/course/WordPairLab";
+import ErrorSpotter from "@components/course/ErrorSpotter";
+import SentenceTransformer from "@components/course/SentenceTransformer";
+import { advancedUnits } from "@data/advanced/units";
+import { pronounPairs, reflexiveErrors, objectPronounTransforms } from "@data/advanced/unit-3";
+import { ArrowRight, Users, UserCheck, Search, Zap } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/advanced/unit-3" as const;
+
+const progressUnits = advancedUnits.map((u) => ({
+  id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs,
+}));
+---
+
+<Base lang={lang} tkey={tkey}
+  title="Unit 3: Pronouns Done Right | Speak with Confidence | NY English Teacher"
+  description="Subject vs object pronouns, reflexive traps, direct vs indirect objects. Fix the pronoun errors that mark advanced speakers as non-native. Free B2-C1 English lesson for Spanish speakers."
+>
+  <CourseProgress client:load units={progressUnits} currentUnit={3} basePath="/en/course/advanced" lang="en" courseId="advanced" />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-violet-400 text-sm font-semibold mb-3">
+          <Users class="w-4 h-4" />
+          Unit 3
+        </div>
+        <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Pronouns Done Right
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Pronoun errors are subtle — but they're one of the fastest tells of a non-native
+          speaker. "Between you and I" sounds educated but is actually wrong. "Please contact
+          myself" sounds professional but is a reflexive misuse. This unit cleans up every
+          pronoun trap advanced speakers fall into.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <UserCheck class="w-3.5 h-3.5" /> Subject vs Object
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <Search class="w-3.5 h-3.5" /> Reflexive Traps
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <Zap class="w-3.5 h-3.5" /> Object Placement
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Subject vs Object Pronouns</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          He or him? She or her? The "remove the other person" test makes it instant.
+        </p>
+        <WordPairLab client:visible pairs={pronounPairs} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Reflexive Pronouns — When They're Wrong</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          "Please contact myself" sounds professional. It's not — it's wrong. Tap the misused
+          reflexive in each sentence.
+        </p>
+        <ErrorSpotter client:visible items={reflexiveErrors} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Direct vs Indirect Object Pronouns</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">
+          "I gave to her the book" vs "I gave her the book" — word order matters more than you think.
+        </p>
+        <SentenceTransformer client:visible transforms={objectPronounTransforms} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a href="/en/course/advanced/unit-2/" class="text-sm text-slate-500 hover:text-violet-600 transition-colors">&larr; Unit 2</a>
+        <Button href="/en/course/advanced/unit-4/" variant="primary" size="md">
+          Unit 4: Which, That, Who, When <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/en/course/advanced/unit-4.astro
+++ b/src/pages/en/course/advanced/unit-4.astro
@@ -1,0 +1,108 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WordPairLab from "@components/course/WordPairLab";
+import ErrorSpotter from "@components/course/ErrorSpotter";
+import SentenceTransformer from "@components/course/SentenceTransformer";
+import { advancedUnits } from "@data/advanced/units";
+import { whichThatPairs, whoWhomErrors, relativeClauseTransforms } from "@data/advanced/unit-4";
+import { ArrowRight, Link, GitBranch, Search, Zap } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/advanced/unit-4" as const;
+
+const progressUnits = advancedUnits.map((u) => ({
+  id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs,
+}));
+---
+
+<Base lang={lang} tkey={tkey}
+  title="Unit 4: Which, That, Who, When | Speak with Confidence | NY English Teacher"
+  description="Which vs that, who vs whom, when, where, whose — relative clauses drilled until you stop hesitating. Free B2-C1 English lesson for Spanish speakers."
+>
+  <CourseProgress client:load units={progressUnits} currentUnit={4} basePath="/en/course/advanced" lang="en" courseId="advanced" />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-violet-400 text-sm font-semibold mb-3">
+          <Link class="w-4 h-4" />
+          Unit 4
+        </div>
+        <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Which, That, Who, When
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Spanish uses "que" for everything. English splits this into "which," "that,"
+          "who," "whom," "whose," "where," and "when" — each with its own rules. This
+          unit drills the distinctions until you stop hesitating mid-sentence.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <GitBranch class="w-3.5 h-3.5" /> Which vs That
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <Search class="w-3.5 h-3.5" /> Who vs Whom
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <Zap class="w-3.5 h-3.5" /> When, Where, Whose
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">1</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Which vs That</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">
+        Defining vs non-defining. The comma rule. And why "everything which" is always wrong.
+      </p>
+      <WordPairLab client:visible pairs={whichThatPairs} lang="en" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">2</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Who vs Whom</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">
+        The he/him test makes it easy. Plus: why "whom" is dying in spoken English and when you
+        should still use it.
+      </p>
+      <ErrorSpotter client:visible items={whoWhomErrors} lang="en" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">3</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">When, Where, Whose</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">
+        Join choppy sentences into fluid ones using relative pronouns for time, place, and possession.
+      </p>
+      <SentenceTransformer client:visible transforms={relativeClauseTransforms} lang="en" />
+    </div></div>
+  </section>
+
+  <section class="py-12 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a href="/en/course/advanced/unit-3/" class="text-sm text-slate-500 hover:text-violet-600 transition-colors">&larr; Unit 3</a>
+        <Button href="/en/course/advanced/" variant="primary" size="md">
+          Course Overview <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/avanzado/index.astro
+++ b/src/pages/es/curso/avanzado/index.astro
@@ -128,7 +128,7 @@ const iconMap: Record<string, any> = {
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
         {advancedUnits.map((unit) => {
           const Icon = iconMap[unit.icon];
-          const isAvailable = unit.id < 3;
+          const isAvailable = unit.id < 5;
           return (
             <a
               href={isAvailable ? `/es/curso/avanzado/${unit.slugEs}/` : undefined}

--- a/src/pages/es/curso/avanzado/unidad-3.astro
+++ b/src/pages/es/curso/avanzado/unidad-3.astro
@@ -1,0 +1,102 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WordPairLab from "@components/course/WordPairLab";
+import ErrorSpotter from "@components/course/ErrorSpotter";
+import SentenceTransformer from "@components/course/SentenceTransformer";
+import { advancedUnits } from "@data/advanced/units";
+import { pronounPairs, reflexiveErrors, objectPronounTransforms } from "@data/advanced/unit-3";
+import { ArrowRight, Users, UserCheck, Search, Zap } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/advanced/unit-3" as const;
+
+const progressUnits = advancedUnits.map((u) => ({
+  id: u.id, slug: u.slugEs, title: u.title, titleEs: u.titleEs,
+}));
+---
+
+<Base lang={lang} tkey={tkey}
+  title="Unidad 3: Pronombres Bien Usados | Habla con Confianza | NY English Teacher"
+  description="Sujeto vs objeto, trampas reflexivas, objeto directo vs indirecto. Corrige los errores de pronombres que delatan a hablantes avanzados como no nativos. Lección B2-C1 gratis para hispanohablantes."
+>
+  <CourseProgress client:load units={progressUnits} currentUnit={3} basePath="/es/curso/avanzado" lang="es" courseId="advanced" />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-violet-400 text-sm font-semibold mb-3">
+          <Users class="w-4 h-4" />
+          Unidad 3
+        </div>
+        <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Pronombres Bien Usados
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Los errores de pronombres son sutiles — pero son una de las señales más rápidas
+          de un hablante no nativo. "Between you and I" suena educado pero en realidad es
+          incorrecto. "Please contact myself" suena profesional pero es un mal uso del
+          reflexivo. Esta unidad limpia todas las trampas de pronombres.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <UserCheck class="w-3.5 h-3.5" /> Sujeto vs Objeto
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <Search class="w-3.5 h-3.5" /> Trampas Reflexivas
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <Zap class="w-3.5 h-3.5" /> Colocación de Objetos
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">1</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Pronombres de Sujeto vs Objeto</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">¿He o him? ¿She o her? La prueba de "quita a la otra persona" lo hace instantáneo.</p>
+      <WordPairLab client:visible pairs={pronounPairs} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">2</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Pronombres Reflexivos — Cuándo Están Mal</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">"Please contact myself" suena profesional. No lo es — es incorrecto. Toca el reflexivo mal usado en cada oración.</p>
+      <ErrorSpotter client:visible items={reflexiveErrors} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">3</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Pronombres de Objeto Directo vs Indirecto</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">"I gave to her the book" vs "I gave her the book" — el orden de las palabras importa más de lo que piensas.</p>
+      <SentenceTransformer client:visible transforms={objectPronounTransforms} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-12 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a href="/es/curso/avanzado/unidad-2/" class="text-sm text-slate-500 hover:text-violet-600 transition-colors">&larr; Unidad 2</a>
+        <Button href="/es/curso/avanzado/unidad-4/" variant="primary" size="md">
+          Unidad 4: Which, That, Who, When <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/avanzado/unidad-4.astro
+++ b/src/pages/es/curso/avanzado/unidad-4.astro
@@ -1,0 +1,101 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WordPairLab from "@components/course/WordPairLab";
+import ErrorSpotter from "@components/course/ErrorSpotter";
+import SentenceTransformer from "@components/course/SentenceTransformer";
+import { advancedUnits } from "@data/advanced/units";
+import { whichThatPairs, whoWhomErrors, relativeClauseTransforms } from "@data/advanced/unit-4";
+import { ArrowRight, Link, GitBranch, Search, Zap } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/advanced/unit-4" as const;
+
+const progressUnits = advancedUnits.map((u) => ({
+  id: u.id, slug: u.slugEs, title: u.title, titleEs: u.titleEs,
+}));
+---
+
+<Base lang={lang} tkey={tkey}
+  title="Unidad 4: Which, That, Who, When | Habla con Confianza | NY English Teacher"
+  description="Which vs that, who vs whom, when, where, whose — cláusulas relativas practicadas hasta que dejes de dudar. Lección B2-C1 gratis para hispanohablantes."
+>
+  <CourseProgress client:load units={progressUnits} currentUnit={4} basePath="/es/curso/avanzado" lang="es" courseId="advanced" />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-violet-400 text-sm font-semibold mb-3">
+          <Link class="w-4 h-4" />
+          Unidad 4
+        </div>
+        <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Which, That, Who, When
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          El español usa "que" para todo. El inglés lo divide en "which," "that,"
+          "who," "whom," "whose," "where," y "when" — cada uno con sus propias reglas.
+          Esta unidad practica las distinciones hasta que dejes de dudar a mitad de oración.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <GitBranch class="w-3.5 h-3.5" /> Which vs That
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <Search class="w-3.5 h-3.5" /> Who vs Whom
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium">
+            <Zap class="w-3.5 h-3.5" /> When, Where, Whose
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">1</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Which vs That</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">Definitorias vs no definitorias. La regla de la coma. Y por qué "everything which" siempre está mal.</p>
+      <WordPairLab client:visible pairs={whichThatPairs} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">2</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Who vs Whom</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">La prueba de he/him lo hace fácil. Además: por qué "whom" está muriendo en el inglés hablado y cuándo deberías usarlo todavía.</p>
+      <ErrorSpotter client:visible items={whoWhomErrors} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">3</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">When, Where, Whose</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">Une oraciones cortas en oraciones fluidas usando pronombres relativos para tiempo, lugar y posesión.</p>
+      <SentenceTransformer client:visible transforms={relativeClauseTransforms} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-12 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a href="/es/curso/avanzado/unidad-3/" class="text-sm text-slate-500 hover:text-violet-600 transition-colors">&larr; Unidad 3</a>
+        <Button href="/es/curso/avanzado/" variant="primary" size="md">
+          Resumen del Curso <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary

### Unit 3 — Pronouns Done Right
- **Section 1** (WordPairLab): subject/object pairs — \"between you and I\" trap, \"us developers\" test
- **Section 2** (ErrorSpotter): reflexive misuses — \"contact myself\", \"written by myself\", \"theirselves\"
- **Section 3** (SentenceTransformer): direct/indirect object fixes — \"gave to her the book\", \"explain me\", \"ask to you\"

### Unit 4 — Which, That, Who, When
- **Section 1** (WordPairLab): which vs that — defining/non-defining, comma rule, \"everything which\" hard rule
- **Section 2** (ErrorSpotter): who/whom — the \"I believe\" parenthetical trap, overcorrection to \"whom\" in subject position
- **Section 3** (SentenceTransformer): when/where/whose — choppy sentences → fluid relative clauses

Both units unlocked on EN + ES landing pages. Build: 250 URLs, zero errors.

## Test plan
- [x] \`npm run build\` passes (250 URLs)
- [ ] Visit \`/en/course/advanced/unit-3/\` and \`/unit-4/\` — all sections render
- [ ] Verify ES mirrors at \`/es/curso/avanzado/unidad-3/\` and \`/unidad-4/\`
- [ ] Units 3+4 unlocked on landing pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)