### PR TITLE
feat: add Courage While Leading corporate package page (EN + ES)

### DIFF
--- a/src/data/service-faqs.ts
+++ b/src/data/service-faqs.ts
@@ -404,5 +404,51 @@ export const serviceFaqs: Record<string, ServiceFaqSet> = {
         answer: "Nuestro enfoque principal es comunicación oral — llamadas, demos y reuniones. Sin embargo, podemos ayudarte a crear y practicar versiones verbales de tus propuestas, elevator pitches, y los patrones de lenguaje persuasivo que se trasladan a tus seguimientos escritos."
       }
     ]
+  },
+  "corporate-package": {
+    en: [
+      {
+        question: "How is this different from sending employees to a regular English course?",
+        answer: "A standard English course teaches grammar and vocabulary to a generic syllabus. This program builds around each participant's actual role, their real presentations, and their specific communication gaps — then uses peer pressure in the group session to surface the gap between private preparation and public performance. That's a different problem and a different solution."
+      },
+      {
+        question: "What level of English do participants need to join this program?",
+        answer: "Participants should be able to hold a professional English conversation — at least intermediate level (B1+). This is not a beginner program. The work in Phase 1 is preparation for performance, not foundational language learning."
+      },
+      {
+        question: "What happens if a participant has a bad group presentation session?",
+        answer: "A difficult group session is part of the design, not a failure. It produces precise data about exactly where that person's gap is — which is more valuable than a comfortable session that masks the real problem. Robert uses Phase 3 to debrief directly, honestly, and constructively with each participant."
+      },
+      {
+        question: "How is pricing structured for a team?",
+        answer: "The program is priced at 600 MXN per session per participant. Total investment per participant typically ranges from 7,200 to 10,200 MXN across all three phases, depending on session frequency and schedule. Mexican facturas are issued monthly and a consolidated invoice is available for the company."
+      },
+      {
+        question: "Can we run this program in Spanish?",
+        answer: "The program is conducted in English — that's the point. Robert understands Spanish and can provide context or clarification in Spanish when needed, but the coaching sessions and group presentation are in English. The pressure of speaking English in front of peers is the core mechanism of the program."
+      }
+    ],
+    es: [
+      {
+        question: "¿En qué se diferencia esto de enviar empleados a un curso de inglés regular?",
+        answer: "Un curso de inglés estándar enseña gramática y vocabulario con un temario genérico. Este programa está construido alrededor del rol real de cada participante, sus presentaciones reales y sus brechas de comunicación específicas — y luego usa la presión de pares en la sesión grupal para sacar a la luz la brecha entre la preparación privada y el desempeño público. Es un problema diferente y requiere una solución diferente."
+      },
+      {
+        question: "¿Qué nivel de inglés necesitan tener los participantes para unirse a este programa?",
+        answer: "Los participantes deben poder sostener una conversación profesional en inglés — al menos nivel intermedio (B1+). Este no es un programa para principiantes. El trabajo en la Fase 1 es preparación para el desempeño, no aprendizaje del idioma desde cero."
+      },
+      {
+        question: "¿Qué pasa si un participante tiene una mala sesión de presentación grupal?",
+        answer: "Una sesión grupal difícil es parte del diseño, no un fracaso. Produce datos precisos sobre exactamente dónde está la brecha de esa persona — lo cual es más valioso que una sesión cómoda que oculta el problema real. Robert usa la Fase 3 para debriefar directa, honesta y constructivamente con cada participante."
+      },
+      {
+        question: "¿Cómo se estructura el precio para un equipo?",
+        answer: "El programa tiene un precio de 600 MXN por sesión por participante. La inversión total por participante típicamente oscila entre 7,200 y 10,200 MXN a lo largo de las tres fases, según la frecuencia de sesiones y la agenda. Las facturas mexicanas se emiten mensualmente y hay una factura consolidada disponible para la empresa."
+      },
+      {
+        question: "¿Podemos hacer este programa en español?",
+        answer: "El programa se realiza en inglés — ese es el punto. Robert entiende español y puede proporcionar contexto o aclaraciones en español cuando sea necesario, pero las sesiones de coaching y la presentación grupal son en inglés. La presión de hablar inglés frente a los pares es el mecanismo central del programa."
+      }
+    ]
   }
 };

--- a/src/data/services.ts
+++ b/src/data/services.ts
@@ -99,6 +99,19 @@ export const services: Service[] = [
   },
 ] as const;
 
