### PR TITLE
feat: data deletion page + legal docs update for Meta app review

### DIFF
--- a/src/content/legal/en/data-deletion.md
+++ b/src/content/legal/en/data-deletion.md
@@ -1,0 +1,90 @@
+---
+title: "Data Deletion Instructions"
+lastUpdated: "2026-04-10"
+translations:
+  es: "/es/legal/data-deletion/"
+seo:
+  title: "Data Deletion Instructions - New York English Teacher"
+  description: "How to request deletion of your personal data held by the New York English Messenger Assistant. Simple instructions with a 30-day response commitment."
+---
+
+## Data Deletion Instructions
+
+**For the New York English Messenger Assistant**
+
+**Last Updated: April 10, 2026**
+
+This page explains how to request deletion of any personal data we hold about you as a result of interacting with the **New York English Facebook Messenger Assistant**.
+
+**Quick version:** Email **privacy@newyorkenglish.com** with the subject line **"Data Deletion Request"**, or send a WhatsApp message to **+52 33 1559 0572** with the message **"Please delete my data"**. We will confirm deletion within 30 days.
+
+---
+
+## What Data We Hold About You
+
+When you message the New York English Facebook Page and interact with our Messenger Assistant, we temporarily store:
+
+- Your Facebook-Scoped User ID (PSID)
+- Your public first and last name (as shown on your Facebook profile)
+- The content of your recent messages
+- Your language preference (English or Spanish)
+- Timestamps of your messages
+- Short-term conversation state
+
+All of this data is stored in Cloudflare Workers KV and is **automatically deleted** on a rolling schedule: conversation history and language preferences expire after 1 hour, and handoff state expires after 30 minutes. In most cases, your data has already been deleted before you even send a request.
+
+For the full list and context, see our [Privacy Policy](/en/legal/privacy-policy/).
+
+---
+
+## How to Request Deletion
+
+Choose whichever channel is easiest for you.
+
+### Option A — Email
+
+Send an email to **privacy@newyorkenglish.com**
+
+- **Subject:** Data Deletion Request
+- **Body:** Include the name you use on Facebook, or a description of when you last messaged the page, so we can locate and delete the correct records.
+
+### Option B — WhatsApp
+
+Send a message to **+52 33 1559 0572**
+
+- **Message:** Please delete my data
+- Include your Facebook display name so we can match the request to the correct conversation.
+
+### Option C — Facebook Messenger
+
+Send the message **"Please delete my data"** directly to the New York English Page on Messenger. A human operator will process the request manually.
+
+---
+
+## What We Will Do
+
+Within **30 days** of receiving your request, we will:
+
+1. Locate any data we currently hold about you
+2. Permanently delete all conversation history, language preferences, PSID-linked records, and any other personal data associated with your account
+3. Send you a confirmation when deletion is complete (via the same channel you used to make your request)
+
+---
+
+## What We Cannot Delete
+
+We may retain the following because it cannot be tied back to your personal identity:
+
+- **Aggregated, anonymized analytics** — e.g., how many messages were processed today. This data contains no personal identifiers.
+- **Anonymized error logs** — technical error reports sent to our monitoring system may contain timestamps and stack traces, but do not contain your message content or Facebook identity.
+- **Data held by Meta/Facebook** — we cannot delete data that Meta retains under its own policies. To manage data held by Meta directly, use Facebook's data controls at [facebook.com/settings](https://www.facebook.com/settings).
+
+---
+
+## Contact
+
+For questions about this process, or to follow up on a request:
+
+- **Email:** privacy@newyorkenglish.com
+- **WhatsApp:** +52 33 1559 0572
+- **Operator:** Robert Cushman, New York English, Guadalajara, Mexico

--- a/src/content/legal/en/privacy-policy.md
+++ b/src/content/legal/en/privacy-policy.md
@@ -1,30 +1,46 @@
 ---
 title: "Privacy Policy"
-lastUpdated: "2025-04-10"
+lastUpdated: "2026-04-10"
 translations:
   es: "/es/legal/privacy-policy/"
 seo:
   title: "Privacy Policy - How We Protect Your Information"
-  description: "Understand how we collect, use, and safeguard your personal information on the New York English Teacher website for coaching services."
+  description: "Understand how we collect, use, and safeguard your personal information on the New York English Teacher website and Facebook Messenger assistant."
 ---
 
 ## Privacy Policy
 
-**Last Updated: April 10, 2025**
+**Last Updated: April 10, 2026**
 
 ## Introduction
 
-Welcome to our Privacy Policy. We are committed to protecting your personal information. This policy outlines how Happy Healthy Choices, LLC (owner of the New York English Teacher website, referred to as “we,” “us,” or “our”) collects, uses, and protects your data when you use our website and services.
+Welcome to our Privacy Policy. New York English is an executive English coaching service operated by **Robert Cushman**, based in Guadalajara, Mexico. This policy explains how we collect, use, and protect your personal information when you use our website (nyenglishteacher.com) and our Facebook Messenger Assistant.
+
+If you have questions, contact us at **privacy@newyorkenglish.com**.
 
 ## Information We Collect
 
-We may collect the following personal information:
+### Website
 
-- **Contact Information**: Name, email address, phone number.
-- **Technical Information**: IP address, browser type, device details, and cookie data.
-- **Usage Information**: Pages visited, time spent on site, and interactions with content.
+When you use nyenglishteacher.com, we may collect:
+
+- **Contact Information**: Name, email address, phone number (submitted via forms)
+- **Technical Information**: IP address, browser type, device details, and cookie data
+- **Usage Information**: Pages visited, time spent on site, interactions with content
 
 > _Note: We do **not** collect or store credit card or payment information directly._
+
+### Facebook Messenger Assistant
+
+When you message the New York English Facebook Page and interact with our AI-powered Messenger Assistant, we receive and process:
+
+- Your **Facebook-Scoped User ID (PSID)** — an anonymous identifier provided by Meta, unique to our Page
+- Your **public first and last name** as shown on your Facebook profile
+- The **content of your messages**
+- Your **language preference** (English or Spanish)
+- **Timestamps** of your messages
+
+We do **not** collect your email address, phone number, Facebook friends list, or any other profile data beyond what is listed above.
 
 ## How We Collect Information
 
