### PR TITLE
feat: advanced Unit 7 — Contractions, Flipped

### DIFF
--- a/src/data/advanced/unit-7.ts
+++ b/src/data/advanced/unit-7.ts
@@ -1,0 +1,232 @@
+// Unit 7: "Contractions, Flipped" — Full course content
+//
+// Section 1: Advanced contractions in declaratives — WordPairLab
+//   (expanded form vs natural contracted form)
+// Section 2: Negative contractions and double negatives to avoid — ErrorSpotter
+// Section 3: When NOT to use contractions — register and emphasis — SentenceTransformer
+
+import type { WordPair, ErrorSpotterItem, SentenceTransform } from "./types";
+
+// ─── Section 1: Advanced Contractions (WordPairLab) ─────────────────────────
+// These go BEYOND basic contractions (I'm, he's, we'll) into the multi-level
+// contractions that native speakers use in everyday speech but that advanced
+// learners rarely attempt.
+
+export const advancedContractions: WordPair[] = [
+  {
+    weak: "I would have called you if I had known.",
+    weakEs: "Te habría llamado si hubiera sabido.",
+    strong: "I'd've called you if I'd known.",
+    strongEs: "Te habría llamado si hubiera sabido.",
+    weakHighlight: "would have",
+    strongHighlight: "I'd've",
+    why: "'I'd've' = I would have. This double contraction is how native speakers actually talk. It sounds like 'I-duv.' If you say 'I would have' in casual conversation, you sound like a textbook — correct, but stiff.",
+    whyEs: "'I'd've' = I would have. Esta doble contracción es como realmente hablan los nativos. Suena como 'I-duv.' Si dices 'I would have' en conversación casual, suenas como un libro de texto — correcto, pero rígido.",
+    category: "Double contraction",
+    categoryEs: "Contracción doble",
+  },
+  {
+    weak: "She should not have said that in the meeting.",
+    weakEs: "Ella no debería haber dicho eso en la reunión.",
+    strong: "She shouldn't've said that in the meeting.",
+    strongEs: "Ella no debería haber dicho eso en la reunión.",
+    weakHighlight: "should not have",
+    strongHighlight: "shouldn't've",
+    why: "'Shouldn't've' = should not have. Three words compressed into one beat: 'SHOOD-n-tuv.' This is natural in spoken English. You'll almost never see it written formally, but you'll hear it constantly.",
+    whyEs: "'Shouldn't've' = should not have. Tres palabras comprimidas en un golpe: 'SHOOD-n-tuv.' Esto es natural en el inglés hablado. Casi nunca lo verás escrito formalmente, pero lo escucharás constantemente.",
+    category: "Double contraction",
+    categoryEs: "Contracción doble",
+  },
+  {
+    weak: "They could not have finished it without your help.",
+    weakEs: "No podrían haberlo terminado sin tu ayuda.",
+    strong: "They couldn't've finished it without your help.",
+    strongEs: "No podrían haberlo terminado sin tu ayuda.",
+    weakHighlight: "could not have",
+    strongHighlight: "couldn't've",
+    why: "'Couldn't've' = could not have. Sounds like 'COOD-n-tuv.' The pattern is always the same: modal + n't + 've. Once you hear it, you can't unhear it — and once you start using it, you sound dramatically more natural.",
+    whyEs: "'Couldn't've' = could not have. Suena como 'COOD-n-tuv.' El patrón siempre es el mismo: modal + n't + 've. Una vez que lo escuchas, no puedes dejar de escucharlo — y una vez que empiezas a usarlo, suenas dramáticamente más natural.",
+    category: "Double contraction",
+    categoryEs: "Contracción doble",
+  },
+  {
+    weak: "It would have been better to ask first.",
+    weakEs: "Habría sido mejor preguntar primero.",
+    strong: "It'd've been better to ask first.",
+    strongEs: "Habría sido mejor preguntar primero.",
+    weakHighlight: "would have",
+    strongHighlight: "It'd've",
+    why: "'It'd've' = it would have. This one is almost never written, but in speech it flows naturally: 'it-duv.' Native speakers don't think about it — the compression happens automatically. That's your goal: stop expanding, start compressing.",
+    whyEs: "'It'd've' = it would have. Esta casi nunca se escribe, pero en el habla fluye naturalmente: 'it-duv.' Los nativos no lo piensan — la compresión pasa automáticamente. Esa es tu meta: deja de expandir, empieza a comprimir.",
+    category: "Double contraction",
+    categoryEs: "Contracción doble",
+  },
+  {
+    weak: "Who would have thought that would happen?",
+    weakEs: "¿Quién habría pensado que eso pasaría?",
+    strong: "Who'd've thought that'd happen?",
+    strongEs: "¿Quién habría pensado que eso pasaría?",
+    weakHighlight: "would have",
+    strongHighlight: "Who'd've",
+    why: "Two double contractions in one sentence: 'Who'd've' (who would have) and 'that'd' (that would). In fast speech this becomes 'hoo-duv THOT thad HAP-n.' This is peak native compression — and it's 100% grammatically correct.",
+    whyEs: "Dos contracciones dobles en una oración: 'Who'd've' (who would have) y 'that'd' (that would). En el habla rápida esto se vuelve 'hoo-duv THOT thad HAP-n.' Esta es la máxima compresión nativa — y es 100% gramaticalmente correcta.",
+    category: "Double contraction",
+    categoryEs: "Contracción doble",
+  },
+  {
+    weak: "You will have finished by then, right?",
+    weakEs: "Ya habrás terminado para entonces, ¿verdad?",
+    strong: "You'll've finished by then, right?",
+    strongEs: "Ya habrás terminado para entonces, ¿verdad?",
+    weakHighlight: "will have",
+    strongHighlight: "You'll've",
+    why: "'You'll've' = you will have. Sounds like 'yool-uv.' Future perfect in spoken English almost always contracts. Saying 'you will have' in conversation sounds overly deliberate — like you're reading aloud from a grammar book.",
+    whyEs: "'You'll've' = you will have. Suena como 'yool-uv.' El futuro perfecto en el inglés hablado casi siempre se contrae. Decir 'you will have' en conversación suena demasiado deliberado — como si leyeras en voz alta de un libro de gramática.",
+    category: "Double contraction",
+    categoryEs: "Contracción doble",
+  },
+  {
+    weak: "That is not going to work.",
+    weakEs: "Eso no va a funcionar.",
+    strong: "That's not gonna work.",
+    strongEs: "Eso no va a funcionar.",
+    weakHighlight: "is not going to",
+    strongHighlight: "not gonna",
+    why: "'Gonna' = going to. It's not slang — it's standard spoken English in all but the most formal contexts. News anchors, CEOs, and professors all say 'gonna.' If you avoid it, you sound like you're trying too hard.",
+    whyEs: "'Gonna' = going to. No es jerga — es inglés hablado estándar en todos los contextos excepto los más formales. Presentadores de noticias, CEOs y profesores dicen 'gonna.' Si lo evitas, suenas como si te esforzaras demasiado.",
+    category: "Informal contraction",
+    categoryEs: "Contracción informal",
+  },
+  {
+    weak: "I want to try the new restaurant downtown.",
+    weakEs: "Quiero probar el nuevo restaurante en el centro.",
+    strong: "I wanna try the new restaurant downtown.",
+    strongEs: "Quiero probar el nuevo restaurante en el centro.",
+    weakHighlight: "want to",
+    strongHighlight: "wanna",
+    why: "'Wanna' = want to. Like 'gonna,' it's standard casual spoken English. Saying 'want to' in casual speech creates a rhythmic mismatch — like wearing a suit to a barbecue. The words are correct but the register is wrong.",
+    whyEs: "'Wanna' = want to. Como 'gonna,' es inglés hablado casual estándar. Decir 'want to' en el habla casual crea un desajuste rítmico — como usar traje en una parrillada. Las palabras son correctas pero el registro está mal.",
+    category: "Informal contraction",
+    categoryEs: "Contracción informal",
+  },
+];
+
+// ─── Section 2: Negative Contractions & Double Negatives (ErrorSpotter) ──────
+// Common errors advanced Spanish speakers make with negative contractions,
+// influenced by Spanish grammar where double negatives are correct.
+
+export const negativeErrors: ErrorSpotterItem[] = [
+  {
+    sentence: "I don't know nothing about the new policy.",
+    errorWord: "nothing",
+    improved: "I don't know anything about the new policy.",
+    sentenceEs: "No sé nada sobre la nueva política.",
+    improvedEs: "No sé nada sobre la nueva política.",
+    explanation:
+      "In Spanish, 'no sé nada' (double negative) is correct. In English, two negatives cancel out: 'I don't know nothing' literally means 'I know something.' Use 'anything' with 'don't': 'I don't know anything.' Or use 'nothing' without 'don't': 'I know nothing.'",
+    explanationEs:
+      "En español, 'no sé nada' (doble negación) es correcto. En inglés, dos negativos se cancelan: 'I don't know nothing' literalmente significa 'sé algo.' Usa 'anything' con 'don't': 'I don't know anything.' O usa 'nothing' sin 'don't': 'I know nothing.'",
+  },
+  {
+    sentence: "She can't find her keys nowhere.",
+    errorWord: "nowhere",
+    improved: "She can't find her keys anywhere.",
+    sentenceEs: "No puede encontrar sus llaves en ningún lado.",
+    improvedEs: "No puede encontrar sus llaves en ningún lado.",
+    explanation:
+      "'Can't' + 'nowhere' = double negative. In standard English, this means she CAN find them somewhere. Use 'anywhere' with 'can't': 'She can't find her keys anywhere.' Or: 'She can find her keys nowhere' (correct but formal/literary).",
+    explanationEs:
+      "'Can't' + 'nowhere' = doble negación. En inglés estándar, esto significa que SÍ puede encontrarlas en algún lugar. Usa 'anywhere' con 'can't': 'She can't find her keys anywhere.'",
+  },
+  {
+    sentence: "We didn't see nobody at the office yesterday.",
+    errorWord: "nobody",
+    improved: "We didn't see anybody at the office yesterday.",
+    sentenceEs: "No vimos a nadie en la oficina ayer.",
+    improvedEs: "No vimos a nadie en la oficina ayer.",
+    explanation:
+      "'Didn't' + 'nobody' = double negative. Pattern: 'don't/didn't/can't/won't' + 'anybody/anything/anywhere/anyone.' NEVER pair a contracted negative with another negative word. Spanish does this naturally — English doesn't.",
+    explanationEs:
+      "'Didn't' + 'nobody' = doble negación. Patrón: 'don't/didn't/can't/won't' + 'anybody/anything/anywhere/anyone.' NUNCA combines un negativo contraído con otra palabra negativa. El español lo hace naturalmente — el inglés no.",
+  },
+  {
+    sentence: "He told me that he won't never do that again.",
+    errorWord: "never",
+    improved: "He told me that he'll never do that again.",
+    sentenceEs: "Me dijo que nunca volverá a hacer eso.",
+    improvedEs: "Me dijo que nunca volverá a hacer eso.",
+    explanation:
+      "'Won't' + 'never' = double negative. Fix: drop one. 'He'll never do that again' or 'He won't ever do that again.' Both are correct — pick one negative. This is the most common double-negative error for Spanish speakers because 'no... nunca' is perfectly natural in Spanish.",
+    explanationEs:
+      "'Won't' + 'never' = doble negación. Solución: elimina uno. 'He'll never do that again' o 'He won't ever do that again.' Ambos son correctos — elige un negativo. Este es el error de doble negación más común para hispanohablantes porque 'no... nunca' es perfectamente natural en español.",
+  },
+  {
+    sentence: "They haven't told me nothing about the deadline.",
+    errorWord: "nothing",
+    improved: "They haven't told me anything about the deadline.",
+    sentenceEs: "No me han dicho nada sobre la fecha límite.",
+    improvedEs: "No me han dicho nada sobre la fecha límite.",
+    explanation:
+      "'Haven't' + 'nothing' = double negative. By now you see the pattern: whenever you use a negative contraction (don't, didn't, can't, won't, haven't, hasn't, isn't, aren't), every other word in the sentence must be the positive version: anything, anyone, anywhere, ever — never the negative.",
+    explanationEs:
+      "'Haven't' + 'nothing' = doble negación. Ya ves el patrón: siempre que uses una contracción negativa (don't, didn't, can't, won't, haven't, hasn't, isn't, aren't), cada otra palabra en la oración debe ser la versión positiva: anything, anyone, anywhere, ever — nunca la negativa.",
+  },
+];
+
+// ─── Section 3: When NOT to Contract (SentenceTransformer) ──────────────────
+// Contractions are natural in casual speech, but in certain contexts they
+// sound wrong, weaken your message, or change the meaning. This section
+// teaches register awareness: when to expand for power.
+
+export const noContractTransforms: SentenceTransform[] = [
+  {
+    flat: "We aren't going to accept those terms.",
+    flatEs: "No vamos a aceptar esos términos.",
+    strong: "We are NOT going to accept those terms.",
+    strongEs: "No vamos a aceptar esos términos.",
+    technique: "Emphasis",
+    techniqueEs: "Énfasis",
+    why: "When you want to stress a negative, expand and emphasize the 'not.' 'We aren't' is neutral. 'We are NOT' carries weight and authority. In negotiations, presentations, and high-stakes conversations, expanding the negative signals conviction.",
+    whyEs: "Cuando quieres enfatizar un negativo, expande y enfatiza el 'not.' 'We aren't' es neutral. 'We are NOT' lleva peso y autoridad. En negociaciones, presentaciones y conversaciones de alto riesgo, expandir el negativo señala convicción.",
+  },
+  {
+    flat: "I can't believe they approved the budget.",
+    flatEs: "No puedo creer que aprobaron el presupuesto.",
+    strong: "I cannot believe they approved the budget.",
+    strongEs: "No puedo creer que aprobaron el presupuesto.",
+    technique: "Emphasis",
+    techniqueEs: "Énfasis",
+    why: "'Cannot' is one word — not 'can not.' When you write or say 'cannot,' it hits harder than 'can't.' 'Can't' is everyday. 'Cannot' is deliberate. Use it when disbelief, refusal, or formal emphasis is the goal.",
+    whyEs: "'Cannot' es una sola palabra — no 'can not.' Cuando escribes o dices 'cannot,' tiene más impacto que 'can't.' 'Can't' es cotidiano. 'Cannot' es deliberado. Úsalo cuando la incredulidad, rechazo o énfasis formal es la meta.",
+  },
+  {
+    flat: "It's important that we're transparent with stakeholders.",
+    flatEs: "Es importante que seamos transparentes con las partes interesadas.",
+    strong: "It is important that we are transparent with stakeholders.",
+    strongEs: "Es importante que seamos transparentes con las partes interesadas.",
+    technique: "Formal register",
+    techniqueEs: "Registro formal",
+    why: "In board meetings, client presentations, and written reports, expanding contractions signals seriousness. 'It's important' is casual. 'It is important' is boardroom English. The formality isn't stuffy — it's strategic.",
+    whyEs: "En juntas directivas, presentaciones a clientes e informes escritos, expandir las contracciones señala seriedad. 'It's important' es casual. 'It is important' es inglés de sala de juntas. La formalidad no es rígida — es estratégica.",
+  },
+  {
+    flat: "I'm honored to be here today and I'd like to thank the committee.",
+    flatEs: "Me siento honrado de estar aquí hoy y me gustaría agradecer al comité.",
+    strong: "I am honored to be here today, and I would like to thank the committee.",
+    strongEs: "Me siento honrado de estar aquí hoy, y me gustaría agradecer al comité.",
+    technique: "Formal register",
+    techniqueEs: "Registro formal",
+    why: "Speeches, award acceptances, and formal openings demand expanded forms. 'I'm honored' sounds like a text message. 'I am honored' sounds like a leader. When the moment calls for gravity, give every word its full weight.",
+    whyEs: "Discursos, aceptaciones de premios y aperturas formales exigen formas expandidas. 'I'm honored' suena como un mensaje de texto. 'I am honored' suena como un líder. Cuando el momento pide gravedad, dale a cada palabra su peso completo.",
+  },
+  {
+    flat: "That's not what I said. I didn't say we should cancel.",
+    flatEs: "Eso no es lo que dije. No dije que debemos cancelar.",
+    strong: "That is not what I said. I did not say we should cancel.",
+    strongEs: "Eso no es lo que dije. No dije que debemos cancelar.",
+    technique: "Clarification / defense",
+    techniqueEs: "Aclaración / defensa",
+    why: "When correcting a misquote or defending your position, expanding contractions slows the listener down and forces them to hear each word. 'I didn't say' is casual and dismissable. 'I did NOT say' is precise and undeniable. Lawyers do this instinctively.",
+    whyEs: "Al corregir una cita errónea o defender tu posición, expandir contracciones desacelera al oyente y lo obliga a escuchar cada palabra. 'I didn't say' es casual y descartable. 'I did NOT say' es preciso e innegable. Los abogados hacen esto instintivamente.",
+  },
+];

