### PR TITLE
feat: executive course foundation (PR 1/5)

### DIFF
--- a/docs/EXECUTIVE-COURSE-PLAN.md
+++ b/docs/EXECUTIVE-COURSE-PLAN.md
@@ -1,182 +1,272 @@
 # Executive Communication Course Plan — "Communicate Like a Leader" (C1 → C2)
 
-**Status:** Planned, build deferred until Advanced course ships
+**Status:** Plan finalized 2026-04-16 after analysis of two of Robert's real executive lessons (one C1, one C2, same student). Ready to build.
 **Target audience:** Founders, executives, senior professionals — people who already communicate competently in English but want to **lead** in English
 **Tagline:** *Communicate Like a Leader*
-**Pricing:** **Paid** (with free preview units, paywall added in Phase 2). Strong funnel into Robert's 1-on-1 coaching.
+**Level:** C1 core with optional C2 "Elite" upgrades throughout
+**Pricing:** Free during launch (Phase 1). Stripe paywall Phase 2. Strongest funnel into Robert's 1-on-1 coaching.
 
 ---
 
 ## The thesis
 
-This course is fundamentally different from the first three. **It is essentially a productized version of Robert's 1-on-1 executive coaching.** The conversion play is:
+This course is fundamentally different from the first three. It is **a productized version of Robert's 1-on-1 executive coaching**, modeled directly on his proven drill-based pedagogy — the same teaching pattern he uses successfully with senior Fortune 500 clients.
 
-1. **The course gets executives in the door** — they pay a small amount or commit an email for premium content
-2. **The course makes 1-on-1 coaching feel inevitable** — every unit reminds the learner that personalized coaching will accelerate them faster
-3. **Strong, well-placed CTAs convert course completers into coaching clients**
+**The conversion play:**
+1. The course gets executives in the door — free now, paid later
+2. The course makes 1-on-1 coaching feel inevitable — every unit reminds the learner that a real coach accelerates them further
+3. Strong, well-placed CTAs convert course completers into coaching clients
 
-Robert IS the differentiator. His Bronx-born background, his Fortune 500 client roster, his personality — none of that can be copied by AI or generic course platforms. The course should feel like an extended seminar with Robert, not a textbook.
+Robert IS the differentiator. His Bronx-born delivery, his Fortune 500 client roster, his voice — none of it can be copied by AI or generic course platforms. The course should feel like an extended drill session with Robert, not a textbook.
 
 ---
 
-## What's CUT from this course (deliberate)
+## Pedagogy (derived from Robert's real lessons)
+
+Every unit section follows a very specific rhythm:
+
+1. **Goal** — what the learner will be able to do after this section
+2. **Why this matters** — the stakes at senior level
+3. **Core drill** — weak version → stronger options → integrated model reply
+4. **Technique focus / "Why this works"** — one-line strategic principle
+5. **Rapid Repeat** — 3-5 reusable sentence stems, say aloud
+6. **Final Shift** — Before: X / After: Y
+
+### The core drill pattern: Weak → Strong → Elite
+
+- **Weak:** Vague, hedging, generic. *"We looked into the issue."*
+- **Strong (C1):** Decisive, specific. *"We investigated the issue."*
+- **Elite (C2):** Analytically sharper. *"We diagnosed the root cause."*
+
+Most drills present **2-3 strong options** with a **usage guide** (when to use each) and an **integrated model reply** that uses all options in one fluent sentence. The goal is not to memorize synonyms — it's to train the ear to hear the strategic distinction.
+
+### Speaking-first, not reading-first
+
+Every drill has a "say aloud" prompt. Audio playback via Azure Neural TTS is critical — learners hear the model reply, then repeat it. The `AudioButton` shared component from the Advanced course handles this.
+
+### Named frameworks are memorizable products
+
+Executives walk away with specific, named mental models they can deploy under pressure:
+- **Cause → Action → Outcome** (simple status/update)
+- **Problem → Impact → Solution → Recommendation** (driving decisions)
+- **Context → Tension → Insight → Action → Outcome** (strategic storytelling)
+- **Acknowledge → Explain → Action → Prevention** (tough questions)
+- **State → Issue → Action → Timeline** (board updates)
+- **Defensive → Executive → Strategic** (reframing under pressure)
+
+---
+
+## What is CUT from this course (deliberate)
 
 | Cut | Why |
 |---|---|
-| **The written email unit** | Same reasoning as advanced — anyone who needs polished writing has Claude/ChatGPT. Spoken executive communication is the irreplaceable skill. |
-| **Verb tense drills** | Assumed mastered by C1+. |
-| **Phrasal verbs** | Same as before. |
-| **Modal drills** | Same as before. |
-| **Vocabulary memorization** | C1 learners build vocabulary by reading and listening, not by memorizing flashcards. |
+| Written email unit | Executive writing needs = Claude/ChatGPT. Spoken command under pressure is the irreplaceable skill. |
+| Verb tense drills | Assumed mastered by C1+. |
+| Phrasal verbs, modals, vocabulary memorization | C1 learners build vocabulary by reading and listening — not by memorizing lists. |
+| Case study analysis | Originally planned, but Robert's real lessons are pure drill, not analysis. Cut. |
+| Small talk, networking, cross-cultural as standalone units | Too "MBA textbook." Dilute the linguistic-authority positioning. Integrated into application units where relevant. |
 
 ---
 
-## 10-unit outline (3 sections per unit)
+## 10-unit outline (rebuilt on Robert's proven pedagogy)
 
-| # | Title | Section 1 | Section 2 | Section 3 |
-|---|---|---|---|---|
-| 1 | **Executive Presence in English** | How leaders speak — pace, pause, and presence | Eliminating filler and hedging language | Sounding decisive without sounding aggressive |
-| 2 | **Meetings That Move Forward** | Opening, steering, and closing a meeting | Interrupting politely and holding the floor | Disagreeing professionally — the diplomatic toolkit |
-| 3 | **Presentations & Public Speaking** | Structuring a talk for English-speaking audiences | Signposting language that keeps listeners engaged | Handling Q&A, including hostile questions |
-| 4 | **Negotiation Language** | Positioning, anchoring, and concession language | Diplomatic "no" — refusing without damaging the relationship | Closing the deal in English |
-| 5 | **Small Talk & Relationship Building** | Opening conversations with clients and colleagues | Networking events — what to say beyond "what do you do?" | Building rapport across the meeting, the meal, and the follow-up |
-| 6 | **Difficult Conversations** | Giving feedback without offending | Receiving feedback with poise | Conflict, apology, and repair language |
-| 7 | **Storytelling for Business** | The narrative arc in pitches and proposals | Data storytelling — making numbers memorable | Personal anecdotes that build credibility |
-| 8 | **Cross-Cultural Communication** | American business culture — directness, small talk, hierarchy | Meeting and call norms across cultures | Avoiding misunderstandings with international teams |
-| 9 | **Leadership Vocabulary & Register** | The language of strategy, vision, and execution | Business idioms that signal seniority | Avoiding jargon that makes you sound junior |
-| 10 | **Your Executive Voice** | Personal brand in English — how you want to be heard | Building a long-term communication practice | **Capstone: a recorded executive presentation with coaching feedback** |
+**Units 1-6 = Mechanics.** Teach the linguistic habits of executive speech.
+**Units 7-9 = Applications.** Apply the mechanics to specific senior-level situations.
+**Unit 10 = Integration + Capstone.**
 
-**Final Assessment:** Different from the multiple-choice exams in the other courses. See "The capstone strategy" below.
+| # | Title | Core focus | Frameworks taught |
+|---|---|---|---|
+| 1 | **Executive Word Choice** | Verb precision drills (the core Robert drill). Weak→Strong→Elite ladder. "We didn't just X, we Y" rapid drill. | Usage-guide system |
+| 2 | **Eliminating Weak Language** | Filler and hedging elimination. Calibrated certainty — direct without aggressive. Controlled assertion. | — |
+| 3 | **Structured Responses & Connectors** | Organizing thinking in real time. Executive connectors. | Cause→Action→Outcome. Problem→Impact→Solution→Recommendation. |
+| 4 | **Controlled Tone Under Pressure** | Defensive→Executive→Strategic reframing. Downgrade emotion, upgrade control. | 3-tier reframe ladder |
+| 5 | **Strategic Storytelling** | Fact → meaning → direction. Turning updates into influence. | Context→Tension→Insight→Action→Outcome |
+| 6 | **The Impromptu Toolkit** | 60-second replies under pressure. Three flagship scenarios. | Board Update, Tough Question, Drive Decision |
+| 7 | **High-Stakes Meetings** | Applying mechanics to meetings. Opening/closing. Holding the floor. Diplomatic disagreement. | — |
+| 8 | **Feedback and Difficult Conversations** | Giving feedback without offending. Receiving with poise. Conflict, apology, repair. | — |
+| 9 | **Negotiation and Driving Decisions** | Anchoring, concessions, diplomatic "no". Closing language. | Problem→Impact→Solution→Recommendation applied |
+| 10 | **Your Executive Voice + Capstone** | Integration. Personal brand in English. Long-term practice. **Capstone recording submission.** | All |
 
----
+### Section structure within each unit
 
-## Component reuse from advanced
+Each unit has **3 sections**. Each section follows Robert's rhythm (Goal → Why → Drill → Technique Focus → Rapid Repeat → Final Shift).
 
-The 5 reusable components built for advanced will work here too:
-- `WordPairLab` for U9 (vocabulary register comparisons)
-- `SentenceTransformer` for U1 (eliminating hedging) and U7 (data storytelling)
-- `ErrorSpotter` for U6 (feedback phrasing pitfalls)
-
-Most executive sections will use **less interactivity, more analysis**. Each unit will lean on:
-- **Case studies** — real examples of executive communication (public-domain speeches, leaked memos, famous interviews) with analytical reveals
-- **Frameworks** — SCQA, BLUF, Pyramid Principle, Aristotle's ethos/pathos/logos
-- **Robert's voice** in the prose — opinionated, specific, premium-feeling
-
-This means the executive course will need at most **1-2 new components**:
-
-| Component | Purpose |
-|---|---|
-| `CaseStudyLab` | Show an executive example (text + context), analytical reveal explaining why it worked |
-| `RhetoricalPatternLab` (optional) | Show a rhetorical pattern (rule of three, contrast pair, callback), give examples, learner identifies the pattern in new examples |
+Example — Unit 1 sections:
+- **1.1** Verb Precision — core "weak → 3 strong options" drill
+- **1.2** Progressive Discovery — "identified → isolated → exposed" depth language
+- **1.3** Integrated Executive Phrasing — putting it into model replies
 
 ---
 
-## The capstone strategy — Unit 10 + Final Assessment
+## C1 vs C2 progression (how one course serves both levels)
 
-Robert's outline says Unit 10 ends with "a recorded executive presentation with coaching feedback." This is the **single most important conversion moment in the entire course**.
+Rather than build two separate courses, each drill surfaces **progressive tiers**:
 