@@ -33,24 +49,48 @@ Information is collected through:
 - Online forms you complete voluntarily
 - Cookies and tracking technologies
 - Analytics tools (e.g., Google Analytics)
+- The Facebook Messenger Platform (for Messenger Assistant interactions)
 
 ## How We Use Your Information
 
 We use your data to:
 
-- Provide and improve our services
-- Communicate with you about services and inquiries
-- Personalize your experience on the site
+- Provide and improve our coaching services
+- Respond to your inquiries via the website or Messenger Assistant
+- Maintain short-term conversation context in the Messenger Assistant
+- Detect and respond in your preferred language (English or Spanish)
 - Analyze site usage and performance
-- Maintain the security of our website
+- Maintain the security of our website and services
 - Comply with legal obligations
 
-## Data Sharing and Disclosure
+**We do not use Messenger data for advertising, profiling, or resale.**
 
-We **do not sell or rent** your personal information. Your data may be shared only when necessary:
+## Data Retention
 
-- With trusted third-party service providers who assist in operating our website
-- When required to comply with legal obligations or valid law enforcement requests
+**Website data:** Retained as long as necessary to provide the services you requested, or as required by law.
+
+**Messenger Assistant data:** Stored temporarily in Cloudflare Workers KV and automatically deleted on a rolling schedule:
+
+- Conversation history: **1 hour**, then automatically deleted
+- Language preference: **1 hour**, then automatically deleted
+- Human-handoff state: **30 minutes**, then automatically deleted
+
+We do not maintain long-term storage of Messenger conversations.
+
+## Third Parties
+
+We do **not** sell or rent your personal data. Your data may be shared only when necessary:
+
+- With trusted service providers who help operate our website and services
+- When required by law or valid legal process
+
+For the Messenger Assistant specifically, your messages are transmitted to the following processors:
+
+- **Meta Platforms, Inc.** — delivers messages via the Messenger Platform. [Privacy Policy](https://www.facebook.com/privacy/policy)
+- **Anthropic, PBC** — provides the Claude AI model that generates responses. [Privacy Policy](https://www.anthropic.com/legal/privacy)
+- **Cloudflare, Inc.** — hosts the Worker, provides KV storage and AI Gateway routing. [Privacy Policy](https://www.cloudflare.com/privacypolicy/)
+- **Qdrant Solutions GmbH** — hosts the vector database used to retrieve relevant content. [Privacy Policy](https://qdrant.tech/legal/privacy-policy/)
+- **Functional Software, Inc. (Sentry)** — receives error reports for monitoring purposes. [Privacy Policy](https://sentry.io/privacy/)
 
 ## Your Rights
 
@@ -62,24 +102,34 @@ Depending on your location, you may have the right to:
 - Object to or restrict how your data is processed
 - Withdraw previously given consent
 
-To exercise any of these rights, please contact us using the information below.
+To exercise any of these rights, contact us at **privacy@newyorkenglish.com**.
+
+## Data Deletion
+
+You can request deletion of all data we hold about you at any time. Full instructions are at:
+
+**https://www.nyenglishteacher.com/en/legal/data-deletion/**
 
 ## Data Security
 
-We use appropriate technical and organizational safeguards to protect your data. However, no method of online transmission or storage is completely secure.
+We use appropriate technical and organizational safeguards to protect your data, including encrypted transit (HTTPS/TLS) and encrypted secrets storage. However, no method of online transmission or storage is completely secure.
 
 ## Cookies and Tracking Technologies
 
-Our website uses cookies to improve your browsing experience. You can manage cookie preferences in your browser settings.
+Our website uses cookies to improve your browsing experience. You can manage cookie preferences in your browser settings. The Messenger Assistant itself does not use cookies.
 
-## Children’s Privacy
+## Children's Privacy
 
-Our services are not intended for individuals under the age of 13. We do not knowingly collect data from children. If we learn we have received information from a child under 13, we will delete it promptly.
+Our services are intended for **adults aged 18 and over**. We do not knowingly collect data from anyone under 18. If we learn we have received information from a minor, we will delete it promptly. Contact us at **privacy@newyorkenglish.com** if you believe this has occurred.
 
 ## Changes to This Privacy Policy
 
-We may occasionally update this Privacy Policy. When changes occur, we will update the “Last Updated” date above. We encourage you to review this page periodically.
+We may occasionally update this Privacy Policy. When changes occur, we will update the "Last Updated" date at the top of this page. Material changes will also be announced on the website.
 
 ## Contact Us
 
-If you have any questions or concerns about this Privacy Policy, please contact us using our contact form.
+For any privacy-related questions, data access requests, or concerns:
+
+- **Email:** privacy@newyorkenglish.com
+- **WhatsApp:** +52 33 1559 0572
+- **Operator:** Robert Cushman, New York English, Guadalajara, Mexico

--- a/src/content/legal/en/terms-of-service.md
+++ b/src/content/legal/en/terms-of-service.md
@@ -1,63 +1,82 @@
 ---
 title: "Terms and Conditions of Use"
-lastUpdated: "2025-04-10"
+lastUpdated: "2026-04-10"
 translations:
   es: "/es/legal/terms-of-service/"
 seo:
   title: "Terms of Service - New York English Teacher"
-  description: "Terms and conditions for New York English Teacher's website and coaching services. Includes user rights, acceptable use policies, and service commitments."
+  description: "Terms and conditions for New York English Teacher's website, coaching services, and AI-powered Messenger Assistant. Includes acceptable use, disclaimers, and service commitments."
 ---
 
 ## Terms and Conditions of Use
 
-**Effective Date:** April 2, 2023  
-**Last Updated:** April 10, 2025
+**Effective Date:** April 2, 2023
+**Last Updated:** April 10, 2026
 
 ## Introduction
 
-Welcome to the New York English Teacher (“NYET”) website and online services (the “Site”), which offers English lessons and quizzes online. By accessing or using the Site and any of its information, tools, features, and functionality (collectively, the “Services”), you agree to enter into a binding contract with NYET.
+Welcome to the New York English Teacher ("NYET") website and online services (the "Site"), which offers English coaching, lessons, and quizzes for professionals. By accessing or using the Site and any of its information, tools, features, and functionality (collectively, the "Services"), you agree to enter into a binding contract with NYET.
 
-Whether you are a “Visitor” (browsing the Site) or a “User” (actively using the Services), these Terms and Conditions of Use (the “Terms”) apply to you. The term “you” refers to either a Visitor or a User. The term “we” refers to NYET and its affiliates.
+Whether you are a "Visitor" (browsing the Site) or a "User" (actively using the Services), these Terms and Conditions of Use (the "Terms") apply to you. The term "you" refers to either a Visitor or a User. The term "we" refers to New York English Teacher, operated by Robert Cushman, Guadalajara, Mexico.
 
 ## Definitions
 
-- **"NYET"**, **"we"**, **"us"**, or **"our"** refers to New York English Teacher and its affiliates.
-- **"Site"** refers to our website and online services.
-- **"Services"** includes all tools, features, lessons, quizzes, and content offered through the Site.
+- **"NYET"**, **"we"**, **"us"**, or **"our"** refers to New York English Teacher, operated by Robert Cushman.
+- **"Site"** refers to our website and online services at nyenglishteacher.com.
+- **"Services"** includes all tools, features, lessons, quizzes, coaching, and content offered through the Site or our Facebook Messenger Assistant.
 - **"User"**, **"you"**, or **"your"** refers to anyone using or accessing the Site or Services, whether registered or not.
 
 ## Acceptance of Terms
 
-By using the Services, you agree to be bound by these Terms and NYET's [Privacy Policy](#), which together constitute the full agreement between you and NYET (the “Agreement”). If you do not agree with these Terms, please do not use the Services.
+By using the Services, you agree to be bound by these Terms and NYET's [Privacy Policy](/en/legal/privacy-policy/), which together constitute the full agreement between you and NYET (the "Agreement"). If you do not agree with these Terms, please do not use the Services.
 
 To use the Services, you must:
 
-- Be at least 16 years old, or at least 13 years old with a parent or guardian’s consent.
+- Be at least **18 years old**.
 - Be legally capable of entering into a binding contract.
-- Ensure that all registration information you provide is truthful, accurate, and kept up to date.
-
-We encourage you to save or print a copy of this Agreement for your records.
+- Ensure that all information you provide is truthful, accurate, and kept up to date.
 
 ## Acceptable Use
 
 You agree not to use the Services to:
 
-- Violate any laws or regulations;
-- Infringe on the rights or privacy of others;
-- Distribute viruses, malware, or harmful software;
-- Attempt to gain unauthorized access to our systems;
-- Interfere with the proper working of the Services;
-- Send spam or other unauthorized communications.
+- Violate any laws or regulations
+- Infringe on the rights or privacy of others
+- Distribute viruses, malware, or harmful software
+- Attempt to gain unauthorized access to our systems
+- Attempt to extract, reverse-engineer, or exploit the AI model, prompts, or infrastructure via the Messenger Assistant
+- Interfere with the proper working of the Services
+- Send spam or other unauthorized communications
+- Harass, threaten, or abuse Robert Cushman or any other user
+
+## Facebook Messenger Assistant
+
+NYET operates an AI-powered Messenger Assistant on the New York English Facebook Page. By interacting with it, you also agree to the following:
+
+### What the Assistant Does
+
+The Messenger Assistant answers questions about our English coaching services, pricing, scheduling, and related topics. It is available in English and Spanish.
+
+### The Assistant's Limitations
+
+The Messenger Assistant is an **informational tool powered by AI**. Please understand:
+
+- It may occasionally produce **incorrect, incomplete, or outdated information**. Always verify critical details — especially pricing, scheduling, and availability — directly with Robert before making any decisions.
+- It is **not a replacement for human English coaching**. The assistant handles inquiries only. Actual coaching, lessons, and feedback come from Robert directly.
+- It is **not a substitute for professional advice** of any kind.
+- Responses are generated in real time and may vary between sessions.
+
+### Data and Privacy
+
+Your use of the Messenger Assistant is also governed by our [Privacy Policy](/en/legal/privacy-policy/). For information on how to request deletion of your data, see our [Data Deletion Instructions](/en/legal/data-deletion/).
 
 ## Changes to the Agreement & Termination
 
-NYET may update or modify the Agreement at any time at our sole discretion. When we make material changes, we will notify you via the Site or Services. By continuing to use the Services after changes are made, you acknowledge your acceptance of the updated Terms.
+NYET may update or modify the Agreement at any time. When we make material changes, we will notify you via the Site or Services. By continuing to use the Services after changes are made, you acknowledge your acceptance of the updated Terms.
 
-We may also modify, suspend, or discontinue any part of the Services or the Site at any time without prior notice or liability.
+We may also modify, suspend, or discontinue any part of the Services at any time without prior notice or liability.
 
-These Terms remain in effect until terminated by either you or NYET. We reserve the right to suspend or terminate your access to the Services at our discretion. If your access is terminated, you agree that NYET shall not be liable to you or any third party.
-
-To request termination of your registered account, please contact us directly.
+These Terms remain in effect until terminated by either you or NYET. We reserve the right to suspend or terminate your access to the Services at our discretion.
 
 ## Intellectual Property
 
@@ -67,16 +86,20 @@ You retain rights to any content you submit to the platform but grant NYET a non
 
 ## Disclaimer of Warranties
 
-The Services are provided "as is" and "as available" without warranties of any kind. NYET does not guarantee that the Services will be uninterrupted, secure, or error-free.
+The Services are provided **"as is"** and **"as available"** without warranties of any kind, either express or implied. NYET does not guarantee that the Services will be uninterrupted, secure, or error-free.
 
 ## Limitation of Liability
 
-To the fullest extent permitted by law, NYET shall not be liable for any indirect, incidental, or consequential damages, including loss of data, profits, or goodwill, resulting from your use of the Services.
+To the fullest extent permitted by applicable law, NYET and Robert Cushman shall not be liable for any indirect, incidental, special, consequential, or punitive damages, including loss of data, profits, or goodwill, resulting from your use of the Services.
 
 ## Governing Law
 
-These Terms shall be governed by the laws of the State of New York, without regard to its conflict of laws provisions.
+These Terms shall be governed by the laws of **Mexico**, without regard to its conflict of laws provisions. Any disputes arising from or relating to the Services shall be handled in the courts of **Guadalajara, Jalisco, Mexico**, unless otherwise required by applicable consumer protection law.
 
 ## Contact Us
 
-Do you have any questions or concerns about this Privacy Policy? Please don’t hesitate to contact us through our contact form.
+For questions or concerns about these Terms:
+
+- **Email:** privacy@newyorkenglish.com
+- **WhatsApp:** +52 33 1559 0572
+- **Operator:** Robert Cushman, New York English, Guadalajara, Mexico

--- a/src/content/legal/es/data-deletion.md
+++ b/src/content/legal/es/data-deletion.md
@@ -1,0 +1,90 @@
+---
+title: "Instrucciones de Eliminación de Datos"
+lastUpdated: "2026-04-10"
+translations:
+  en: "/en/legal/data-deletion/"
+seo:
+  title: "Instrucciones de Eliminación de Datos - New York English Teacher"
+  description: "Cómo solicitar la eliminación de tus datos personales almacenados por el Asistente de Messenger de New York English. Instrucciones simples con compromiso de respuesta en 30 días."
+---
+
+## Instrucciones de Eliminación de Datos
+
+**Para el Asistente de Facebook Messenger de New York English**
+
+**Última Actualización: 10 de abril de 2026**
+
+Esta página explica cómo solicitar la eliminación de cualquier dato personal que tengamos sobre ti como resultado de interactuar con el **Asistente de Facebook Messenger de New York English**.
+
+**Versión rápida:** Envía un correo a **privacy@newyorkenglish.com** con el asunto **"Solicitud de Eliminación de Datos"**, o envía un mensaje de WhatsApp al **+52 33 1559 0572** con el mensaje **"Por favor elimina mis datos"**. Confirmaremos la eliminación en un plazo de 30 días.
+
+---
+
+## Qué Datos Tenemos Sobre Ti
+
+Cuando envías un mensaje a la página de Facebook de New York English e interactúas con nuestro Asistente de Messenger, almacenamos temporalmente:
+
+- Tu ID de Usuario Vinculado a la Página de Facebook (PSID)
+- Tu nombre y apellido públicos (tal como aparecen en tu perfil de Facebook)
+- El contenido de tus mensajes recientes
+- Tu preferencia de idioma (inglés o español)
+- Marcas de tiempo de tus mensajes
+- Estado breve de la conversación
+
+Todos estos datos se almacenan en Cloudflare Workers KV y se **eliminan automáticamente**: el historial de conversación y las preferencias de idioma expiran después de 1 hora, y el estado de transferencia a humano expira después de 30 minutos. En la mayoría de los casos, tus datos ya han sido eliminados antes de que envíes una solicitud.
+
+Para la lista completa y el contexto, consulta nuestra [Política de Privacidad](/es/legal/privacy-policy/).
+
+---
+
+## Cómo Solicitar la Eliminación
+
+Elige el canal que te resulte más conveniente.
+
+### Opción A — Correo Electrónico
+
+Envía un correo a **privacy@newyorkenglish.com**
+
+- **Asunto:** Solicitud de Eliminación de Datos
+- **Cuerpo:** Incluye el nombre que usas en Facebook, o una descripción de cuándo enviaste tu último mensaje a la página, para que podamos localizar y eliminar los registros correctos.
+
+### Opción B — WhatsApp
+
+Envía un mensaje al **+52 33 1559 0572**
+
+- **Mensaje:** Por favor elimina mis datos
+- Incluye tu nombre de perfil de Facebook para que podamos relacionar la solicitud con la conversación correcta.
+
+### Opción C — Facebook Messenger
+
+Envía el mensaje **"Por favor elimina mis datos"** directamente a la página de New York English en Messenger. Un operador humano procesará la solicitud manualmente.
+
+---
+
+## Qué Haremos
+
+Dentro de los **30 días** de recibir tu solicitud:
+
+1. Localizaremos cualquier dato que tengamos actualmente sobre ti
+2. Eliminaremos permanentemente todo el historial de conversación, preferencias de idioma, registros vinculados al PSID y cualquier otro dato personal asociado con tu cuenta
+3. Te enviaremos una confirmación cuando se complete la eliminación (por el mismo canal que usaste para hacer la solicitud)
+
+---
+
+## Qué No Podemos Eliminar
+
+Podemos conservar lo siguiente porque no puede vincularse a tu identidad personal:
+
+- **Análisis agregados y anonimizados** — por ejemplo, cuántos mensajes se procesaron hoy. Estos datos no contienen identificadores personales.
+- **Registros de errores anonimizados** — los informes técnicos de errores enviados a nuestro sistema de monitoreo pueden contener marcas de tiempo y trazas de error, pero no contienen el contenido de tus mensajes ni tu identidad de Facebook.
+- **Datos en poder de Meta/Facebook** — no podemos eliminar los datos que Meta conserva bajo sus propias políticas. Para gestionar los datos en poder de Meta directamente, utiliza los controles de datos de Facebook en [facebook.com/settings](https://www.facebook.com/settings).
+
+---
+
+## Contacto
+
+Para preguntas sobre este proceso o para dar seguimiento a una solicitud:
+
+- **Correo electrónico:** privacy@newyorkenglish.com
+- **WhatsApp:** +52 33 1559 0572
+- **Operador:** Robert Cushman, New York English, Guadalajara, México

--- a/src/content/legal/es/privacy-policy.md
+++ b/src/content/legal/es/privacy-policy.md
@@ -1,30 +1,46 @@
 ---
 title: "Política de Privacidad"
-lastUpdated: "2025-04-10"
+lastUpdated: "2026-04-10"
 translations:
   en: "/en/legal/privacy-policy/"
 seo:
   title: "Política de Privacidad - Cómo Protegemos Tu Información"
-  description: "Comprende cómo recopilamos, usamos y protegemos tu información personal en el sitio web de New York English Teacher para servicios de coaching."
+  description: "Comprende cómo recopilamos, usamos y protegemos tu información personal en el sitio web de New York English Teacher y el asistente de Facebook Messenger."
 ---
 
 ## Política de Privacidad
 
-**Última Actualización: 10 de abril de 2025**
+**Última Actualización: 10 de abril de 2026**
 
 ## Introducción
 
-Bienvenido a nuestra Política de Privacidad. Nos comprometemos a proteger tu información personal. Esta política describe cómo Happy Healthy Choices, LLC (propietaria del sitio web New York English Teacher, referido como “nosotros” o “nuestro”) recopila, usa y protege tus datos cuando utilizas nuestro sitio web y servicios.
+Bienvenido a nuestra Política de Privacidad. New York English es un servicio de coaching ejecutivo de inglés operado por **Robert Cushman**, con sede en Guadalajara, México. Esta política explica cómo recopilamos, usamos y protegemos tu información personal cuando utilizas nuestro sitio web (nyenglishteacher.com) y nuestro Asistente de Facebook Messenger.
+
+Si tienes preguntas, contáctanos en **privacy@newyorkenglish.com**.
 
 ## Información que Recopilamos
 
-Podemos recopilar la siguiente información personal:
+### Sitio Web
 
-- **Información de Contacto**: Nombre, dirección de correo electrónico, número de teléfono.
-- **Información Técnica**: Dirección IP, tipo de navegador, detalles del dispositivo y datos de cookies.
-- **Información de Uso**: Páginas visitadas, tiempo empleado en el sitio e interacciones con el contenido.
+Cuando utilizas nyenglishteacher.com, podemos recopilar:
+
+- **Información de Contacto**: Nombre, dirección de correo electrónico, número de teléfono (enviados mediante formularios)
+- **Información Técnica**: Dirección IP, tipo de navegador, detalles del dispositivo y datos de cookies
+- **Información de Uso**: Páginas visitadas, tiempo empleado en el sitio e interacciones con el contenido
 
 > _Nota: **No** recopilamos ni almacenamos directamente información de tarjetas de crédito o pagos._
+
+### Asistente de Facebook Messenger
+
+Cuando envías un mensaje a la página de Facebook de New York English e interactúas con nuestro Asistente de Messenger impulsado por IA, recibimos y procesamos:
+
+- Tu **ID de Usuario Vinculado a la Página de Facebook (PSID)** — un identificador anónimo proporcionado por Meta, único para nuestra Página
+- Tu **nombre y apellido públicos** tal como aparecen en tu perfil de Facebook
+- El **contenido de tus mensajes**
+- Tu **preferencia de idioma** (inglés o español)
+- Las **marcas de tiempo** de tus mensajes
+
+**No** recopilamos tu correo electrónico, número de teléfono, lista de amigos de Facebook ni ningún otro dato de perfil más allá de lo indicado anteriormente.
 
 ## Cómo Recopilamos Información
 
@@ -33,24 +49,48 @@ La información se recopila a través de:
 - Formularios en línea que completas voluntariamente
 - Cookies y tecnologías de seguimiento
 - Herramientas de análisis (por ejemplo, Google Analytics)
+- La Plataforma de Facebook Messenger (para interacciones con el Asistente de Messenger)
 
 ## Cómo Usamos Tu Información
 
 Usamos tus datos para:
 
-- Proveer y mejorar nuestros servicios
-- Comunicarnos contigo sobre servicios y consultas
-- Personalizar tu experiencia en el sitio
+- Proveer y mejorar nuestros servicios de coaching
+- Responder a tus consultas a través del sitio web o el Asistente de Messenger
+- Mantener el contexto breve de la conversación en el Asistente de Messenger
+- Detectar y responder en tu idioma preferido (inglés o español)
 - Analizar el uso y rendimiento del sitio
-- Mantener la seguridad de nuestro sitio web
+- Mantener la seguridad de nuestro sitio web y servicios
 - Cumplir con obligaciones legales
 
-## Intercambio y Divulgación de Datos
+**No utilizamos los datos de Messenger para publicidad, perfilamiento ni reventa.**
+
+## Retención de Datos
+
+**Datos del sitio web:** Se conservan durante el tiempo necesario para proporcionar los servicios solicitados, o según lo exija la ley.
+
+**Datos del Asistente de Messenger:** Se almacenan temporalmente en Cloudflare Workers KV y se eliminan automáticamente:
+
+- Historial de conversación: **1 hora**, luego se elimina automáticamente
+- Preferencia de idioma: **1 hora**, luego se elimina automáticamente
+- Estado de transferencia a humano: **30 minutos**, luego se elimina automáticamente
+
+No mantenemos almacenamiento a largo plazo de conversaciones de Messenger.
+
+## Terceros
 
 **No vendemos ni rentamos** tu información personal. Tus datos pueden ser compartidos solo cuando sea necesario:
 
-- Con proveedores de servicios de confianza que nos asisten en la operación de nuestro sitio web
-- Cuando se requiera para cumplir con obligaciones legales o solicitudes válidas de las fuerzas del orden
+- Con proveedores de servicios de confianza que nos ayudan a operar nuestro sitio web y servicios
+- Cuando lo requiera la ley o un proceso legal válido
+
+Específicamente para el Asistente de Messenger, tus mensajes son transmitidos a los siguientes procesadores:
+
+- **Meta Platforms, Inc.** — entrega mensajes a través de la Plataforma Messenger. [Política de Privacidad](https://www.facebook.com/privacy/policy)
+- **Anthropic, PBC** — proporciona el modelo de IA Claude que genera las respuestas. [Política de Privacidad](https://www.anthropic.com/legal/privacy)
+- **Cloudflare, Inc.** — aloja el Worker y proporciona almacenamiento KV y enrutamiento de AI Gateway. [Política de Privacidad](https://www.cloudflare.com/privacypolicy/)
+- **Qdrant Solutions GmbH** — aloja la base de datos vectorial utilizada para recuperar contenido relevante. [Política de Privacidad](https://qdrant.tech/legal/privacy-policy/)
+- **Functional Software, Inc. (Sentry)** — recibe informes de errores para monitoreo. [Política de Privacidad](https://sentry.io/privacy/)
 
 ## Tus Derechos
 
@@ -62,24 +102,34 @@ Dependiendo de tu ubicación, puedes tener derecho a:
 - Oponerte o restringir cómo se procesan tus datos
 - Retirar el consentimiento previamente otorgado
 
-Para ejercer cualquiera de estos derechos, por favor contáctanos usando la información a continuación.
+Para ejercer cualquiera de estos derechos, contáctanos en **privacy@newyorkenglish.com**.
+
+## Eliminación de Datos
+
+Puedes solicitar la eliminación de todos los datos que tenemos sobre ti en cualquier momento. Las instrucciones completas se encuentran en:
+
+**https://www.nyenglishteacher.com/es/legal/data-deletion/**
 
 ## Seguridad de los Datos
 
-Utilizamos medidas de seguridad técnicas y organizativas apropiadas para proteger tus datos. Sin embargo, ningún método de transmisión o almacenamiento en línea es completamente seguro.
+Utilizamos medidas de seguridad técnicas y organizativas apropiadas para proteger tus datos, incluyendo tránsito cifrado (HTTPS/TLS) y almacenamiento seguro de secretos. Sin embargo, ningún método de transmisión o almacenamiento en línea es completamente seguro.
 
 ## Cookies y Tecnologías de Seguimiento
 
-Nuestro sitio web utiliza cookies para mejorar tu experiencia de navegación. Puedes gestionar las preferencias de cookies en la configuración de tu navegador.
+Nuestro sitio web utiliza cookies para mejorar tu experiencia de navegación. Puedes gestionar las preferencias de cookies en la configuración de tu navegador. El Asistente de Messenger en sí no utiliza cookies.
 
-## Privacidad de los Niños
+## Privacidad de los Menores
 
-Nuestros servicios no están destinados a personas menores de 13 años. No recopilamos conscientemente datos de niños. Si descubrimos que hemos recibido información de un niño menor de 13 años, la eliminaremos de inmediato.
+Nuestros servicios están destinados a **personas adultas mayores de 18 años**. No recopilamos conscientemente datos de personas menores de 18 años. Si descubrimos que hemos recibido información de un menor, la eliminaremos de inmediato. Contáctanos en **privacy@newyorkenglish.com** si crees que esto ha ocurrido.
 
 ## Cambios a Esta Política de Privacidad
 
-Podemos actualizar ocasionalmente esta Política de Privacidad. Cuando ocurran cambios, actualizaremos la fecha de “Última Actualización” que aparece arriba. Te recomendamos revisar esta página periódicamente.
+Podemos actualizar ocasionalmente esta Política de Privacidad. Cuando ocurran cambios, actualizaremos la fecha de "Última Actualización" en la parte superior de esta página. Los cambios materiales también se anunciarán en el sitio web.
 
 ## Contáctanos
 
-¿Tienes preguntas o inquietudes sobre esta Política de Privacidad? No dudes en contactarnos a través de nuestro formulario de contacto.
+Para cualquier pregunta relacionada con la privacidad, solicitudes de acceso a datos o inquietudes:
+
+- **Correo electrónico:** privacy@newyorkenglish.com
+- **WhatsApp:** +52 33 1559 0572
+- **Operador:** Robert Cushman, New York English, Guadalajara, México

--- a/src/content/legal/es/terms-of-service.md
+++ b/src/content/legal/es/terms-of-service.md
@@ -1,63 +1,82 @@
 ---
 title: "Términos y Condiciones de Uso"
-lastUpdated: "2025-04-10"
+lastUpdated: "2026-04-10"
 translations:
   en: "/en/legal/terms-of-service/"
 seo:
   title: "Términos de Servicio - New York English Teacher"
-  description: "Términos y condiciones para el sitio web y servicios de coaching de New York English Teacher. Incluye derechos de usuario y políticas de uso."
+  description: "Términos y condiciones para el sitio web, servicios de coaching y Asistente de Messenger con IA de New York English Teacher. Incluye uso aceptable, descargos de responsabilidad y compromisos de servicio."
 ---
 
 ## Términos y Condiciones de Uso
 
 **Fecha de Entrada en Vigor:** 2 de abril de 2023
-**Última Actualización:** 10 de abril de 2025
+**Última Actualización:** 10 de abril de 2026
 
 ## Introducción
 
-Bienvenido al sitio web y servicios en línea de New York English Teacher (“NYET”) (el “Sitio”), que ofrece lecciones y cuestionarios de inglés en línea. Al acceder o utilizar el Sitio y cualquiera de su información, herramientas, características y funcionalidades (colectivamente, los “Servicios”), aceptas celebrar un contrato vinculante con NYET.
+Bienvenido al sitio web y servicios en línea de New York English Teacher ("NYET") (el "Sitio"), que ofrece coaching ejecutivo de inglés, lecciones y cuestionarios para profesionales. Al acceder o utilizar el Sitio y cualquiera de su información, herramientas, características y funcionalidades (colectivamente, los "Servicios"), aceptas celebrar un contrato vinculante con NYET.
 
-Ya seas un “Visitante” (navegando por el Sitio) o un “Usuario” (utilizando activamente los Servicios), estos Términos y Condiciones de Uso (los “Términos”) se aplican a ti. El término “tú” se refiere tanto a un Visitante como a un Usuario. El término “nosotros” se refiere a NYET y sus afiliados.
+Ya seas un "Visitante" (navegando por el Sitio) o un "Usuario" (utilizando activamente los Servicios), estos Términos y Condiciones de Uso (los "Términos") se aplican a ti. El término "tú" se refiere tanto a un Visitante como a un Usuario. El término "nosotros" se refiere a New York English Teacher, operado por Robert Cushman, Guadalajara, México.
 
 ## Definiciones
 
-- **"NYET"**, **"nosotros"** o **"nuestro"** se refiere a New York English Teacher y sus afiliados.
-- **"Sitio"** se refiere a nuestro sitio web y servicios en línea.
-- **"Servicios"** incluye todas las herramientas, características, lecciones, cuestionarios y contenido ofrecido a través del Sitio.
+- **"NYET"**, **"nosotros"** o **"nuestro"** se refiere a New York English Teacher, operado por Robert Cushman.
+- **"Sitio"** se refiere a nuestro sitio web y servicios en línea en nyenglishteacher.com.
+- **"Servicios"** incluye todas las herramientas, características, lecciones, cuestionarios, coaching y contenido ofrecido a través del Sitio o nuestro Asistente de Facebook Messenger.
 - **"Usuario"**, **"tú"** o **"tu"** se refiere a cualquier persona que use o acceda al Sitio o Servicios, esté registrada o no.
 
 ## Aceptación de los Términos
 
-Al utilizar los Servicios, aceptas estar sujeto a estos Términos y a la [Política de Privacidad](#) de NYET, que en conjunto constituyen el acuerdo completo entre tú y NYET (el “Acuerdo”). Si no estás de acuerdo con estos Términos, por favor no utilices los Servicios.
+Al utilizar los Servicios, aceptas estar sujeto a estos Términos y a la [Política de Privacidad](/es/legal/privacy-policy/) de NYET, que en conjunto constituyen el acuerdo completo entre tú y NYET (el "Acuerdo"). Si no estás de acuerdo con estos Términos, por favor no utilices los Servicios.
 
 Para utilizar los Servicios, debes:
 
-- Tener al menos 16 años, o al menos 13 años con el consentimiento de un padre o tutor.
+- Tener al menos **18 años**.
 - Ser legalmente capaz de celebrar un contrato vinculante.
-- Asegurarte de que toda la información de registro que proporciones sea veraz, precisa y se mantenga actualizada.
-
-Te recomendamos guardar o imprimir una copia de este Acuerdo para tus registros.
+- Asegurarte de que toda la información que proporciones sea veraz, precisa y se mantenga actualizada.
 
 ## Uso Aceptable
 
 Te comprometes a no utilizar los Servicios para:
 
-- Violar leyes o regulaciones;
-- Infringir los derechos o la privacidad de otros;
-- Distribuir virus, malware o software dañino;
-- Intentar obtener acceso no autorizado a nuestros sistemas;
-- Interferir con el funcionamiento adecuado de los Servicios;
-- Enviar spam u otras comunicaciones no autorizadas.
+- Violar leyes o regulaciones
+- Infringir los derechos o la privacidad de otros
+- Distribuir virus, malware o software dañino
+- Intentar obtener acceso no autorizado a nuestros sistemas
+- Intentar extraer, realizar ingeniería inversa o explotar el modelo de IA, prompts o infraestructura a través del Asistente de Messenger
+- Interferir con el funcionamiento adecuado de los Servicios
+- Enviar spam u otras comunicaciones no autorizadas
+- Acosar, amenazar o abusar de Robert Cushman o cualquier otro usuario
+
+## Asistente de Facebook Messenger
+
+NYET opera un Asistente de Messenger impulsado por IA en la página de Facebook de New York English. Al interactuar con él, también aceptas lo siguiente:
+
+### Qué Hace el Asistente
+
+El Asistente de Messenger responde preguntas sobre nuestros servicios de coaching de inglés, precios, horarios y temas relacionados. Está disponible en inglés y español.
+
+### Limitaciones del Asistente
+
+El Asistente de Messenger es una **herramienta informativa impulsada por IA**. Por favor comprende que:
+
+- Ocasionalmente puede producir **información incorrecta, incompleta u desactualizada**. Siempre verifica los detalles críticos — especialmente precios, horarios y disponibilidad — directamente con Robert antes de tomar decisiones.
+- **No es un reemplazo del coaching humano de inglés**. El asistente solo gestiona consultas. El coaching real, las lecciones y la retroalimentación provienen directamente de Robert.
+- **No es un sustituto de asesoramiento profesional** de ningún tipo.
+- Las respuestas se generan en tiempo real y pueden variar entre sesiones.
+
+### Datos y Privacidad
+
+Tu uso del Asistente de Messenger también está regido por nuestra [Política de Privacidad](/es/legal/privacy-policy/). Para información sobre cómo solicitar la eliminación de tus datos, consulta nuestras [Instrucciones de Eliminación de Datos](/es/legal/data-deletion/).
 
 ## Cambios al Acuerdo y Terminación
 
-NYET puede actualizar o modificar el Acuerdo en cualquier momento a nuestra entera discreción. Cuando realicemos cambios materiales, te notificaremos a través del Sitio o los Servicios. Al continuar utilizando los Servicios después de que se realicen los cambios, reconoces tu aceptación de los Términos actualizados.
+NYET puede actualizar o modificar el Acuerdo en cualquier momento. Cuando realicemos cambios materiales, te notificaremos a través del Sitio o los Servicios. Al continuar utilizando los Servicios después de que se realicen los cambios, reconoces tu aceptación de los Términos actualizados.
 
-También podemos modificar, suspender o descontinuar cualquier parte de los Servicios o el Sitio en cualquier momento sin previo aviso ni responsabilidad.
+También podemos modificar, suspender o descontinuar cualquier parte de los Servicios en cualquier momento sin previo aviso ni responsabilidad.
 
-Estos Términos permanecen en vigor hasta que sean terminados por ti o por NYET. Nos reservamos el derecho de suspender o terminar tu acceso a los Servicios a nuestra discreción. Si tu acceso es terminado, aceptas que NYET no será responsable ante ti ni ante ningún tercero.
-
-Para solicitar la terminación de tu cuenta registrada, por favor contáctanos directamente.
+Estos Términos permanecen en vigor hasta que sean terminados por ti o por NYET. Nos reservamos el derecho de suspender o terminar tu acceso a los Servicios a nuestra discreción.
 
 ## Propiedad Intelectual
 
@@ -67,16 +86,20 @@ Conservas los derechos sobre cualquier contenido que envíes a la plataforma, pe
 
 ## Exclusión de Garantías
 
-Los Servicios se proporcionan "tal cual" y "según disponibilidad" sin garantías de ningún tipo. NYET no garantiza que los Servicios serán ininterrumpidos, seguros o libres de errores.
+Los Servicios se proporcionan **"tal cual"** y **"según disponibilidad"** sin garantías de ningún tipo, ya sean expresas o implícitas. NYET no garantiza que los Servicios serán ininterrumpidos, seguros o libres de errores.
 
 ## Limitación de Responsabilidad
 
-En la máxima medida permitida por la ley, NYET no será responsable de ningún daño indirecto, incidental o consecuente, incluyendo pérdida de datos, ganancias o buena voluntad, resultante de tu uso de los Servicios.
+En la máxima medida permitida por la ley aplicable, NYET y Robert Cushman no serán responsables de ningún daño indirecto, incidental, especial, consecuente o punitivo, incluyendo pérdida de datos, ganancias o buena voluntad, resultante de tu uso de los Servicios.
 
 ## Ley Aplicable
 
-Estos Términos se regirán por las leyes del Estado de Nueva York, sin tener en cuenta sus disposiciones sobre conflicto de leyes.
+Estos Términos se regirán por las leyes de **México**, sin tener en cuenta sus disposiciones sobre conflicto de leyes. Cualquier disputa derivada de o relacionada con los Servicios se resolverá en los tribunales de **Guadalajara, Jalisco, México**, salvo que la ley de protección al consumidor aplicable requiera otra cosa.
 
 ## Contáctanos
 
-¿Tienes preguntas o inquietudes sobre esta Política de Privacidad? No dudes en contactarnos a través de nuestro formulario de contacto.
+Para preguntas o inquietudes sobre estos Términos:
+
+- **Correo electrónico:** privacy@newyorkenglish.com
+- **WhatsApp:** +52 33 1559 0572
+- **Operador:** Robert Cushman, New York English, Guadalajara, México

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -52,6 +52,7 @@ export type TKey =
   | "resources/salary-negotiation-script"
   | "legal/privacy-policy"
   | "legal/terms-of-service"
+  | "legal/data-deletion"
   | "thank-you"
   | "services/executive-english"
   | "services/high-stakes-english"
@@ -168,6 +169,7 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
       "/en/resources/salary-negotiation-script/",
     "legal/privacy-policy": "/en/legal/privacy-policy/",
     "legal/terms-of-service": "/en/legal/terms-of-service/",
+    "legal/data-deletion": "/en/legal/data-deletion/",
     "services/executive-english": "/en/services/executive-english/",
     "services/high-stakes-english": "/en/services/high-stakes-english/",
     "services/interview-prep": "/en/services/interview-prep/",
@@ -294,6 +296,7 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
       "/es/recursos/script-negociacion-salario/",
     "legal/privacy-policy": "/es/legal/privacy-policy/",
     "legal/terms-of-service": "/es/legal/terms-of-service/",
+    "legal/data-deletion": "/es/legal/data-deletion/",
     "services/executive-english": "/es/servicios/ingles-para-ejecutivos/",
     "services/high-stakes-english": "/es/servicios/ingles-para-presentaciones/",
     "services/interview-prep": "/es/servicios/preparacion-para-entrevistas/",
@@ -432,6 +435,7 @@ export function getAllTKeys(): TKey[] {
     "resources/salary-negotiation-script",
     "legal/privacy-policy",
     "legal/terms-of-service",
+    "legal/data-deletion",
     "services/executive-english",
     "services/high-stakes-english",
     "services/interview-prep",

--- a/src/pages/en/legal/data-deletion.astro
+++ b/src/pages/en/legal/data-deletion.astro
@@ -1,0 +1,37 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import InnerHero from '@components/sections/InnerHero.astro';
+import { getCollection } from "astro:content";
+
+const lang = 'en';
+const tkey = 'legal/data-deletion';
+
+const legalData = await getCollection('legal');
+const entry = legalData.find((item: { slug: string; data: { title: string; seo?: { title?: string; description?: string } } }) => item.slug === 'en/data-deletion');
+
+if (!entry) {
+  throw new Error('Data deletion content not found');
+}
+
+const { Content } = await entry.render();
+
+const heroContent = {
+  title: entry.data.title,
+  description: entry.data.seo?.description || "",
+  overlayOpacity: 0.8
+} as const;
+---
+
+<Base
+  lang="en"
+  tkey={tkey}
+  title={entry.data.seo?.title || entry.data.title}
+  description={entry.data.seo?.description || ""}
+>
+  <InnerHero content={heroContent} />
+  <article class="site-container--small mx-auto px-8 prose pb-base pt-16">
+    <Content />
+  </article>
+</Base>

--- a/src/pages/es/legal/data-deletion.astro
+++ b/src/pages/es/legal/data-deletion.astro
@@ -1,0 +1,47 @@
+---
+export const prerender = true;
+
+import Base from '@layouts/Base.astro';
+import InnerHero from '@components/sections/InnerHero.astro';
+import { getLegalContent } from '@utils/legalContent.js';
+
+const legalData = await getLegalContent('data-deletion', 'es');
+const { Content } = legalData;
+const entry = legalData;
+
+const lang = 'es';
+const translations = {
+  en: '/en/legal/data-deletion/',
+  es: '/es/legal/data-deletion/'
+};
+
+const heroContent = {
+  title: entry.data.title,
+  description: entry.data.seo?.description || "",
+  overlayOpacity: 0.8
+} as const;
+
+const footerCta = {
+  eyebrow: "",
+  title: "Transforma tu Inglés Profesional Hoy",
+  description: "Reserva tu consulta gratuita para obtener la claridad, confianza e impacto que tu rol demanda.",
+  hideCta: false,
+  button: {
+    text: "Reservar Mi Consulta Gratuita",
+    link: "/es/reservar/",
+    variant: "primary" as const
+  }
+} as const;
+---
+
+<Base
+  tkey="legal/data-deletion"
+  lang="es"
+  title={entry.data.seo?.title || entry.data.title}
+  description={entry.data.seo?.description || ""}
+>
+  <InnerHero content={heroContent} />
+  <article class="site-container--small mx-auto px-8 prose pb-base pt-16">
+    <Content />
+  </article>
+</Base>


### PR DESCRIPTION
## Summary

- Adds `/en/legal/data-deletion/` and `/es/legal/data-deletion/` — full bilingual data deletion instructions for the Facebook Messenger Assistant
- Registers `legal/data-deletion` TKey in `src/lib/i18n.ts` (type union, EN/ES routes, sitemap array)
- Updates Privacy Policy and Terms of Service (EN + ES) with Messenger data handling details, processor list (Meta, Anthropic, Cloudflare, Qdrant, Sentry), and cross-links to the new deletion page

## Why

Required by Meta for Facebook Login / Messenger Platform app review. These two URLs go into the Meta app settings:
- **Privacy Policy:** https://www.nyenglishteacher.com/en/legal/privacy-policy/
- **Data Deletion:** https://www.nyenglishteacher.com/en/legal/data-deletion/

## Test plan

- [x] `npm run build` passes clean (391 pages, 0 errors, sitemap valid)
- [ ] Verify `/en/legal/data-deletion/` and `/es/legal/data-deletion/` render after deploy
- [ ] Verify hreflang EN↔ES link is present on both data deletion pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)