--- a/src/pages/en/course/advanced/index.astro
+++ b/src/pages/en/course/advanced/index.astro
@@ -131,7 +131,7 @@ const iconMap: Record<string, any> = {
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
         {advancedUnits.map((unit) => {
           const Icon = iconMap[unit.icon];
-          const isAvailable = unit.id < 7;
+          const isAvailable = unit.id < 8;
           return (
             <a
               href={isAvailable ? `/en/course/advanced/${unit.slug}/` : undefined}

--- a/src/pages/en/course/advanced/unit-7.astro
+++ b/src/pages/en/course/advanced/unit-7.astro
@@ -1,0 +1,96 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WordPairLab from "@components/course/WordPairLab";
+import ErrorSpotter from "@components/course/ErrorSpotter";
+import SentenceTransformer from "@components/course/SentenceTransformer";
+import { advancedUnits } from "@data/advanced/units";
+import { advancedContractions, negativeErrors, noContractTransforms } from "@data/advanced/unit-7";
+import { ArrowRight, Zap, ShieldAlert, Scale } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/advanced/unit-7" as const;
+const progressUnits = advancedUnits.map((u) => ({ id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base lang={lang} tkey={tkey}
+  title="Unit 7: Contractions, Flipped | Speak with Confidence | NY English Teacher"
+  description="Advanced contractions like I'd've and shouldn't've — plus when NOT to contract. Master the compression and expansion of spoken English. Free advanced English lesson for B2-C1 Spanish speakers."
+>
+  <CourseProgress client:load units={progressUnits} currentUnit={7} basePath="/en/course/advanced" lang="en" courseId="advanced" />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-violet-400 text-sm font-semibold mb-3"><Zap class="w-4 h-4" /> Unit 7</div>
+        <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Contractions, Flipped
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Native speakers compress words constantly — I'd've, shouldn't've, gonna, wanna.
+          These aren't slang. They're how English actually sounds. But knowing when to
+          expand back out — for emphasis, formality, or power — is equally important.
+          This unit teaches both directions.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Zap class="w-3.5 h-3.5" /> Advanced Contractions</span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><ShieldAlert class="w-3.5 h-3.5" /> Double Negatives</span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Scale class="w-3.5 h-3.5" /> Register Awareness</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">1</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Advanced Contractions</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">
+        Beyond I'm, he's, and we'll — these are the double contractions and informal
+        compressions that make you sound like a native speaker, not a textbook.
+      </p>
+      <WordPairLab client:visible pairs={advancedContractions} lang="en" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">2</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Negative Contractions & Double Negatives</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">
+        In Spanish, double negatives are correct. In English, they cancel each other out.
+        Tap the word that creates the double negative in each sentence.
+      </p>
+      <ErrorSpotter client:visible items={negativeErrors} lang="en" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">3</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">When NOT to Contract</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">
+        Contractions compress. But sometimes you need to expand — for emphasis, formality,
+        or precision. Knowing when to switch registers is what separates an advanced
+        speaker from a truly polished one.
+      </p>
+      <SentenceTransformer client:visible transforms={noContractTransforms} lang="en" />
+    </div></div>
+  </section>
+
+  <section class="py-12 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto flex justify-between items-center">
+      <a href="/en/course/advanced/unit-6/" class="text-sm text-slate-500 hover:text-violet-600 transition-colors">&larr; Unit 6</a>
+      <Button href="/en/course/advanced/" variant="primary" size="md">Course Overview <ArrowRight class="w-4 h-4 ml-1" /></Button>
+    </div></div>
+  </section>
+</Base>

--- a/src/pages/es/curso/avanzado/index.astro
+++ b/src/pages/es/curso/avanzado/index.astro
@@ -128,7 +128,7 @@ const iconMap: Record<string, any> = {
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
         {advancedUnits.map((unit) => {
           const Icon = iconMap[unit.icon];
-          const isAvailable = unit.id < 7;
+          const isAvailable = unit.id < 8;
           return (
             <a
               href={isAvailable ? `/es/curso/avanzado/${unit.slugEs}/` : undefined}

--- a/src/pages/es/curso/avanzado/unidad-7.astro
+++ b/src/pages/es/curso/avanzado/unidad-7.astro
@@ -1,0 +1,77 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WordPairLab from "@components/course/WordPairLab";
+import ErrorSpotter from "@components/course/ErrorSpotter";
+import SentenceTransformer from "@components/course/SentenceTransformer";
+import { advancedUnits } from "@data/advanced/units";
+import { advancedContractions, negativeErrors, noContractTransforms } from "@data/advanced/unit-7";
+import { ArrowRight, Zap, ShieldAlert, Scale } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/advanced/unit-7" as const;
+const progressUnits = advancedUnits.map((u) => ({ id: u.id, slug: u.slugEs, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base lang={lang} tkey={tkey}
+  title="Unidad 7: Contracciones, Invertidas | Habla con Confianza | NY English Teacher"
+  description="Contracciones avanzadas como I'd've y shouldn't've — y cuándo NO contraer. Domina la compresión y expansión del inglés hablado. Lección B2-C1 gratis para hispanohablantes."
+>
+  <CourseProgress client:load units={progressUnits} currentUnit={7} basePath="/es/curso/avanzado" lang="es" courseId="advanced" />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-8 pb-16 md:pt-12 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-violet-400 text-sm font-semibold mb-3"><Zap class="w-4 h-4" /> Unidad 7</div>
+        <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Contracciones, Invertidas
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Los hablantes nativos comprimen palabras constantemente — I'd've, shouldn't've,
+          gonna, wanna. No son jerga. Son como realmente suena el inglés. Pero saber
+          cuándo expandir — por énfasis, formalidad o poder — es igualmente importante.
+          Esta unidad enseña ambas direcciones.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Zap class="w-3.5 h-3.5" /> Contracciones Avanzadas</span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><ShieldAlert class="w-3.5 h-3.5" /> Dobles Negativos</span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Scale class="w-3.5 h-3.5" /> Conciencia de Registro</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2"><span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">1</span><h2 class="text-2xl md:text-3xl font-bold text-slate-900">Contracciones Avanzadas</h2></div>
+      <p class="text-slate-500 mb-8 ml-11">Más allá de I'm, he's y we'll — estas son las contracciones dobles y compresiones informales que te hacen sonar como un nativo, no como un libro de texto.</p>
+      <WordPairLab client:visible pairs={advancedContractions} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2"><span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">2</span><h2 class="text-2xl md:text-3xl font-bold text-slate-900">Contracciones Negativas y Dobles Negativos</h2></div>
+      <p class="text-slate-500 mb-8 ml-11">En español, los dobles negativos son correctos. En inglés, se cancelan entre sí. Toca la palabra que crea el doble negativo en cada oración.</p>
+      <ErrorSpotter client:visible items={negativeErrors} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2"><span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">3</span><h2 class="text-2xl md:text-3xl font-bold text-slate-900">Cuándo NO Contraer</h2></div>
+      <p class="text-slate-500 mb-8 ml-11">Las contracciones comprimen. Pero a veces necesitas expandir — por énfasis, formalidad o precisión. Saber cuándo cambiar de registro es lo que separa a un hablante avanzado de uno verdaderamente pulido.</p>
+      <SentenceTransformer client:visible transforms={noContractTransforms} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-12 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto flex justify-between items-center">
+      <a href="/es/curso/avanzado/unidad-6/" class="text-sm text-slate-500 hover:text-violet-600 transition-colors">&larr; Unidad 6</a>
+      <Button href="/es/curso/avanzado/" variant="primary" size="md">Resumen del Curso <ArrowRight class="w-4 h-4 ml-1" /></Button>
+    </div></div>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary
- **Section 1: Advanced Contractions** — Double contractions (I'd've, shouldn't've, couldn't've) and informal compressions (gonna, wanna) via WordPairLab
- **Section 2: Negative Contractions & Double Negatives** — Spanish-influenced double negative errors via ErrorSpotter (don't + nothing → don't + anything)
- **Section 3: When NOT to Contract** — Register awareness: expanding for emphasis, formality, and precision via SentenceTransformer
- Hub pages updated to show Unit 7 as available (EN + ES)

## Test plan
- [ ] Verify Unit 7 EN and ES pages load with all 3 sections
- [ ] Check WordPairLab, ErrorSpotter, and SentenceTransformer components render correctly
- [ ] Confirm bilingual content displays properly
- [ ] Verify course hub shows Unit 7 as clickable (not "Coming soon")
- [ ] Check navigation links (← Unit 6 / Course Overview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)