-We will NOT build in-browser audio recording for v1 (same reason as advanced — it's a 1-3 day side project that distracts from shipping content). Instead, the capstone will be:
+- **Default view:** C1 — Weak → Strong
+- **Optional C2 expansion:** Reveals the "Elite" upgrade with a **C2 Insight** callout (e.g., *"Differentiates reactive vs strategic delay"* or *"Moves from communication → alignment → influence"*)
 
-1. **A clear prompt** — "Record a 90-second executive update on a project you're leading. Use the SCQA framework. Submit it via email or book a strategy session."
-2. **A submission CTA** — Two paths:
-    - **Path A:** Email the recording to a dedicated address (e.g., `capstone@nyenglishteacher.com`). Robert listens and replies personally with feedback within 48 hours.
+**Benefits:**
+- C1 learner gets a focused, achievable course
+- C2 learner can push into the Elite tier for real stretch
+- Robert uses the same course to coach both levels of client
+
+**Technical note:** The `VerbUpgradeLab` component must support 2-tier (C1 only) or 3-tier (C1+C2) modes via the data file.
+
+---
+
+## Components
+
+### Reused from Advanced course (no new build)
+- `AudioButton` — Azure Neural TTS playback on all model replies (`en-US-AvaNeural` / `es-MX-DaliaNeural`)
+- `SentenceTransformer` — backup/general transformation drill where appropriate
+
+### New components for this course
+
+| Component | Purpose | Primary units |
+|---|---|---|
+| `VerbUpgradeLab` | Weak verb sentence → 2-3 stronger options with usage guide → "C2 Insight" callout → integrated model reply with audio | U1 (core), U3, U9 |
+| `WeakStrongElite` | 3-tier ladder drill (weak → strong → elite). Simpler than VerbUpgradeLab — single-line progression | U2, U4 |
+| `StructuredResponseBuilder` | Prompt → weak reply → model reply in named parts → expandable "why it works" reveal | U3, U6, U8, U9 |
+| `ConnectorDrill` | Transition upgrade — raw sentence pair → connected version with labeled connector | U3 |
+| `StoryBuilder` | Flat description → 5-step strategic narrative (Context→Tension→Insight→Action→Outcome) | U5 |
+| `RapidRepeat` | 3-5 reusable sentence stems with AudioButton, "say aloud" affordance | Every unit (section footer) |
+| `ImpromptuScenario` | Scenario + framework + 60-second timer + model answer with audio | U6, U9 |
+| `FinalShiftCard` | Display-only: "Before: X. After: Y." transformation summary | Every unit ending |
+
+**Total: 8 new, 2 reused = 10 components.** Most new components are small and share similar structure (data-in, audio-out, reveal affordance).
+
+---
+
+## The capstone strategy
+
+Unit 10 ends with a recorded executive presentation with Robert's personal feedback. **This is the single most important conversion moment in the entire course.**
+
+We will NOT build in-browser audio recording for v1 (same reasoning as Advanced — 1-3 days of side work that distracts from shipping content). Instead:
+
+1. **A clear prompt** — *"Record a 90-second executive update on a project you're leading. Use the Context → Tension → Insight → Action → Outcome framework. Submit it via email or book a strategy session."*
+2. **Two submission paths:**
+    - **Path A:** Email the recording to a dedicated address (`capstone@nyenglishteacher.com`). Robert listens and replies personally within 48 hours.
     - **Path B:** Book a free 30-minute strategy session and present it live to Robert.
-3. **The funnel hook** — Either path puts the executive into direct contact with Robert. The strategy session converts at a high rate. Path A nurtures the email list and creates a personalized touch point.
+3. **The funnel hook** — Either path puts the executive into direct contact with Robert. Path B converts at the highest rate. Path A nurtures the email list with a personalized touch.
 
-This is **the entire point of the executive course.** The capstone IS the conversion event.
+**The capstone IS the conversion event.** Everything leads here.
 
 ---
 
 ## Pricing & Phase 1 vs Phase 2
 
-### Phase 1 (build now, ship after Advanced)
+### Phase 1 (build now)
+**Free during launch.** Frame as *"Early Access — free for the first wave of executives."* Removes friction while we learn what content lands, builds testimonials, aligns with the real conversion (coaching).
 
-**Free during launch.** Frame it as "Early Access — free for the first wave of executives." This:
-- Removes friction during the period when we're still learning what content lands
-- Builds testimonials and case studies before charging
-- Lets us gather feedback before locking in a price point
-- Aligns with "free with strategy session booking" — the real conversion is the coaching
+### Phase 2 (after content validates)
+Add Stripe paywall. Recommended: **Course + strategy session bundle at $299.** The session is the real value driver. Course alone at $149 as a secondary option.
 
-### Phase 2 (after we know the content works)
-
-Add a Stripe paywall. Three pricing options to consider when we get there:
-
-| Option | Price | Notes |
-|---|---|---|
-| **A) Standalone course** | $99–$149 one-time | Self-serve, lower commitment |
-| **B) Course + strategy session** | $299 bundle | Includes one 30-minute session with Robert. The session is the value driver. |
-| **C) Course free, coaching paid** | Free / $499 per coaching package | Course as lead magnet only. Highest funnel volume, lowest course revenue. |
-
-**Recommendation when we get to Phase 2:** Option B. Bundles the course with a touch point with Robert, captures actual revenue, and the strategy session anchors the value perception.
-
-**Why we're deferring this:** Building Stripe checkout, payment tracking, course access gating (per-user paid status), and refund handling is a substantial system — probably 2-3 days on its own. We don't want to spend that time before we know the product is good. Free during launch reduces risk.
+Deferred because Stripe checkout, access gating, and refund handling is ~2-3 days of work that shouldn't block shipping.
 
 ---
 
-## Files to be created (estimated)
+## Files to be created
 
-### React components (1-2 new)
-- `src/components/course/CaseStudyLab.tsx`
-- `src/components/course/RhetoricalPatternLab.tsx` (optional)
+### React components (8 new)
+- `src/components/course/VerbUpgradeLab.tsx`
+- `src/components/course/WeakStrongElite.tsx`
+- `src/components/course/StructuredResponseBuilder.tsx`
+- `src/components/course/ConnectorDrill.tsx`
+- `src/components/course/StoryBuilder.tsx`
+- `src/components/course/RapidRepeat.tsx`
+- `src/components/course/ImpromptuScenario.tsx`
+- `src/components/course/FinalShiftCard.tsx`
 
 ### Data files (12)
 - `src/data/executive/types.ts`
 - `src/data/executive/units.ts`
 - `src/data/executive/unit-1.ts` through `unit-10.ts`
-- `src/data/executive/assessment.ts` (smaller than a full exam — capstone-focused)
+- `src/data/executive/capstone.ts`
 
 ### Page files (24)
-- `src/pages/en/course/executive/index.astro` + 10 unit pages + assessment page (12 EN)
-- `src/pages/es/curso/ejecutivo/index.astro` + 10 unit pages + assessment page (12 ES)
+- `src/pages/en/course/executive/index.astro` + 10 unit pages + capstone page
+- `src/pages/es/curso/ejecutivo/index.astro` + 10 unit pages + capstone page
 
 ### Modified files
 - `src/lib/i18n.ts` — add 12 new TKey entries + routes
 - `src/pages/en/courses/index.astro` and `src/pages/es/cursos/index.astro` — add Executive course card
 
-**Total: ~38 new files, 3 modified.** Slightly less than advanced because the components are mostly reused.
+**Total: ~44 new files, 3 modified.**
 
 ---
 
-## Build order (recommended PR cadence)
+## Build order (5 PRs)
 
 | PR | Contents |
 |---|---|
-| **PR 1** | Foundation — i18n routes, types, units metadata, landing page (EN+ES), CaseStudyLab component |
-| **PR 2** | Units 1, 2, 3 |
-| **PR 3** | Units 4, 5, 6 |
+| **PR 1** | Foundation: i18n routes, types, units metadata, landing pages (EN+ES), `VerbUpgradeLab`, `RapidRepeat`, `FinalShiftCard`, courses hub card |
+| **PR 2** | Units 1, 2, 3 + `WeakStrongElite`, `StructuredResponseBuilder`, `ConnectorDrill` |
+| **PR 3** | Units 4, 5, 6 + `StoryBuilder`, `ImpromptuScenario` |
 | **PR 4** | Units 7, 8, 9 |
-| **PR 5** | Unit 10 + Capstone funnel + courses hub card |
+| **PR 5** | Unit 10 + Capstone funnel + capstone email handler + capstone landing page |
 
-Same cadence as advanced. Defer the Stripe paywall to a Phase 2 PR after we ship and validate.
+PR 1 is heavier (3 components) because we front-load the foundational drill component (`VerbUpgradeLab`) and the display utilities (`RapidRepeat`, `FinalShiftCard`) that appear in every unit. PRs 4-5 are lighter — no new components, just content authoring.
 
 ---
 
 ## URL structure
 
 - EN landing: `/en/course/executive/`
-- EN unit: `/en/course/executive/unit-1/` through `/unit-10/`
-- EN assessment: `/en/course/executive/assessment/`
+- EN units: `/en/course/executive/unit-1/` through `/unit-10/`
+- EN capstone: `/en/course/executive/capstone/`
 - ES landing: `/es/curso/ejecutivo/`
-- ES unit: `/es/curso/ejecutivo/unidad-1/` through `/unidad-10/`
-- ES assessment: `/es/curso/ejecutivo/evaluacion/`
+- ES units: `/es/curso/ejecutivo/unidad-1/` through `/unidad-10/`
+- ES capstone: `/es/curso/ejecutivo/reto-final/`
+
+---
+
+## Content authoring strategy
+
+The two reference lessons Robert has shared are the **canonical style guide**. Claude drafts drills matching that voice; Robert reviews and corrects.
+
+**Voice rules (from analyzing real lessons):**
+- Direct, specific, no fluff
+- Every drill has a concrete scenario (operations, strategy, team, client, performance)
+- Weak examples are relatable — things real executives actually say
+- Strong examples sound like Robert would say them
+- "Why this works" reveals are **one-liners**, not paragraphs
+- "C2 Insight" callouts name the **strategic distinction**, not the grammar
+- "Final Shift" cards use exact Before/After contrast
+
+**Quality bar:** Production-grade, client-facing. This course represents Robert's business. Each drill should feel like it came from the same coach who delivered the two reference lessons.
 
 ---
 
 ## What this course does NOT try to be
 
-- A grammar refresher (intermediate handled that)
-- A cultural exchange program
-- A networking platform
+- A grammar refresher (Intermediate handled that)
+- A cultural exchange or networking program
+- A soft-skills or leadership course with English as a wrapper
 - A self-paced certification program
 - A replacement for 1-on-1 coaching
 
-It is **a focused, premium-positioned series of leadership communication lessons designed to convert qualified executives into Robert's coaching clients.** Every unit serves that goal.
+It is **a focused, premium-positioned series of linguistic command drills designed to convert qualified executives into Robert's coaching clients.** Every unit serves that goal.
 
 ---
 
 ## Open questions / decisions for later
 
-- **Robert recording video intros for each unit** — flagged in the original alignment discussion. Robert declined for now ("not ready to record a video right now"). If/when he changes his mind, even 2-3 minute video intros per unit would dramatically increase perceived value and conversion. Worth revisiting after Phase 1 ships.
-- **Whether to write a separate Spanish version of the case studies** — most executive content references American business culture and English-language sources. Translation may be straightforward, but some cultural context will need adaptation.
-- **Whether to bundle the course with Robert's existing executive training products** (the Cushlabs offerings, etc.). Worth a strategic conversation when we get to Phase 2 paywall.
-- **Whether to create a private Slack/Discord community for executive course enrollees** — could be a high-value add but creates ongoing moderation work.
+- **Robert recording video intros per unit** — flagged originally, Robert declined for Phase 1. If revisited after launch, 2-3 minute intros would dramatically increase perceived value and conversion.
+- **Spanish adaptation** — most executive phrasing is English-specific. The Spanish course should teach Spanish speakers how to handle *English* executive situations — not translate word-for-word. Handle during content authoring, unit by unit.
+- **Bundling with Cushlabs executive offerings** — worth strategic conversation at Phase 2 paywall.
+- **Private community** (Slack/Discord for enrollees) — high-value add but creates ongoing moderation overhead. Defer to post-launch.
+
+---
+
+## Success metrics
+
+**Phase 1 (free launch):**
+- 50+ course completions in first 90 days
+- 10+ capstone submissions (email or strategy session)
+- 5+ strategy sessions booked from capstone path
+- 2+ coaching clients converted from strategy sessions
+
+**Phase 2 (paywall):**
+- $10K+ revenue in first 90 days post-paywall
+- Landing page → purchase conversion > 2%
+- Course-to-coaching funnel: 10%+ of course buyers convert to coaching package