+// Corporate program — rendered as its own section on the services index,
+// not in the individual-coaching grid, so it lives as a standalone export.
+export const corporatePackage: Service = {
+  title: "Courage While Leading in English",
+  icon: "🏢",
+  description:
+    "A 12-week program for senior leadership teams. Individual preparation, group presentation under peer pressure, and a final assessment — designed to close the gap between private fluency and public performance.",
+  link: "/en/services/corporate-package/",
+  backgroundImage: executiveEnglishImage,
+  squareImage: executiveEnglishSquareImage,
+  slug: "corporate-package",
+};
+
 // Spanish version
 export const serviciosEs: Service[] = [
   // 1. Ejecutivos y Directores
@@ -168,6 +181,17 @@ export const serviciosEs: Service[] = [
     slug: "ingles-para-presentaciones",
   },
 ] as const;
+
+export const paqueteCorporativo: Service = {
+  title: "Valentía al Liderar en Inglés",
+  icon: "🏢",
+  description:
+    "Un programa de 12 semanas para equipos de liderazgo senior. Preparación individual, presentación grupal bajo presión de pares y evaluación final — diseñado para cerrar la brecha entre la fluidez privada y el desempeño público.",
+  link: "/es/servicios/paquete-corporativo/",
+  backgroundImage: executiveEnglishImage,
+  squareImage: executiveEnglishSquareImage,
+  slug: "paquete-corporativo",
+};
 
 // Updated professional profiles to match standardized categories
 export const professionalProfiles = [

--- a/src/data/translationMaps.ts
+++ b/src/data/translationMaps.ts
@@ -31,6 +31,7 @@ export const serviceMap: TranslationMap = {
   "logistics-english": "ingles-para-logistica",
   "professional-english": "ingles-para-profesionales",
   "high-stakes-english": "ingles-para-presentaciones",
+  "corporate-package": "paquete-corporativo",
   // Additional mappings that might be needed
   //'interview-prep': 'preparacion-para-entrevistas',
   //'medical-english': 'ingles-para-medicos',

--- a/src/pages/en/services/corporate-package.astro
+++ b/src/pages/en/services/corporate-package.astro
@@ -1,0 +1,213 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import InnerHero from "@components/sections/InnerHero.astro";
+import Challenge from "@components/sections/Challenge.astro";
+import CtaSection from "@components/sections/CtaSection.astro";
+import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
+import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
+import { serviceFaqs } from "@data/service-faqs";
+import { services } from "@data/services";
+
+const serviceData = services.find((s) => s.slug === "corporate-package");
+if (!serviceData) {
+  throw new Error("Corporate package service data not found");
+}
+
+const title = "Courage While Leading in English — Corporate Team Program | NY";
+const seoDescription =
+  "A 12-week corporate coaching program for senior leadership teams. Individual preparation, peer-pressure group presentations, and a final assessment — all in English.";
+
+const heroContent = {
+  title: "Your leadership team is ready. Their English isn't keeping up.",
+  description:
+    "A 12-week program that uses peer pressure — not a classroom — to close the gap between preparation and performance.",
+  backgroundImage: serviceData.backgroundImage,
+  overlayOpacity: 0.75,
+};
+
+const challengeContent = {
+  headline: "The Problem Most L&D Programs Miss",
+  painPoints: [
+    "Your senior leaders communicate well in private English sessions — but freeze, rush, or switch to Spanish the moment their peers are watching.",
+    "Generic English courses produce certificates, not performance. Your team sits through a curriculum built for someone else.",
+    "The gap between 'functional English' and 'executive English' shows up in the boardroom, not in a grammar test.",
+  ],
+  icon: "💡",
+  image: serviceData.squareImage,
+  quizCta: {
+    text: "Take the Executive Communication Assessment — 60 seconds.",
+    link: "/en/quiz/executives/question/1",
+    linkLabel: "Start the Quiz →",
+  },
+};
+
+const ctaContent = {
+  eyebrow: "Corporate Programs",
+  title: "Ready to build a leadership team that leads in English?",
+  description:
+    "This program requires a discovery call to scope for your group size, schedule, and goals. Robert responds within 24 hours.",
+  buttonText: "Contact Robert on WhatsApp",
+  buttonLink: "https://wa.me/523315590572",
+  whatToExpectTitle: "In Your Discovery Call, We Will:",
+  whatToExpectList: [
+    "Assess your team's current English communication baseline",
+    "Scope the program for your group size, schedule, and industry context",
+    "Define what a successful outcome looks like for your leadership team",
+  ],
+};
+
+const faqs = serviceFaqs["corporate-package"]?.en || [];
+---
+
+<Base
+  title={title}
+  description={seoDescription}
+  lang="en"
+  tkey="services/corporate-package"
+  hideCta={true}
+  customHreflangs={[
+    {
+      lang: "en-US",
+      href: "https://www.nyenglishteacher.com/en/services/corporate-package/",
+    },
+    {
+      lang: "es-MX",
+      href: "https://www.nyenglishteacher.com/es/servicios/paquete-corporativo/",
+    },
+  ]}
+  customCanonical="https://www.nyenglishteacher.com/en/services/corporate-package/"
+>
+  <!-- Hero -->
+  <InnerHero content={heroContent} />
+
+  <!-- Challenge -->
+  <Challenge content={challengeContent} background="white" padding="lg" />
+
+  <!-- Program Structure -->
+  <section class="bg-light py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <h2 class="text-3xl font-bold mb-2 text-center">How the Program Works</h2>
+      <p class="text-center text-gray-600 mb-12">12 weeks. 3 phases. One goal: your team leads in English.</p>
+
+      <div class="grid gap-8 md:grid-cols-3">
+        <!-- Phase 1 -->
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div class="text-sm font-semibold text-primary uppercase tracking-wide mb-2">Weeks 1–8</div>
+          <h3 class="text-xl font-bold mb-3">Phase 1 — Individual Assessment & Preparation</h3>
+          <p class="text-gray-600 mb-4">Each participant works privately with Robert. Weeks 1–2 establish an honest baseline. Weeks 3–8 are targeted preparation built around their real presentation content and role.</p>
+          <div class="text-sm text-gray-500">
+            <strong>8–12 sessions per participant</strong><br />
+            4,800 – 7,200 MXN
+          </div>
+        </div>
+
+        <!-- Phase 2 -->
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div class="text-sm font-semibold text-primary uppercase tracking-wide mb-2">Weeks 9–10</div>
+          <h3 class="text-xl font-bold mb-3">Phase 2 — Group Presentation</h3>
+          <p class="text-gray-600 mb-4">Every participant delivers their prepared presentation in English to the full leadership group — often for the first time. The pressure is real, deliberate, and productive. Breakthroughs happen here.</p>
+          <div class="text-sm text-gray-500">
+            <strong>1–2 group sessions</strong><br />
+            600 – 1,200 MXN per participant
+          </div>
+        </div>
+
+        <!-- Phase 3 -->
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div class="text-sm font-semibold text-primary uppercase tracking-wide mb-2">Weeks 11–12</div>
+          <h3 class="text-xl font-bold mb-3">Phase 3 — Lessons Learned & Final Assessment</h3>
+          <p class="text-gray-600 mb-4">Individual debrief sessions with direct, honest feedback. A final assessment measures progress against the Week 1–2 baseline. Each participant receives a written roadmap. The company receives a consolidated progress report.</p>
+          <div class="text-sm text-gray-500">
+            <strong>2–3 sessions per participant</strong><br />
+            1,200 – 1,800 MXN
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Investment -->
+  <section class="bg-white py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <h2 class="text-3xl font-bold mb-2 text-center">Investment</h2>
+      <p class="text-center text-gray-600 mb-10">600 MXN per session per participant. Mexican facturas issued monthly.</p>
+
+      <div class="max-w-2xl mx-auto bg-gray-50 rounded-xl p-8 border border-gray-200">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-gray-200">
+              <th class="text-left pb-3 font-semibold">Scenario</th>
+              <th class="text-right pb-3 font-semibold">Per Participant</th>
+              <th class="text-right pb-3 font-semibold">5-Person Team</th>
+            </tr>
+          </thead>
+          <tbody class="text-gray-600">
+            <tr class="border-b border-gray-100">
+              <td class="py-3">Conservative (12 sessions)</td>
+              <td class="text-right py-3">7,200 MXN</td>
+              <td class="text-right py-3">~36,000 MXN</td>
+            </tr>
+            <tr class="border-b border-gray-100">
+              <td class="py-3">Moderate (14–15 sessions)</td>
+              <td class="text-right py-3">8,400 – 9,000 MXN</td>
+              <td class="text-right py-3">~42,000–45,000 MXN</td>
+            </tr>
+            <tr>
+              <td class="py-3">Intensive (17 sessions)</td>
+              <td class="text-right py-3">10,200 MXN</td>
+              <td class="text-right py-3">~51,000 MXN</td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="text-xs text-gray-400 mt-4">Total varies because schedules vary — not every participant attends every possible session. USD pricing available for international companies.</p>
+      </div>
+
+      <div class="max-w-2xl mx-auto mt-6 bg-amber-50 border border-amber-200 rounded-xl p-6 text-sm text-amber-900">
+        <strong>Results depend on individual commitment.</strong> The program is designed to create breakthroughs — but breakthroughs require preparation between sessions, honest engagement with feedback, and the willingness to perform under pressure. Participants who prepare seriously typically see significant performance gains. Those who attend but don't prepare will see limited results.
+      </div>
+    </div>
+  </section>
+
+  <!-- Outcomes -->
+  <section class="bg-light py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <h2 class="text-3xl font-bold mb-10 text-center">What This Program Produces</h2>
+      <div class="grid gap-6 md:grid-cols-2">
+        <div>
+          <h3 class="font-bold text-lg mb-4">For Each Participant</h3>
+          <ul class="space-y-3 text-gray-600">
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Measurable improvement in English fluency under peer pressure — not just in isolated practice</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Delivered a real prepared presentation in English to a peer-level audience</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> A precise map of their own communication gaps — not a vague feeling, a specific target</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Greater confidence in meetings with US leadership, global clients, and English-speaking stakeholders</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> A written roadmap for continued development after the program</li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">For the Company</h3>
+          <ul class="space-y-3 text-gray-600">
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> A senior team that can represent the company in English without bottlenecks</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> A structured L&D investment with observable performance outcomes, not just certificates</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> A consolidated progress report for HR and executive review</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> The beginning of a culture shift — from avoiding English to preparing for it</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> An unexpected side effect: peers see each other differently, which changes dynamics in real meetings</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <CtaSection content={ctaContent} />
+
+  <!-- FAQ -->
+  <ServiceFAQ faqs={faqs} lang="en" />
+
+  <BreadcrumbSchema items={[
+    { name: "Home", url: "https://www.nyenglishteacher.com/en/" },
+    { name: "Services", url: "https://www.nyenglishteacher.com/en/services/" },
+    { name: "Courage While Leading in English", url: "https://www.nyenglishteacher.com/en/services/corporate-package/" }
+  ]} />
+</Base>

--- a/src/pages/en/services/corporate-package.astro
+++ b/src/pages/en/services/corporate-package.astro
@@ -8,12 +8,7 @@ import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
 import { serviceFaqs } from "@data/service-faqs";
-import { services } from "@data/services";
-
-const serviceData = services.find((s) => s.slug === "corporate-package");
-if (!serviceData) {
-  throw new Error("Corporate package service data not found");
-}
+import { corporatePackage as serviceData } from "@data/services";
 
 const title = "Courage While Leading in English — Corporate Team Program | NY";
 const seoDescription =

--- a/src/pages/en/services/index.astro
+++ b/src/pages/en/services/index.astro
@@ -70,12 +70,77 @@ const ctaContent = {
   <!-- Hero Section - Reused from homepage for consistency -->
   <Hero content={heroContent} />
 
-  <!-- Services Grid -->
+  <!-- Individual Coaching Services Grid -->
   <ServicesGrid
     services={services}
-    title=""
-    description=""
+    title="Individual Coaching"
+    description="Private 1-on-1 sessions built around your role, your industry, and the specific moments where your English matters most."
   />
+
+  <!-- Corporate Programs Section -->
+  <section class="py-20 px-6 bg-gray-900">
+    <div class="max-w-5xl mx-auto">
+      <div class="text-xs font-semibold uppercase tracking-widest text-blue-400 mb-3">For Companies &amp; Leadership Teams</div>
+      <div class="grid md:grid-cols-2 gap-12 items-center">
+        <div>
+          <h2 class="text-3xl md:text-4xl font-bold text-white mb-4">
+            Courage While Leading in English
+          </h2>
+          <p class="text-gray-300 text-lg mb-6 leading-relaxed">
+            A 12-week structured program for senior leadership groups. Individual preparation, group presentation under peer pressure, and a final assessment — designed to close the gap between private fluency and public performance.
+          </p>
+          <ul class="space-y-3 mb-8">
+            <li class="flex items-start gap-3 text-gray-300">
+              <span class="text-blue-400 font-bold mt-0.5">→</span>
+              <span><strong class="text-white">Weeks 1–8:</strong> Individual assessment and targeted preparation with Robert</span>
+            </li>
+            <li class="flex items-start gap-3 text-gray-300">
+              <span class="text-blue-400 font-bold mt-0.5">→</span>
+              <span><strong class="text-white">Weeks 9–10:</strong> Group presentation session — peer pressure as the training mechanism</span>
+            </li>
+            <li class="flex items-start gap-3 text-gray-300">
+              <span class="text-blue-400 font-bold mt-0.5">→</span>
+              <span><strong class="text-white">Weeks 11–12:</strong> Individual feedback, final assessment, and progress reports</span>
+            </li>
+          </ul>
+          <div class="flex flex-col sm:flex-row gap-4">
+            <a
+              href="/en/services/corporate-package/"
+              class="inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold px-8 py-4 rounded-lg transition-colors text-center"
+            >
+              See the Full Program
+            </a>
+            <a
+              href="https://wa.me/523315590572"
+              class="inline-block border border-gray-600 hover:border-gray-400 text-gray-300 hover:text-white font-semibold px-8 py-4 rounded-lg transition-colors text-center"
+            >
+              Contact Robert on WhatsApp
+            </a>
+          </div>
+        </div>
+        <div class="hidden md:block">
+          <div class="bg-gray-800 rounded-xl p-8 border border-gray-700">
+            <div class="text-gray-400 text-sm uppercase tracking-wide mb-4">Investment</div>
+            <div class="text-white text-2xl font-bold mb-1">600 MXN <span class="text-gray-400 font-normal text-lg">/ session</span></div>
+            <div class="text-gray-400 text-sm mb-6">~7,200 – 10,200 MXN per participant</div>
+            <div class="space-y-2 text-sm text-gray-300 mb-6">
+              <div class="flex justify-between"><span>Program duration</span><span class="text-white">12 weeks</span></div>
+              <div class="flex justify-between"><span>Group size</span><span class="text-white">3–8 leaders</span></div>
+              <div class="flex justify-between"><span>Format</span><span class="text-white">Individual + Group</span></div>
+              <div class="flex justify-between"><span>Facturas</span><span class="text-white">Included</span></div>
+              <div class="flex justify-between"><span>Progress reports</span><span class="text-white">Included</span></div>
+            </div>
+            <a
+              href="/en/services/corporate-package/"
+              class="block text-center text-blue-400 hover:text-blue-300 text-sm font-medium transition-colors"
+            >
+              Full program details →
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
 
   <!-- Professional Profiles Section -->
   <ProfessionalProfiles

--- a/src/pages/es/servicios/index.astro
+++ b/src/pages/es/servicios/index.astro
@@ -71,12 +71,77 @@ const professionalProfilesContent = {
   <!-- Hero Section -->
   <Hero content={heroContent} />
 
-  <!-- Services Grid -->
+  <!-- Servicios de Coaching Individual -->
   <ServicesGrid
     services={serviciosEs}
-    title=""
-    description=""
+    title="Coaching Individual"
+    description="Sesiones privadas 1-a-1 construidas alrededor de tu rol, tu industria y los momentos específicos donde tu inglés importa más."
   />
+
+  <!-- Sección Programas Corporativos -->
+  <section class="py-20 px-6 bg-gray-900">
+    <div class="max-w-5xl mx-auto">
+      <div class="text-xs font-semibold uppercase tracking-widest text-blue-400 mb-3">Para Empresas y Equipos de Liderazgo</div>
+      <div class="grid md:grid-cols-2 gap-12 items-center">
+        <div>
+          <h2 class="text-3xl md:text-4xl font-bold text-white mb-4">
+            Valentía al Liderar en Inglés
+          </h2>
+          <p class="text-gray-300 text-lg mb-6 leading-relaxed">
+            Un programa estructurado de 12 semanas para grupos de liderazgo senior. Preparación individual, presentación grupal bajo presión de pares y evaluación final — diseñado para cerrar la brecha entre la fluidez privada y el desempeño público.
+          </p>
+          <ul class="space-y-3 mb-8">
+            <li class="flex items-start gap-3 text-gray-300">
+              <span class="text-blue-400 font-bold mt-0.5">→</span>
+              <span><strong class="text-white">Semanas 1–8:</strong> Evaluación individual y preparación dirigida con Robert</span>
+            </li>
+            <li class="flex items-start gap-3 text-gray-300">
+              <span class="text-blue-400 font-bold mt-0.5">→</span>
+              <span><strong class="text-white">Semanas 9–10:</strong> Sesión de presentación grupal — la presión de pares como mecanismo de entrenamiento</span>
+            </li>
+            <li class="flex items-start gap-3 text-gray-300">
+              <span class="text-blue-400 font-bold mt-0.5">→</span>
+              <span><strong class="text-white">Semanas 11–12:</strong> Retroalimentación individual, evaluación final y reportes de progreso</span>
+            </li>
+          </ul>
+          <div class="flex flex-col sm:flex-row gap-4">
+            <a
+              href="/es/servicios/paquete-corporativo/"
+              class="inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold px-8 py-4 rounded-lg transition-colors text-center"
+            >
+              Ver el Programa Completo
+            </a>
+            <a
+              href="https://wa.me/523315590572"
+              class="inline-block border border-gray-600 hover:border-gray-400 text-gray-300 hover:text-white font-semibold px-8 py-4 rounded-lg transition-colors text-center"
+            >
+              Contactar a Robert por WhatsApp
+            </a>
+          </div>
+        </div>
+        <div class="hidden md:block">
+          <div class="bg-gray-800 rounded-xl p-8 border border-gray-700">
+            <div class="text-gray-400 text-sm uppercase tracking-wide mb-4">Inversión</div>
+            <div class="text-white text-2xl font-bold mb-1">600 MXN <span class="text-gray-400 font-normal text-lg">/ sesión</span></div>
+            <div class="text-gray-400 text-sm mb-6">~7,200 – 10,200 MXN por participante</div>
+            <div class="space-y-2 text-sm text-gray-300 mb-6">
+              <div class="flex justify-between"><span>Duración del programa</span><span class="text-white">12 semanas</span></div>
+              <div class="flex justify-between"><span>Tamaño del grupo</span><span class="text-white">3–8 líderes</span></div>
+              <div class="flex justify-between"><span>Formato</span><span class="text-white">Individual + Grupal</span></div>
+              <div class="flex justify-between"><span>Facturas</span><span class="text-white">Incluidas</span></div>
+              <div class="flex justify-between"><span>Reportes de progreso</span><span class="text-white">Incluidos</span></div>
+            </div>
+            <a
+              href="/es/servicios/paquete-corporativo/"
+              class="block text-center text-blue-400 hover:text-blue-300 text-sm font-medium transition-colors"
+            >
+              Detalles completos del programa →
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
 
   <!-- Professional Profiles Section -->
   <ProfessionalProfiles

--- a/src/pages/es/servicios/paquete-corporativo.astro
+++ b/src/pages/es/servicios/paquete-corporativo.astro
@@ -8,12 +8,7 @@ import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
 import { serviceFaqs } from "@data/service-faqs";
-import { serviciosEs } from "@data/services";
-
-const serviceData = serviciosEs.find((s) => s.slug === "paquete-corporativo");
-if (!serviceData) {
-  throw new Error("Corporate package service data (ES) not found");
-}
+import { paqueteCorporativo as serviceData } from "@data/services";
 
 const title = "Valentía al Liderar en Inglés — Programa Corporativo | NY";
 const seoDescription =

--- a/src/pages/es/servicios/paquete-corporativo.astro
+++ b/src/pages/es/servicios/paquete-corporativo.astro
@@ -1,0 +1,213 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import InnerHero from "@components/sections/InnerHero.astro";
+import Challenge from "@components/sections/Challenge.astro";
+import CtaSection from "@components/sections/CtaSection.astro";
+import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
+import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
+import { serviceFaqs } from "@data/service-faqs";
+import { serviciosEs } from "@data/services";
+
+const serviceData = serviciosEs.find((s) => s.slug === "paquete-corporativo");
+if (!serviceData) {
+  throw new Error("Corporate package service data (ES) not found");
+}
+
+const title = "Valentía al Liderar en Inglés — Programa Corporativo | NY";
+const seoDescription =
+  "Un programa corporativo de 12 semanas para equipos de liderazgo senior. Preparación individual, presentaciones grupales bajo presión de pares y evaluación final — todo en inglés.";
+
+const heroContent = {
+  title: "Tu equipo directivo está listo. Su inglés no les está siguiendo el ritmo.",
+  description:
+    "Un programa de 12 semanas que usa la presión de pares — no un salón de clases — para cerrar la brecha entre preparación y desempeño.",
+  backgroundImage: serviceData.backgroundImage,
+  overlayOpacity: 0.75,
+};
+
+const challengeContent = {
+  headline: "El Problema que la Mayoría de los Programas de L&D Ignoran",
+  painPoints: [
+    "Tus líderes senior se comunican bien en sesiones privadas de inglés — pero se congelan, se apresuran o cambian al español en el momento en que sus pares los están observando.",
+    "Los cursos genéricos de inglés producen certificados, no desempeño. Tu equipo sigue un temario construido para otra persona.",
+    "La brecha entre 'inglés funcional' e 'inglés ejecutivo' se muestra en la sala de juntas, no en un examen de gramática.",
+  ],
+  icon: "💡",
+  image: serviceData.squareImage,
+  quizCta: {
+    text: "Realiza la Evaluación de Comunicación Ejecutiva — 60 segundos.",
+    link: "/en/quiz/executives/question/1",
+    linkLabel: "Iniciar la Evaluación →",
+  },
+};
+
+const ctaContent = {
+  eyebrow: "Programas Corporativos",
+  title: "¿Listo para construir un equipo directivo que lidere en inglés?",
+  description:
+    "Este programa requiere una llamada de descubrimiento para definir el alcance según el tamaño de tu grupo, agenda y objetivos. Robert responde en 24 horas.",
+  buttonText: "Contactar a Robert por WhatsApp",
+  buttonLink: "https://wa.me/523315590572",
+  whatToExpectTitle: "En Tu Llamada de Descubrimiento:",
+  whatToExpectList: [
+    "Evaluaremos la línea base actual de comunicación en inglés de tu equipo",
+    "Definiremos el alcance del programa para tu tamaño de grupo, agenda y contexto de industria",
+    "Estableceremos cómo se ve un resultado exitoso para tu equipo de liderazgo",
+  ],
+};
+
+const faqs = serviceFaqs["corporate-package"]?.es || [];
+---
+
+<Base
+  title={title}
+  description={seoDescription}
+  lang="es"
+  tkey="services/corporate-package"
+  hideCta={true}
+  customHreflangs={[
+    {
+      lang: "en-US",
+      href: "https://www.nyenglishteacher.com/en/services/corporate-package/",
+    },
+    {
+      lang: "es-MX",
+      href: "https://www.nyenglishteacher.com/es/servicios/paquete-corporativo/",
+    },
+  ]}
+  customCanonical="https://www.nyenglishteacher.com/es/servicios/paquete-corporativo/"
+>
+  <!-- Hero -->
+  <InnerHero content={heroContent} />
+
+  <!-- Challenge -->
+  <Challenge content={challengeContent} background="white" padding="lg" />
+
+  <!-- Estructura del Programa -->
+  <section class="bg-light py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <h2 class="text-3xl font-bold mb-2 text-center">Cómo Funciona el Programa</h2>
+      <p class="text-center text-gray-600 mb-12">12 semanas. 3 fases. Un objetivo: tu equipo lidera en inglés.</p>
+
+      <div class="grid gap-8 md:grid-cols-3">
+        <!-- Fase 1 -->
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div class="text-sm font-semibold text-primary uppercase tracking-wide mb-2">Semanas 1–8</div>
+          <h3 class="text-xl font-bold mb-3">Fase 1 — Evaluación Individual y Preparación</h3>
+          <p class="text-gray-600 mb-4">Cada participante trabaja en privado con Robert. Las semanas 1–2 establecen una línea base honesta. Las semanas 3–8 son preparación dirigida construida alrededor del contenido real de su presentación y rol.</p>
+          <div class="text-sm text-gray-500">
+            <strong>8–12 sesiones por participante</strong><br />
+            4,800 – 7,200 MXN
+          </div>
+        </div>
+
+        <!-- Fase 2 -->
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div class="text-sm font-semibold text-primary uppercase tracking-wide mb-2">Semanas 9–10</div>
+          <h3 class="text-xl font-bold mb-3">Fase 2 — Presentación Grupal</h3>
+          <p class="text-gray-600 mb-4">Cada participante entrega su presentación preparada en inglés frente al grupo completo de liderazgo — muchas veces por primera vez. La presión es real, deliberada y productiva. Los avances ocurren aquí.</p>
+          <div class="text-sm text-gray-500">
+            <strong>1–2 sesiones grupales</strong><br />
+            600 – 1,200 MXN por participante
+          </div>
+        </div>
+
+        <!-- Fase 3 -->
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div class="text-sm font-semibold text-primary uppercase tracking-wide mb-2">Semanas 11–12</div>
+          <h3 class="text-xl font-bold mb-3">Fase 3 — Lecciones Aprendidas y Evaluación Final</h3>
+          <p class="text-gray-600 mb-4">Sesiones individuales de debrief con retroalimentación directa y honesta. Una evaluación final mide el progreso contra la línea base de las semanas 1–2. Cada participante recibe un plan de ruta escrito. La empresa recibe un reporte de progreso consolidado.</p>
+          <div class="text-sm text-gray-500">
+            <strong>2–3 sesiones por participante</strong><br />
+            1,200 – 1,800 MXN
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Inversión -->
+  <section class="bg-white py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <h2 class="text-3xl font-bold mb-2 text-center">Inversión</h2>
+      <p class="text-center text-gray-600 mb-10">600 MXN por sesión por participante. Facturas mexicanas emitidas mensualmente.</p>
+
+      <div class="max-w-2xl mx-auto bg-gray-50 rounded-xl p-8 border border-gray-200">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-gray-200">
+              <th class="text-left pb-3 font-semibold">Escenario</th>
+              <th class="text-right pb-3 font-semibold">Por Participante</th>
+              <th class="text-right pb-3 font-semibold">Equipo de 5</th>
+            </tr>
+          </thead>
+          <tbody class="text-gray-600">
+            <tr class="border-b border-gray-100">
+              <td class="py-3">Conservador (12 sesiones)</td>
+              <td class="text-right py-3">7,200 MXN</td>
+              <td class="text-right py-3">~36,000 MXN</td>
+            </tr>
+            <tr class="border-b border-gray-100">
+              <td class="py-3">Moderado (14–15 sesiones)</td>
+              <td class="text-right py-3">8,400 – 9,000 MXN</td>
+              <td class="text-right py-3">~42,000–45,000 MXN</td>
+            </tr>
+            <tr>
+              <td class="py-3">Intensivo (17 sesiones)</td>
+              <td class="text-right py-3">10,200 MXN</td>
+              <td class="text-right py-3">~51,000 MXN</td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="text-xs text-gray-400 mt-4">El total varía porque las agendas varían — no todos los participantes asisten a todas las sesiones posibles. Precios en USD disponibles para empresas internacionales.</p>
+      </div>
+
+      <div class="max-w-2xl mx-auto mt-6 bg-amber-50 border border-amber-200 rounded-xl p-6 text-sm text-amber-900">
+        <strong>Los resultados dependen del compromiso individual.</strong> El programa está diseñado para crear avances — pero los avances requieren preparación entre sesiones, participación honesta con la retroalimentación y disposición a actuar bajo presión. Los participantes que se preparan seriamente típicamente ven ganancias de desempeño significativas. Los que asisten pero no se preparan verán resultados limitados.
+      </div>
+    </div>
+  </section>
+
+  <!-- Resultados -->
+  <section class="bg-light py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <h2 class="text-3xl font-bold mb-10 text-center">Qué Produce Este Programa</h2>
+      <div class="grid gap-6 md:grid-cols-2">
+        <div>
+          <h3 class="font-bold text-lg mb-4">Para Cada Participante</h3>
+          <ul class="space-y-3 text-gray-600">
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Mejora medible en la fluidez del inglés bajo presión de pares — no solo en práctica aislada</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Entregó una presentación real preparada en inglés frente a una audiencia de nivel par</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Un mapa preciso de sus propias brechas de comunicación — no una sensación vaga, un objetivo específico</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Mayor confianza en reuniones con liderazgo en EE.UU., clientes globales y partes interesadas angloparlantes</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Un plan de ruta escrito para desarrollo continuo después del programa</li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Para la Empresa</h3>
+          <ul class="space-y-3 text-gray-600">
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Un equipo senior que puede representar a la empresa en inglés sin cuellos de botella</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Una inversión estructurada en L&D con resultados de desempeño observables, no solo certificados</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Un reporte de progreso consolidado para RH y revisión ejecutiva</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> El inicio de un cambio cultural — de evitar el inglés a prepararse para él</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Un efecto secundario inesperado: los pares se ven mutuamente con nuevos ojos, cambiando la dinámica en las reuniones reales</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <CtaSection content={ctaContent} />
+
+  <!-- FAQ -->
+  <ServiceFAQ faqs={faqs} lang="es" />
+
+  <BreadcrumbSchema items={[
+    { name: "Inicio", url: "https://www.nyenglishteacher.com/es/" },
+    { name: "Servicios", url: "https://www.nyenglishteacher.com/es/servicios/" },
+    { name: "Valentía al Liderar en Inglés", url: "https://www.nyenglishteacher.com/es/servicios/paquete-corporativo/" }
+  ]} />
+</Base>


### PR DESCRIPTION
## Summary

- New corporate program page at \`/en/services/corporate-package/\` and \`/es/servicios/paquete-corporativo/\` — full 12-week structure, investment table, outcomes grid, 5 FAQs per language, WhatsApp CTA
- Services index pages now split into **Individual Coaching** (6-service grid) + **Corporate Programs** dark-section with phase overview, investment card, and link to the full page
- Added hreflang cross-links between EN/ES corporate pages
- Added corporate-package FAQs to \`service-faqs.ts\`
- Added \`corporate-package → paquete-corporativo\` to \`translationMaps.ts\`

## Test plan

- [ ] \`/en/services/\` — individual grid shows 6 services, corporate section appears below
- [ ] \`/es/servicios/\` — same in Spanish
- [ ] \`/en/services/corporate-package/\` — 3-phase structure, investment table, outcomes, FAQ, WhatsApp CTA
- [ ] \`/es/servicios/paquete-corporativo/\` — same in Spanish
- [ ] Hreflang alternates correct on both corporate pages
- [ ] **Image TODO:** Replace executive-english placeholder with a dedicated corporate/team image before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)