### PR TITLE
feat: advanced Unit 8 — Prefixes & Suffixes with Azure TTS

### DIFF
--- a/src/components/course/WordBuilder.tsx
+++ b/src/components/course/WordBuilder.tsx
@@ -1,0 +1,253 @@
+// WordBuilder — interactive word decomposition component for advanced course.
+//
+// Breaks a word into prefix + root + suffix, color-codes each part, and
+// explains what each piece means. The learner sees the whole word, taps to
+// reveal the breakdown, then hears it pronounced via Azure Neural TTS.
+//
+// Used in: U8 (Prefixes & Suffixes)
+
+import { useState, useCallback, useRef } from "react";
+import { ArrowDown, RotateCcw, Volume2, Loader2 } from "lucide-react";
+import type { WordBreakdown } from "@data/advanced/types";
+
+interface Props {
+  words: WordBreakdown[];
+  lang: "en" | "es";
+}
+
+const roleColors: Record<string, { bg: string; text: string; label: string; labelEs: string }> = {
+  prefix: { bg: "bg-violet-100", text: "text-violet-700", label: "prefix", labelEs: "prefijo" },
+  root:   { bg: "bg-amber-100",  text: "text-amber-700",  label: "root",   labelEs: "raíz" },
+  suffix: { bg: "bg-emerald-100", text: "text-emerald-700", label: "suffix", labelEs: "sufijo" },
+};
+
+function AzureAudioButton({ text, className = "" }: { text: string; className?: string }) {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const cacheRef = useRef<Map<string, string>>(new Map());
+
+  const speak = useCallback(async () => {
+    // Stop any current playback
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.currentTime = 0;
+    }
+
+    setIsPlaying(true);
+
+    try {
+      let audioUrl = cacheRef.current.get(text);
+
+      if (!audioUrl) {
+        const response = await fetch("/api/tts/synthesize", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ text, lang: "en" }),
+        });
+
+        if (!response.ok) throw new Error(`TTS error: ${response.status}`);
+
+        const blob = await response.blob();
+        if (blob.size < 100) throw new Error("Audio too small");
+
+        audioUrl = URL.createObjectURL(blob);
+        cacheRef.current.set(text, audioUrl);
+      }
+
+      const audio = new Audio(audioUrl);
+      audioRef.current = audio;
+      audio.addEventListener("ended", () => setIsPlaying(false));
+      audio.addEventListener("error", () => setIsPlaying(false));
+      await audio.play();
+    } catch {
+      // Fallback to browser SpeechSynthesis
+      if ("speechSynthesis" in window) {
+        speechSynthesis.cancel();
+        const u = new SpeechSynthesisUtterance(text);
+        u.lang = "en-US";
+        u.rate = 0.85;
+        u.onend = () => setIsPlaying(false);
+        u.onerror = () => setIsPlaying(false);
+        speechSynthesis.speak(u);
+      } else {
+        setIsPlaying(false);
+      }
+    }
+  }, [text]);
+
+  return (
+    <button
+      type="button"
+      onClick={speak}
+      className={`inline-flex items-center justify-center w-9 h-9 rounded-full transition-all duration-200 ${
+        isPlaying
+          ? "bg-amber-500 text-white scale-110 shadow-lg shadow-amber-500/30"
+          : "bg-slate-100 text-slate-600 hover:bg-amber-100 hover:text-amber-600 hover:scale-105"
+      } ${className}`}
+      aria-label={`Listen to: ${text}`}
+      title={`Listen: "${text}"`}
+    >
+      {isPlaying ? <Loader2 size={18} className="animate-spin" /> : <Volume2 size={18} />}
+    </button>
+  );
+}
+
+export default function WordBuilder({ words, lang }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isRevealed, setIsRevealed] = useState(false);
+
+  const current = words[currentIndex];
+  const isLast = currentIndex === words.length - 1;
+
+  const handleReveal = () => setIsRevealed(true);
+
+  const handleNext = () => {
+    if (!isLast) {
+      setCurrentIndex((i) => i + 1);
+      setIsRevealed(false);
+    }
+  };
+
+  const handleRestart = () => {
+    setCurrentIndex(0);
+    setIsRevealed(false);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Progress */}
+      <div className="flex items-center justify-between text-sm text-slate-500">
+        <span>
+          {lang === "es" ? "Palabra" : "Word"} {currentIndex + 1} / {words.length}
+        </span>
+        <div className="flex gap-1">
+          {words.map((_, i) => (
+            <div
+              key={i}
+              className={`w-2 h-2 rounded-full transition-colors ${
+                i < currentIndex
+                  ? "bg-violet-500"
+                  : i === currentIndex
+                    ? "bg-amber-500"
+                    : "bg-slate-200"
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Word card */}
+      <div className="bg-white border border-slate-200 rounded-2xl shadow-sm overflow-hidden">
+        {/* The whole word */}
+        <div className="p-8 text-center border-b border-slate-100">
+          <div className="flex items-center justify-center gap-3">
+            <span className="text-4xl md:text-5xl font-bold text-slate-900 tracking-tight">
+              {current.word}
+            </span>
+            <AzureAudioButton text={current.word} />
+          </div>
+          {!isRevealed && (
+            <p className="text-slate-400 text-sm mt-3">
+              {lang === "es"
+                ? "¿Puedes identificar las partes de esta palabra?"
+                : "Can you identify the parts of this word?"}
+            </p>
+          )}
+        </div>
+
+        {/* Reveal button or breakdown */}
+        {!isRevealed ? (
+          <button
+            onClick={handleReveal}
+            className="w-full py-4 flex items-center justify-center gap-2 text-violet-600 font-semibold hover:bg-violet-50 transition-colors"
+          >
+            <ArrowDown size={18} />
+            {lang === "es" ? "Mostrar descomposición" : "Show breakdown"}
+          </button>
+        ) : (
+          <div className="p-6 space-y-6">
+            {/* Parts breakdown */}
+            <div className="flex flex-wrap items-center justify-center gap-2">
+              {current.parts.map((part, i) => {
+                const colors = roleColors[part.role];
+                return (
+                  <div key={i} className="text-center">
+                    <div
+                      className={`${colors.bg} ${colors.text} px-4 py-2 rounded-xl text-2xl md:text-3xl font-bold`}
+                    >
+                      {part.text}
+                    </div>
+                    <span className={`text-xs font-semibold uppercase tracking-wider mt-1 block ${colors.text}`}>
+                      {lang === "es" ? colors.labelEs : colors.label}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Part meanings */}
+            <div className="space-y-2">
+              {current.parts.map((part, i) => {
+                const colors = roleColors[part.role];
+                return (
+                  <div key={i} className="flex items-start gap-3 text-sm">
+                    <span
+                      className={`${colors.bg} ${colors.text} px-2 py-0.5 rounded font-bold text-xs shrink-0 mt-0.5`}
+                    >
+                      {part.text}
+                    </span>
+                    <span className="text-slate-600">
+                      {lang === "es" ? part.meaningEs : part.meaning}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Full meaning */}
+            <div className="bg-slate-50 rounded-xl p-4">
+              <p className="text-sm font-semibold text-slate-700 mb-1">
+                {lang === "es" ? "Significado completo:" : "Full meaning:"}
+              </p>
+              <p className="text-slate-600">
+                {lang === "es" ? current.fullMeaningEs : current.fullMeaning}
+              </p>
+            </div>
+
+            {/* Related example */}
+            {current.relatedExample && (
+              <div className="flex items-start gap-2 text-sm text-slate-500 border-t border-slate-100 pt-4">
+                <span className="text-violet-500 font-semibold shrink-0">
+                  {lang === "es" ? "Relacionada:" : "Related:"}
+                </span>
+                <span>
+                  {lang === "es" ? current.relatedExampleEs : current.relatedExample}
+                </span>
+              </div>
+            )}
+
+            {/* Navigation */}
+            <div className="flex justify-end pt-2">
+              {isLast ? (
+                <button
+                  onClick={handleRestart}
+                  className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-violet-600 text-white font-semibold hover:bg-violet-700 transition-colors text-sm"
+                >
+                  <RotateCcw size={16} />
+                  {lang === "es" ? "Empezar de nuevo" : "Start over"}
+                </button>
+              ) : (
+                <button
+                  onClick={handleNext}
+                  className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-violet-600 text-white font-semibold hover:bg-violet-700 transition-colors text-sm"
+                >
+                  {lang === "es" ? "Siguiente palabra" : "Next word"}
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/data/advanced/unit-8.ts
+++ b/src/data/advanced/unit-8.ts
@@ -1,0 +1,234 @@
+// Unit 8: "Prefixes & Suffixes" — Full course content
+//
+// Section 1: Common prefixes and what they actually mean — WordBuilder
+// Section 2: Suffixes that change word class — WordBuilder
+// Section 3: Building vocabulary by decoding word parts — SentenceTransformer
+
+import type { WordBreakdown, SentenceTransform } from "./types";
+
+// ─── Section 1: Prefixes (WordBuilder) ──────────────────────────────────────
+// The most common English prefixes that Spanish speakers can decode once they
+// learn the pattern. Each word is broken into prefix + root (+ optional suffix).
+
+export const prefixWords: WordBreakdown[] = [
+  {
+    word: "uncomfortable",
+    parts: [
+      { text: "un-", role: "prefix", meaning: "not / opposite of", meaningEs: "no / lo opuesto de" },
+      { text: "comfort", role: "root", meaning: "ease, relief", meaningEs: "comodidad, alivio" },
+      { text: "-able", role: "suffix", meaning: "capable of being", meaningEs: "capaz de ser" },
+    ],
+    fullMeaning: "Not capable of being at ease — the opposite of comfortable.",
+    fullMeaningEs: "No capaz de estar cómodo — lo opuesto de comfortable.",
+    relatedExample: "un- works the same way in: unhappy, unfair, unlikely, unbelievable, unexpected",
+    relatedExampleEs: "un- funciona igual en: unhappy, unfair, unlikely, unbelievable, unexpected",
+  },
+  {
+    word: "disapprove",
+    parts: [
+      { text: "dis-", role: "prefix", meaning: "opposite of / remove", meaningEs: "opuesto de / quitar" },
+      { text: "approve", role: "root", meaning: "to agree, to accept", meaningEs: "aprobar, aceptar" },
+    ],
+    fullMeaning: "To not approve — to express an unfavorable opinion.",
+    fullMeaningEs: "No aprobar — expresar una opinión desfavorable.",
+    relatedExample: "dis- reverses the action: disagree, disconnect, disqualify, dishonest, disrespect",
+    relatedExampleEs: "dis- revierte la acción: disagree, disconnect, disqualify, dishonest, disrespect",
+  },
+  {
+    word: "misunderstand",
+    parts: [
+      { text: "mis-", role: "prefix", meaning: "wrongly / badly", meaningEs: "incorrectamente / mal" },
+      { text: "understand", role: "root", meaning: "to comprehend", meaningEs: "comprender" },
+    ],
+    fullMeaning: "To understand wrongly — to get the wrong meaning from something.",
+    fullMeaningEs: "Comprender incorrectamente — obtener un significado equivocado de algo.",
+    relatedExample: "mis- means 'wrong': mispronounce, mislead, misjudge, misplace, misinform",
+    relatedExampleEs: "mis- significa 'mal/incorrecto': mispronounce, mislead, misjudge, misplace, misinform",
+  },
+  {
+    word: "overestimate",
+    parts: [
+      { text: "over-", role: "prefix", meaning: "too much / excessively", meaningEs: "demasiado / excesivamente" },
+      { text: "estimate", role: "root", meaning: "to guess the value/amount", meaningEs: "calcular el valor/cantidad" },
+    ],
+    fullMeaning: "To estimate too high — to think something is bigger, better, or more than it actually is.",
+    fullMeaningEs: "Calcular demasiado alto — pensar que algo es más grande, mejor o más de lo que realmente es.",
+    relatedExample: "over- means 'too much': overwork, overthink, overreact, oversimplify, overcook",
+    relatedExampleEs: "over- significa 'demasiado': overwork, overthink, overreact, oversimplify, overcook",
+  },
+  {
+    word: "underpaid",
+    parts: [
+      { text: "under-", role: "prefix", meaning: "too little / below", meaningEs: "demasiado poco / debajo" },
+      { text: "paid", role: "root", meaning: "received money for work", meaningEs: "recibió dinero por trabajo" },
+    ],
+    fullMeaning: "Paid too little — receiving less money than deserved for work done.",
+    fullMeaningEs: "Pagado demasiado poco — recibir menos dinero del merecido por el trabajo realizado.",
+    relatedExample: "under- is the opposite of over-: undervalue, underperform, underestimate, understaffed",
+    relatedExampleEs: "under- es lo opuesto de over-: undervalue, underperform, underestimate, understaffed",
+  },
+  {
+    word: "rewrite",
+    parts: [
+      { text: "re-", role: "prefix", meaning: "again / back", meaningEs: "de nuevo / otra vez" },
+      { text: "write", role: "root", meaning: "to compose text", meaningEs: "componer texto" },
+    ],
+    fullMeaning: "To write again — to revise or compose a new version of something.",
+    fullMeaningEs: "Escribir de nuevo — revisar o componer una nueva versión de algo.",
+    relatedExample: "re- means 'again': rebuild, reconsider, redesign, reconnect, reevaluate",
+    relatedExampleEs: "re- significa 'de nuevo': rebuild, reconsider, redesign, reconnect, reevaluate",
+  },
+  {
+    word: "preview",
+    parts: [
+      { text: "pre-", role: "prefix", meaning: "before", meaningEs: "antes" },
+      { text: "view", role: "root", meaning: "to see / a look at something", meaningEs: "ver / una mirada a algo" },
+    ],
+    fullMeaning: "To see before — an advance look at something before it's released or completed.",
+    fullMeaningEs: "Ver antes — un vistazo anticipado a algo antes de que se lance o complete.",
+    relatedExample: "pre- means 'before': predict, prevent, premature, prerequisite, preschool",
+    relatedExampleEs: "pre- significa 'antes': predict, prevent, premature, prerequisite, preschool",
+  },
+];
+
+// ─── Section 2: Suffixes That Change Word Class (WordBuilder) ───────────────
+// These suffixes transform verbs/adjectives into nouns, nouns into adjectives,
+// etc. Understanding them lets you generate dozens of words from one root.
+
+export const suffixWords: WordBreakdown[] = [
+  {
+    word: "communication",
+    parts: [
+      { text: "communicate", role: "root", meaning: "to exchange information (verb)", meaningEs: "intercambiar información (verbo)" },
+      { text: "-tion", role: "suffix", meaning: "turns a verb into a noun (the act of)", meaningEs: "convierte un verbo en sustantivo (el acto de)" },
+    ],
+    fullMeaning: "The act of communicating — the process of exchanging information.",
+    fullMeaningEs: "El acto de comunicar — el proceso de intercambiar información.",
+    relatedExample: "-tion/-sion makes nouns from verbs: education, celebration, decision, permission, creation",
+    relatedExampleEs: "-tion/-sion crea sustantivos de verbos: education, celebration, decision, permission, creation",
+  },
+  {
+    word: "development",
+    parts: [
+      { text: "develop", role: "root", meaning: "to grow or create (verb)", meaningEs: "crecer o crear (verbo)" },
+      { text: "-ment", role: "suffix", meaning: "the result or process of (noun)", meaningEs: "el resultado o proceso de (sustantivo)" },
+    ],
+    fullMeaning: "The process or result of developing — growth, progress, or advancement.",
+    fullMeaningEs: "El proceso o resultado de desarrollar — crecimiento, progreso o avance.",
+    relatedExample: "-ment makes nouns: achievement, management, improvement, environment, investment",
+    relatedExampleEs: "-ment crea sustantivos: achievement, management, improvement, environment, investment",
+  },
+  {
+    word: "happiness",
+    parts: [
+      { text: "happy", role: "root", meaning: "feeling joy (adjective)", meaningEs: "sentir alegría (adjetivo)" },
+      { text: "-ness", role: "suffix", meaning: "the state or quality of (noun)", meaningEs: "el estado o cualidad de (sustantivo)" },
+    ],
+    fullMeaning: "The state of being happy — the quality of feeling joyful.",
+    fullMeaningEs: "El estado de estar feliz — la cualidad de sentirse alegre.",
+    relatedExample: "-ness makes nouns from adjectives: kindness, darkness, weakness, awareness, sadness",
+    relatedExampleEs: "-ness crea sustantivos de adjetivos: kindness, darkness, weakness, awareness, sadness",
+  },
+  {
+    word: "strengthen",
+    parts: [
+      { text: "strength", role: "root", meaning: "power, force (noun)", meaningEs: "fuerza, poder (sustantivo)" },
+      { text: "-en", role: "suffix", meaning: "to make or become (verb)", meaningEs: "hacer o volverse (verbo)" },
+    ],
+    fullMeaning: "To make stronger — to increase in strength or force.",
+    fullMeaningEs: "Hacer más fuerte — aumentar en fuerza o poder.",
+    relatedExample: "-en makes verbs: widen, deepen, shorten, brighten, frighten, tighten, loosen",
+    relatedExampleEs: "-en crea verbos: widen, deepen, shorten, brighten, frighten, tighten, loosen",
+  },
+  {
+    word: "powerful",
+    parts: [
+      { text: "power", role: "root", meaning: "strength, control (noun)", meaningEs: "fuerza, control (sustantivo)" },
+      { text: "-ful", role: "suffix", meaning: "full of (adjective)", meaningEs: "lleno de (adjetivo)" },
+    ],
+    fullMeaning: "Full of power — having great strength, influence, or effect.",
+    fullMeaningEs: "Lleno de poder — tener gran fuerza, influencia o efecto.",
+    relatedExample: "-ful makes adjectives: beautiful, grateful, hopeful, meaningful, resourceful",
+    relatedExampleEs: "-ful crea adjetivos: beautiful, grateful, hopeful, meaningful, resourceful",
+  },
+  {
+    word: "careless",
+    parts: [
+      { text: "care", role: "root", meaning: "attention, concern (noun)", meaningEs: "atención, preocupación (sustantivo)" },
+      { text: "-less", role: "suffix", meaning: "without (adjective)", meaningEs: "sin (adjetivo)" },
+    ],
+    fullMeaning: "Without care — not paying enough attention, leading to mistakes.",
+    fullMeaningEs: "Sin cuidado — no prestar suficiente atención, lo que lleva a errores.",
+    relatedExample: "-less is the opposite of -ful: hopeless, useless, endless, homeless, reckless",
+    relatedExampleEs: "-less es lo opuesto de -ful: hopeless, useless, endless, homeless, reckless",
+  },
+  {
+    word: "basically",
+    parts: [
+      { text: "basic", role: "root", meaning: "fundamental (adjective)", meaningEs: "fundamental (adjetivo)" },
+      { text: "-ally", role: "suffix", meaning: "in the manner of (adverb)", meaningEs: "de la manera de (adverbio)" },
+    ],
+    fullMeaning: "In a basic manner — fundamentally, at the most essential level.",
+    fullMeaningEs: "De manera básica — fundamentalmente, en el nivel más esencial.",
+    relatedExample: "-ly/-ally makes adverbs: professionally, personally, dramatically, automatically",
+    relatedExampleEs: "-ly/-ally crea adverbios: professionally, personally, dramatically, automatically",
+  },
+];
+
+// ─── Section 3: Decoding Unknown Words (SentenceTransformer) ────────────────
+// Real-world sentences containing complex words that can be decoded by
+// recognizing their prefix/root/suffix parts. The "flat" version shows the
+// mystery word; the "strong" version decodes it in place.
+
+export const decodingTransforms: SentenceTransform[] = [
+  {
+    flat: "The CEO's decision was irreversible — we couldn't go back.",
+    flatEs: "La decisión del CEO fue irreversible — no podíamos volver atrás.",
+    strong: "ir- (not) + reverse (go back) + -ible (capable of) = not capable of being reversed",
+    strongEs: "ir- (no) + reverse (volver) + -ible (capaz de) = no capaz de ser revertido",
+    technique: "Prefix + Root + Suffix",
+    techniqueEs: "Prefijo + Raíz + Sufijo",
+    why: "'Irreversible' looks intimidating until you break it down: ir- means 'not' (like un-), reverse means 'go back,' -ible means 'capable of.' Three simple parts = one complex word decoded. The prefix ir- is the negative form used before words starting with R: irregular, irresponsible, irrational.",
+    whyEs: "'Irreversible' parece intimidante hasta que lo descompones: ir- significa 'no' (como un-), reverse significa 'volver,' -ible significa 'capaz de.' Tres partes simples = una palabra compleja decodificada. El prefijo ir- es la forma negativa usada antes de palabras que empiezan con R.",
+  },
+  {
+    flat: "The report was full of unsubstantiated claims about the competitor.",
+    flatEs: "El informe estaba lleno de afirmaciones infundadas sobre el competidor.",
+    strong: "un- (not) + substantiate (prove with evidence) + -ed (past) = not proven with evidence",
+    strongEs: "un- (no) + substantiate (probar con evidencia) + -ed (pasado) = no probado con evidencia",
+    technique: "Prefix + Root + Suffix",
+    techniqueEs: "Prefijo + Raíz + Sufijo",
+    why: "You don't need to have memorized 'unsubstantiated.' If you know un- (not) and recognize 'substance' inside the root (something solid/real), you can deduce it means 'not backed by solid evidence.' This is how native speakers handle new words too — they decode, not memorize.",
+    whyEs: "No necesitas haber memorizado 'unsubstantiated.' Si sabes que un- (no) y reconoces 'substance' dentro de la raíz (algo sólido/real), puedes deducir que significa 'no respaldado por evidencia sólida.' Así es como los nativos manejan palabras nuevas también — decodifican, no memorizan.",
+  },
+  {
+    flat: "She was promoted for her resourcefulness during the crisis.",
+    flatEs: "Fue promovida por su ingeniosidad durante la crisis.",
+    strong: "resource (available supply) + -ful (full of) + -ness (state of) = the state of being full of resources",
+    strongEs: "resource (recurso disponible) + -ful (lleno de) + -ness (estado de) = el estado de estar lleno de recursos",
+    technique: "Root + Suffix + Suffix",
+    techniqueEs: "Raíz + Sufijo + Sufijo",
+    why: "Double suffixes are common: resource → resourceful (adjective: full of resources) → resourcefulness (noun: the quality of being resourceful). Each suffix changes the word class. Once you see this stacking pattern, you can build and decode hundreds of words.",
+    whyEs: "Los sufijos dobles son comunes: resource → resourceful (adjetivo: lleno de recursos) → resourcefulness (sustantivo: la cualidad de ser ingenioso). Cada sufijo cambia la clase de palabra. Una vez que ves este patrón de apilamiento, puedes construir y decodificar cientos de palabras.",
+  },
+  {
+    flat: "The restructuring of the department was overdue and long-awaited.",
+    flatEs: "La reestructuración del departamento estaba atrasada y esperada desde hace tiempo.",
+    strong: "re- (again) + structure (organize) + -ing (process) / over- (beyond) + due (expected time)",
+    strongEs: "re- (de nuevo) + structure (organizar) + -ing (proceso) / over- (más allá) + due (tiempo esperado)",
+    technique: "Two decoded words",
+    techniqueEs: "Dos palabras decodificadas",
+    why: "Two prefix words in one sentence: 'restructuring' = organizing again (re- + structure + -ing). 'Overdue' = past the expected time (over- + due). When you read English with prefix awareness, complex sentences become transparent. You stop looking up words and start decoding them.",
+    whyEs: "Dos palabras con prefijo en una oración: 'restructuring' = organizar de nuevo (re- + structure + -ing). 'Overdue' = pasado el tiempo esperado (over- + due). Cuando lees inglés con conciencia de prefijos, las oraciones complejas se vuelven transparentes.",
+  },
+  {
+    flat: "His presentation was disorganized and unconvincing to the board.",
+    flatEs: "Su presentación fue desorganizada y poco convincente para la junta.",
+    strong: "dis- (not) + organized (arranged) / un- (not) + convince (persuade) + -ing (doing)",
+    strongEs: "dis- (no) + organized (organizado) / un- (no) + convince (persuadir) + -ing (haciendo)",
+    technique: "Two negative prefixes",
+    techniqueEs: "Dos prefijos negativos",
+    why: "English has FOUR main negative prefixes: un-, dis-, mis-, in-/im-/ir-/il-. They all mean 'not' but attach to different roots. There's no rule for which one goes with which word — but once you recognize them, you can instantly decode any negative word you've never seen before.",
+    whyEs: "El inglés tiene CUATRO prefijos negativos principales: un-, dis-, mis-, in-/im-/ir-/il-. Todos significan 'no' pero se adjuntan a diferentes raíces. No hay una regla para cuál va con cuál — pero una vez que los reconoces, puedes decodificar instantáneamente cualquier palabra negativa que nunca hayas visto.",
+  },
+];

--- a/src/pages/en/course/advanced/index.astro
+++ b/src/pages/en/course/advanced/index.astro
@@ -138,7 +138,7 @@ const iconMap: Record<string, any> = {
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
         {advancedUnits.map((unit) => {
           const Icon = iconMap[unit.icon];
-          const isAvailable = unit.id < 8;
+          const isAvailable = unit.id < 9;
           return (
             <a
               href={isAvailable ? `/en/course/advanced/${unit.slug}/` : undefined}

--- a/src/pages/en/course/advanced/unit-8.astro
+++ b/src/pages/en/course/advanced/unit-8.astro
@@ -1,0 +1,96 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WordBuilder from "@components/course/WordBuilder";
+import SentenceTransformer from "@components/course/SentenceTransformer";
+import { advancedUnits } from "@data/advanced/units";
+import { prefixWords, suffixWords, decodingTransforms } from "@data/advanced/unit-8";
+import { ArrowRight, Puzzle, Layers, Zap } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/advanced/unit-8" as const;
+const progressUnits = advancedUnits.map((u) => ({ id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base lang={lang} tkey={tkey}
+  title="Unit 8: Prefixes & Suffixes — Decode Any English Word | Speak with Confidence | NY English Teacher"
+  description="Learn the prefixes and suffixes that unlock thousands of English words. un-, dis-, mis-, over-, -tion, -ment, -ness, -ful, -less. Stop memorizing vocabulary — start decoding it. Free advanced English lesson for B2-C1 Spanish speakers."
+>
+  <CourseProgress client:load units={progressUnits} currentUnit={8} basePath="/en/course/advanced" lang="en" courseId="advanced" />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-violet-400 text-sm font-semibold mb-3"><Puzzle class="w-4 h-4" /> Unit 8</div>
+        <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Prefixes & Suffixes
+        </h1>
+        <p class="text-lg text-slate-200 max-w-2xl leading-relaxed">
+          Most English words are built from reusable parts. Learn the 12 most common
+          prefixes and suffixes and you'll decode thousands of words you've never seen
+          before — without a dictionary. Stop memorizing. Start decoding.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Puzzle class="w-3.5 h-3.5" /> Prefixes</span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Layers class="w-3.5 h-3.5" /> Suffixes</span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Zap class="w-3.5 h-3.5" /> Word Decoding</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">1</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Prefixes: The Front of the Word</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">
+        A prefix changes the meaning of a word — usually to its opposite or to add
+        "too much," "again," or "before." Tap each word to see how the prefix works,
+        then listen to the pronunciation.
+      </p>
+      <WordBuilder client:visible words={prefixWords} lang="en" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">2</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Suffixes: The Back of the Word</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">
+        A suffix changes what TYPE of word it is — verb to noun, noun to adjective,
+        adjective to adverb. Master these 7 suffixes and you can generate dozens of
+        new words from any root you already know.
+      </p>
+      <WordBuilder client:visible words={suffixWords} lang="en" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2">
+        <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">3</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Decode Words in Context</h2>
+      </div>
+      <p class="text-slate-500 mb-8 ml-11">
+        Now put it all together. Read each sentence, identify the complex word, and
+        see if you can decode it before revealing the breakdown. This is how native
+        speakers handle unfamiliar words — they decode, not memorize.
+      </p>
+      <SentenceTransformer client:visible transforms={decodingTransforms} lang="en" />
+    </div></div>
+  </section>
+
+  <section class="py-12 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto flex justify-between items-center">
+      <a href="/en/course/advanced/unit-7/" class="text-sm text-slate-500 hover:text-violet-600 transition-colors">&larr; Unit 7</a>
+      <Button href="/en/course/advanced/" variant="primary" size="md">Course Overview <ArrowRight class="w-4 h-4 ml-1" /></Button>
+    </div></div>
+  </section>
+</Base>

--- a/src/pages/es/curso/avanzado/index.astro
+++ b/src/pages/es/curso/avanzado/index.astro
@@ -135,7 +135,7 @@ const iconMap: Record<string, any> = {
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
         {advancedUnits.map((unit) => {
           const Icon = iconMap[unit.icon];
-          const isAvailable = unit.id < 8;
+          const isAvailable = unit.id < 9;
           return (
             <a
               href={isAvailable ? `/es/curso/avanzado/${unit.slugEs}/` : undefined}

--- a/src/pages/es/curso/avanzado/unidad-8.astro
+++ b/src/pages/es/curso/avanzado/unidad-8.astro
@@ -1,0 +1,75 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WordBuilder from "@components/course/WordBuilder";
+import SentenceTransformer from "@components/course/SentenceTransformer";
+import { advancedUnits } from "@data/advanced/units";
+import { prefixWords, suffixWords, decodingTransforms } from "@data/advanced/unit-8";
+import { ArrowRight, Puzzle, Layers, Zap } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/advanced/unit-8" as const;
+const progressUnits = advancedUnits.map((u) => ({ id: u.id, slug: u.slugEs, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base lang={lang} tkey={tkey}
+  title="Unidad 8: Prefijos y Sufijos — Decodifica Cualquier Palabra | Habla con Confianza | NY English Teacher"
+  description="Aprende los prefijos y sufijos que desbloquean miles de palabras en inglés. un-, dis-, mis-, over-, -tion, -ment, -ness, -ful, -less. Deja de memorizar vocabulario — empieza a decodificarlo. Lección B2-C1 gratis."
+>
+  <CourseProgress client:load units={progressUnits} currentUnit={8} basePath="/es/curso/avanzado" lang="es" courseId="advanced" />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-violet-400 text-sm font-semibold mb-3"><Puzzle class="w-4 h-4" /> Unidad 8</div>
+        <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Prefijos y Sufijos
+        </h1>
+        <p class="text-lg text-slate-200 max-w-2xl leading-relaxed">
+          La mayoría de las palabras en inglés están construidas con partes reutilizables.
+          Aprende los 12 prefijos y sufijos más comunes y decodificarás miles de palabras
+          que nunca has visto — sin diccionario. Deja de memorizar. Empieza a decodificar.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Puzzle class="w-3.5 h-3.5" /> Prefijos</span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Layers class="w-3.5 h-3.5" /> Sufijos</span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-violet-500/20 text-violet-300 text-sm font-medium"><Zap class="w-3.5 h-3.5" /> Decodificación</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2"><span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">1</span><h2 class="text-2xl md:text-3xl font-bold text-slate-900">Prefijos: El Frente de la Palabra</h2></div>
+      <p class="text-slate-500 mb-8 ml-11">Un prefijo cambia el significado de una palabra — generalmente a su opuesto o agrega "demasiado," "de nuevo," o "antes." Toca cada palabra para ver cómo funciona el prefijo, luego escucha la pronunciación.</p>
+      <WordBuilder client:visible words={prefixWords} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2"><span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">2</span><h2 class="text-2xl md:text-3xl font-bold text-slate-900">Sufijos: La Parte Final de la Palabra</h2></div>
+      <p class="text-slate-500 mb-8 ml-11">Un sufijo cambia el TIPO de palabra — verbo a sustantivo, sustantivo a adjetivo, adjetivo a adverbio. Domina estos 7 sufijos y podrás generar docenas de palabras nuevas de cualquier raíz que ya conozcas.</p>
+      <WordBuilder client:visible words={suffixWords} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto">
+      <div class="flex items-center gap-3 mb-2"><span class="flex items-center justify-center w-8 h-8 rounded-lg bg-violet-500 text-white text-sm font-bold">3</span><h2 class="text-2xl md:text-3xl font-bold text-slate-900">Decodifica Palabras en Contexto</h2></div>
+      <p class="text-slate-500 mb-8 ml-11">Ahora ponlo todo junto. Lee cada oración, identifica la palabra compleja y ve si puedes decodificarla antes de revelar la descomposición. Así es como los nativos manejan palabras desconocidas — decodifican, no memorizan.</p>
+      <SentenceTransformer client:visible transforms={decodingTransforms} lang="es" />
+    </div></div>
+  </section>
+
+  <section class="py-12 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4"><div class="max-w-3xl mx-auto flex justify-between items-center">
+      <a href="/es/curso/avanzado/unidad-7/" class="text-sm text-slate-500 hover:text-violet-600 transition-colors">&larr; Unidad 7</a>
+      <Button href="/es/curso/avanzado/" variant="primary" size="md">Resumen del Curso <ArrowRight class="w-4 h-4 ml-1" /></Button>
+    </div></div>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary
- **New WordBuilder component** — interactive word decomposition with color-coded prefix/root/suffix (violet/amber/emerald), Azure Neural TTS pronunciation, audio caching, and responsive mobile layout
- **Section 1: Prefixes** — 7 words covering un-, dis-, mis-, over-, under-, re-, pre-
- **Section 2: Suffixes** — 7 words covering -tion, -ment, -ness, -en, -ful, -less, -ally
- **Section 3: Decode in Context** — 5 real-world sentences with complex words to decode (SentenceTransformer)
- Hub pages updated to show Unit 8 as available (EN + ES)

## Azure TTS Integration
WordBuilder uses Azure Neural TTS via `/api/tts/synthesize` (same endpoint as blog SpeakEnglish component) with browser SpeechSynthesis fallback. Audio responses are cached client-side.

## Test plan
- [ ] Verify Unit 8 EN and ES pages load with all 3 sections
- [ ] Test WordBuilder reveal interaction (tap → color-coded breakdown)
- [ ] Test Azure TTS audio button on each word
- [ ] Verify mobile layout (375px) — parts stack correctly
- [ ] Check Section 3 SentenceTransformer renders properly
- [ ] Confirm course hub shows Unit 8 as clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)