### PR TITLE
feat: advanced Units 5 + 6 — Articles and Pronunciation

### DIFF
--- a/src/components/course/MinimalPairDrill.tsx
+++ b/src/components/course/MinimalPairDrill.tsx
@@ -1,0 +1,134 @@
+// MinimalPairDrill — reusable component for the advanced course.
+//
+// Shows two words that differ by a single sound (ship/sheep, walk/work).
+// The learner sees both, plays audio for each, and reads the distinction
+// tip. Used primarily in Unit 6 (Pronunciation) but available for any
+// unit that needs sound discrimination practice.
+
+import { useState } from "react";
+import { RotateCcw, Volume2 } from "lucide-react";
+import AudioButton from "./AudioButton";
+import type { MinimalPair } from "@data/advanced/types";
+
+interface Props {
+  pairs: MinimalPair[];
+  lang: "en" | "es";
+}
+
+export default function MinimalPairDrill({ pairs, lang }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isRevealed, setIsRevealed] = useState(false);
+
+  const current = pairs[currentIndex];
+  const isLast = currentIndex === pairs.length - 1;
+
+  const handleReveal = () => setIsRevealed(true);
+
+  const handleNext = () => {
+    if (!isLast) {
+      setCurrentIndex(currentIndex + 1);
+      setIsRevealed(false);
+    }
+  };
+
+  const handleRestart = () => {
+    setCurrentIndex(0);
+    setIsRevealed(false);
+  };
+
+  return (
+    <section className="space-y-6">
+      {/* Progress */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-slate-500">
+          {lang === "es" ? "Par" : "Pair"} {currentIndex + 1} / {pairs.length}
+        </span>
+        <button
+          onClick={handleRestart}
+          className="text-xs text-slate-400 hover:text-violet-600 inline-flex items-center gap-1 transition-colors"
+        >
+          <RotateCcw size={12} />
+          {lang === "es" ? "Reiniciar" : "Restart"}
+        </button>
+      </div>
+
+      <div className="w-full h-1.5 bg-slate-100 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-violet-500 rounded-full transition-all duration-300"
+          style={{ width: `${((currentIndex + 1) / pairs.length) * 100}%` }}
+        />
+      </div>
+
+      {/* The two words side by side */}
+      <div className="bg-white rounded-2xl border-2 border-slate-200 overflow-hidden">
+        {/* Distinction label */}
+        <div className="px-6 pt-6 pb-2">
+          <span className="text-xs font-semibold uppercase tracking-wider text-violet-600">
+            {lang === "es" ? current.distinctionEs : current.distinction}
+          </span>
+        </div>
+
+        {/* Word pair cards */}
+        <div className="grid grid-cols-2 gap-4 px-6 pb-4">
+          <div className="bg-blue-50 border-2 border-blue-200 rounded-xl p-4 text-center space-y-3">
+            <p className="text-2xl font-bold text-blue-900">{current.wordA}</p>
+            <AudioButton text={current.wordA} size="md" />
+            <p className="text-xs text-blue-600 leading-relaxed italic">
+              "{current.exampleA}"
+            </p>
+          </div>
+          <div className="bg-amber-50 border-2 border-amber-200 rounded-xl p-4 text-center space-y-3">
+            <p className="text-2xl font-bold text-amber-900">{current.wordB}</p>
+            <AudioButton text={current.wordB} size="md" />
+            <p className="text-xs text-amber-600 leading-relaxed italic">
+              "{current.exampleB}"
+            </p>
+          </div>
+        </div>
+
+        {/* Tip reveal */}
+        <div className="px-6 pb-6">
+          {!isRevealed ? (
+            <button
+              onClick={handleReveal}
+              className="w-full py-3 rounded-xl border-2 border-dashed border-violet-300 text-violet-600 font-medium hover:bg-violet-50 transition-colors text-sm"
+            >
+              <Volume2 size={14} className="inline mr-1" />
+              {lang === "es"
+                ? "Toca para ver el tip de pronunciación"
+                : "Tap to see the pronunciation tip"}
+            </button>
+          ) : (
+            <div className="bg-violet-50 border border-violet-200 rounded-xl p-4">
+              <p className="text-sm text-slate-700 leading-relaxed">
+                {lang === "es" ? current.tipEs : current.tip}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Next button */}
+      {isRevealed && !isLast && (
+        <div className="flex justify-end">
+          <button
+            onClick={handleNext}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-violet-500 text-white font-medium hover:bg-violet-400 transition-colors shadow-sm"
+          >
+            {lang === "es" ? "Siguiente par" : "Next pair"}
+          </button>
+        </div>
+      )}
+
+      {isRevealed && isLast && (
+        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 text-center">
+          <p className="text-emerald-800 font-medium text-sm">
+            {lang === "es"
+              ? "¡Bien hecho! Has practicado todos los pares mínimos."
+              : "Well done! You've practiced all the minimal pairs."}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/data/advanced/unit-5.ts
+++ b/src/data/advanced/unit-5.ts
@@ -1,0 +1,220 @@
+// Unit 5: "Articles: A, An, The, or Nothing" — Full course content
+//
+// Section 1: When to use "a/an" vs "the" — WordPairLab
+// Section 2: When to use no article (zero article) — ErrorSpotter
+// Section 3: The traps — institutions, places, abstract nouns — SentenceTransformer
+
+import type { WordPair, ErrorSpotterItem, SentenceTransform } from "./types";
+
+// ─── Section 1: A/An vs The (WordPairLab) ────────────────────────────────────
+
+export const articlePairs: WordPair[] = [
+  {
+    weak: "I saw the movie last night. It was amazing.",
+    weakEs: "Vi la película anoche. Fue increíble.",
+    strong: "I saw a movie last night. It was amazing.",
+    strongEs: "Vi una película anoche. Fue increíble.",
+    weakHighlight: "the",
+    strongHighlight: "a",
+    why: "First mention of a non-specific movie → 'a movie.' The listener doesn't know which movie yet. If you'd already mentioned it ('Have you seen Oppenheimer?' → 'Yes, I saw THE movie'), then 'the' is correct. First mention = 'a/an.' Already known = 'the.'",
+    whyEs: "Primera mención de una película no específica → 'a movie.' El oyente no sabe cuál película todavía. Si ya la hubieras mencionado, entonces 'the' sería correcto. Primera mención = 'a/an.' Ya conocido = 'the.'",
+    category: "First mention rule",
+    categoryEs: "Regla de primera mención",
+  },
+  {
+    weak: "She is a doctor. A doctor works at General Hospital.",
+    weakEs: "Ella es doctora. La doctora trabaja en el Hospital General.",
+    strong: "She is a doctor. The doctor works at General Hospital.",
+    strongEs: "Ella es doctora. La doctora trabaja en el Hospital General.",
+    weakHighlight: "A doctor works",
+    strongHighlight: "The doctor works",
+    why: "Second mention of the same doctor → 'the.' Once you've introduced a noun with 'a/an,' every subsequent reference uses 'the.' This is the most fundamental article rule in English and the one Spanish speakers get wrong most often.",
+    whyEs: "Segunda mención de la misma doctora → 'the.' Una vez que introduces un sustantivo con 'a/an,' cada referencia subsiguiente usa 'the.' Esta es la regla de artículos más fundamental en inglés.",
+    category: "Second mention rule",
+    categoryEs: "Regla de segunda mención",
+  },
+  {
+    weak: "Can you pass a salt, please?",
+    weakEs: "¿Me pasas una sal, por favor?",
+    strong: "Can you pass the salt, please?",
+    strongEs: "¿Me pasas la sal, por favor?",
+    weakHighlight: "a salt",
+    strongHighlight: "the salt",
+    why: "There's only one salt shaker on the table — both speakers know which one. When the item is UNIQUE in the context (the sun, the moon, the president, the salt on our table), use 'the.' Spanish does this the same way ('la sal'), so this one should feel natural.",
+    whyEs: "Solo hay un salero en la mesa — ambos hablantes saben cuál. Cuando el artículo es ÚNICO en el contexto (the sun, the moon, the president), usa 'the.' El español hace lo mismo ('la sal').",
+    category: "Unique in context",
+    categoryEs: "Único en contexto",
+  },
+  {
+    weak: "I need the new laptop for work.",
+    weakEs: "Necesito una laptop nueva para el trabajo.",
+    strong: "I need a new laptop for work.",
+    strongEs: "Necesito una laptop nueva para el trabajo.",
+    weakHighlight: "the",
+    strongHighlight: "a",
+    why: "No specific laptop has been discussed — you're talking about ANY new laptop. When you mean 'one of many' or 'any,' use 'a/an.' 'The' would mean a specific laptop both speakers already know about: 'the new laptop we discussed yesterday.'",
+    whyEs: "No se ha discutido ninguna laptop específica — estás hablando de CUALQUIER laptop nueva. Cuando quieres decir 'una de muchas' o 'cualquiera,' usa 'a/an.'",
+    category: "Specific vs general",
+    categoryEs: "Específico vs general",
+  },
+  {
+    weak: "He is best manager I've ever had.",
+    weakEs: "Él es el mejor gerente que he tenido.",
+    strong: "He is the best manager I've ever had.",
+    strongEs: "Él es el mejor gerente que he tenido.",
+    weakHighlight: "is best",
+    strongHighlight: "is the best",
+    why: "Superlatives ALWAYS take 'the': the best, the worst, the most important, the first, the last. There's only one 'best' — it's unique by definition. Dropping 'the' before a superlative is one of the most noticeable Spanish-speaker errors.",
+    whyEs: "Los superlativos SIEMPRE llevan 'the': the best, the worst, the most important, the first, the last. Solo hay un 'best' — es único por definición. Omitir 'the' antes de un superlativo es uno de los errores más notorios de los hispanohablantes.",
+    category: "Superlatives",
+    categoryEs: "Superlativos",
+  },
+  {
+    weak: "I have the headache.",
+    weakEs: "Tengo un dolor de cabeza.",
+    strong: "I have a headache.",
+    strongEs: "Tengo un dolor de cabeza.",
+    weakHighlight: "the headache",
+    strongHighlight: "a headache",
+    why: "With symptoms and conditions, English uses 'a': 'a headache,' 'a cold,' 'a fever,' 'a sore throat.' Spanish uses 'dolor de cabeza' (no article) or 'un dolor de cabeza.' The 'the' version would mean a specific headache you've been discussing: 'the headache I had yesterday is back.'",
+    whyEs: "Con síntomas y condiciones, el inglés usa 'a': 'a headache,' 'a cold,' 'a fever,' 'a sore throat.' La versión con 'the' significaría un dolor de cabeza específico que estuviste discutiendo.",
+    category: "Health expressions",
+    categoryEs: "Expresiones de salud",
+  },
+];
+
+// ─── Section 2: Zero Article — When to Use Nothing (ErrorSpotter) ────────────
+
+export const zeroArticleErrors: ErrorSpotterItem[] = [
+  {
+    sentence: "The life is beautiful when you have the love.",
+    errorWord: "The",
+    improved: "Life is beautiful when you have love.",
+    sentenceEs: "La vida es hermosa cuando tienes el amor.",
+    improvedEs: "La vida es hermosa cuando tienes amor.",
+    explanation:
+      "Abstract nouns used in a GENERAL sense take NO article: life, love, death, time, freedom, justice. Spanish uses 'la vida,' 'el amor' — English drops the article entirely. 'THE life' would mean a specific life: 'the life of a soldier.'",
+    explanationEs:
+      "Los sustantivos abstractos usados en sentido GENERAL no llevan artículo: life, love, death, time, freedom, justice. El español usa 'la vida,' 'el amor' — el inglés quita el artículo por completo.",
+  },
+  {
+    sentence: "I like the music, especially the jazz.",
+    errorWord: "the",
+    improved: "I like music, especially jazz.",
+    sentenceEs: "Me gusta la música, especialmente el jazz.",
+    improvedEs: "Me gusta la música, especialmente el jazz.",
+    explanation:
+      "When talking about music/genres IN GENERAL, no article. 'I like music' (all music). 'I like the music' means specific music: 'I like the music at this restaurant.' Same for food: 'I like coffee' (general) vs. 'I like the coffee here' (specific).",
+    explanationEs:
+      "Cuando hablas de música/géneros EN GENERAL, no hay artículo. 'I like music' (toda la música). 'I like the music' significa música específica: 'I like the music at this restaurant.'",
+  },
+  {
+    sentence: "She goes to the work by the bus every morning.",
+    errorWord: "the",
+    improved: "She goes to work by bus every morning.",
+    sentenceEs: "Ella va al trabajo en el autobús cada mañana.",
+    improvedEs: "Ella va al trabajo en autobús cada mañana.",
+    explanation:
+      "Fixed expressions with 'go to' drop the article: go to work, go to school, go to bed, go to church, go to prison. Transport with 'by' also drops it: by bus, by car, by train, by plane. Spanish keeps the article in both cases, which causes this error.",
+    explanationEs:
+      "Expresiones fijas con 'go to' eliminan el artículo: go to work, go to school, go to bed, go to church, go to prison. El transporte con 'by' también: by bus, by car, by train, by plane.",
+  },
+  {
+    sentence: "The breakfast is the most important meal of the day.",
+    errorWord: "The",
+    improved: "Breakfast is the most important meal of the day.",
+    sentenceEs: "El desayuno es la comida más importante del día.",
+    improvedEs: "El desayuno es la comida más importante del día.",
+    explanation:
+      "Meals IN GENERAL take no article: breakfast, lunch, dinner. 'I had breakfast at 7.' 'Breakfast is important.' But specific meals DO: 'The breakfast at that hotel was terrible.' Notice: 'the most important meal' keeps 'the' because it's a superlative — only the general noun drops it.",
+    explanationEs:
+      "Las comidas EN GENERAL no llevan artículo: breakfast, lunch, dinner. 'I had breakfast at 7.' Pero comidas específicas SÍ: 'The breakfast at that hotel was terrible.'",
+  },
+  {
+    sentence: "He is studying the engineering at the MIT.",
+    errorWord: "the",
+    improved: "He is studying engineering at MIT.",
+    sentenceEs: "Él está estudiando la ingeniería en el MIT.",
+    improvedEs: "Él está estudiando ingeniería en el MIT.",
+    explanation:
+      "Two rules at once. Academic subjects take no article: engineering, medicine, mathematics, history. Most university names also take no article: MIT, Harvard, Stanford, Oxford. Exceptions: 'the University of Texas' (with 'of'), 'the Sorbonne' (tradition).",
+    explanationEs:
+      "Dos reglas a la vez. Las materias académicas no llevan artículo: engineering, medicine, mathematics. La mayoría de universidades tampoco: MIT, Harvard, Stanford. Excepciones: 'the University of Texas' (con 'of').",
+  },
+  {
+    sentence: "The honesty is a quality that I value in the people.",
+    errorWord: "The",
+    improved: "Honesty is a quality that I value in people.",
+    sentenceEs: "La honestidad es una cualidad que valoro en la gente.",
+    improvedEs: "La honestidad es una cualidad que valoro en la gente.",
+    explanation:
+      "Two zero-article nouns: 'honesty' (abstract quality, general) and 'people' (general group). Spanish uses 'la honestidad' and 'la gente' — English uses neither. 'A quality' is correct because it's one of many qualities (countable, first mention).",
+    explanationEs:
+      "Dos sustantivos sin artículo: 'honesty' (cualidad abstracta, general) y 'people' (grupo general). El español usa 'la honestidad' y 'la gente' — el inglés no usa ninguno.",
+  },
+];
+
+// ─── Section 3: Article Traps (SentenceTransformer) ──────────────────────────
+
+export const articleTrapTransforms: SentenceTransform[] = [
+  {
+    flat: "He was taken to the hospital. He went to the school after.",
+    flatEs: "Lo llevaron al hospital. Fue a la escuela después.",
+    strong: "He was taken to hospital. He went to school after.",
+    strongEs: "Lo llevaron al hospital. Fue a la escuela después.",
+    technique: "institutions as purpose",
+    techniqueEs: "instituciones como propósito",
+    why: "When someone goes to an institution FOR ITS PURPOSE, no article: go to hospital (as a patient), go to school (as a student), go to prison (as a prisoner), go to church (to pray). WITH an article means visiting: 'I went to the hospital to visit my friend' (not as a patient). This distinction doesn't exist in Spanish.",
+    whyEs: "Cuando alguien va a una institución POR SU PROPÓSITO, sin artículo: go to hospital (como paciente), go to school (como estudiante). CON artículo significa visitar: 'I went to the hospital to visit my friend' (no como paciente).",
+  },
+  {
+    flat: "I play the guitar and she plays the tennis.",
+    flatEs: "Yo toco la guitarra y ella juega al tenis.",
+    strong: "I play the guitar and she plays tennis.",
+    strongEs: "Yo toco la guitarra y ella juega al tenis.",
+    technique: "instruments vs sports",
+    techniqueEs: "instrumentos vs deportes",
+    why: "Musical instruments take 'the': play the guitar, play the piano, play the violin. Sports take NO article: play tennis, play soccer, play chess. Spanish uses 'la guitarra' and 'el tenis' — English splits them. This is pure memorization.",
+    whyEs: "Los instrumentos musicales llevan 'the': play the guitar, play the piano. Los deportes NO llevan artículo: play tennis, play soccer. El español usa ambos — el inglés los divide.",
+  },
+  {
+    flat: "The Mount Everest is in the Asia, near the Nepal.",
+    flatEs: "El Monte Everest está en Asia, cerca de Nepal.",
+    strong: "Mount Everest is in Asia, near Nepal.",
+    strongEs: "El Monte Everest está en Asia, cerca de Nepal.",
+    technique: "geography rules",
+    techniqueEs: "reglas de geografía",
+    why: "No article for: continents (Asia, Europe), countries (Nepal, France), individual mountains (Mount Everest), cities (Paris), lakes (Lake Michigan). USE 'the' for: mountain ranges (the Alps), rivers (the Nile), oceans (the Pacific), deserts (the Sahara), countries with 'kingdom/states/republic' (the UK, the US).",
+    whyEs: "Sin artículo para: continentes (Asia), países (Nepal), montañas individuales (Mount Everest), ciudades (Paris), lagos (Lake Michigan). USA 'the' para: cordilleras (the Alps), ríos (the Nile), océanos (the Pacific), países con 'kingdom/states' (the UK).",
+  },
+  {
+    flat: "She arrived at the Monday and left at the Friday.",
+    flatEs: "Ella llegó el lunes y se fue el viernes.",
+    strong: "She arrived on Monday and left on Friday.",
+    strongEs: "Ella llegó el lunes y se fue el viernes.",
+    technique: "days, months, seasons",
+    techniqueEs: "días, meses, estaciones",
+    why: "Days of the week and months take NO article: on Monday, in January, in summer. Spanish uses 'el lunes,' 'en enero' — English drops the article. Also note: English uses 'on' for days and 'in' for months/seasons, not 'at.'",
+    whyEs: "Los días de la semana y meses NO llevan artículo: on Monday, in January, in summer. El español usa 'el lunes,' 'en enero' — el inglés quita el artículo. También nota: el inglés usa 'on' para días y 'in' para meses.",
+  },
+  {
+    flat: "I had the dinner at the home last the night.",
+    flatEs: "Cené en casa la noche pasada.",
+    strong: "I had dinner at home last night.",
+    strongEs: "Cené en casa anoche.",
+    technique: "fixed expressions",
+    techniqueEs: "expresiones fijas",
+    why: "Three zero-article patterns in one sentence: meals (dinner), 'at home' (fixed expression), and time expressions (last night, last week, next month). Spanish uses articles for all three ('la cena,' 'en la casa,' 'la noche pasada'). In English, they're all bare.",
+    whyEs: "Tres patrones sin artículo en una oración: comidas (dinner), 'at home' (expresión fija), y expresiones de tiempo (last night, last week, next month). El español usa artículos para los tres.",
+  },
+  {
+    flat: "The water is essential for the life on the Earth.",
+    flatEs: "El agua es esencial para la vida en la Tierra.",
+    strong: "Water is essential for life on Earth.",
+    strongEs: "El agua es esencial para la vida en la Tierra.",
+    technique: "general truths + planet name",
+    techniqueEs: "verdades generales + nombre de planeta",
+    why: "General truths about substances and concepts drop ALL articles: 'Water is essential' (water in general), 'for life' (life in general), 'on Earth' (Earth as a proper noun/planet). Spanish loads all three with articles. This sentence is the ultimate article test — every 'the' that feels natural in Spanish is wrong in English.",
+    whyEs: "Las verdades generales sobre sustancias y conceptos eliminan TODOS los artículos: 'Water is essential' (agua en general), 'for life' (vida en general), 'on Earth' (Tierra como nombre propio). El español carga los tres con artículos. Esta oración es la prueba definitiva de artículos.",
+  },
+];

--- a/src/data/advanced/unit-6.ts
+++ b/src/data/advanced/unit-6.ts
@@ -1,0 +1,188 @@
+// Unit 6: "Pronunciation: Hitting the Hard Sounds" — Full course content
+//
+// Section 1: The S sound — plurals, possessives, third-person verbs — MinimalPairDrill
+// Section 2: -en endings — strengthen, tighten, written, spoken — ErrorSpotter
+// Section 3: TH, R, and the vowels that give you away — MinimalPairDrill
+
+import type { MinimalPair, ErrorSpotterItem } from "./types";
+
+// ─── Section 1: The S Sound (MinimalPairDrill) ───────────────────────────────
+
+export const sSoundPairs: MinimalPair[] = [
+  {
+    wordA: "cats",
+    wordB: "dogs",
+    distinction: "S = /s/ after voiceless sounds vs S = /z/ after voiced sounds",
+    distinctionEs: "S = /s/ después de sonidos sordos vs S = /z/ después de sonidos sonoros",
+    exampleA: "I have two cats.",
+    exampleAEs: "Tengo dos gatos.",
+    exampleB: "I have three dogs.",
+    exampleBEs: "Tengo tres perros.",
+    tip: "The S at the end of plural nouns is NOT always /s/. After voiceless consonants (t, k, p, f), it's /s/: cats, books, cups. After voiced consonants (g, d, b, v, n, m, l) and vowels, it's /z/: dogs, beds, lives, shoes. Most Spanish speakers say /s/ for everything — that's the tell.",
+    tipEs: "La S al final de sustantivos plurales NO siempre es /s/. Después de consonantes sordas (t, k, p, f), es /s/: cats, books, cups. Después de consonantes sonoras (g, d, b, v, n, m, l) y vocales, es /z/: dogs, beds, lives, shoes.",
+  },
+  {
+    wordA: "watches",
+    wordB: "plays",
+    distinction: "S = /ɪz/ (extra syllable) after sibilants vs S = /z/ after vowels",
+    distinctionEs: "S = /ɪz/ (sílaba extra) después de sibilantes vs S = /z/ después de vocales",
+    exampleA: "She watches TV every night.",
+    exampleAEs: "Ella ve televisión cada noche.",
+    exampleB: "He plays guitar on weekends.",
+    exampleBEs: "Él toca guitarra los fines de semana.",
+    tip: "After S, Z, SH, CH, X, and GE/DGE sounds, the S ending becomes a full extra syllable /ɪz/: watch-ES, bus-ES, charg-ES. This is the one most Spanish speakers DO pronounce correctly — because Spanish adds a similar vowel sound. The hard ones are the silent /s/ and /z/ above.",
+    tipEs: "Después de sonidos S, Z, SH, CH, X y GE/DGE, la terminación S se vuelve una sílaba extra /ɪz/: watch-ES, bus-ES, charg-ES. Esta es la que la mayoría de hispanohablantes SÍ pronuncian correctamente.",
+  },
+  {
+    wordA: "he works",
+    wordB: "he lives",
+    distinction: "Third-person S follows the same /s/ vs /z/ rule as plurals",
+    distinctionEs: "La S de tercera persona sigue la misma regla de /s/ vs /z/ que los plurales",
+    exampleA: "He works at a bank.",
+    exampleAEs: "Él trabaja en un banco.",
+    exampleB: "He lives in Mexico City.",
+    exampleBEs: "Él vive en la Ciudad de México.",
+    tip: "The same rule applies to third-person verb endings: 'works' = /wɜːrks/ (voiceless K → /s/). 'Lives' = /lɪvz/ (voiced V → /z/). 'Watches' = /wɒtʃɪz/ (sibilant CH → /ɪz/). If you master the S-sound rule, your plurals AND your verbs sound native.",
+    tipEs: "La misma regla aplica a las terminaciones de tercera persona: 'works' = /wɜːrks/ (K sorda → /s/). 'Lives' = /lɪvz/ (V sonora → /z/). Si dominas la regla del sonido S, tus plurales Y tus verbos suenan nativos.",
+  },
+  {
+    wordA: "Tom's book",
+    wordB: "Maria's car",
+    distinction: "Possessive S follows the same voicing rules",
+    distinctionEs: "La S posesiva sigue las mismas reglas de sonoridad",
+    exampleA: "That's Tom's book on the table.",
+    exampleAEs: "Ese es el libro de Tom en la mesa.",
+    exampleB: "Maria's car is in the parking lot.",
+    exampleBEs: "El carro de Maria está en el estacionamiento.",
+    tip: "Possessive 'S follows the SAME rule: after voiceless sounds → /s/ (Tom's, Kate's, Jack's). After voiced sounds → /z/ (Maria's, John's, Bob's). After sibilants → /ɪz/ (Ross's, Liz's, George's). One rule covers plurals, verbs, AND possessives.",
+    tipEs: "La S posesiva sigue la MISMA regla: después de sordas → /s/ (Tom's, Kate's). Después de sonoras → /z/ (Maria's, John's). Después de sibilantes → /ɪz/ (Ross's, Liz's). Una regla cubre plurales, verbos Y posesivos.",
+  },
+];
+
+// ─── Section 2: -EN Endings (ErrorSpotter) ───────────────────────────────────
+// The trap: Spanish speakers add a vowel sound to -en endings, making
+// "written" sound like "WRIT-en" instead of "WRIT-n." The -en is barely
+// a syllable in natural English — almost swallowed.
+
+export const enEndingErrors: ErrorSpotterItem[] = [
+  {
+    sentence: "The document was writ-TEN by the manager yesterday.",
+    errorWord: "writ-TEN",
+    improved: "The document was written by the manager yesterday.",
+    sentenceEs: "El documento fue escrito por el gerente ayer.",
+    improvedEs: "El documento fue escrito por el gerente ayer.",
+    explanation:
+      "'Written' has two syllables, but the second is almost silent: WRIT-n, not writ-TEN. The -en ending reduces to a schwa-like /n/ sound. Spanish speakers over-pronounce it because Spanish doesn't reduce unstressed syllables the way English does.",
+    explanationEs:
+      "'Written' tiene dos sílabas, pero la segunda es casi silenciosa: WRIT-n, no writ-TEN. La terminación -en se reduce a un sonido /n/ tipo schwa. Los hispanohablantes la sobre-pronuncian porque el español no reduce sílabas átonas como lo hace el inglés.",
+  },
+  {
+    sentence: "We need to strength-EN the security protocols.",
+    errorWord: "strength-EN",
+    improved: "We need to strengthen the security protocols.",
+    sentenceEs: "Necesitamos fortalecer los protocolos de seguridad.",
+    improvedEs: "Necesitamos fortalecer los protocolos de seguridad.",
+    explanation:
+      "'Strengthen' = STRENG-thən. The -en ending is a quick, unstressed syllable — almost the same duration as a single consonant. Don't give it equal weight with the first syllable. The same pattern: tighten (TAIT-n), frighten (FRAIT-n), lighten (LAIT-n).",
+    explanationEs:
+      "'Strengthen' = STRENG-thən. La terminación -en es una sílaba rápida y sin acento — casi la misma duración que una sola consonante. El mismo patrón: tighten (TAIT-n), frighten (FRAIT-n), lighten (LAIT-n).",
+  },
+  {
+    sentence: "Has the project been for-GOT-ten or is it still active?",
+    errorWord: "for-GOT-ten",
+    improved: "Has the project been forgotten or is it still active?",
+    sentenceEs: "¿El proyecto ha sido olvidado o todavía está activo?",
+    improvedEs: "¿El proyecto ha sido olvidado o todavía está activo?",
+    explanation:
+      "'Forgotten' = fər-GOT-n. Three syllables, but the last one is barely there. The stress is on GOT, and the -en melts into a nasal /n/ that almost attaches to the 't' before it: fər-GOT-n. Same for 'spoken' (SPO-kn), 'broken' (BRO-kn), 'chosen' (CHO-zn).",
+    explanationEs:
+      "'Forgotten' = fər-GOT-n. Tres sílabas, pero la última apenas existe. El acento está en GOT, y el -en se derrite en un /n/ nasal: fər-GOT-n. Lo mismo para 'spoken' (SPO-kn), 'broken' (BRO-kn), 'chosen' (CHO-zn).",
+  },
+  {
+    sentence: "The child-REN are play-ING in the garden.",
+    errorWord: "child-REN",
+    improved: "The children are playing in the garden.",
+    sentenceEs: "Los niños están jugando en el jardín.",
+    improvedEs: "Los niños están jugando en el jardín.",
+    explanation:
+      "'Children' = CHIL-drən. The stress is on CHIL, and -dren is a quick, light syllable. Spanish speakers often say child-REN with equal stress on both syllables. In English, unstressed syllables get compressed — they're quieter, shorter, and use the schwa vowel /ə/.",
+    explanationEs:
+      "'Children' = CHIL-drən. El acento está en CHIL, y -dren es una sílaba rápida y ligera. Los hispanohablantes frecuentemente dicen child-REN con acento igual en ambas sílabas. En inglés, las sílabas átonas se comprimen.",
+  },
+  {
+    sentence: "The kitch-EN needs to be clean-ED before the guests arrive.",
+    errorWord: "kitch-EN",
+    improved: "The kitchen needs to be cleaned before the guests arrive.",
+    sentenceEs: "La cocina necesita ser limpiada antes de que lleguen los invitados.",
+    improvedEs: "La cocina necesita ser limpiada antes de que lleguen los invitados.",
+    explanation:
+      "'Kitchen' = KITCH-ən. The -en is a schwa, not a full vowel. Compare with 'cleaned' — the -ed ending is similarly reduced to /d/ after a voiced sound. Both -en and -ed endings get swallowed in natural speech. Giving them full pronunciation is the #1 rhythm tell.",
+    explanationEs:
+      "'Kitchen' = KITCH-ən. El -en es una schwa, no una vocal completa. Compara con 'cleaned' — la terminación -ed se reduce de manera similar a /d/ después de un sonido sonoro. Dar pronunciación completa a estos es la señal de ritmo #1.",
+  },
+];
+
+// ─── Section 3: TH, R, and Vowels (MinimalPairDrill) ─────────────────────────
+
+export const hardSoundPairs: MinimalPair[] = [
+  {
+    wordA: "think",
+    wordB: "sink",
+    distinction: "TH /θ/ (tongue between teeth) vs S /s/ (tongue behind teeth)",
+    distinctionEs: "TH /θ/ (lengua entre los dientes) vs S /s/ (lengua detrás de los dientes)",
+    exampleA: "I think we should leave early.",
+    exampleAEs: "Creo que deberíamos salir temprano.",
+    exampleB: "The ship will sink in the storm.",
+    exampleBEs: "El barco se hundirá en la tormenta.",
+    tip: "For TH /θ/, your tongue tip must poke out slightly between your upper and lower teeth. If your tongue stays behind your teeth, you're making an S sound. 'Think' with an S becomes 'sink' — completely different word. Practice in front of a mirror until you can see your tongue.",
+    tipEs: "Para TH /θ/, la punta de tu lengua debe asomarse ligeramente entre tus dientes superiores e inferiores. Si tu lengua se queda detrás de los dientes, estás haciendo un sonido S. Practica frente a un espejo hasta que puedas ver tu lengua.",
+  },
+  {
+    wordA: "this",
+    wordB: "dis",
+    distinction: "TH /ð/ (voiced, tongue between teeth) vs D /d/ (tongue on roof)",
+    distinctionEs: "TH /ð/ (sonora, lengua entre dientes) vs D /d/ (lengua en el paladar)",
+    exampleA: "Is this the right address?",
+    exampleAEs: "¿Es esta la dirección correcta?",
+    exampleB: "He dis'd the entire proposal.",
+    exampleBEs: "Él despreció toda la propuesta.",
+    tip: "There are TWO TH sounds: voiceless /θ/ (think, thing, bath) and voiced /ð/ (this, that, the, brother). The voiced one vibrates. Spanish speakers typically replace voiced TH with D — 'dis' instead of 'this.' Same tongue position as /θ/, but with vocal cord vibration.",
+    tipEs: "Hay DOS sonidos TH: sordo /θ/ (think, thing, bath) y sonoro /ð/ (this, that, the, brother). El sonoro vibra. Los hispanohablantes típicamente reemplazan el TH sonoro con D — 'dis' en lugar de 'this.'",
+  },
+  {
+    wordA: "right",
+    wordB: "light",
+    distinction: "R /ɹ/ (tongue curled back) vs L /l/ (tongue touches roof)",
+    distinctionEs: "R /ɹ/ (lengua curvada hacia atrás) vs L /l/ (lengua toca el paladar)",
+    exampleA: "Turn right at the corner.",
+    exampleAEs: "Da vuelta a la derecha en la esquina.",
+    exampleB: "Turn on the light, please.",
+    exampleBEs: "Enciende la luz, por favor.",
+    tip: "English R is NOT the same as Spanish R. For English R, your tongue curls BACKWARD — it never touches the roof of your mouth. For L, your tongue tip touches the ridge behind your upper teeth. Spanish R (trilled or tapped) is a completely different motion. This is the hardest sound for Spanish speakers to master.",
+    tipEs: "La R del inglés NO es la misma que la R del español. Para la R del inglés, tu lengua se curva HACIA ATRÁS — nunca toca el paladar. Para la L, la punta de tu lengua toca la cresta detrás de tus dientes superiores. La R española (vibrante) es un movimiento completamente diferente.",
+  },
+  {
+    wordA: "ship",
+    wordB: "sheep",
+    distinction: "Short I /ɪ/ vs Long EE /iː/",
+    distinctionEs: "I corta /ɪ/ vs EE larga /iː/",
+    exampleA: "The ship arrived at the port.",
+    exampleAEs: "El barco llegó al puerto.",
+    exampleB: "The farmer has fifty sheep.",
+    exampleBEs: "El granjero tiene cincuenta ovejas.",
+    tip: "Short /ɪ/ (ship, bit, sit) is quick and relaxed — your mouth barely opens. Long /iː/ (sheep, beat, seat) is tense and stretched — you smile slightly. Spanish only has one 'i' sound (close to /iː/), so Spanish speakers make both words sound like 'sheep.' The duration AND the mouth tension are both different.",
+    tipEs: "La /ɪ/ corta (ship, bit, sit) es rápida y relajada — tu boca apenas se abre. La /iː/ larga (sheep, beat, seat) es tensa y estirada — sonríes ligeramente. El español solo tiene un sonido 'i' (cercano a /iː/), así que los hispanohablantes hacen que ambas palabras suenen como 'sheep.'",
+  },
+  {
+    wordA: "full",
+    wordB: "fool",
+    distinction: "Short U /ʊ/ vs Long OO /uː/",
+    distinctionEs: "U corta /ʊ/ vs OO larga /uː/",
+    exampleA: "The glass is full.",
+    exampleAEs: "El vaso está lleno.",
+    exampleB: "Don't be a fool.",
+    exampleBEs: "No seas un tonto.",
+    tip: "Short /ʊ/ (full, pull, put, book) is quick and relaxed — your lips round slightly. Long /uː/ (fool, pool, boot, food) is tense with rounded, pushed-forward lips. Spanish 'u' is close to /uː/, so Spanish speakers make 'full' sound like 'fool.' Keep 'full' short and relaxed.",
+    tipEs: "La /ʊ/ corta (full, pull, put, book) es rápida y relajada — tus labios se redondean ligeramente. La /uː/ larga (fool, pool, boot, food) es tensa con labios redondeados y empujados. La 'u' del español está cerca de /uː/, así que los hispanohablantes hacen que 'full' suene como 'fool.'",
+  },
+];

--- a/src/pages/en/course/advanced/index.astro
+++ b/src/pages/en/course/advanced/index.astro
@@ -131,7 +131,7 @@ const iconMap: Record<string, any> = {
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
         {advancedUnits.map((unit) => {
           const Icon = iconMap[unit.icon];
-          const isAvailable = unit.id < 5;
+          const isAvailable = unit.id < 7;
           return (
             <a
               href={isAvailable ? `/en/course/advanced/${unit.slug}/` : undefined}

--- a/src/pages/en/course/advanced/unit-5.astro
+++ b/src/pages/en/course/advanced/unit-5.astro
@@ -1,0 +1,86 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WordPairLab from "@components/course/WordPairLab";
+import ErrorSpotter from "@components/course/ErrorSpotter";
+import SentenceTransformer from "@components/course/SentenceTransformer";
+import { advancedUnits } from "@data/advanced/units";
+import { articlePairs, zeroArticleErrors, articleTrapTransforms } from "@data/advanced/unit-5";
+import { ArrowRight, Type, BookOpen, Search, Zap } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/advanced/unit-5" as const;
+const progressUnits = advancedUnits.map((u) => ({ id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base lang={lang} tkey={tkey}
+  title="Unit 5: Articles — A, An, The, or Nothing | Speak with Confidence | NY English Teacher"
+  description="The lifelong Spanish-speaker error, finally fixed. When to use a/an, the, or no article at all. Free advanced English lesson for B2-C1 Spanish speakers."
+>
+  <CourseProgress client:load units={progressUnits} currentUnit={5} basePath="/en/course/advanced" lang="en" courseId="advanced" />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-violet-400 text-sm font-semibold mb-3"><Type class="w-4 h-4" /> Unit 5</div>
+        <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Articles: A, An, The, or Nothing
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Articles are the single most persistent error for Spanish speakers. They appear
+          in nearly every sentence. Even C2 speakers get them wrong. Spanish uses articles
+          where English doesn't, and English uses them where Spanish doesn't. This unit
+          drills the patterns until article choice becomes instinct.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><BookOpen class="w-3.5 h-3.5" /> A/An vs The</span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Search class="w-3.5 h-3.5" /> Zero Article</span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Zap class="w-3.5 h-3.5" /> Article Traps</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">1</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">When to Use A/An vs The</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">First mention, second mention, unique in context, superlatives — the core rules.</p>
+      <WordPairLab client:visible pairs={articlePairs} lang="en" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">2</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">When to Use No Article</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">Tap the article that shouldn't be there. Spanish uses articles for abstract nouns, meals, and transport — English doesn't.</p>
+      <ErrorSpotter client:visible items={zeroArticleErrors} lang="en" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">3</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Traps: Institutions, Geography, Fixed Expressions</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">The hardest article rules — instruments vs sports, "go to school" vs "go to the school," and the ultimate test sentence.</p>
+      <SentenceTransformer client:visible transforms={articleTrapTransforms} lang="en" />
+    </div></div>
+  </section>
+
+  <section class="py-12 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto flex justify-between items-center">
+      <a href="/en/course/advanced/unit-4/" class="text-sm text-slate-500 hover:text-violet-600 transition-colors">&larr; Unit 4</a>
+      <Button href="/en/course/advanced/unit-6/" variant="primary" size="md">Unit 6: Pronunciation <ArrowRight class="w-4 h-4 ml-1" /></Button>
+    </div></div>
+  </section>
+</Base>

--- a/src/pages/en/course/advanced/unit-6.astro
+++ b/src/pages/en/course/advanced/unit-6.astro
@@ -1,0 +1,94 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import MinimalPairDrill from "@components/course/MinimalPairDrill";
+import ErrorSpotter from "@components/course/ErrorSpotter";
+import { advancedUnits } from "@data/advanced/units";
+import { sSoundPairs, enEndingErrors, hardSoundPairs } from "@data/advanced/unit-6";
+import { ArrowRight, Mic, Volume2, Search } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/advanced/unit-6" as const;
+const progressUnits = advancedUnits.map((u) => ({ id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base lang={lang} tkey={tkey}
+  title="Unit 6: Pronunciation — Hitting the Hard Sounds | Speak with Confidence | NY English Teacher"
+  description="The S endings, -en endings, TH, R, and vowels that give away even fluent Spanish speakers. Targeted minimal pair drills. Free advanced English lesson for B2-C1 Spanish speakers."
+>
+  <CourseProgress client:load units={progressUnits} currentUnit={6} basePath="/en/course/advanced" lang="en" courseId="advanced" />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-violet-400 text-sm font-semibold mb-3"><Mic class="w-4 h-4" /> Unit 6</div>
+        <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Pronunciation: Hitting the Hard Sounds
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Even fluent speakers carry pronunciation tells that signal non-native English.
+          This unit targets the specific sounds that mark Spanish-speaker English: the S
+          endings most people get wrong, the -en endings that get over-pronounced, and the
+          TH/R/vowel sounds that Spanish simply doesn't have.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Volume2 class="w-3.5 h-3.5" /> S Endings</span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Search class="w-3.5 h-3.5" /> -EN Endings</span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Mic class="w-3.5 h-3.5" /> TH, R, Vowels</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">1</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The S Sound</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">
+        One letter, three pronunciations: /s/, /z/, or /ɪz/. Listen to both words in each
+        pair and learn the rule that governs all plurals, verbs, and possessives.
+      </p>
+      <MinimalPairDrill client:visible pairs={sSoundPairs} lang="en" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">2</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">-EN Endings</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">
+        Written, forgotten, strengthen, kitchen — the -en ending is barely a syllable.
+        Tap the over-pronounced version to see how it should really sound.
+      </p>
+      <ErrorSpotter client:visible items={enEndingErrors} lang="en" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">3</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">TH, R, and the Vowels That Give You Away</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">
+        Minimal pairs that target the exact sounds Spanish doesn't have. Listen, compare,
+        and practice until your mouth produces the right one.
+      </p>
+      <MinimalPairDrill client:visible pairs={hardSoundPairs} lang="en" />
+    </div></div>
+  </section>
+
+  <section class="py-12 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto flex justify-between items-center">
+      <a href="/en/course/advanced/unit-5/" class="text-sm text-slate-500 hover:text-violet-600 transition-colors">&larr; Unit 5</a>
+      <Button href="/en/course/advanced/" variant="primary" size="md">Course Overview <ArrowRight class="w-4 h-4 ml-1" /></Button>
+    </div></div>
+  </section>
+</Base>

--- a/src/pages/es/curso/avanzado/index.astro
+++ b/src/pages/es/curso/avanzado/index.astro
@@ -128,7 +128,7 @@ const iconMap: Record<string, any> = {
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
         {advancedUnits.map((unit) => {
           const Icon = iconMap[unit.icon];
-          const isAvailable = unit.id < 5;
+          const isAvailable = unit.id < 7;
           return (
             <a
               href={isAvailable ? `/es/curso/avanzado/${unit.slugEs}/` : undefined}

--- a/src/pages/es/curso/avanzado/unidad-5.astro
+++ b/src/pages/es/curso/avanzado/unidad-5.astro
@@ -1,0 +1,72 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WordPairLab from "@components/course/WordPairLab";
+import ErrorSpotter from "@components/course/ErrorSpotter";
+import SentenceTransformer from "@components/course/SentenceTransformer";
+import { advancedUnits } from "@data/advanced/units";
+import { articlePairs, zeroArticleErrors, articleTrapTransforms } from "@data/advanced/unit-5";
+import { ArrowRight, Type, BookOpen, Search, Zap } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/advanced/unit-5" as const;
+const progressUnits = advancedUnits.map((u) => ({ id: u.id, slug: u.slugEs, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base lang={lang} tkey={tkey}
+  title="Unidad 5: Artículos — A, An, The, o Nada | Habla con Confianza | NY English Teacher"
+  description="El error eterno de los hispanohablantes, finalmente corregido. Cuándo usar a/an, the, o ningún artículo. Lección avanzada B2-C1 gratis para hispanohablantes."
+>
+  <CourseProgress client:load units={progressUnits} currentUnit={5} basePath="/es/curso/avanzado" lang="es" courseId="advanced" />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-violet-400 text-sm font-semibold mb-3"><Type class="w-4 h-4" /> Unidad 5</div>
+        <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">Artículos: A, An, The, o Nada</h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Los artículos son el error más persistente para los hispanohablantes. Aparecen en casi cada oración. Incluso los hablantes C2 los confunden. El español usa artículos donde el inglés no, y el inglés los usa donde el español no. Esta unidad practica los patrones hasta que la elección de artículos se vuelva instintiva.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><BookOpen class="w-3.5 h-3.5" /> A/An vs The</span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Search class="w-3.5 h-3.5" /> Artículo Cero</span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Zap class="w-3.5 h-3.5" /> Trampas de Artículos</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2"><span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">1</span><h2 class="text-2xl md:text-3xl font-bold text-slate-900">Cuándo Usar A/An vs The</h2></div>
+      <p class="text-slate-500 mb-8 ml-11">Primera mención, segunda mención, único en contexto, superlativos — las reglas centrales.</p>
+      <WordPairLab client:visible pairs={articlePairs} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2"><span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">2</span><h2 class="text-2xl md:text-3xl font-bold text-slate-900">Cuándo No Usar Artículo</h2></div>
+      <p class="text-slate-500 mb-8 ml-11">Toca el artículo que sobra. El español usa artículos para sustantivos abstractos, comidas y transporte — el inglés no.</p>
+      <ErrorSpotter client:visible items={zeroArticleErrors} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2"><span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">3</span><h2 class="text-2xl md:text-3xl font-bold text-slate-900">Las Trampas: Instituciones, Geografía, Expresiones Fijas</h2></div>
+      <p class="text-slate-500 mb-8 ml-11">Las reglas de artículos más difíciles — instrumentos vs deportes, "go to school" vs "go to the school," y la oración prueba definitiva.</p>
+      <SentenceTransformer client:visible transforms={articleTrapTransforms} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-12 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto flex justify-between items-center">
+      <a href="/es/curso/avanzado/unidad-4/" class="text-sm text-slate-500 hover:text-violet-600 transition-colors">&larr; Unidad 4</a>
+      <Button href="/es/curso/avanzado/unidad-6/" variant="primary" size="md">Unidad 6: Pronunciación <ArrowRight class="w-4 h-4 ml-1" /></Button>
+    </div></div>
+  </section>
+</Base>

--- a/src/pages/es/curso/avanzado/unidad-6.astro
+++ b/src/pages/es/curso/avanzado/unidad-6.astro
@@ -1,0 +1,76 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import MinimalPairDrill from "@components/course/MinimalPairDrill";
+import ErrorSpotter from "@components/course/ErrorSpotter";
+import { advancedUnits } from "@data/advanced/units";
+import { sSoundPairs, enEndingErrors, hardSoundPairs } from "@data/advanced/unit-6";
+import { ArrowRight, Mic, Volume2, Search } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/advanced/unit-6" as const;
+const progressUnits = advancedUnits.map((u) => ({ id: u.id, slug: u.slugEs, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base lang={lang} tkey={tkey}
+  title="Unidad 6: Pronunciación — Los Sonidos Difíciles | Habla con Confianza | NY English Teacher"
+  description="Las terminaciones en S, terminaciones en -en, TH, R y las vocales que delatan incluso a hispanohablantes fluidos. Ejercicios de pares mínimos. Lección B2-C1 gratis para hispanohablantes."
+>
+  <CourseProgress client:load units={progressUnits} currentUnit={6} basePath="/es/curso/avanzado" lang="es" courseId="advanced" />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-violet-400 text-sm font-semibold mb-3"><Mic class="w-4 h-4" /> Unidad 6</div>
+        <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Pronunciación: Los Sonidos Difíciles
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Incluso los hablantes fluidos llevan detalles de pronunciación que delatan al inglés
+          no nativo. Esta unidad se enfoca en los sonidos específicos que marcan al hispanohablante:
+          las terminaciones en S que la mayoría confunde, las terminaciones en -en que se
+          sobre-pronuncian, y los sonidos TH/R/vocales que el español simplemente no tiene.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Volume2 class="w-3.5 h-3.5" /> Terminaciones en S</span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Search class="w-3.5 h-3.5" /> Terminaciones en -EN</span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Mic class="w-3.5 h-3.5" /> TH, R, Vocales</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2"><span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">1</span><h2 class="text-2xl md:text-3xl font-bold text-slate-900">El Sonido S</h2></div>
+      <p class="text-slate-500 mb-8 ml-11">Una letra, tres pronunciaciones: /s/, /z/, o /ɪz/. Escucha ambas palabras en cada par y aprende la regla que gobierna todos los plurales, verbos y posesivos.</p>
+      <MinimalPairDrill client:visible pairs={sSoundPairs} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2"><span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">2</span><h2 class="text-2xl md:text-3xl font-bold text-slate-900">Terminaciones en -EN</h2></div>
+      <p class="text-slate-500 mb-8 ml-11">Written, forgotten, strengthen, kitchen — la terminación -en apenas es una sílaba. Toca la versión sobre-pronunciada para ver cómo realmente debería sonar.</p>
+      <ErrorSpotter client:visible items={enEndingErrors} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2"><span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">3</span><h2 class="text-2xl md:text-3xl font-bold text-slate-900">TH, R, y las Vocales que Te Delatan</h2></div>
+      <p class="text-slate-500 mb-8 ml-11">Pares mínimos que atacan los sonidos exactos que el español no tiene. Escucha, compara y practica hasta que tu boca produzca el correcto.</p>
+      <MinimalPairDrill client:visible pairs={hardSoundPairs} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-12 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto flex justify-between items-center">
+      <a href="/es/curso/avanzado/unidad-5/" class="text-sm text-slate-500 hover:text-violet-600 transition-colors">&larr; Unidad 5</a>
+      <Button href="/es/curso/avanzado/" variant="primary" size="md">Resumen del Curso <ArrowRight class="w-4 h-4 ml-1" /></Button>
+    </div></div>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary

### Unit 5 — Articles: A, An, The, or Nothing
The lifelong Spanish-speaker error. Three sections drilling when to use a/an, the, or nothing at all.
- **Section 1** (WordPairLab): first/second mention, unique-in-context, superlatives
- **Section 2** (ErrorSpotter): zero-article errors — abstract nouns, meals, transport, subjects
- **Section 3** (SentenceTransformer): article traps — institutions, geography, instruments vs sports. Includes an \"ultimate test\" sentence where every Spanish article is wrong in English.

### Unit 6 — Pronunciation: Hitting the Hard Sounds
New **MinimalPairDrill** component (4th of 5 reusable advanced components). Side-by-side audio word cards with tip reveals.
- **Section 1** (MinimalPairDrill): S sound — /s/ vs /z/ vs /ɪz/ across plurals, verbs, possessives
- **Section 2** (ErrorSpotter): -en endings — over-pronunciation of written, strengthen, kitchen
- **Section 3** (MinimalPairDrill): TH, R, vowels — the sounds Spanish doesn't have

Build: 254 URLs. Advanced course now at 6/10 units.

## Test plan
- [x] \`npm run build\` passes (254 URLs)
- [ ] Visit \`/en/course/advanced/unit-5/\` and \`/unit-6/\`
- [ ] Verify MinimalPairDrill audio buttons work
- [ ] ES mirrors at \`/es/curso/avanzado/unidad-5/\` and \`/unidad-6/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)