--- a/src/components/course/FinalShiftCard.tsx
+++ b/src/components/course/FinalShiftCard.tsx
@@ -1,0 +1,53 @@
+// FinalShiftCard — the Before / After transformation summary that closes
+// every unit in the Executive course.
+//
+// A pure display component. The text contrasts the linguistic habit the
+// learner arrived with against the habit they leave with. This mirrors the
+// "Final Shift" pattern from Robert's real lessons: naming the
+// transformation makes the progress tangible.
+
+import type { FinalShift } from "@data/executive/types";
+
+interface Props {
+  shift: FinalShift;
+  lang: "en" | "es";
+}
+
+export default function FinalShiftCard({ shift, lang }: Props) {
+  const before = lang === "es" ? shift.beforeEs : shift.before;
+  const after = lang === "es" ? shift.afterEs : shift.after;
+
+  return (
+    <section
+      aria-label={lang === "es" ? "Cambio Final" : "Final Shift"}
+      className="bg-gradient-to-br from-slate-900 via-slate-900 to-amber-950 border border-amber-900/40 rounded-2xl p-8 text-center"
+    >
+      <p className="text-[10px] font-mono uppercase tracking-[0.3em] text-amber-400 mb-6">
+        {lang === "es" ? "Cambio Final" : "Final Shift"}
+      </p>
+
+      <div className="grid gap-4 md:grid-cols-[1fr_auto_1fr] items-center">
+        <div className="text-left md:text-right">
+          <p className="text-[10px] font-mono uppercase tracking-widest text-slate-500 mb-2">
+            {lang === "es" ? "Antes" : "Before"}
+          </p>
+          <p className="text-slate-400 leading-relaxed">{before}</p>
+        </div>
+
+        <div
+          aria-hidden="true"
+          className="hidden md:flex items-center justify-center h-full px-2 text-amber-400 text-2xl font-light"
+        >
+          →
+        </div>
+
+        <div className="text-left">
+          <p className="text-[10px] font-mono uppercase tracking-widest text-amber-400 mb-2">
+            {lang === "es" ? "Ahora" : "After"}
+          </p>
+          <p className="text-amber-50 font-medium leading-relaxed">{after}</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/course/RapidRepeat.tsx
+++ b/src/components/course/RapidRepeat.tsx
@@ -1,0 +1,79 @@
+// RapidRepeat — memory-anchoring block that closes every section.
+//
+// Displays 3-5 reusable sentence stems with an AudioButton per stem and a
+// "say aloud" affordance. The learner plays each stem and repeats it three
+// times. This mirrors Robert's "Rapid Repeat" / "Optional Rapid Drill"
+// pattern that reinforces the section's core phrasing.
+
+import { Megaphone, Volume2 } from "lucide-react";
+import AudioButton from "./AudioButton";
+import type { RapidRepeatStem } from "@data/executive/types";
+
+interface Props {
+  stems: RapidRepeatStem[];
+  lang: "en" | "es";
+  /** Optional heading override — defaults to "Rapid Repeat" */
+  heading?: string;
+  headingEs?: string;
+}
+
+export default function RapidRepeat({
+  stems,
+  lang,
+  heading,
+  headingEs,
+}: Props) {
+  const title =
+    lang === "es"
+      ? headingEs ?? "Repetición Rápida"
+      : heading ?? "Rapid Repeat";
+
+  const instruction =
+    lang === "es"
+      ? "Dilas en voz alta. Una oración cada una. Luego repite, más corto y más limpio."
+      : "Say them aloud. One sentence each. Then repeat, shorter and cleaner.";
+
+  return (
+    <section className="bg-slate-900 rounded-2xl border border-slate-800 p-6 space-y-4">
+      <div className="flex items-center gap-2 text-amber-400">
+        <Megaphone size={18} />
+        <h3 className="text-sm font-semibold uppercase tracking-widest">
+          {title}
+        </h3>
+      </div>
+
+      <p className="text-sm text-slate-400 leading-relaxed">{instruction}</p>
+
+      <ul className="space-y-2">
+        {stems.map((stem, idx) => {
+          const text = lang === "es" ? stem.textEs : stem.text;
+          return (
+            <li
+              key={idx}
+              className="flex items-center gap-3 bg-slate-800/80 border border-slate-700 rounded-xl px-4 py-3"
+            >
+              <div className="shrink-0 w-7 h-7 rounded-full bg-amber-500 text-slate-900 text-xs font-bold flex items-center justify-center">
+                {idx + 1}
+              </div>
+              <p className="flex-1 text-base text-slate-100 font-medium leading-relaxed">
+                "{text}"
+              </p>
+              <div className="shrink-0">
+                <AudioButton text={text} size="sm" />
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className="flex items-center gap-2 text-xs text-slate-500 pt-1">
+        <Volume2 size={12} />
+        <span>
+          {lang === "es"
+            ? "Cada frase es un anclaje — memorízala, luego desplégala."
+            : "Each stem is an anchor — memorize it, then deploy it."}
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/src/components/course/VerbUpgradeLab.tsx
+++ b/src/components/course/VerbUpgradeLab.tsx
@@ -1,0 +1,252 @@
+// VerbUpgradeLab — the signature drill of the Executive Communication course.
+//
+// Shows a weak / vague sentence, 2-3 stronger options each with a usage note,
+// and an integrated model reply that uses all options in one fluent sentence.
+// Optional C2 Elite tier reveals a sharper single phrasing plus a C2 Insight
+// callout naming the strategic distinction.
+//
+// This mirrors Robert's proven pedagogy: the learner hears the weak version,
+// studies the usage distinctions, then reveals the integrated model reply and
+// can optionally push past Strong (C1) into Elite (C2).
+
+import { useState } from "react";
+import {
+  ArrowDown,
+  Lightbulb,
+  RotateCcw,
+  Sparkles,
+  Target,
+  Zap,
+} from "lucide-react";
+import AudioButton from "./AudioButton";
+import type { VerbUpgradeItem } from "@data/executive/types";
+
+interface Props {
+  items: VerbUpgradeItem[];
+  lang: "en" | "es";
+}
+
+export default function VerbUpgradeLab({ items, lang }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [revealed, setRevealed] = useState(false);
+  const [eliteRevealed, setEliteRevealed] = useState(false);
+
+  const current = items[currentIndex];
+  const isLast = currentIndex === items.length - 1;
+  const hasElite = Boolean(current.elite);
+
+  const handleReveal = () => setRevealed(true);
+  const handleRevealElite = () => setEliteRevealed(true);
+
+  const handleNext = () => {
+    if (isLast) return;
+    setCurrentIndex(currentIndex + 1);
+    setRevealed(false);
+    setEliteRevealed(false);
+  };
+
+  const handleRestart = () => {
+    setCurrentIndex(0);
+    setRevealed(false);
+    setEliteRevealed(false);
+  };
+
+  const weak = lang === "es" ? current.weakEs : current.weak;
+  const modelReply = lang === "es" ? current.modelReplyEs : current.modelReply;
+  const why = lang === "es" ? current.whyItWorksEs : current.whyItWorks;
+
+  return (
+    <section className="space-y-6">
+      {/* Progress */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-slate-500">
+          {lang === "es" ? "Drill" : "Drill"} {currentIndex + 1} / {items.length}
+        </span>
+        <button
+          onClick={handleRestart}
+          className="text-xs text-slate-400 hover:text-amber-600 inline-flex items-center gap-1 transition-colors"
+        >
+          <RotateCcw size={12} />
+          {lang === "es" ? "Reiniciar" : "Restart"}
+        </button>
+      </div>
+
+      <div className="w-full h-1.5 bg-slate-100 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-amber-500 rounded-full transition-all duration-300"
+          style={{ width: `${((currentIndex + 1) / items.length) * 100}%` }}
+        />
+      </div>
+
+      {/* Card */}
+      <div className="bg-white rounded-2xl border-2 border-slate-200 overflow-hidden">
+        {/* Weak sentence */}
+        <div className="px-6 pt-6">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-2">
+            {lang === "es" ? "El fraseo débil:" : "The weak phrasing:"}
+          </p>
+          <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-base text-slate-700 italic leading-relaxed flex-1">
+                "{weak}"
+              </p>
+              <div className="shrink-0 mt-1">
+                <AudioButton text={lang === "es" ? current.weakEs : current.weak} size="sm" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Options */}
+        <div className="px-6 pt-5">
+          <p className="text-xs font-semibold uppercase tracking-wider text-amber-600 mb-3 flex items-center gap-1">
+            <Target size={12} />
+            {lang === "es" ? "Opciones más fuertes:" : "Stronger options:"}
+          </p>
+          <div className="grid gap-2">
+            {current.options.map((option, idx) => {
+              const verb = lang === "es" ? option.verbEs : option.verb;
+              const usage = lang === "es" ? option.usageEs : option.usage;
+              return (
+                <div
+                  key={idx}
+                  className="bg-amber-50/60 border border-amber-200 rounded-xl p-3 flex items-center gap-3"
+                >
+                  <div className="shrink-0 w-7 h-7 rounded-full bg-amber-500 text-white text-xs font-bold flex items-center justify-center">
+                    {idx + 1}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="font-semibold text-slate-900">{verb}</span>
+                      <AudioButton text={verb} size="sm" />
+                    </div>
+                    <p className="text-xs text-slate-600 mt-0.5">{usage}</p>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Arrow */}
+        <div className="flex justify-center py-4">
+          <ArrowDown className="w-5 h-5 text-slate-300" />
+        </div>
+
+        {/* Model reply */}
+        <div className="px-6 pb-6">
+          <p className="text-xs font-semibold uppercase tracking-wider text-amber-600 mb-2 flex items-center gap-1">
+            <Zap size={12} />
+            {lang === "es"
+              ? "Respuesta modelo integrada:"
+              : "Integrated model reply:"}
+          </p>
+
+          {!revealed ? (
+            <button
+              onClick={handleReveal}
+              className="w-full py-4 rounded-xl border-2 border-dashed border-amber-300 text-amber-600 font-medium hover:bg-amber-50 transition-colors"
+            >
+              {lang === "es"
+                ? "Toca para revelar la respuesta modelo"
+                : "Tap to reveal the model reply"}
+            </button>
+          ) : (
+            <div className="space-y-3">
+              <div className="bg-gradient-to-br from-amber-50 to-amber-100 border-2 border-amber-300 rounded-xl p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <p className="text-base text-slate-900 font-medium leading-relaxed flex-1">
+                    "{modelReply}"
+                  </p>
+                  <div className="shrink-0 mt-1">
+                    <AudioButton text={modelReply} size="sm" />
+                  </div>
+                </div>
+                <div className="mt-3 pt-3 border-t border-amber-200">
+                  <p className="text-xs text-slate-600 leading-relaxed flex items-start gap-1">
+                    <Sparkles size={11} className="text-amber-500 shrink-0 mt-0.5" />
+                    <span>{why}</span>
+                  </p>
+                </div>
+              </div>
+
+              {/* Elite (C2) tier */}
+              {hasElite && current.elite && (
+                <div className="mt-4">
+                  {!eliteRevealed ? (
+                    <button
+                      onClick={handleRevealElite}
+                      className="w-full py-3 rounded-xl border-2 border-dashed border-violet-300 text-violet-700 text-sm font-medium hover:bg-violet-50 transition-colors inline-flex items-center justify-center gap-2"
+                    >
+                      <Lightbulb size={14} />
+                      {lang === "es"
+                        ? "Revelar el nivel C2 Elite"
+                        : "Reveal the C2 Elite tier"}
+                    </button>
+                  ) : (
+                    <div className="bg-gradient-to-br from-violet-50 to-violet-100 border-2 border-violet-300 rounded-xl p-4">
+                      <div className="flex items-center justify-between gap-2 mb-2">
+                        <span className="inline-flex items-center gap-1 text-[10px] font-mono uppercase tracking-wider px-2 py-0.5 rounded-full bg-violet-200 text-violet-800">
+                          C2 Elite
+                        </span>
+                      </div>
+                      <div className="flex items-start justify-between gap-3">
+                        <p className="text-base text-slate-900 font-medium leading-relaxed flex-1">
+                          "{lang === "es"
+                            ? current.elite.modelReplyEs
+                            : current.elite.modelReply}"
+                        </p>
+                        <div className="shrink-0 mt-1">
+                          <AudioButton
+                            text={
+                              lang === "es"
+                                ? current.elite.modelReplyEs
+                                : current.elite.modelReply
+                            }
+                            size="sm"
+                          />
+                        </div>
+                      </div>
+                      <div className="mt-3 pt-3 border-t border-violet-200">
+                        <p className="text-[11px] font-semibold uppercase tracking-wider text-violet-700 mb-1">
+                          {lang === "es" ? "Perspectiva C2" : "C2 Insight"}
+                        </p>
+                        <p className="text-xs text-slate-700 leading-relaxed">
+                          {lang === "es"
+                            ? current.elite.c2InsightEs
+                            : current.elite.c2Insight}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Next button */}
+      {revealed && !isLast && (
+        <div className="flex justify-end">
+          <button
+            onClick={handleNext}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-500 text-white font-medium hover:bg-amber-400 transition-colors shadow-sm"
+          >
+            {lang === "es" ? "Siguiente" : "Next"}
+          </button>
+        </div>
+      )}
+
+      {revealed && isLast && (
+        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 text-center">
+          <p className="text-emerald-800 font-medium text-sm">
+            {lang === "es"
+              ? "Excelente. Has trabajado los drills — ahora di las respuestas modelo en voz alta, tres veces cada una."
+              : "Excellent. You've worked the drills — now say the model replies aloud, three times each."}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/data/executive/types.ts
+++ b/src/data/executive/types.ts
@@ -1,0 +1,201 @@
+// Type definitions shared across the executive course data files.
+//
+// Per docs/EXECUTIVE-COURSE-PLAN.md, every unit section follows Robert's
+// proven rhythm: Goal → Why this matters → Core drill → Technique focus →
+// Rapid Repeat → Final Shift. These types encode each of those drill
+// shapes as pure data so the React components stay simple and so content
+// survives the Astro→React island JSON serialization boundary.
+
+// ─── VerbUpgradeLab ────────────────────────────────────────────────────────
+// The signature Robert drill. A weak sentence, 2-3 stronger options each
+// with a usage note, plus an integrated model reply that uses all options
+// in one fluent sentence. The optional `elite` tier unlocks the C2 upgrade
+// (single sharper phrasing) with a C2 Insight callout describing the
+// strategic distinction the elite phrasing enables.
+export interface VerbUpgradeOption {
+  /** The strong verb or phrase */
+  verb: string;
+  verbEs: string;
+  /** When to use this option (e.g., "broad, neutral, fact-finding") */
+  usage: string;
+  usageEs: string;
+}
+
+export interface VerbUpgradeItem {
+  /** The weak / vague sentence to upgrade */
+  weak: string;
+  weakEs: string;
+  /** 2-3 stronger options, each with a usage note */
+  options: VerbUpgradeOption[];
+  /** Model reply that integrates all options into one fluent sentence */
+  modelReply: string;
+  modelReplyEs: string;
+  /** One-liner explaining why the integrated reply works */
+  whyItWorks: string;
+  whyItWorksEs: string;
+  /** Optional C2 elite tier — a single sharper phrasing */
+  elite?: {
+    verb: string;
+    verbEs: string;
+    /** The integrated model reply at C2 */
+    modelReply: string;
+    modelReplyEs: string;
+    /** The strategic distinction the elite phrasing names */
+    c2Insight: string;
+    c2InsightEs: string;
+  };
+}
+
+// ─── WeakStrongElite ───────────────────────────────────────────────────────
+// Three-tier ladder drill — a single weak sentence upgraded through strong
+// (C1) and optional elite (C2) phrasings. Simpler than VerbUpgradeLab;
+// used for filler elimination and defensive reframing.
+export interface WeakStrongEliteItem {
+  weak: string;
+  weakEs: string;
+  strong: string;
+  strongEs: string;
+  /** Optional elite tier — reveals the C2 upgrade */
+  elite?: string;
+  eliteEs?: string;
+  /** Optional one-line note on why the upgrade matters */
+  note?: string;
+  noteEs?: string;
+}
+
+// ─── StructuredResponseBuilder ─────────────────────────────────────────────
+// Prompt → weak reply → model reply broken into named parts (e.g., Cause /
+// Action / Outcome), with a "why it works" reveal. The named framework is
+// the memorable product the learner walks away with.
+export interface StructuredResponsePart {
+  /** Framework label (e.g., "Cause", "Action", "Outcome") */
+  label: string;
+  labelEs: string;
+  /** The sentence for this part of the model reply */
+  sentence: string;
+  sentenceEs: string;
+}
+
+export interface StructuredResponseItem {
+  /** The executive prompt or question */
+  prompt: string;
+  promptEs: string;
+  /** Fragmented / weak attempt */
+  weak: string;
+  weakEs: string;
+  /** Named framework driving the response */
+  framework: string;
+  frameworkEs: string;
+  /** The model reply broken into labeled parts */
+  parts: StructuredResponsePart[];
+  /** Why this structured version works */
+  whyItWorks: string;
+  whyItWorksEs: string;
+}
+
+// ─── ConnectorDrill ────────────────────────────────────────────────────────
+// Upgrade a weak two-sentence pair into a connected version using a
+// labeled executive connector ("As a result…", "In response…",
+// "Accordingly…", etc.).
+export interface ConnectorDrillItem {
+  weak: string;
+  weakEs: string;
+  strong: string;
+  strongEs: string;
+  /** The specific connector used (e.g., "As a result") */
+  connector: string;
+  connectorEs: string;
+  /** Optional elite tier — a second connector layered in */
+  elite?: string;
+  eliteEs?: string;
+}
+
+// ─── StoryBuilder ──────────────────────────────────────────────────────────
+// Flat description → 5-step strategic narrative (Context → Tension →
+// Insight → Action → Outcome). The learner reveals each step in sequence.
+export interface StoryStep {
+  label: "Context" | "Tension" | "Insight" | "Action" | "Outcome";
+  sentence: string;
+  sentenceEs: string;
+}
+
+export interface StoryBuilderItem {
+  /** The executive prompt that triggers the story */
+  prompt: string;
+  promptEs: string;
+  /** Flat, fact-only attempt */
+  flat: string;
+  flatEs: string;
+  /** The 5-step narrative */
+  steps: StoryStep[];
+  /** One-liner on why this narrative works */
+  whyItWorks: string;
+  whyItWorksEs: string;
+}
+
+// ─── RapidRepeat ───────────────────────────────────────────────────────────
+// 3-5 reusable sentence stems the learner says aloud as memory anchors.
+// Appears at the end of every section.
+export interface RapidRepeatStem {
+  text: string;
+  textEs: string;
+}
+
+// ─── ImpromptuScenario ─────────────────────────────────────────────────────
+// Scenario + named framework + model 60-second reply. Used for U6 (impromptu
+// toolkit) and U9 (decision-driving).
+export interface ImpromptuScenarioItem {
+  /** The impromptu prompt (e.g., "Give us a quick update on operations") */
+  prompt: string;
+  promptEs: string;
+  /** The named framework with its step labels */
+  framework: string;
+  frameworkEs: string;
+  frameworkSteps: string[];
+  frameworkStepsEs: string[];
+  /** Weak attempt */
+  weak: string;
+  weakEs: string;
+  /** Model 60-second reply */
+  modelReply: string;
+  modelReplyEs: string;
+  /** Why it works */
+  whyItWorks: string;
+  whyItWorksEs: string;
+}
+
+// ─── FinalShiftCard ────────────────────────────────────────────────────────
+// Before / After transformation summary that closes every unit.
+export interface FinalShift {
+  before: string;
+  beforeEs: string;
+  after: string;
+  afterEs: string;
+}
+
+// ─── Section & Unit wrappers ───────────────────────────────────────────────
+export type DrillMechanic =
+  | "verb-upgrade"
+  | "weak-strong-elite"
+  | "structured-response"
+  | "connector"
+  | "story"
+  | "impromptu";
+
+export interface UnitSection {
+  /** Section number — always 1, 2, or 3 */
+  number: 1 | 2 | 3;
+  /** Section title shown in the page heading */
+  title: string;
+  titleEs: string;
+  /** The stakes / why this section matters (1-3 sentences) */
+  why: string;
+  whyEs: string;
+  /** Which drill type to render */
+  mechanic: DrillMechanic;
+  /** One-line technique focus shown above the Rapid Repeat block */
+  techniqueFocus: string;
+  techniqueFocusEs: string;
+  /** Rapid Repeat stems — 3 to 5 */
+  rapidRepeat: RapidRepeatStem[];
+}

--- a/src/data/executive/units.ts
+++ b/src/data/executive/units.ts
@@ -1,0 +1,238 @@
+// Executive course unit metadata — "Communicate Like a Leader" (C1-C2)
+//
+// 10 units, 3 sections each, plus a recorded capstone presentation.
+// Units 1-6 teach mechanics, 7-9 apply them to situations, 10 integrates
+// and funnels the learner to the capstone. See
+// docs/EXECUTIVE-COURSE-PLAN.md for the full pedagogy and section rhythm.
+
+export interface ExecutiveUnit {
+  id: number;
+  slug: string;
+  slugEs: string;
+  title: string;
+  titleEs: string;
+  subtitle: string;
+  subtitleEs: string;
+  description: string;
+  descriptionEs: string;
+  /** What learners will be able to do after this unit */
+  outcome: string;
+  outcomeEs: string;
+  /** Lucide icon name for the unit card */
+  icon: string;
+  /** Whether this unit is published yet (false during rolling build) */
+  published: boolean;
+}
+
+export const executiveInfo = {
+  title: "Communicate Like a Leader",
+  titleEs: "Comunica Como un Líder",
+  tagline: "Executive command language under pressure.",
+  taglineEs: "Lenguaje de mando ejecutivo bajo presión.",
+  description:
+    "The productized version of Robert's 1-on-1 executive coaching. Ten units of drill-based training that replace vague, hedging English with the precision, structure, and calm authority senior leaders demand. Not a grammar course — a linguistic command course for C1-C2 speakers who already communicate competently but want to lead in English.",
+  descriptionEs:
+    "La versión productizada del coaching ejecutivo 1-a-1 de Robert. Diez unidades de entrenamiento basado en drills que reemplazan el inglés vago y titubeante con la precisión, estructura y autoridad tranquila que exigen los líderes senior. No es un curso de gramática — es un curso de dominio lingüístico para hablantes C1-C2 que ya se comunican con competencia pero quieren liderar en inglés.",
+  level: "C1 → C2",
+  basePath: {
+    en: "/en/course/executive",
+    es: "/es/curso/ejecutivo",
+  },
+  capstoneSlug: {
+    en: "capstone",
+    es: "reto-final",
+  },
+};
+
+export const executiveUnits: ExecutiveUnit[] = [
+  {
+    id: 1,
+    slug: "unit-1",
+    slugEs: "unidad-1",
+    title: "Executive Word Choice",
+    titleEs: "Elección Ejecutiva de Palabras",
+    subtitle: "Trade vague verbs for surgical precision.",
+    subtitleEs: "Cambia verbos vagos por precisión quirúrgica.",
+    description:
+      "Senior leaders don't 'look into' issues — they investigate, analyze, and diagnose. This unit trains your ear to hear the strategic distinction between similar verbs and rebuilds your speech around the verbs that signal analytical depth.",
+    descriptionEs:
+      "Los líderes senior no 'revisan' los problemas — investigan, analizan y diagnostican. Esta unidad entrena tu oído para escuchar la distinción estratégica entre verbos similares y reconstruye tu discurso alrededor de los verbos que señalan profundidad analítica.",
+    outcome:
+      "You'll replace generic verbs with the precise, strategic language executives expect.",
+    outcomeEs:
+      "Reemplazarás los verbos genéricos con el lenguaje preciso y estratégico que los ejecutivos esperan.",
+    icon: "Target",
+    published: false,
+  },
+  {
+    id: 2,
+    slug: "unit-2",
+    slugEs: "unidad-2",
+    title: "Eliminating Weak Language",
+    titleEs: "Eliminando el Lenguaje Débil",
+    subtitle: "Decisive without aggressive. Calibrated certainty.",
+    subtitleEs: "Decisivo sin ser agresivo. Certeza calibrada.",
+    description:
+      "Over-hedging at senior level signals lack of control — but over-directness reads as aggression. This unit drills the middle path: measured authority. You remove 'I think', 'maybe', 'kind of', and 'sort of' while keeping your tone calm and senior.",
+    descriptionEs:
+      "El exceso de atenuación en el nivel senior señala falta de control — pero el exceso de directividad se percibe como agresión. Esta unidad practica el camino medio: autoridad medida. Eliminas 'I think', 'maybe', 'kind of' y 'sort of' mientras mantienes un tono calmado y senior.",
+    outcome:
+      "You'll speak with calibrated certainty — direct, but never tense.",
+    outcomeEs:
+      "Hablarás con certeza calibrada — directo, pero nunca tenso.",
+    icon: "Zap",
+    published: false,
+  },
+  {
+    id: 3,
+    slug: "unit-3",
+    slugEs: "unidad-3",
+    title: "Structured Responses & Connectors",
+    titleEs: "Respuestas Estructuradas y Conectores",
+    subtitle: "Cause → Action → Outcome. Problem → Impact → Solution → Recommendation.",
+    subtitleEs: "Causa → Acción → Resultado. Problema → Impacto → Solución → Recomendación.",
+    description:
+      "Unstructured speech forces the listener to guess your meaning. Structured speech signals leadership control. This unit gives you two named frameworks plus the executive connectors that reveal your logic in real time.",
+    descriptionEs:
+      "El discurso no estructurado obliga al oyente a adivinar tu significado. El discurso estructurado señala control de liderazgo. Esta unidad te da dos marcos con nombre más los conectores ejecutivos que revelan tu lógica en tiempo real.",
+    outcome:
+      "You'll organize your thinking out loud using named frameworks, under pressure.",
+    outcomeEs:
+      "Organizarás tu pensamiento en voz alta usando marcos con nombre, bajo presión.",
+    icon: "Layers",
+    published: false,
+  },
+  {
+    id: 4,
+    slug: "unit-4",
+    slugEs: "unidad-4",
+    title: "Controlled Tone Under Pressure",
+    titleEs: "Tono Controlado Bajo Presión",
+    subtitle: "Defensive → Executive → Strategic. Never defend. Always reframe.",
+    subtitleEs: "Defensivo → Ejecutivo → Estratégico. Nunca defiendas. Siempre reencuadra.",
+    description:
+      "When leadership challenges you, defensive language signals loss of control. This unit drills the three-tier reframe — taking a defensive line and upgrading it through executive and strategic phrasing — plus the downgrade-emotion / upgrade-control pattern that keeps you measured.",
+    descriptionEs:
+      "Cuando el liderazgo te desafía, el lenguaje defensivo señala pérdida de control. Esta unidad practica el reencuadre de tres niveles — tomar una línea defensiva y elevarla con fraseo ejecutivo y estratégico — además del patrón reducir-emoción / elevar-control que te mantiene medido.",
+    outcome:
+      "You'll respond to pressure with authority, not emotion.",
+    outcomeEs:
+      "Responderás a la presión con autoridad, no con emoción.",
+    icon: "Shield",
+    published: false,
+  },
+  {
+    id: 5,
+    slug: "unit-5",
+    slugEs: "unidad-5",
+    title: "Strategic Storytelling",
+    titleEs: "Narrativa Estratégica",
+    subtitle: "Context → Tension → Insight → Action → Outcome. Facts inform. Stories influence.",
+    subtitleEs: "Contexto → Tensión → Perspectiva → Acción → Resultado. Los hechos informan. Las historias influyen.",
+    description:
+      "At senior level, facts alone are not enough — everyone has access to the data. What executives don't have is clear interpretation. This unit turns flat reporting into strategic narrative using a single five-step structure.",
+    descriptionEs:
+      "En el nivel senior, los hechos solos no son suficientes — todos tienen acceso a los datos. Lo que los ejecutivos no tienen es una interpretación clara. Esta unidad convierte los reportes planos en narrativa estratégica usando una sola estructura de cinco pasos.",
+    outcome:
+      "You'll transform updates into decision-shaping narratives.",
+    outcomeEs:
+      "Transformarás las actualizaciones en narrativas que moldean decisiones.",
+    icon: "BookOpen",
+    published: false,
+  },
+  {
+    id: 6,
+    slug: "unit-6",
+    slugEs: "unidad-6",
+    title: "The Impromptu Toolkit",
+    titleEs: "El Kit de Respuesta Impromptu",
+    subtitle: "Four named frameworks for the moments you can't prepare.",
+    subtitleEs: "Cuatro marcos con nombre para los momentos que no puedes preparar.",
+    description:
+      "Board update. Tough question. Drive decision. Acknowledge and prevent. Four named frameworks — each a 60-second structure — that you can deploy the moment leadership turns to you and says 'what do you think?' The drills here are the closest thing to a script you'll ever have.",
+    descriptionEs:
+      "Actualización de junta directiva. Pregunta difícil. Impulsar decisión. Reconocer y prevenir. Cuatro marcos con nombre — cada uno una estructura de 60 segundos — que puedes desplegar el momento en que el liderazgo te mire y diga '¿qué piensas?' Los drills aquí son lo más cercano a un guion que tendrás jamás.",
+    outcome:
+      "You'll respond to any impromptu question with a named framework.",
+    outcomeEs:
+      "Responderás a cualquier pregunta improvisada con un marco con nombre.",
+    icon: "Clock",
+    published: false,
+  },
+  {
+    id: 7,
+    slug: "unit-7",
+    slugEs: "unidad-7",
+    title: "High-Stakes Meetings",
+    titleEs: "Reuniones de Alto Impacto",
+    subtitle: "Opening. Holding the floor. Diplomatic disagreement.",
+    subtitleEs: "Apertura. Mantener el turno. Desacuerdo diplomático.",
+    description:
+      "Meetings are where executive English either holds up or breaks down. This unit applies the mechanics from Units 1-6 to the specific meeting language you need: opening and closing phrases, interrupting politely, holding the floor when pressed, and disagreeing without damaging the relationship.",
+    descriptionEs:
+      "Las reuniones son donde el inglés ejecutivo se mantiene o se desmorona. Esta unidad aplica las mecánicas de las Unidades 1-6 al lenguaje específico de reuniones que necesitas: frases de apertura y cierre, interrumpir educadamente, mantener el turno bajo presión y discrepar sin dañar la relación.",
+    outcome:
+      "You'll steer meetings in English with the same control you have in Spanish.",
+    outcomeEs:
+      "Dirigirás reuniones en inglés con el mismo control que tienes en español.",
+    icon: "Users",
+    published: false,
+  },
+  {
+    id: 8,
+    slug: "unit-8",
+    slugEs: "unidad-8",
+    title: "Feedback and Difficult Conversations",
+    titleEs: "Retroalimentación y Conversaciones Difíciles",
+    subtitle: "Give feedback without offending. Receive it with poise.",
+    subtitleEs: "Da retroalimentación sin ofender. Recíbela con serenidad.",
+    description:
+      "The hardest conversations at senior level happen in English with people who outrank you, report to you, or partner with you. This unit drills the phrasing for giving tough feedback, receiving it without defensiveness, and navigating conflict, apology, and repair.",
+    descriptionEs:
+      "Las conversaciones más difíciles en el nivel senior ocurren en inglés con personas que te superan, te reportan o se asocian contigo. Esta unidad practica el fraseo para dar retroalimentación difícil, recibirla sin ponerte a la defensiva y navegar conflicto, disculpa y reparación.",
+    outcome:
+      "You'll handle feedback — up, down, or sideways — with senior-grade language.",
+    outcomeEs:
+      "Manejarás la retroalimentación — hacia arriba, hacia abajo o lateral — con lenguaje de nivel senior.",
+    icon: "MessageSquare",
+    published: false,
+  },
+  {
+    id: 9,
+    slug: "unit-9",
+    slugEs: "unidad-9",
+    title: "Negotiation and Driving Decisions",
+    titleEs: "Negociación y Toma de Decisiones",
+    subtitle: "Anchoring, concessions, diplomatic 'no', closing.",
+    subtitleEs: "Anclaje, concesiones, 'no' diplomático, cierre.",
+    description:
+      "Negotiation language and decision-driving are where executive English pays off in hard numbers. This unit drills the positioning, anchoring, and concession language that moves a negotiation forward — plus the Problem → Impact → Solution → Recommendation framework applied to the moment you need leadership approval.",
+    descriptionEs:
+      "El lenguaje de negociación y la toma de decisiones es donde el inglés ejecutivo se traduce en números reales. Esta unidad practica el posicionamiento, anclaje y lenguaje de concesión que avanza una negociación — más el marco Problema → Impacto → Solución → Recomendación aplicado al momento en que necesitas aprobación del liderazgo.",
+    outcome:
+      "You'll lead negotiations and drive decisions in English with measurable outcomes.",
+    outcomeEs:
+      "Liderarás negociaciones e impulsarás decisiones en inglés con resultados medibles.",
+    icon: "TrendingUp",
+    published: false,
+  },
+  {
+    id: 10,
+    slug: "unit-10",
+    slugEs: "unidad-10",
+    title: "Your Executive Voice",
+    titleEs: "Tu Voz Ejecutiva",
+    subtitle: "Integrate everything. Record your capstone. Step into the room as a leader.",
+    subtitleEs: "Integra todo. Graba tu reto final. Entra a la sala como líder.",
+    description:
+      "The capstone unit. A final integration of everything from Units 1-9, plus the prompt that launches your recorded executive presentation. This is the graduation moment — and the bridge into 1-on-1 coaching with Robert.",
+    descriptionEs:
+      "La unidad final. Una integración final de todo desde las Unidades 1-9, más la consigna que lanza tu presentación ejecutiva grabada. Este es el momento de graduación — y el puente al coaching 1-a-1 con Robert.",
+    outcome:
+      "You'll submit a recorded 90-second executive presentation to Robert for personal feedback.",
+    outcomeEs:
+      "Enviarás una presentación ejecutiva grabada de 90 segundos a Robert para recibir retroalimentación personal.",
+    icon: "Crown",
+    published: false,
+  },
+];

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -112,6 +112,18 @@ export type TKey =
   | "course/advanced/unit-9"
   | "course/advanced/unit-10"
   | "course/advanced/exam"
+  | "course/executive"
+  | "course/executive/unit-1"
+  | "course/executive/unit-2"
+  | "course/executive/unit-3"
+  | "course/executive/unit-4"
+  | "course/executive/unit-5"
+  | "course/executive/unit-6"
+  | "course/executive/unit-7"
+  | "course/executive/unit-8"
+  | "course/executive/unit-9"
+  | "course/executive/unit-10"
+  | "course/executive/capstone"
   | "meme-portfolio"
   | "site-index";
 
@@ -238,6 +250,18 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/advanced/unit-9": "/en/course/advanced/unit-9/",
     "course/advanced/unit-10": "/en/course/advanced/unit-10/",
     "course/advanced/exam": "/en/course/advanced/exam/",
+    "course/executive": "/en/course/executive/",
+    "course/executive/unit-1": "/en/course/executive/unit-1/",
+    "course/executive/unit-2": "/en/course/executive/unit-2/",
+    "course/executive/unit-3": "/en/course/executive/unit-3/",
+    "course/executive/unit-4": "/en/course/executive/unit-4/",
+    "course/executive/unit-5": "/en/course/executive/unit-5/",
+    "course/executive/unit-6": "/en/course/executive/unit-6/",
+    "course/executive/unit-7": "/en/course/executive/unit-7/",
+    "course/executive/unit-8": "/en/course/executive/unit-8/",
+    "course/executive/unit-9": "/en/course/executive/unit-9/",
+    "course/executive/unit-10": "/en/course/executive/unit-10/",
+    "course/executive/capstone": "/en/course/executive/capstone/",
     "meme-portfolio": "/en/meme-portfolio/all/",
     "site-index": "/en/site-index/",
   },
@@ -368,6 +392,18 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/advanced/unit-9": "/es/curso/avanzado/unidad-9/",
     "course/advanced/unit-10": "/es/curso/avanzado/unidad-10/",
     "course/advanced/exam": "/es/curso/avanzado/examen/",
+    "course/executive": "/es/curso/ejecutivo/",
+    "course/executive/unit-1": "/es/curso/ejecutivo/unidad-1/",
+    "course/executive/unit-2": "/es/curso/ejecutivo/unidad-2/",
+    "course/executive/unit-3": "/es/curso/ejecutivo/unidad-3/",
+    "course/executive/unit-4": "/es/curso/ejecutivo/unidad-4/",
+    "course/executive/unit-5": "/es/curso/ejecutivo/unidad-5/",
+    "course/executive/unit-6": "/es/curso/ejecutivo/unidad-6/",
+    "course/executive/unit-7": "/es/curso/ejecutivo/unidad-7/",
+    "course/executive/unit-8": "/es/curso/ejecutivo/unidad-8/",
+    "course/executive/unit-9": "/es/curso/ejecutivo/unidad-9/",
+    "course/executive/unit-10": "/es/curso/ejecutivo/unidad-10/",
+    "course/executive/capstone": "/es/curso/ejecutivo/reto-final/",
     "meme-portfolio": "/es/meme-portfolio/all/",
     "site-index": "/es/indice-del-sitio/",
   },

--- a/src/pages/en/course/executive/index.astro
+++ b/src/pages/en/course/executive/index.astro
@@ -1,0 +1,265 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import { executiveInfo, executiveUnits } from "@data/executive/units";
+import {
+  Target,
+  Zap,
+  Layers,
+  Shield,
+  BookOpen,
+  Clock,
+  Users,
+  MessageSquare,
+  TrendingUp,
+  Crown,
+  ArrowRight,
+  Briefcase,
+  Mic,
+  CheckCircle2,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/executive" as const;
+
+const iconMap: Record<string, any> = {
+  Target,
+  Zap,
+  Layers,
+  Shield,
+  BookOpen,
+  Clock,
+  Users,
+  MessageSquare,
+  TrendingUp,
+  Crown,
+};
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Communicate Like a Leader — Executive English Course (C1-C2) | NY English Teacher"
+  description="A paid-quality executive communication course — free during launch. Ten units of drill-based training that replace vague English with precision, structure, and calm authority. The productized version of Robert's 1-on-1 coaching."
+>
+  <!-- Hero -->
+  <section class="relative w-full overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-amber-950 pt-32 pb-20 md:pt-40 md:pb-28">
+    <div class="absolute inset-0 opacity-10">
+      <div class="absolute top-20 left-10 w-72 h-72 bg-amber-500 rounded-full blur-3xl"></div>
+      <div class="absolute bottom-10 right-10 w-96 h-96 bg-slate-400 rounded-full blur-3xl"></div>
+    </div>
+    <div class="site-container mx-auto px-4 relative z-10 text-white">
+      <div class="max-w-3xl">
+        <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-300 text-sm font-semibold mb-6">
+          <Briefcase class="w-4 h-4" />
+          Executive Course · C1 → C2 · Early Access (Free)
+        </div>
+        <h1
+          class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Communicate Like<br />
+          <span class="text-amber-400">a Leader.</span>
+        </h1>
+        <p class="text-xl text-slate-200 mb-8 max-w-2xl leading-relaxed">
+          You already communicate competently in English. This course teaches you to <strong class="text-white">lead</strong> in English — with the precision, structure, and calm authority that senior leaders demand. Not a grammar course. A linguistic command course.
+        </p>
+        <div class="flex flex-wrap gap-4">
+          <Button href="/en/course/executive/unit-1/" variant="primary" size="lg">
+            Start Unit 1 — Free
+            <ArrowRight class="w-5 h-5 ml-1" />
+          </Button>
+          <a
+            href="#units"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            See All 10 Units
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Thesis band -->
+  <section class="py-16 md:py-20 bg-white border-b border-slate-100">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <p class="text-[11px] font-mono uppercase tracking-[0.3em] text-amber-600 mb-4">The Thesis</p>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Weak language creates doubt. Precision creates alignment.
+        </h2>
+        <p class="text-lg text-slate-600 leading-relaxed">
+          At senior level, your language is not descriptive — it is <em>diagnostic and directional</em>. Vague verbs blur meaning. Filler signals hesitation. Unstructured speech forces the listener to guess what you mean. This course drills the specific linguistic habits that separate competent English from executive English.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Value props -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-amber-100 text-amber-700">
+            <Target class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">Drill-Based, Speaking-First</h3>
+          <p class="text-slate-600 leading-relaxed">
+            Every section is a drill: weak → strong → elite. Every model reply has audio. You don't read executive English — you speak it aloud until it's automatic.
+          </p>
+        </div>
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-amber-100 text-amber-700">
+            <Layers class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">Named Frameworks</h3>
+          <p class="text-slate-600 leading-relaxed">
+            Cause → Action → Outcome. Problem → Impact → Solution → Recommendation. Context → Tension → Insight → Action → Outcome. You leave with memorable structures you can deploy under pressure.
+          </p>
+        </div>
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-amber-100 text-amber-700">
+            <Crown class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">C1 Core, C2 Elite</h3>
+          <p class="text-slate-600 leading-relaxed">
+            Each drill runs at two levels. Start with C1 for a focused course. Unlock the C2 Elite tier for analytically sharper phrasing and the strategic distinction behind it.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Unit grid -->
+  <section class="py-16 md:py-20 bg-white" id="units">
+    <div class="site-container mx-auto px-4">
+      <div class="text-center max-w-2xl mx-auto mb-12">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4" style="font-family: 'Noto Sans KR', sans-serif;">
+          Ten Units. Three Sections Each.
+        </h2>
+        <p class="text-slate-600 leading-relaxed">
+          Units 1-6 teach the mechanics. Units 7-9 apply them to meetings, feedback, and negotiation. Unit 10 integrates everything and launches your recorded capstone.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
+        {executiveUnits.map((unit) => {
+          const Icon = iconMap[unit.icon];
+          const isAvailable = unit.published;
+          return (
+            <a
+              href={isAvailable ? `/en/course/executive/${unit.slug}/` : undefined}
+              class:list={[
+                "group flex items-start gap-4 p-5 rounded-xl border transition-all duration-200",
+                isAvailable
+                  ? "bg-amber-50 border-amber-300 hover:shadow-md hover:border-amber-400 cursor-pointer"
+                  : "bg-white border-slate-200 opacity-75",
+              ]}
+            >
+              <div
+                class:list={[
+                  "flex items-center justify-center w-12 h-12 rounded-xl shrink-0",
+                  isAvailable ? "bg-amber-500 text-white" : "bg-slate-100 text-slate-400",
+                ]}
+              >
+                {Icon && <Icon class="w-6 h-6" />}
+              </div>
+              <div>
+                <div class="flex items-center gap-2">
+                  <span
+                    class:list={[
+                      "text-xs font-bold uppercase tracking-wider",
+                      isAvailable ? "text-amber-700" : "text-slate-400",
+                    ]}
+                  >
+                    Unit {unit.id}
+                  </span>
+                  {!isAvailable && (
+                    <span class="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-400">
+                      Coming soon
+                    </span>
+                  )}
+                </div>
+                <h3
+                  class:list={[
+                    "text-lg font-bold mt-0.5",
+                    isAvailable ? "text-slate-900" : "text-slate-600",
+                  ]}
+                >
+                  {unit.title}
+                </h3>
+                <p class="text-sm text-slate-500 mt-1">{unit.subtitle}</p>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <!-- Capstone tease -->
+  <section class="py-16 md:py-20 bg-slate-950 text-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-amber-500/20 text-amber-300 text-xs font-semibold mb-5">
+          <Mic class="w-3.5 h-3.5" />
+          Unit 10 — The Capstone
+        </div>
+        <h2 class="text-3xl md:text-4xl font-bold mb-6 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Your executive voice, recorded.
+        </h2>
+        <p class="text-lg text-slate-300 leading-relaxed mb-6">
+          The course closes with a 90-second executive presentation on a project you're leading. You submit it by email — and Robert listens and replies personally within 48 hours. Or you book a strategy session and present it live. Either path puts you in direct conversation with the coach behind every drill in this course.
+        </p>
+        <div class="flex flex-wrap gap-3 text-sm text-slate-400">
+          <span class="inline-flex items-center gap-1.5">
+            <CheckCircle2 class="w-4 h-4 text-amber-400" />
+            Personal feedback from Robert
+          </span>
+          <span class="inline-flex items-center gap-1.5">
+            <CheckCircle2 class="w-4 h-4 text-amber-400" />
+            48-hour turnaround
+          </span>
+          <span class="inline-flex items-center gap-1.5">
+            <CheckCircle2 class="w-4 h-4 text-amber-400" />
+            No recording tools required
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Who it's for -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6" style="font-family: 'Noto Sans KR', sans-serif;">
+          Is this course for you?
+        </h2>
+        <div class="space-y-4 text-slate-600 leading-relaxed">
+          <p>
+            This course is for <strong>founders, executives, and senior professionals</strong> who already communicate competently in English but need to lead in English. You're not trying to survive a conversation — you're trying to run a meeting, close a deal, deliver a board update, or give difficult feedback in a language that isn't your first.
+          </p>
+          <p>
+            If your English still lacks fluency at the sentence level, start with the <a href="/en/course/advanced/" class="text-amber-600 hover:text-amber-500 underline">advanced course</a> — it fixes the granular errors that make even fluent speakers sound non-native. This course picks up where advanced leaves off.
+          </p>
+          <p>
+            This is also the productized version of Robert's 1-on-1 executive coaching. If you want the accelerated version, the capstone unit funnels directly into a strategy session with Robert.
+          </p>
+        </div>
+        <div class="mt-8 flex flex-wrap gap-3">
+          <Button href="/en/course/executive/unit-1/" variant="primary" size="md">
+            Start Unit 1
+            <ArrowRight class="w-4 h-4 ml-1" />
+          </Button>
+          <Button href="/en/book/" variant="secondary" size="md">
+            Or work 1-on-1 with Robert
+            <ArrowRight class="w-4 h-4 ml-1" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/en/courses/index.astro
+++ b/src/pages/en/courses/index.astro
@@ -6,9 +6,11 @@ import Button from "@components/ui/Button.astro";
 import { courseInfo, units } from "@data/course/units";
 import { intermediateInfo, intermediateUnits } from "@data/intermediate/units";
 import { advancedInfo, advancedUnits } from "@data/advanced/units";
+import { executiveInfo, executiveUnits } from "@data/executive/units";
 import {
   Sparkles,
   Puzzle,
+  Crown,
   ArrowRight,
   CheckCircle2,
   GraduationCap,
@@ -20,6 +22,7 @@ const tkey = "courses" as const;
 const beginnerAvailable = units.length;
 const intermediateAvailable = intermediateUnits.length;
 const advancedAvailable = advancedUnits.filter((u) => u.id === 1).length;
+const executiveAvailable = executiveUnits.filter((u) => u.published).length;
 ---
 
 <Base
@@ -54,7 +57,7 @@ const advancedAvailable = advancedUnits.filter((u) => u.id === 1).length;
   <!-- Course cards -->
   <section class="py-16 md:py-20 bg-slate-50">
     <div class="site-container mx-auto px-4">
-      <div class="max-w-5xl mx-auto grid md:grid-cols-3 gap-6">
+      <div class="max-w-6xl mx-auto grid md:grid-cols-2 lg:grid-cols-4 gap-6">
 
         <!-- Beginner -->
         <a
@@ -196,15 +199,62 @@ const advancedAvailable = advancedUnits.filter((u) => u.id === 1).length;
             </div>
           </div>
         </a>
+
+        <!-- Executive -->
+        <a
+          href="/en/course/executive/"
+          class="group block bg-white rounded-2xl border border-slate-200 overflow-hidden hover:shadow-xl hover:border-amber-400 transition-all duration-200"
+        >
+          <div class="bg-gradient-to-br from-slate-900 via-slate-800 to-amber-900 p-6 text-white min-h-[180px] flex flex-col justify-end">
+            <div class="flex items-center gap-2 text-amber-300 text-xs font-bold uppercase tracking-wider mb-2">
+              <Crown class="w-3.5 h-3.5" />
+              Level C1–C2 — Executive
+            </div>
+            <h2 class="text-2xl md:text-3xl font-bold mb-2" style="font-family: 'Noto Sans KR', sans-serif;">
+              {executiveInfo.title}
+            </h2>
+            <p class="text-amber-100 text-sm leading-relaxed">
+              {executiveInfo.tagline}
+            </p>
+          </div>
+          <div class="p-6">
+            <p class="text-slate-600 text-sm leading-relaxed mb-4">
+              The productized version of Robert's 1-on-1 executive coaching. Drill-based, speaking-first training for senior leaders who need to lead in English.
+            </p>
+            <ul class="space-y-2 mb-6">
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>Word precision, structured responses & named frameworks</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>C1 core with optional C2 Elite tier per drill</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>Capstone: recorded exec presentation + personal feedback</span>
+              </li>
+            </ul>
+            <div class="flex items-center justify-between">
+              <span class="text-xs font-semibold text-amber-600 uppercase tracking-wider">
+                {executiveAvailable > 0
+                  ? `${executiveAvailable} unit${executiveAvailable === 1 ? "" : "s"} available · more coming`
+                  : "Early access · building now"}
+              </span>
+              <span class="inline-flex items-center gap-1 text-amber-600 font-semibold text-sm group-hover:gap-2 transition-all">
+                Start course
+                <ArrowRight class="w-4 h-4" />
+              </span>
+            </div>
+          </div>
+        </a>
       </div>
 
       <!-- Which one? -->
       <div class="max-w-3xl mx-auto mt-16 text-center">
         <h3 class="text-2xl font-bold text-slate-900 mb-3">Not sure which one to start?</h3>
         <p class="text-slate-600 mb-6">
-          If you can introduce yourself, order food, and read simple signs in English — start with
-          the <strong>intermediate</strong> course. If English still feels brand new, start with
-          the <strong>beginner</strong> course. You can always switch later — your progress is saved separately for each course.
+          If English still feels brand new, start with the <strong>beginner</strong> course. If you can hold a conversation, start with <strong>intermediate</strong>. If your English is fluent but not polished, go to <strong>advanced</strong>. And if you're a senior leader who already communicates competently in English but wants to <em>lead</em> in English, go straight to <strong>executive</strong>. Your progress is saved separately for each course.
         </p>
         <Button href="/en/services/" variant="secondary" size="md">
           Or work 1-on-1 with Robert

--- a/src/pages/es/curso/ejecutivo/index.astro
+++ b/src/pages/es/curso/ejecutivo/index.astro
@@ -1,0 +1,265 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import { executiveInfo, executiveUnits } from "@data/executive/units";
+import {
+  Target,
+  Zap,
+  Layers,
+  Shield,
+  BookOpen,
+  Clock,
+  Users,
+  MessageSquare,
+  TrendingUp,
+  Crown,
+  ArrowRight,
+  Briefcase,
+  Mic,
+  CheckCircle2,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/executive" as const;
+
+const iconMap: Record<string, any> = {
+  Target,
+  Zap,
+  Layers,
+  Shield,
+  BookOpen,
+  Clock,
+  Users,
+  MessageSquare,
+  TrendingUp,
+  Crown,
+};
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Comunica Como un Líder — Curso Ejecutivo de Inglés (C1-C2) | NY English Teacher"
+  description="Un curso ejecutivo de calidad premium — gratis durante el lanzamiento. Diez unidades de entrenamiento basado en drills que reemplazan el inglés vago con precisión, estructura y autoridad tranquila. La versión productizada del coaching 1-a-1 de Robert."
+>
+  <!-- Hero -->
+  <section class="relative w-full overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-amber-950 pt-32 pb-20 md:pt-40 md:pb-28">
+    <div class="absolute inset-0 opacity-10">
+      <div class="absolute top-20 left-10 w-72 h-72 bg-amber-500 rounded-full blur-3xl"></div>
+      <div class="absolute bottom-10 right-10 w-96 h-96 bg-slate-400 rounded-full blur-3xl"></div>
+    </div>
+    <div class="site-container mx-auto px-4 relative z-10 text-white">
+      <div class="max-w-3xl">
+        <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-300 text-sm font-semibold mb-6">
+          <Briefcase class="w-4 h-4" />
+          Curso Ejecutivo · C1 → C2 · Acceso Anticipado (Gratis)
+        </div>
+        <h1
+          class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Comunica Como<br />
+          <span class="text-amber-400">un Líder.</span>
+        </h1>
+        <p class="text-xl text-slate-200 mb-8 max-w-2xl leading-relaxed">
+          Ya te comunicas con competencia en inglés. Este curso te enseña a <strong class="text-white">liderar</strong> en inglés — con la precisión, estructura y autoridad tranquila que exigen los líderes senior. No es un curso de gramática. Es un curso de dominio lingüístico.
+        </p>
+        <div class="flex flex-wrap gap-4">
+          <Button href="/es/curso/ejecutivo/unidad-1/" variant="primary" size="lg">
+            Empezar Unidad 1 — Gratis
+            <ArrowRight class="w-5 h-5 ml-1" />
+          </Button>
+          <a
+            href="#units"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            Ver las 10 Unidades
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Thesis band -->
+  <section class="py-16 md:py-20 bg-white border-b border-slate-100">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <p class="text-[11px] font-mono uppercase tracking-[0.3em] text-amber-600 mb-4">La Tesis</p>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          El lenguaje débil crea dudas. La precisión crea alineación.
+        </h2>
+        <p class="text-lg text-slate-600 leading-relaxed">
+          En el nivel senior, tu lenguaje no es descriptivo — es <em>diagnóstico y direccional</em>. Los verbos vagos borran el significado. Los rellenos señalan titubeo. El discurso no estructurado obliga al oyente a adivinar lo que quieres decir. Este curso entrena los hábitos lingüísticos específicos que separan el inglés competente del inglés ejecutivo.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Value props -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-amber-100 text-amber-700">
+            <Target class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">Basado en Drills, Hablado Primero</h3>
+          <p class="text-slate-600 leading-relaxed">
+            Cada sección es un drill: débil → fuerte → elite. Cada respuesta modelo tiene audio. No lees inglés ejecutivo — lo hablas en voz alta hasta que sea automático.
+          </p>
+        </div>
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-amber-100 text-amber-700">
+            <Layers class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">Marcos con Nombre</h3>
+          <p class="text-slate-600 leading-relaxed">
+            Causa → Acción → Resultado. Problema → Impacto → Solución → Recomendación. Contexto → Tensión → Perspectiva → Acción → Resultado. Sales con estructuras memorables que puedes desplegar bajo presión.
+          </p>
+        </div>
+        <div class="text-center space-y-3 p-6">
+          <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-amber-100 text-amber-700">
+            <Crown class="w-7 h-7" />
+          </div>
+          <h3 class="text-xl font-bold text-slate-900">Núcleo C1, Elite C2</h3>
+          <p class="text-slate-600 leading-relaxed">
+            Cada drill corre a dos niveles. Empieza con C1 para un curso enfocado. Desbloquea el nivel Elite C2 para fraseo analíticamente más agudo y la distinción estratégica detrás de él.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Unit grid -->
+  <section class="py-16 md:py-20 bg-white" id="units">
+    <div class="site-container mx-auto px-4">
+      <div class="text-center max-w-2xl mx-auto mb-12">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4" style="font-family: 'Noto Sans KR', sans-serif;">
+          Diez Unidades. Tres Secciones Cada Una.
+        </h2>
+        <p class="text-slate-600 leading-relaxed">
+          Las Unidades 1-6 enseñan las mecánicas. Las Unidades 7-9 las aplican a reuniones, retroalimentación y negociación. La Unidad 10 integra todo y lanza tu reto final grabado.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
+        {executiveUnits.map((unit) => {
+          const Icon = iconMap[unit.icon];
+          const isAvailable = unit.published;
+          return (
+            <a
+              href={isAvailable ? `/es/curso/ejecutivo/${unit.slugEs}/` : undefined}
+              class:list={[
+                "group flex items-start gap-4 p-5 rounded-xl border transition-all duration-200",
+                isAvailable
+                  ? "bg-amber-50 border-amber-300 hover:shadow-md hover:border-amber-400 cursor-pointer"
+                  : "bg-white border-slate-200 opacity-75",
+              ]}
+            >
+              <div
+                class:list={[
+                  "flex items-center justify-center w-12 h-12 rounded-xl shrink-0",
+                  isAvailable ? "bg-amber-500 text-white" : "bg-slate-100 text-slate-400",
+                ]}
+              >
+                {Icon && <Icon class="w-6 h-6" />}
+              </div>
+              <div>
+                <div class="flex items-center gap-2">
+                  <span
+                    class:list={[
+                      "text-xs font-bold uppercase tracking-wider",
+                      isAvailable ? "text-amber-700" : "text-slate-400",
+                    ]}
+                  >
+                    Unidad {unit.id}
+                  </span>
+                  {!isAvailable && (
+                    <span class="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-400">
+                      Próximamente
+                    </span>
+                  )}
+                </div>
+                <h3
+                  class:list={[
+                    "text-lg font-bold mt-0.5",
+                    isAvailable ? "text-slate-900" : "text-slate-600",
+                  ]}
+                >
+                  {unit.titleEs}
+                </h3>
+                <p class="text-sm text-slate-500 mt-1">{unit.subtitleEs}</p>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <!-- Capstone tease -->
+  <section class="py-16 md:py-20 bg-slate-950 text-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-amber-500/20 text-amber-300 text-xs font-semibold mb-5">
+          <Mic class="w-3.5 h-3.5" />
+          Unidad 10 — El Reto Final
+        </div>
+        <h2 class="text-3xl md:text-4xl font-bold mb-6 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Tu voz ejecutiva, grabada.
+        </h2>
+        <p class="text-lg text-slate-300 leading-relaxed mb-6">
+          El curso cierra con una presentación ejecutiva de 90 segundos sobre un proyecto que lideras. La envías por correo — y Robert escucha y responde personalmente en 48 horas. O reservas una sesión de estrategia y la presentas en vivo. Cualquiera de los dos caminos te pone en conversación directa con el coach detrás de cada drill de este curso.
+        </p>
+        <div class="flex flex-wrap gap-3 text-sm text-slate-400">
+          <span class="inline-flex items-center gap-1.5">
+            <CheckCircle2 class="w-4 h-4 text-amber-400" />
+            Retroalimentación personal de Robert
+          </span>
+          <span class="inline-flex items-center gap-1.5">
+            <CheckCircle2 class="w-4 h-4 text-amber-400" />
+            Respuesta en 48 horas
+          </span>
+          <span class="inline-flex items-center gap-1.5">
+            <CheckCircle2 class="w-4 h-4 text-amber-400" />
+            Sin herramientas de grabación especiales
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Who it's for -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6" style="font-family: 'Noto Sans KR', sans-serif;">
+          ¿Es este curso para ti?
+        </h2>
+        <div class="space-y-4 text-slate-600 leading-relaxed">
+          <p>
+            Este curso es para <strong>fundadores, ejecutivos y profesionales senior</strong> que ya se comunican con competencia en inglés pero necesitan liderar en inglés. No estás tratando de sobrevivir una conversación — estás tratando de dirigir una reunión, cerrar un trato, entregar una actualización a la junta directiva o dar retroalimentación difícil en un idioma que no es el primero.
+          </p>
+          <p>
+            Si tu inglés aún carece de fluidez a nivel de oración, empieza con el <a href="/es/curso/avanzado/" class="text-amber-600 hover:text-amber-500 underline">curso avanzado</a> — corrige los errores granulares que hacen que incluso los hablantes fluidos suenen no nativos. Este curso continúa donde termina el avanzado.
+          </p>
+          <p>
+            Esta es también la versión productizada del coaching ejecutivo 1-a-1 de Robert. Si quieres la versión acelerada, la unidad final del curso te conduce directamente a una sesión de estrategia con Robert.
+          </p>
+        </div>
+        <div class="mt-8 flex flex-wrap gap-3">
+          <Button href="/es/curso/ejecutivo/unidad-1/" variant="primary" size="md">
+            Empezar Unidad 1
+            <ArrowRight class="w-4 h-4 ml-1" />
+          </Button>
+          <Button href="/es/reservar/" variant="secondary" size="md">
+            O trabaja 1-a-1 con Robert
+            <ArrowRight class="w-4 h-4 ml-1" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/cursos/index.astro
+++ b/src/pages/es/cursos/index.astro
@@ -6,9 +6,11 @@ import Button from "@components/ui/Button.astro";
 import { courseInfo, units } from "@data/course/units";
 import { intermediateInfo, intermediateUnits } from "@data/intermediate/units";
 import { advancedInfo, advancedUnits } from "@data/advanced/units";
+import { executiveInfo, executiveUnits } from "@data/executive/units";
 import {
   Sparkles,
   Puzzle,
+  Crown,
   ArrowRight,
   CheckCircle2,
   GraduationCap,
@@ -20,6 +22,7 @@ const tkey = "courses" as const;
 const beginnerAvailable = units.length;
 const intermediateAvailable = intermediateUnits.length;
 const advancedAvailable = advancedUnits.filter((u) => u.id === 1).length;
+const executiveAvailable = executiveUnits.filter((u) => u.published).length;
 ---
 
 <Base
@@ -52,7 +55,7 @@ const advancedAvailable = advancedUnits.filter((u) => u.id === 1).length;
 
   <section class="py-16 md:py-20 bg-slate-50">
     <div class="site-container mx-auto px-4">
-      <div class="max-w-5xl mx-auto grid md:grid-cols-3 gap-6">
+      <div class="max-w-6xl mx-auto grid md:grid-cols-2 lg:grid-cols-4 gap-6">
 
         <!-- Beginner -->
         <a
@@ -194,15 +197,61 @@ const advancedAvailable = advancedUnits.filter((u) => u.id === 1).length;
             </div>
           </div>
         </a>
+
+        <!-- Executive -->
+        <a
+          href="/es/curso/ejecutivo/"
+          class="group block bg-white rounded-2xl border border-slate-200 overflow-hidden hover:shadow-xl hover:border-amber-400 transition-all duration-200"
+        >
+          <div class="bg-gradient-to-br from-slate-900 via-slate-800 to-amber-900 p-6 text-white min-h-[180px] flex flex-col justify-end">
+            <div class="flex items-center gap-2 text-amber-300 text-xs font-bold uppercase tracking-wider mb-2">
+              <Crown class="w-3.5 h-3.5" />
+              Nivel C1–C2 — Ejecutivo
+            </div>
+            <h2 class="text-2xl md:text-3xl font-bold mb-2" style="font-family: 'Noto Sans KR', sans-serif;">
+              {executiveInfo.titleEs}
+            </h2>
+            <p class="text-amber-100 text-sm leading-relaxed">
+              {executiveInfo.taglineEs}
+            </p>
+          </div>
+          <div class="p-6">
+            <p class="text-slate-600 text-sm leading-relaxed mb-4">
+              La versión productizada del coaching ejecutivo 1-a-1 de Robert. Entrenamiento basado en drills, hablado primero, para líderes senior que necesitan liderar en inglés.
+            </p>
+            <ul class="space-y-2 mb-6">
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>Precisión de palabra, respuestas estructuradas y marcos con nombre</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>Núcleo C1 con nivel Elite C2 opcional por drill</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>Reto final: presentación ejecutiva grabada + retroalimentación personal</span>
+              </li>
+            </ul>
+            <div class="flex items-center justify-between">
+              <span class="text-xs font-semibold text-amber-600 uppercase tracking-wider">
+                {executiveAvailable > 0
+                  ? `${executiveAvailable} unidad${executiveAvailable === 1 ? "" : "es"} disponible${executiveAvailable === 1 ? "" : "s"} · más en camino`
+                  : "Acceso anticipado · construyendo ahora"}
+              </span>
+              <span class="inline-flex items-center gap-1 text-amber-600 font-semibold text-sm group-hover:gap-2 transition-all">
+                Empezar curso
+                <ArrowRight class="w-4 h-4" />
+              </span>
+            </div>
+          </div>
+        </a>
       </div>
 
       <div class="max-w-3xl mx-auto mt-16 text-center">
         <h3 class="text-2xl font-bold text-slate-900 mb-3">¿No sabes con cuál empezar?</h3>
         <p class="text-slate-600 mb-6">
-          Si puedes presentarte, pedir comida y leer letreros simples en inglés — empieza con el
-          curso <strong>intermedio</strong>. Si el inglés todavía se siente totalmente nuevo,
-          empieza con el curso <strong>principiante</strong>. Puedes cambiar después — tu
-          progreso se guarda por separado para cada curso.
+          Si el inglés todavía se siente totalmente nuevo, empieza con el curso <strong>principiante</strong>. Si puedes sostener una conversación, empieza con <strong>intermedio</strong>. Si tu inglés es fluido pero no pulido, pasa a <strong>avanzado</strong>. Y si eres un líder senior que ya se comunica con competencia en inglés pero quiere <em>liderar</em> en inglés, ve directo al curso <strong>ejecutivo</strong>. Tu progreso se guarda por separado para cada curso.
         </p>
         <Button href="/es/servicios/" variant="secondary" size="md">
           O trabaja 1-a-1 con Robert


### PR DESCRIPTION
## Summary
First of five PRs building the Executive Communication course ("Communicate Like a Leader", C1-C2). This PR lands the foundation the remaining four PRs will build on.

**What's included:**
- **i18n routing:** 12 new TKey entries mapped to \`/en/course/executive/*\` and \`/es/curso/ejecutivo/*\`
- **Data scaffolding:** \`src/data/executive/types.ts\` (all drill shapes including the Weak→Strong→Elite ladder) and \`units.ts\` (metadata for all 10 units)
- **Three core components:**
  - \`VerbUpgradeLab\` — signature drill: weak sentence → 2-3 strong options with usage notes → integrated model reply → optional C2 Elite tier with C2 Insight callout
  - \`RapidRepeat\` — memory-anchor block with 3-5 reusable sentence stems and audio
  - \`FinalShiftCard\` — Before/After transformation summary that closes every unit
- **EN + ES landing pages** at \`/en/course/executive/\` and \`/es/curso/ejecutivo/\` — hero, thesis band, value props, unit grid, capstone teaser, audience framing
- **Courses hub** updated with Executive card (both locales), grid restructured to four columns on large screens

All 10 units currently show as "Coming soon" — PRs 2-5 flip \`published: true\` as content lands.

## Pedagogy notes
Plan was rewritten (see \`docs/EXECUTIVE-COURSE-PLAN.md\`, landed in the first commit on this branch) after analyzing two real executive lessons Robert shared. The course is now built around drill-based, speaking-first pedagogy with named frameworks — a productized version of Robert's 1-on-1 coaching, not a generic MBA course.

## Test plan
- [ ] Visit \`/en/course/executive/\` and \`/es/curso/ejecutivo/\` on the preview URL — verify hero, value props, unit grid (all locked), capstone section, audience framing
- [ ] Visit \`/en/courses/\` and \`/es/cursos/\` — verify the Executive card renders as the 4th card in the grid
- [ ] Confirm hreflang resolves between EN and ES landing pages
- [ ] Lighthouse spot-check on the landing page
- [ ] No regressions on existing course pages (beginner / intermediate / advanced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)