### PR TITLE
fix: TTS pronunciation — IPA phoneme support + audio on flat sentences

### DIFF
--- a/api/tts/synthesize.ts
+++ b/api/tts/synthesize.ts
@@ -6,8 +6,13 @@
  * API key stays server-side — never exposed to the browser.
  *
  * POST /api/tts/synthesize
- * Body: { text: string, voice?: string, lang?: "en" | "es" }
+ * Body: { text: string, voice?: string, lang?: "en" | "es", phoneme?: string }
  * Response: audio/mpeg binary
+ *
+ * The optional `phoneme` field accepts an IPA string that overrides how
+ * Azure pronounces the text. Example: { text: "uncomfortable", phoneme: "ʌnˈkʌmf.tɚ.bəl" }
+ * This wraps the text in an SSML <phoneme> tag server-side so the client
+ * never needs to craft raw SSML.
  */
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
@@ -68,7 +73,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(500).json({ error: "TTS service not configured" });
   }
 
-  const { text, voice, lang } = req.body || {};
+  const { text, voice, lang, phoneme } = req.body || {};
 
   if (!text || typeof text !== "string") {
     return res.status(400).json({ error: "Missing or invalid 'text' field" });
@@ -98,10 +103,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // Extract language tag from voice name (e.g., "en-US" from "en-US-AndrewNeural")
   const voiceLang = selectedVoice.split("-").slice(0, 2).join("-");
 
-  // Build SSML
+  // Build SSML content — optionally wrap in <phoneme> for pronunciation override
+  const escapedText = escapeXml(cleanText);
+  const ipaRegex = /^[\u0020-\u007E\u00C0-\u024F\u0250-\u02AF\u0300-\u036F\u2000-\u206F.ˈˌːˑ]+$/;
+  const textContent =
+    phoneme && typeof phoneme === "string" && phoneme.length <= 100 && ipaRegex.test(phoneme)
+      ? `<phoneme alphabet="ipa" ph="${escapeXml(phoneme)}">${escapedText}</phoneme>`
+      : escapedText;
+
   const ssml = `<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" xml:lang="${voiceLang}">
   <voice name="${selectedVoice}">
-    <prosody rate="0.9">${escapeXml(cleanText)}</prosody>
+    <prosody rate="0.9">${textContent}</prosody>
   </voice>
 </speak>`;
 

--- a/src/components/course/SentenceTransformer.tsx
+++ b/src/components/course/SentenceTransformer.tsx
@@ -70,9 +70,14 @@ export default function SentenceTransformer({ transforms, lang }: Props) {
             {lang === "es" ? "La versión plana:" : "The flat version:"}
           </p>
           <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
-            <p className="text-base text-slate-700 italic leading-relaxed">
-              "{current.flat}"
-            </p>
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-base text-slate-700 italic leading-relaxed flex-1">
+                "{current.flat}"
+              </p>
+              <div className="shrink-0 mt-1">
+                <AudioButton text={current.flat} size="sm" />
+              </div>
+            </div>
             <p className="text-sm text-slate-400 mt-1">{current.flatEs}</p>
           </div>
         </div>
@@ -101,14 +106,9 @@ export default function SentenceTransformer({ transforms, lang }: Props) {
           ) : (
             <div className="space-y-3">
               <div className="bg-gradient-to-br from-amber-50 to-amber-100 border-2 border-amber-300 rounded-xl p-4">
-                <div className="flex items-start justify-between gap-3">
-                  <p className="text-base text-slate-900 font-medium leading-relaxed flex-1">
-                    "{current.strong}"
-                  </p>
-                  <div className="shrink-0 mt-1">
-                    <AudioButton text={current.strong} size="sm" />
-                  </div>
-                </div>
+                <p className="text-base text-slate-900 font-medium leading-relaxed">
+                  "{current.strong}"
+                </p>
                 <p className="text-sm text-slate-500 mt-2">{current.strongEs}</p>
 
                 {/* Technique badge + explanation */}

--- a/src/components/course/WordBuilder.tsx
+++ b/src/components/course/WordBuilder.tsx
@@ -21,7 +21,7 @@ const roleColors: Record<string, { bg: string; text: string; label: string; labe
   suffix: { bg: "bg-emerald-100", text: "text-emerald-700", label: "suffix", labelEs: "sufijo" },
 };
 
-function AzureAudioButton({ text, className = "" }: { text: string; className?: string }) {
+function AzureAudioButton({ text, phoneme, className = "" }: { text: string; phoneme?: string; className?: string }) {
   const [isPlaying, setIsPlaying] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const cacheRef = useRef<Map<string, string>>(new Map());
@@ -42,7 +42,7 @@ function AzureAudioButton({ text, className = "" }: { text: string; className?: 
         const response = await fetch("/api/tts/synthesize", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ text, lang: "en" }),
+          body: JSON.stringify({ text, lang: "en", ...(phoneme && { phoneme }) }),
         });
 
         if (!response.ok) throw new Error(`TTS error: ${response.status}`);
@@ -73,7 +73,7 @@ function AzureAudioButton({ text, className = "" }: { text: string; className?: 
         setIsPlaying(false);
       }
     }
-  }, [text]);
+  }, [text, phoneme]);
 
   return (
     <button
@@ -144,7 +144,7 @@ export default function WordBuilder({ words, lang }: Props) {
             <span className="text-4xl md:text-5xl font-bold text-slate-900 tracking-tight">
               {current.word}
             </span>
-            <AzureAudioButton text={current.word} />
+            <AzureAudioButton text={current.word} phoneme={current.phoneme} />
           </div>
           {!isRevealed && (
             <p className="text-slate-400 text-sm mt-3">

--- a/src/data/advanced/types.ts
+++ b/src/data/advanced/types.ts
@@ -96,6 +96,8 @@ export interface MinimalPair {
 export interface WordBreakdown {
   /** The whole word */
   word: string;
+  /** Optional IPA phoneme for Azure TTS pronunciation override */
+  phoneme?: string;
   /** Each meaningful piece in order */
   parts: Array<{
     text: string;

--- a/src/data/advanced/unit-8.ts
+++ b/src/data/advanced/unit-8.ts
@@ -13,6 +13,7 @@ import type { WordBreakdown, SentenceTransform } from "./types";
 export const prefixWords: WordBreakdown[] = [
   {
     word: "uncomfortable",
+    phoneme: "ʌnˈkʌmf.tɚ.bəl",
     parts: [
       { text: "un-", role: "prefix", meaning: "not / opposite of", meaningEs: "no / lo opuesto de" },
       { text: "comfort", role: "root", meaning: "ease, relief", meaningEs: "comodidad, alivio" },
@@ -36,6 +37,7 @@ export const prefixWords: WordBreakdown[] = [
   },
   {
     word: "misunderstand",
+    phoneme: "ˌmɪs.ʌn.dɚˈstænd",
     parts: [
       { text: "mis-", role: "prefix", meaning: "wrongly / badly", meaningEs: "incorrectamente / mal" },
       { text: "understand", role: "root", meaning: "to comprehend", meaningEs: "comprender" },
@@ -47,6 +49,7 @@ export const prefixWords: WordBreakdown[] = [
   },
   {
     word: "overestimate",
+    phoneme: "ˌoʊ.vɚˈɛs.tɪ.meɪt",
     parts: [
       { text: "over-", role: "prefix", meaning: "too much / excessively", meaningEs: "demasiado / excesivamente" },
       { text: "estimate", role: "root", meaning: "to guess the value/amount", meaningEs: "calcular el valor/cantidad" },
@@ -98,6 +101,7 @@ export const prefixWords: WordBreakdown[] = [
 export const suffixWords: WordBreakdown[] = [
   {
     word: "communication",
+    phoneme: "kəˌmjuː.nɪˈkeɪ.ʃən",
     parts: [
       { text: "communicate", role: "root", meaning: "to exchange information (verb)", meaningEs: "intercambiar información (verbo)" },
       { text: "-tion", role: "suffix", meaning: "turns a verb into a noun (the act of)", meaningEs: "convierte un verbo en sustantivo (el acto de)" },
@@ -131,6 +135,7 @@ export const suffixWords: WordBreakdown[] = [
   },
   {
     word: "strengthen",
+    phoneme: "ˈstrɛŋ.θən",
     parts: [
       { text: "strength", role: "root", meaning: "power, force (noun)", meaningEs: "fuerza, poder (sustantivo)" },
       { text: "-en", role: "suffix", meaning: "to make or become (verb)", meaningEs: "hacer o volverse (verbo)" },
@@ -164,6 +169,7 @@ export const suffixWords: WordBreakdown[] = [
   },
   {
     word: "basically",
+    phoneme: "ˈbeɪ.sɪ.kli",
     parts: [
       { text: "basic", role: "root", meaning: "fundamental (adjective)", meaningEs: "fundamental (adjetivo)" },
       { text: "-ally", role: "suffix", meaning: "in the manner of (adverb)", meaningEs: "de la manera de (adverbio)" },


### PR DESCRIPTION
## Summary
- **Azure TTS API**: Added optional `phoneme` parameter (IPA) — wraps text in SSML `<phoneme>` tag for pronunciation override. Validates IPA string format and length.
- **SentenceTransformer**: Moved audio button from the "version with impact" to the "flat version" — students need to hear the real English sentence pronounced, not the decomposition formula
- **WordBuilder**: Passes phoneme hints to Azure TTS when available
- **Unit 8 data**: Added IPA phonemes for `uncomfortable` (ʌnˈkʌmf.tɚ.bəl), `misunderstand`, `overestimate`, `communication`, `strengthen`, `basically`

## Why
"Uncomfortable" was being mispronounced by Azure TTS. The IPA phoneme override forces correct pronunciation. This pattern is reusable for any word that needs correction in future units.

## Test plan
- [ ] Verify "uncomfortable" pronounces correctly with IPA override
- [ ] Confirm audio button appears on flat version in SentenceTransformer (Units 1, 7, 8)
- [ ] Confirm no audio button on the impact/strong version
- [ ] Test fallback to browser speech when Azure is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)