### PR TITLE
feat: executive course units 1-3 + drill components (PR 2/5)

### DIFF
--- a/src/components/course/ConnectorDrill.tsx
+++ b/src/components/course/ConnectorDrill.tsx
@@ -1,32 +1,21 @@
-// VerbUpgradeLab — the signature drill of the Executive Communication course.
+// ConnectorDrill — transition upgrade drill.
 //
-// Shows a weak / vague sentence, 2-3 stronger options each with a usage note,
-// and an integrated model reply that uses all options in one fluent sentence.
-// Optional C2 Elite tier reveals a sharper single phrasing plus a C2 Insight
-// callout naming the strategic distinction.
-//
-// This mirrors Robert's proven pedagogy: the learner hears the weak version,
-// studies the usage distinctions, then reveals the integrated model reply and
-// can optionally push past Strong (C1) into Elite (C2).
+// A weak two-sentence pair ("We had delays. We are fixing it.") is
+// upgraded into a connected version using a labeled executive connector
+// ("As a result…", "In response…", "Accordingly…"). Optional elite tier
+// layers in a second connector for more sophisticated phrasing.
 
 import { useState } from "react";
-import {
-  ArrowDown,
-  Lightbulb,
-  RotateCcw,
-  Sparkles,
-  Target,
-  Zap,
-} from "lucide-react";
+import { ArrowDown, Link2, RotateCcw, Zap } from "lucide-react";
 import AudioButton from "./AudioButton";
-import type { VerbUpgradeItem } from "@data/executive/types";
+import type { ConnectorDrillItem } from "@data/executive/types";
 
 interface Props {
-  items: VerbUpgradeItem[];
+  items: ConnectorDrillItem[];
   lang: "en" | "es";
 }
 
-export default function VerbUpgradeLab({ items, lang }: Props) {
+export default function ConnectorDrill({ items, lang }: Props) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [revealed, setRevealed] = useState(false);
   const [eliteRevealed, setEliteRevealed] = useState(false);
@@ -34,6 +23,8 @@ export default function VerbUpgradeLab({ items, lang }: Props) {
   const current = items[currentIndex];
   const isLast = currentIndex === items.length - 1;
   const hasElite = Boolean(current.elite);
+
+  const connector = lang === "es" ? current.connectorEs : current.connector;
 
   const handleReveal = () => setRevealed(true);
   const handleRevealElite = () => setEliteRevealed(true);
@@ -51,14 +42,12 @@ export default function VerbUpgradeLab({ items, lang }: Props) {
     setEliteRevealed(false);
   };
 
-  const why = lang === "es" ? current.whyItWorksEs : current.whyItWorks;
-
   return (
     <section className="space-y-6">
-      {/* Progress */}
       <div className="flex items-center justify-between">
         <span className="text-sm text-slate-500">
-          {lang === "es" ? "Drill" : "Drill"} {currentIndex + 1} / {items.length}
+          {lang === "es" ? "Conector" : "Connector"} {currentIndex + 1} /{" "}
+          {items.length}
         </span>
         <button
           onClick={handleRestart}
@@ -76,12 +65,11 @@ export default function VerbUpgradeLab({ items, lang }: Props) {
         />
       </div>
 
-      {/* Card */}
       <div className="bg-white rounded-2xl border-2 border-slate-200 overflow-hidden">
-        {/* Weak sentence */}
+        {/* Weak */}
         <div className="px-6 pt-6">
           <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-2">
-            {lang === "es" ? "El fraseo débil:" : "The weak phrasing:"}
+            {lang === "es" ? "Sin conectar:" : "Unconnected:"}
           </p>
           <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
             <div className="flex items-start justify-between gap-3">
@@ -96,48 +84,22 @@ export default function VerbUpgradeLab({ items, lang }: Props) {
           </div>
         </div>
 
-        {/* Options */}
-        <div className="px-6 pt-5">
-          <p className="text-xs font-semibold uppercase tracking-wider text-amber-600 mb-3 flex items-center gap-1">
-            <Target size={12} />
-            {lang === "es" ? "Opciones más fuertes:" : "Stronger options:"}
-          </p>
-          <div className="grid gap-2">
-            {current.options.map((option, idx) => (
-              <div
-                key={idx}
-                className="bg-amber-50/60 border border-amber-200 rounded-xl p-3 flex items-center gap-3"
-              >
-                <div className="shrink-0 w-7 h-7 rounded-full bg-amber-500 text-white text-xs font-bold flex items-center justify-center">
-                  {idx + 1}
-                </div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <span className="font-semibold text-slate-900">{option.verb}</span>
-                    <AudioButton text={option.verb} size="sm" />
-                  </div>
-                  <p className="text-xs text-slate-600 mt-0.5">
-                    {lang === "es" ? option.usageEs : option.usage}
-                  </p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Arrow */}
-        <div className="flex justify-center py-4">
+        <div className="flex justify-center py-3">
           <ArrowDown className="w-5 h-5 text-slate-300" />
         </div>
 
-        {/* Model reply */}
+        {/* Strong with connector */}
         <div className="px-6 pb-6">
-          <p className="text-xs font-semibold uppercase tracking-wider text-amber-600 mb-2 flex items-center gap-1">
-            <Zap size={12} />
-            {lang === "es"
-              ? "Respuesta modelo integrada:"
-              : "Integrated model reply:"}
-          </p>
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-xs font-semibold uppercase tracking-wider text-amber-600 flex items-center gap-1">
+              <Zap size={12} />
+              {lang === "es" ? "Conectado:" : "Connected:"}
+            </p>
+            <span className="inline-flex items-center gap-1 text-[10px] font-mono uppercase tracking-wider px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200">
+              <Link2 size={10} />
+              {connector}
+            </span>
+          </div>
 
           {!revealed ? (
             <button
@@ -145,80 +107,62 @@ export default function VerbUpgradeLab({ items, lang }: Props) {
               className="w-full py-4 rounded-xl border-2 border-dashed border-amber-300 text-amber-600 font-medium hover:bg-amber-50 transition-colors"
             >
               {lang === "es"
-                ? "Toca para revelar la respuesta modelo"
-                : "Tap to reveal the model reply"}
+                ? "Toca para revelar la versión conectada"
+                : "Tap to reveal the connected version"}
             </button>
           ) : (
             <div className="space-y-3">
               <div className="bg-gradient-to-br from-amber-50 to-amber-100 border-2 border-amber-300 rounded-xl p-4">
                 <div className="flex items-start justify-between gap-3">
                   <p className="text-base text-slate-900 font-medium leading-relaxed flex-1">
-                    "{current.modelReply}"
+                    "{current.strong}"
                   </p>
                   <div className="shrink-0 mt-1">
-                    <AudioButton text={current.modelReply} size="sm" />
+                    <AudioButton text={current.strong} size="sm" />
                   </div>
                 </div>
-                <p className="text-sm text-slate-500 mt-2">{current.modelReplyEs}</p>
-                <div className="mt-3 pt-3 border-t border-amber-200">
-                  <p className="text-xs text-slate-600 leading-relaxed flex items-start gap-1">
-                    <Sparkles size={11} className="text-amber-500 shrink-0 mt-0.5" />
-                    <span>{why}</span>
-                  </p>
-                </div>
+                <p className="text-sm text-slate-500 mt-2">{current.strongEs}</p>
               </div>
 
-              {/* Elite (C2) tier */}
               {hasElite && current.elite && (
-                <div className="mt-4">
+                <>
                   {!eliteRevealed ? (
                     <button
                       onClick={handleRevealElite}
                       className="w-full py-3 rounded-xl border-2 border-dashed border-violet-300 text-violet-700 text-sm font-medium hover:bg-violet-50 transition-colors inline-flex items-center justify-center gap-2"
                     >
-                      <Lightbulb size={14} />
+                      <Link2 size={12} />
                       {lang === "es"
                         ? "Revelar el nivel C2 Elite"
                         : "Reveal the C2 Elite tier"}
                     </button>
                   ) : (
                     <div className="bg-gradient-to-br from-violet-50 to-violet-100 border-2 border-violet-300 rounded-xl p-4">
-                      <div className="flex items-center justify-between gap-2 mb-2">
-                        <span className="inline-flex items-center gap-1 text-[10px] font-mono uppercase tracking-wider px-2 py-0.5 rounded-full bg-violet-200 text-violet-800">
-                          C2 Elite
-                        </span>
-                      </div>
+                      <span className="inline-flex items-center gap-1 text-[10px] font-mono uppercase tracking-wider px-2 py-0.5 rounded-full bg-violet-200 text-violet-800 mb-2">
+                        C2 Elite
+                      </span>
                       <div className="flex items-start justify-between gap-3">
                         <p className="text-base text-slate-900 font-medium leading-relaxed flex-1">
-                          "{current.elite.modelReply}"
+                          "{current.elite}"
                         </p>
                         <div className="shrink-0 mt-1">
-                          <AudioButton text={current.elite.modelReply} size="sm" />
+                          <AudioButton text={current.elite} size="sm" />
                         </div>
                       </div>
-                      <p className="text-sm text-slate-500 mt-2">
-                        {current.elite.modelReplyEs}
-                      </p>
-                      <div className="mt-3 pt-3 border-t border-violet-200">
-                        <p className="text-[11px] font-semibold uppercase tracking-wider text-violet-700 mb-1">
-                          {lang === "es" ? "Perspectiva C2" : "C2 Insight"}
+                      {current.eliteEs && (
+                        <p className="text-sm text-slate-500 mt-2">
+                          {current.eliteEs}
                         </p>
-                        <p className="text-xs text-slate-700 leading-relaxed">
-                          {lang === "es"
-                            ? current.elite.c2InsightEs
-                            : current.elite.c2Insight}
-                        </p>
-                      </div>
+                      )}
                     </div>
                   )}
-                </div>
+                </>
               )}
             </div>
           )}
         </div>
       </div>
 
-      {/* Next button */}
       {revealed && !isLast && (
         <div className="flex justify-end">
           <button
@@ -234,8 +178,8 @@ export default function VerbUpgradeLab({ items, lang }: Props) {
         <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 text-center">
           <p className="text-emerald-800 font-medium text-sm">
             {lang === "es"
-              ? "Excelente. Has trabajado los drills — ahora di las respuestas modelo en voz alta, tres veces cada una."
-              : "Excellent. You've worked the drills — now say the model replies aloud, three times each."}
+              ? "Has practicado los conectores. Conectar ideas = sonar más inteligente al instante."
+              : "You've worked the connectors. Connecting ideas = sounding more intelligent, instantly."}
           </p>
         </div>
       )}

--- a/src/components/course/RapidRepeat.tsx
+++ b/src/components/course/RapidRepeat.tsx
@@ -45,25 +45,25 @@ export default function RapidRepeat({
       <p className="text-sm text-slate-400 leading-relaxed">{instruction}</p>
 
       <ul className="space-y-2">
-        {stems.map((stem, idx) => {
-          const text = lang === "es" ? stem.textEs : stem.text;
-          return (
-            <li
-              key={idx}
-              className="flex items-center gap-3 bg-slate-800/80 border border-slate-700 rounded-xl px-4 py-3"
-            >
-              <div className="shrink-0 w-7 h-7 rounded-full bg-amber-500 text-slate-900 text-xs font-bold flex items-center justify-center">
-                {idx + 1}
-              </div>
-              <p className="flex-1 text-base text-slate-100 font-medium leading-relaxed">
-                "{text}"
+        {stems.map((stem, idx) => (
+          <li
+            key={idx}
+            className="flex items-start gap-3 bg-slate-800/80 border border-slate-700 rounded-xl px-4 py-3"
+          >
+            <div className="shrink-0 mt-0.5 w-7 h-7 rounded-full bg-amber-500 text-slate-900 text-xs font-bold flex items-center justify-center">
+              {idx + 1}
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-base text-slate-100 font-medium leading-relaxed">
+                "{stem.text}"
               </p>
-              <div className="shrink-0">
-                <AudioButton text={text} size="sm" />
-              </div>
-            </li>
-          );
-        })}
+              <p className="text-xs text-slate-400 mt-0.5">{stem.textEs}</p>
+            </div>
+            <div className="shrink-0 mt-0.5">
+              <AudioButton text={stem.text} size="sm" />
+            </div>
+          </li>
+        ))}
       </ul>
 
       <div className="flex items-center gap-2 text-xs text-slate-500 pt-1">

--- a/src/components/course/StructuredResponseBuilder.tsx
+++ b/src/components/course/StructuredResponseBuilder.tsx
@@ -1,0 +1,208 @@
+// StructuredResponseBuilder — prompt → model reply in labeled parts.
+//
+// Shows an executive prompt, a weak attempt, and the model reply broken
+// into the parts of a named framework (e.g., Cause / Action / Outcome,
+// or Problem / Impact / Solution / Recommendation). The learner reveals
+// the structured reply part-by-part, then expands "why it works."
+//
+// Used in U3 (structured responses), U6 (impromptu), U8 (difficult
+// conversations), U9 (driving decisions).
+
+import { useState } from "react";
+import { ArrowDown, RotateCcw, Sparkles, Zap } from "lucide-react";
+import AudioButton from "./AudioButton";
+import type { StructuredResponseItem } from "@data/executive/types";
+
+interface Props {
+  items: StructuredResponseItem[];
+  lang: "en" | "es";
+}
+
+export default function StructuredResponseBuilder({ items, lang }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [revealed, setRevealed] = useState(false);
+  const [whyShown, setWhyShown] = useState(false);
+
+  const current = items[currentIndex];
+  const isLast = currentIndex === items.length - 1;
+
+  const framework = lang === "es" ? current.frameworkEs : current.framework;
+  const why = lang === "es" ? current.whyItWorksEs : current.whyItWorks;
+
+  // Concatenate all English parts into one spoken model reply
+  const fullReply = current.parts.map((p) => p.sentence).join(" ");
+
+  const handleReveal = () => setRevealed(true);
+  const handleShowWhy = () => setWhyShown(true);
+
+  const handleNext = () => {
+    if (isLast) return;
+    setCurrentIndex(currentIndex + 1);
+    setRevealed(false);
+    setWhyShown(false);
+  };
+
+  const handleRestart = () => {
+    setCurrentIndex(0);
+    setRevealed(false);
+    setWhyShown(false);
+  };
+
+  return (
+    <section className="space-y-6">
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-slate-500">
+          {lang === "es" ? "Escenario" : "Scenario"} {currentIndex + 1} /{" "}
+          {items.length}
+        </span>
+        <button
+          onClick={handleRestart}
+          className="text-xs text-slate-400 hover:text-amber-600 inline-flex items-center gap-1 transition-colors"
+        >
+          <RotateCcw size={12} />
+          {lang === "es" ? "Reiniciar" : "Restart"}
+        </button>
+      </div>
+
+      <div className="w-full h-1.5 bg-slate-100 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-amber-500 rounded-full transition-all duration-300"
+          style={{ width: `${((currentIndex + 1) / items.length) * 100}%` }}
+        />
+      </div>
+
+      <div className="bg-white rounded-2xl border-2 border-slate-200 overflow-hidden">
+        {/* Prompt */}
+        <div className="px-6 pt-6">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-2">
+            {lang === "es" ? "La pregunta ejecutiva:" : "The executive prompt:"}
+          </p>
+          <div className="bg-slate-900 text-white rounded-xl p-4">
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-base font-medium leading-relaxed flex-1">
+                "{current.prompt}"
+              </p>
+              <div className="shrink-0 mt-1">
+                <AudioButton text={current.prompt} size="sm" />
+              </div>
+            </div>
+            <p className="text-sm text-slate-400 mt-1">{current.promptEs}</p>
+          </div>
+        </div>
+
+        {/* Weak attempt */}
+        <div className="px-6 pt-4">
+          <p className="text-xs font-semibold uppercase tracking-wider text-red-500 mb-2">
+            {lang === "es" ? "Respuesta débil:" : "Weak attempt:"}
+          </p>
+          <div className="bg-red-50 border border-red-200 rounded-xl p-3">
+            <p className="text-sm text-red-900 italic leading-relaxed">
+              "{current.weak}"
+            </p>
+            <p className="text-xs text-red-700/70 mt-1">{current.weakEs}</p>
+          </div>
+        </div>
+
+        <div className="flex justify-center py-4">
+          <ArrowDown className="w-5 h-5 text-slate-300" />
+        </div>
+
+        {/* Model reply */}
+        <div className="px-6 pb-6">
+          <div className="flex items-center justify-between mb-3">
+            <p className="text-xs font-semibold uppercase tracking-wider text-amber-600 flex items-center gap-1">
+              <Zap size={12} />
+              {lang === "es" ? "Respuesta modelo:" : "Model reply:"}
+            </p>
+            <span className="text-[10px] font-mono uppercase tracking-wider px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200">
+              {framework}
+            </span>
+          </div>
+
+          {!revealed ? (
+            <button
+              onClick={handleReveal}
+              className="w-full py-4 rounded-xl border-2 border-dashed border-amber-300 text-amber-600 font-medium hover:bg-amber-50 transition-colors"
+            >
+              {lang === "es"
+                ? "Toca para revelar la respuesta estructurada"
+                : "Tap to reveal the structured reply"}
+            </button>
+          ) : (
+            <div className="space-y-3">
+              <div className="bg-gradient-to-br from-amber-50 to-amber-100 border-2 border-amber-300 rounded-xl overflow-hidden">
+                <ul className="divide-y divide-amber-200">
+                  {current.parts.map((part, idx) => {
+                    const label = lang === "es" ? part.labelEs : part.label;
+                    return (
+                      <li key={idx} className="p-4">
+                        <div className="flex items-center gap-2 mb-1.5">
+                          <span className="text-[10px] font-mono uppercase tracking-wider px-2 py-0.5 rounded bg-amber-500 text-white">
+                            {label}
+                          </span>
+                        </div>
+                        <p className="text-sm text-slate-900 leading-relaxed">
+                          {part.sentence}
+                        </p>
+                        <p className="text-xs text-slate-500 mt-1 leading-relaxed">
+                          {part.sentenceEs}
+                        </p>
+                      </li>
+                    );
+                  })}
+                </ul>
+                <div className="px-4 py-3 bg-amber-100 border-t-2 border-amber-300 flex items-center justify-between gap-3">
+                  <p className="text-xs font-medium text-amber-800">
+                    {lang === "es"
+                      ? "Escucha toda la respuesta integrada:"
+                      : "Listen to the full integrated reply:"}
+                  </p>
+                  <AudioButton text={fullReply} size="sm" />
+                </div>
+              </div>
+
+              {/* Why it works */}
+              {!whyShown ? (
+                <button
+                  onClick={handleShowWhy}
+                  className="w-full py-3 rounded-xl border border-dashed border-slate-300 text-slate-500 text-sm hover:bg-slate-50 transition-colors inline-flex items-center justify-center gap-2"
+                >
+                  <Sparkles size={12} />
+                  {lang === "es" ? "¿Por qué funciona?" : "Why it works"}
+                </button>
+              ) : (
+                <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
+                  <p className="text-sm text-slate-700 leading-relaxed flex items-start gap-2">
+                    <Sparkles size={12} className="text-amber-500 shrink-0 mt-0.5" />
+                    <span>{why}</span>
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {revealed && !isLast && (
+        <div className="flex justify-end">
+          <button
+            onClick={handleNext}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-500 text-white font-medium hover:bg-amber-400 transition-colors shadow-sm"
+          >
+            {lang === "es" ? "Siguiente escenario" : "Next scenario"}
+          </button>
+        </div>
+      )}
+
+      {revealed && isLast && (
+        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 text-center">
+          <p className="text-emerald-800 font-medium text-sm">
+            {lang === "es"
+              ? "Has trabajado los escenarios. El siguiente paso: di las respuestas modelo en voz alta hasta que la estructura se vuelva automática."
+              : "You've worked the scenarios. Next step: say the model replies aloud until the structure becomes automatic."}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/course/WeakStrongElite.tsx
+++ b/src/components/course/WeakStrongElite.tsx
@@ -1,0 +1,183 @@
+// WeakStrongElite — three-tier ladder drill.
+//
+// A single weak sentence is progressively upgraded through Strong (C1)
+// and optional Elite (C2) phrasings. Simpler than VerbUpgradeLab: no
+// alternative options, no usage guide — just a single line elevated
+// across three rungs. Used for filler elimination (U2) and defensive
+// reframing (U4).
+
+import { useState } from "react";
+import { ArrowDown, Lightbulb, RotateCcw, Zap } from "lucide-react";
+import AudioButton from "./AudioButton";
+import type { WeakStrongEliteItem } from "@data/executive/types";
+
+interface Props {
+  items: WeakStrongEliteItem[];
+  lang: "en" | "es";
+}
+
+export default function WeakStrongElite({ items, lang }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [strongRevealed, setStrongRevealed] = useState(false);
+  const [eliteRevealed, setEliteRevealed] = useState(false);
+
+  const current = items[currentIndex];
+  const isLast = currentIndex === items.length - 1;
+  const hasElite = Boolean(current.elite);
+
+  const note = lang === "es" ? current.noteEs : current.note;
+
+  const handleReveal = () => setStrongRevealed(true);
+  const handleRevealElite = () => setEliteRevealed(true);
+
+  const handleNext = () => {
+    if (isLast) return;
+    setCurrentIndex(currentIndex + 1);
+    setStrongRevealed(false);
+    setEliteRevealed(false);
+  };
+
+  const handleRestart = () => {
+    setCurrentIndex(0);
+    setStrongRevealed(false);
+    setEliteRevealed(false);
+  };
+
+  return (
+    <section className="space-y-6">
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-slate-500">
+          {lang === "es" ? "Drill" : "Drill"} {currentIndex + 1} / {items.length}
+        </span>
+        <button
+          onClick={handleRestart}
+          className="text-xs text-slate-400 hover:text-amber-600 inline-flex items-center gap-1 transition-colors"
+        >
+          <RotateCcw size={12} />
+          {lang === "es" ? "Reiniciar" : "Restart"}
+        </button>
+      </div>
+
+      <div className="w-full h-1.5 bg-slate-100 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-amber-500 rounded-full transition-all duration-300"
+          style={{ width: `${((currentIndex + 1) / items.length) * 100}%` }}
+        />
+      </div>
+
+      <div className="bg-white rounded-2xl border-2 border-slate-200 overflow-hidden">
+        {/* Weak */}
+        <div className="px-6 pt-6">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-2">
+            {lang === "es" ? "Débil" : "Weak"}
+          </p>
+          <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-base text-slate-700 italic leading-relaxed flex-1">
+                "{current.weak}"
+              </p>
+              <div className="shrink-0 mt-1">
+                <AudioButton text={current.weak} size="sm" />
+              </div>
+            </div>
+            <p className="text-sm text-slate-400 mt-1">{current.weakEs}</p>
+          </div>
+        </div>
+
+        {/* Strong */}
+        <div className="px-6 pt-4">
+          <div className="flex justify-center py-2">
+            <ArrowDown className="w-5 h-5 text-slate-300" />
+          </div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-amber-600 mb-2 flex items-center gap-1">
+            <Zap size={12} />
+            {lang === "es" ? "Fuerte (C1)" : "Strong (C1)"}
+          </p>
+
+          {!strongRevealed ? (
+            <button
+              onClick={handleReveal}
+              className="w-full py-4 rounded-xl border-2 border-dashed border-amber-300 text-amber-600 font-medium hover:bg-amber-50 transition-colors"
+            >
+              {lang === "es"
+                ? "Toca para revelar la versión C1"
+                : "Tap to reveal the C1 version"}
+            </button>
+          ) : (
+            <div className="bg-gradient-to-br from-amber-50 to-amber-100 border-2 border-amber-300 rounded-xl p-4">
+              <div className="flex items-start justify-between gap-3">
+                <p className="text-base text-slate-900 font-medium leading-relaxed flex-1">
+                  "{current.strong}"
+                </p>
+                <div className="shrink-0 mt-1">
+                  <AudioButton text={current.strong} size="sm" />
+                </div>
+              </div>
+              <p className="text-sm text-slate-500 mt-2">{current.strongEs}</p>
+              {note && (
+                <p className="text-xs text-slate-600 mt-3 pt-3 border-t border-amber-200 leading-relaxed">
+                  {note}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Elite */}
+        <div className="px-6 pt-3 pb-6">
+          {strongRevealed && hasElite && current.elite && (
+            <>
+              {!eliteRevealed ? (
+                <button
+                  onClick={handleRevealElite}
+                  className="w-full mt-3 py-3 rounded-xl border-2 border-dashed border-violet-300 text-violet-700 text-sm font-medium hover:bg-violet-50 transition-colors inline-flex items-center justify-center gap-2"
+                >
+                  <Lightbulb size={14} />
+                  {lang === "es" ? "Revelar el nivel C2 Elite" : "Reveal the C2 Elite tier"}
+                </button>
+              ) : (
+                <div className="mt-3 bg-gradient-to-br from-violet-50 to-violet-100 border-2 border-violet-300 rounded-xl p-4">
+                  <span className="inline-flex items-center gap-1 text-[10px] font-mono uppercase tracking-wider px-2 py-0.5 rounded-full bg-violet-200 text-violet-800 mb-2">
+                    C2 Elite
+                  </span>
+                  <div className="flex items-start justify-between gap-3">
+                    <p className="text-base text-slate-900 font-medium leading-relaxed flex-1">
+                      "{current.elite}"
+                    </p>
+                    <div className="shrink-0 mt-1">
+                      <AudioButton text={current.elite} size="sm" />
+                    </div>
+                  </div>
+                  {current.eliteEs && (
+                    <p className="text-sm text-slate-500 mt-2">{current.eliteEs}</p>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      {strongRevealed && !isLast && (
+        <div className="flex justify-end">
+          <button
+            onClick={handleNext}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-500 text-white font-medium hover:bg-amber-400 transition-colors shadow-sm"
+          >
+            {lang === "es" ? "Siguiente" : "Next"}
+          </button>
+        </div>
+      )}
+
+      {strongRevealed && isLast && (
+        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 text-center">
+          <p className="text-emerald-800 font-medium text-sm">
+            {lang === "es"
+              ? "Has terminado los drills. Ahora di las versiones fuertes en voz alta, tres veces cada una."
+              : "You've finished the drills. Now say the strong versions aloud, three times each."}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/data/executive/unit-1.ts
+++ b/src/data/executive/unit-1.ts
@@ -1,0 +1,308 @@
+// Unit 1 — Executive Word Choice
+// "Trade vague verbs for surgical precision."
+//
+// Three sections:
+// 1.1 Verb Precision — the core Robert drill (VerbUpgradeLab)
+// 1.2 Progressive Discovery — layered analytical depth (VerbUpgradeLab)
+// 1.3 Integrated Executive Phrasing — full sentences (WeakStrongElite)
+//
+// Content sourced from Robert's real C1 and C2 executive lessons.
+
+import type {
+  VerbUpgradeItem,
+  WeakStrongEliteItem,
+  UnitSection,
+  FinalShift,
+} from "./types";
+
+// ─── Section metadata ──────────────────────────────────────────────────────
+
+export const unit1Sections: UnitSection[] = [
+  {
+    number: 1,
+    title: "Verb Precision",
+    titleEs: "Precisión Verbal",
+    why: "At senior level, weak verbs signal shallow thinking. If your verbs are generic, your meaning becomes soft. In this section, you train your ear and your mouth to produce verbs that communicate precision, control, and analytical depth.",
+    whyEs: "En el nivel senior, los verbos débiles señalan pensamiento superficial. Si tus verbos son genéricos, tu significado se vuelve suave. En esta sección, entrenas tu oído y tu boca para producir verbos que comunican precisión, control y profundidad analítica.",
+    mechanic: "verb-upgrade",
+    techniqueFocus: "Each strong option serves a different strategic purpose. Learn when to use each — don't just memorize synonyms.",
+    techniqueFocusEs: "Cada opción fuerte sirve un propósito estratégico diferente. Aprende cuándo usar cada una — no solo memorices sinónimos.",
+    rapidRepeat: [
+      { text: "We investigated the issue.", textEs: "Investigamos el problema." },
+      { text: "We contained the impact.", textEs: "Contuvimos el impacto." },
+      { text: "We restructured the approach.", textEs: "Reestructuramos el enfoque." },
+      { text: "We validated the assumptions.", textEs: "Validamos los supuestos." },
+      { text: "We unblocked execution.", textEs: "Desbloqueamos la ejecución." },
+    ],
+  },
+  {
+    number: 2,
+    title: "Progressive Discovery",
+    titleEs: "Descubrimiento Progresivo",
+    why: "Strong executives don't just name what happened — they show depth of analysis. Progressive verbs move from surface observation to root cause. This signals that you understand the layers of a problem, not just the headline.",
+    whyEs: "Los ejecutivos fuertes no solo nombran lo que pasó — muestran profundidad de análisis. Los verbos progresivos van de la observación superficial a la causa raíz. Esto señala que entiendes las capas de un problema, no solo el titular.",
+    mechanic: "verb-upgrade",
+    techniqueFocus: "Each set of three verbs moves from surface → system → cause. Use all three in sequence to signal layered thinking.",
+    techniqueFocusEs: "Cada conjunto de tres verbos va de superficie → sistema → causa. Usa los tres en secuencia para señalar pensamiento en capas.",
+    rapidRepeat: [
+      { text: "We identified the issue early.", textEs: "Identificamos el problema temprano." },
+      { text: "We isolated its impact.", textEs: "Aislamos su impacto." },
+      { text: "We exposed a deeper structural weakness.", textEs: "Expusimos una debilidad estructural más profunda." },
+      { text: "We operationalized the initiative.", textEs: "Operacionalizamos la iniciativa." },
+    ],
+  },
+  {
+    number: 3,
+    title: "Integrated Executive Phrasing",
+    titleEs: "Fraseo Ejecutivo Integrado",
+    why: "Now that you know the individual verbs, this section puts them into the kind of full sentences a senior leader would actually say. The goal is fluency — not just knowing the right word, but deploying it in real executive speech.",
+    whyEs: "Ahora que conoces los verbos individuales, esta sección los pone en el tipo de oraciones completas que un líder senior realmente diría. La meta es fluidez — no solo saber la palabra correcta, sino desplegarla en el discurso ejecutivo real.",
+    mechanic: "weak-strong-elite",
+    techniqueFocus: "The contrast pattern 'We didn't just X — we Y' is a powerful rhetorical device. It makes your upgrade visible to the listener.",
+    techniqueFocusEs: "El patrón de contraste 'No solo hicimos X — hicimos Y' es un recurso retórico poderoso. Hace que tu mejora sea visible para el oyente.",
+    rapidRepeat: [
+      { text: "We didn't just identify the issue — we diagnosed the underlying cause.", textEs: "No solo identificamos el problema — diagnosticamos la causa subyacente." },
+      { text: "We didn't just delay execution — we re-sequenced priorities.", textEs: "No solo retrasamos la ejecución — re-secuenciamos las prioridades." },
+      { text: "We didn't just communicate — we aligned and influenced.", textEs: "No solo comunicamos — alineamos e influimos." },
+    ],
+  },
+];
+
+// ─── Section 1.1 — Verb Precision (VerbUpgradeLab) ─────────────────────────
+
+export const unit1Section1Drills: VerbUpgradeItem[] = [
+  {
+    weak: "We looked into the issue.",
+    weakEs: "Revisamos el problema.",
+    options: [
+      { verb: "Investigated", verbEs: "Investigamos", usage: "Broad, neutral, fact-finding", usageEs: "Amplio, neutral, búsqueda de hechos" },
+      { verb: "Audited", verbEs: "Auditamos", usage: "Compliance, controls, process review", usageEs: "Cumplimiento, controles, revisión de procesos" },
+      { verb: "Diagnosed", verbEs: "Diagnosticamos", usage: "Root cause, technical or structural problem", usageEs: "Causa raíz, problema técnico o estructural" },
+    ],
+    modelReply: "We investigated the issue to understand the timeline, audited the process to identify control failures, and diagnosed the root cause as a breakdown in cross-functional coordination.",
+    modelReplyEs: "Investigamos el problema para entender la línea de tiempo, auditamos el proceso para identificar fallas de control y diagnosticamos la causa raíz como una falla en la coordinación interfuncional.",
+    whyItWorks: "Moves from surface → system → cause. Signals layered thinking.",
+    whyItWorksEs: "Va de superficie → sistema → causa. Señala pensamiento en capas.",
+    elite: {
+      verb: "Diagnosed",
+      verbEs: "Diagnosticamos",
+      modelReply: "We initially investigated the issue to establish a factual baseline, then analyzed the contributing variables to understand emerging patterns, and ultimately diagnosed the root cause as a structural breakdown in cross-functional coordination.",
+      modelReplyEs: "Inicialmente investigamos el problema para establecer una base factual, luego analizamos las variables contribuyentes para entender los patrones emergentes, y finalmente diagnosticamos la causa raíz como una falla estructural en la coordinación interfuncional.",
+      c2Insight: "Replaces 'audited' with 'analyzed' — shifts from compliance to strategic interpretation.",
+      c2InsightEs: "Reemplaza 'audited' con 'analyzed' — cambia de cumplimiento a interpretación estratégica.",
+    },
+  },
+  {
+    weak: "We fixed the problem.",
+    weakEs: "Arreglamos el problema.",
+    options: [
+      { verb: "Contained", verbEs: "Contuvimos", usage: "Stopped spread — immediate", usageEs: "Detuvo la propagación — inmediato" },
+      { verb: "Mitigated", verbEs: "Mitigamos", usage: "Reduced the severity", usageEs: "Redujo la gravedad" },
+      { verb: "Resolved", verbEs: "Resolvimos", usage: "Eliminated the cause", usageEs: "Eliminó la causa" },
+    ],
+    modelReply: "We contained the issue immediately to prevent further escalation, mitigated the operational impact in the short term, and subsequently resolved the root cause through targeted process changes.",
+    modelReplyEs: "Contuvimos el problema inmediatamente para prevenir mayor escalación, mitigamos el impacto operacional a corto plazo y posteriormente resolvimos la causa raíz a través de cambios de proceso específicos.",
+    whyItWorks: "Separates time horizons: immediate → short-term → structural. Shows you control the full lifecycle.",
+    whyItWorksEs: "Separa horizontes de tiempo: inmediato → corto plazo → estructural. Muestra que controlas todo el ciclo.",
+    elite: {
+      verb: "Resolved",
+      verbEs: "Resolvimos",
+      modelReply: "We contained the issue immediately, mitigated the operational impact within the first 24 hours, and fully resolved the problem by end of week.",
+      modelReplyEs: "Contuvimos el problema inmediatamente, mitigamos el impacto operacional dentro de las primeras 24 horas y resolvimos completamente el problema para fin de semana.",
+      c2Insight: "Adding specific time markers ('within 24 hours', 'by end of week') transforms vague reassurance into executive credibility.",
+      c2InsightEs: "Agregar marcadores de tiempo específicos ('dentro de 24 horas', 'para fin de semana') transforma la vaga tranquilidad en credibilidad ejecutiva.",
+    },
+  },
+  {
+    weak: "We changed the plan.",
+    weakEs: "Cambiamos el plan.",
+    options: [
+      { verb: "Adjusted", verbEs: "Ajustamos", usage: "Small modification", usageEs: "Modificación pequeña" },
+      { verb: "Revised", verbEs: "Revisamos", usage: "Meaningful correction", usageEs: "Corrección significativa" },
+      { verb: "Restructured", verbEs: "Reestructuramos", usage: "Fundamental redesign", usageEs: "Rediseño fundamental" },
+    ],
+    modelReply: "We initially adjusted the plan to stabilize execution, then revised key assumptions as conditions evolved, and ultimately restructured the approach to better align with long-term objectives.",
+    modelReplyEs: "Inicialmente ajustamos el plan para estabilizar la ejecución, luego revisamos supuestos clave conforme evolucionaron las condiciones y finalmente reestructuramos el enfoque para alinearlo mejor con los objetivos a largo plazo.",
+    whyItWorks: "Shows escalation awareness — you matched the size of the change to the size of the problem.",
+    whyItWorksEs: "Muestra conciencia de escalación — igualaste el tamaño del cambio al tamaño del problema.",
+  },
+  {
+    weak: "We checked the data.",
+    weakEs: "Revisamos los datos.",
+    options: [
+      { verb: "Verified", verbEs: "Verificamos", usage: "Checked if it is true or correct", usageEs: "Comprobó si es verdadero o correcto" },
+      { verb: "Validated", verbEs: "Validamos", usage: "Confirmed reliability or soundness", usageEs: "Confirmó confiabilidad o solidez" },
+      { verb: "Cross-checked", verbEs: "Cotejamos", usage: "Compared across multiple sources", usageEs: "Comparó entre múltiples fuentes" },
+    ],
+    modelReply: "We verified the reported figures, validated the underlying assumptions, and cross-checked the data against our internal dashboard.",
+    modelReplyEs: "Verificamos las cifras reportadas, validamos los supuestos subyacentes y cotejamos los datos contra nuestro tablero interno.",
+    whyItWorks: "Three levels of data confidence: accuracy → reliability → consistency.",
+    whyItWorksEs: "Tres niveles de confianza en datos: exactitud → confiabilidad → consistencia.",
+    elite: {
+      verb: "Reconciled",
+      verbEs: "Conciliamos",
+      modelReply: "We verified the reported figures, validated the underlying assumptions, and reconciled discrepancies across multiple data sources.",
+      modelReplyEs: "Verificamos las cifras reportadas, validamos los supuestos subyacentes y conciliamos discrepancias entre múltiples fuentes de datos.",
+      c2Insight: "'Reconciled' replaces 'cross-checked' — moves from comparison to resolution of differences.",
+      c2InsightEs: "'Reconciled' reemplaza 'cross-checked' — pasa de comparación a resolución de diferencias.",
+    },
+  },
+  {
+    weak: "We helped the team.",
+    weakEs: "Ayudamos al equipo.",
+    options: [
+      { verb: "Supported", verbEs: "Apoyamos", usage: "General assistance", usageEs: "Asistencia general" },
+      { verb: "Enabled", verbEs: "Habilitamos", usage: "Gave capability or resources", usageEs: "Dio capacidad o recursos" },
+      { verb: "Unblocked", verbEs: "Desbloqueamos", usage: "Removed barriers", usageEs: "Eliminó barreras" },
+    ],
+    modelReply: "We supported the team with additional guidance, enabled faster execution by assigning new resources, and unblocked delivery by resolving the legal dependency.",
+    modelReplyEs: "Apoyamos al equipo con orientación adicional, habilitamos una ejecución más rápida asignando nuevos recursos y desbloqueamos la entrega al resolver la dependencia legal.",
+    whyItWorks: "Shows three different kinds of help — guidance, capability, barrier removal — not just generic 'assistance'.",
+    whyItWorksEs: "Muestra tres tipos diferentes de ayuda — orientación, capacidad, eliminación de barreras — no solo 'asistencia' genérica.",
+  },
+  {
+    weak: "We talked to the client.",
+    weakEs: "Hablamos con el cliente.",
+    options: [
+      { verb: "Briefed", verbEs: "Informamos", usage: "Delivered a structured update", usageEs: "Entregó una actualización estructurada" },
+      { verb: "Aligned with", verbEs: "Nos alineamos con", usage: "Achieved shared understanding", usageEs: "Logró entendimiento compartido" },
+      { verb: "Consulted with", verbEs: "Consultamos con", usage: "Sought input or perspective", usageEs: "Buscó aportaciones o perspectiva" },
+    ],
+    modelReply: "We briefed the client on the current situation, aligned on revised expectations, and consulted with them on priority sequencing.",
+    modelReplyEs: "Informamos al cliente sobre la situación actual, nos alineamos en expectativas revisadas y los consultamos sobre la secuenciación de prioridades.",
+    whyItWorks: "Moves from communication → alignment → influence. Three verbs, three levels of engagement.",
+    whyItWorksEs: "Va de comunicación → alineación → influencia. Tres verbos, tres niveles de engagement.",
+    elite: {
+      verb: "Negotiated",
+      verbEs: "Negociamos",
+      modelReply: "We briefed the client on the current situation, aligned on revised expectations, and negotiated key priorities to ensure a feasible path forward.",
+      modelReplyEs: "Informamos al cliente sobre la situación actual, nos alineamos en expectativas revisadas y negociamos las prioridades clave para asegurar un camino viable hacia adelante.",
+      c2Insight: "Replaces 'consulted' with 'negotiated' — shifts from seeking input to influencing the outcome.",
+      c2InsightEs: "Reemplaza 'consulted' con 'negotiated' — cambia de buscar aportes a influir en el resultado.",
+    },
+  },
+];
+
+// ─── Section 1.2 — Progressive Discovery (VerbUpgradeLab) ──────────────────
+
+export const unit1Section2Drills: VerbUpgradeItem[] = [
+  {
+    weak: "We found a problem.",
+    weakEs: "Encontramos un problema.",
+    options: [
+      { verb: "Identified", verbEs: "Identificamos", usage: "Recognized its presence", usageEs: "Reconoció su presencia" },
+      { verb: "Isolated", verbEs: "Aislamos", usage: "Narrowed the scope", usageEs: "Redujo el alcance" },
+      { verb: "Exposed", verbEs: "Expusimos", usage: "Revealed a hidden issue", usageEs: "Reveló un problema oculto" },
+    ],
+    modelReply: "We identified the issue early in the process, isolated its impact to a specific segment, and ultimately exposed a deeper structural weakness in the system.",
+    modelReplyEs: "Identificamos el problema temprano en el proceso, aislamos su impacto a un segmento específico y finalmente expusimos una debilidad estructural más profunda en el sistema.",
+    whyItWorks: "Shows progressive discovery depth — you went deeper than the surface.",
+    whyItWorksEs: "Muestra profundidad de descubrimiento progresivo — fuiste más allá de la superficie.",
+  },
+  {
+    weak: "We made a decision.",
+    weakEs: "Tomamos una decisión.",
+    options: [
+      { verb: "Determined", verbEs: "Determinamos", usage: "Concluded based on analysis", usageEs: "Concluyó basándose en análisis" },
+      { verb: "Prioritized", verbEs: "Priorizamos", usage: "Ranked against alternatives", usageEs: "Clasificó contra alternativas" },
+      { verb: "Committed", verbEs: "Nos comprometimos", usage: "Locked direction", usageEs: "Fijó la dirección" },
+    ],
+    modelReply: "We determined the most viable course of action based on available data, prioritized it against competing initiatives, and committed to execution with full alignment.",
+    modelReplyEs: "Determinamos el curso de acción más viable basándonos en los datos disponibles, lo priorizamos contra iniciativas competidoras y nos comprometimos a la ejecución con alineación completa.",
+    whyItWorks: "Shows decision maturity and finality — analysis → ranking → commitment.",
+    whyItWorksEs: "Muestra madurez y finalidad en la decisión — análisis → clasificación → compromiso.",
+  },
+  {
+    weak: "We reviewed the situation.",
+    weakEs: "Revisamos la situación.",
+    options: [
+      { verb: "Assessed", verbEs: "Evaluamos", usage: "Evaluated current state", usageEs: "Evaluó el estado actual" },
+      { verb: "Re-evaluated", verbEs: "Re-evaluamos", usage: "Challenged prior assumptions", usageEs: "Cuestionó supuestos previos" },
+      { verb: "Reframed", verbEs: "Reencuadramos", usage: "Changed the interpretation", usageEs: "Cambió la interpretación" },
+    ],
+    modelReply: "We assessed the current situation, re-evaluated our initial assumptions, and ultimately reframed the challenge to better align with strategic priorities.",
+    modelReplyEs: "Evaluamos la situación actual, re-evaluamos nuestros supuestos iniciales y finalmente reencuadramos el desafío para alinearlo mejor con las prioridades estratégicas.",
+    whyItWorks: "Shows intellectual flexibility and leadership thinking — you changed HOW you see the problem.",
+    whyItWorksEs: "Muestra flexibilidad intelectual y pensamiento de liderazgo — cambiaste CÓMO ves el problema.",
+  },
+  {
+    weak: "We managed the risk.",
+    weakEs: "Gestionamos el riesgo.",
+    options: [
+      { verb: "Assessed", verbEs: "Evaluamos", usage: "Evaluated exposure", usageEs: "Evaluó la exposición" },
+      { verb: "Mitigated", verbEs: "Mitigamos", usage: "Reduced impact", usageEs: "Redujo el impacto" },
+      { verb: "Controlled", verbEs: "Controlamos", usage: "Actively governed ongoing risk", usageEs: "Gobernó activamente el riesgo continuo" },
+    ],
+    modelReply: "We assessed the level of exposure early, mitigated the most critical risks, and established controls to manage ongoing uncertainty.",
+    modelReplyEs: "Evaluamos el nivel de exposición temprano, mitigamos los riesgos más críticos y establecimos controles para gestionar la incertidumbre continua.",
+    whyItWorks: "Shows full lifecycle risk thinking — evaluate → reduce → govern.",
+    whyItWorksEs: "Muestra pensamiento de riesgo de ciclo completo — evaluar → reducir → gobernar.",
+  },
+  {
+    weak: "We started the initiative.",
+    weakEs: "Iniciamos la iniciativa.",
+    options: [
+      { verb: "Initiated", verbEs: "Iniciamos", usage: "Formal beginning", usageEs: "Inicio formal" },
+      { verb: "Launched", verbEs: "Lanzamos", usage: "Visible rollout", usageEs: "Despliegue visible" },
+      { verb: "Operationalized", verbEs: "Operacionalizamos", usage: "Embedded into execution", usageEs: "Incorporado a la ejecución" },
+    ],
+    modelReply: "We initiated the initiative at a strategic level, launched it across key stakeholders, and operationalized it to ensure consistent execution.",
+    modelReplyEs: "Iniciamos la iniciativa a nivel estratégico, la lanzamos entre los stakeholders clave y la operacionalizamos para asegurar una ejecución consistente.",
+    whyItWorks: "Differentiates idea from execution reality — concept → visibility → embedded operation.",
+    whyItWorksEs: "Diferencia la idea de la realidad de ejecución — concepto → visibilidad → operación incorporada.",
+  },
+];
+
+// ─── Section 1.3 — Integrated Executive Phrasing (WeakStrongElite) ──────────
+
+export const unit1Section3Drills: WeakStrongEliteItem[] = [
+  {
+    weak: "We looked at Q3 and figured out some issues.",
+    weakEs: "Revisamos el Q3 y encontramos algunos problemas.",
+    strong: "We analyzed Q3 performance and identified several operational inefficiencies.",
+    strongEs: "Analizamos el rendimiento del Q3 e identificamos varias ineficiencias operativas.",
+    elite: "We analyzed Q3 performance, isolated the key drivers of underperformance, and exposed a systemic gap in execution consistency.",
+    eliteEs: "Analizamos el rendimiento del Q3, aislamos los principales impulsores del bajo rendimiento y expusimos una brecha sistémica en la consistencia de ejecución.",
+  },
+  {
+    weak: "We had delays and worked on them.",
+    weakEs: "Tuvimos retrasos y trabajamos en ellos.",
+    strong: "We experienced delays. In response, we are implementing corrective actions.",
+    strongEs: "Experimentamos retrasos. En respuesta, estamos implementando acciones correctivas.",
+    elite: "We experienced delays driven by bottlenecks in execution. In response, we restructured workflows and reallocated resources to stabilize delivery.",
+    eliteEs: "Experimentamos retrasos causados por cuellos de botella en la ejecución. En respuesta, reestructuramos los flujos de trabajo y reasignamos recursos para estabilizar la entrega.",
+  },
+  {
+    weak: "We're not sure what happened but we'll look into it.",
+    weakEs: "No estamos seguros de qué pasó pero lo revisaremos.",
+    strong: "The root cause is not yet confirmed. We are investigating and will report findings by end of day.",
+    strongEs: "La causa raíz aún no está confirmada. Estamos investigando y reportaremos hallazgos para el final del día.",
+    elite: "The root cause is not yet confirmed. We have contained the impact and are conducting a structured investigation. We will report findings and a corrective action plan by end of day.",
+    eliteEs: "La causa raíz aún no está confirmada. Hemos contenido el impacto y estamos realizando una investigación estructurada. Reportaremos hallazgos y un plan de acción correctiva para el final del día.",
+  },
+  {
+    weak: "The team did good work and we got better results.",
+    weakEs: "El equipo hizo un buen trabajo y obtuvimos mejores resultados.",
+    strong: "The team strengthened execution consistency, and performance improved as a result.",
+    strongEs: "El equipo fortaleció la consistencia de ejecución y el rendimiento mejoró como resultado.",
+    elite: "The team strengthened execution consistency, optimized resource allocation, and accelerated delivery timelines — resulting in measurable performance gains.",
+    eliteEs: "El equipo fortaleció la consistencia de ejecución, optimizó la asignación de recursos y aceleró los plazos de entrega — resultando en ganancias de rendimiento medibles.",
+  },
+  {
+    weak: "We changed some things and the client was okay with it.",
+    weakEs: "Cambiamos algunas cosas y al cliente le pareció bien.",
+    strong: "We revised the scope, briefed the client on the changes, and aligned on revised expectations.",
+    strongEs: "Revisamos el alcance, informamos al cliente sobre los cambios y nos alineamos en expectativas revisadas.",
+    elite: "We revised the scope to reflect current priorities, briefed the client on the rationale, and negotiated revised timelines to maintain delivery confidence.",
+    eliteEs: "Revisamos el alcance para reflejar las prioridades actuales, informamos al cliente sobre la justificación y negociamos plazos revisados para mantener la confianza en la entrega.",
+  },
+];
+
+// ─── Final Shift ────────────────────────────────────────────────────────────
+
+export const unit1FinalShift: FinalShift = {
+  before: "You used generic verbs that blurred your meaning and reduced confidence in your judgment.",
+  beforeEs: "Usabas verbos genéricos que difuminaban tu significado y reducían la confianza en tu juicio.",
+  after: "You choose verbs with surgical precision — each one signals a specific level of analysis, action, or commitment.",
+  afterEs: "Eliges verbos con precisión quirúrgica — cada uno señala un nivel específico de análisis, acción o compromiso.",
+};

--- a/src/data/executive/unit-2.ts
+++ b/src/data/executive/unit-2.ts
@@ -1,0 +1,238 @@
+// Unit 2 — Eliminating Weak Language
+// "Decisive without aggressive. Calibrated certainty."
+//
+// Three sections:
+// 2.1 Filler Elimination — remove hedging (WeakStrongElite)
+// 2.2 Controlled Assertion — declarative sentence stems (WeakStrongElite)
+// 2.3 Calibrated Certainty — direct without tense (WeakStrongElite)
+//
+// Content sourced from Robert's real C1 and C2 executive lessons.
+
+import type {
+  WeakStrongEliteItem,
+  UnitSection,
+  FinalShift,
+} from "./types";
+
+// ─── Section metadata ──────────────────────────────────────────────────────
+
+export const unit2Sections: UnitSection[] = [
+  {
+    number: 1,
+    title: "Filler Elimination",
+    titleEs: "Eliminación de Rellenos",
+    why: "At lower levels, people hedge because they lack confidence. At senior level, over-hedging signals lack of control. Fillers like 'I think', 'maybe', 'kind of', and 'sort of' drain authority from every sentence they touch.",
+    whyEs: "En niveles más bajos, las personas atenúan porque les falta confianza. En el nivel senior, atenuar demasiado señala falta de control. Los rellenos como 'I think', 'maybe', 'kind of' y 'sort of' drenan autoridad de cada oración que tocan.",
+    mechanic: "weak-strong-elite",
+    techniqueFocus: "When you remove filler, your tone must still sound measured. Senior leaders sound direct, but not tense.",
+    techniqueFocusEs: "Cuando eliminas los rellenos, tu tono debe seguir sonando medido. Los líderes senior suenan directos, pero no tensos.",
+    rapidRepeat: [
+      { text: "The issue is the timeline.", textEs: "El problema es la línea de tiempo." },
+      { text: "The data shows a clear pattern.", textEs: "Los datos muestran un patrón claro." },
+      { text: "We need to move faster.", textEs: "Necesitamos movernos más rápido." },
+      { text: "This creates risk.", textEs: "Esto crea riesgo." },
+      { text: "The priority is execution.", textEs: "La prioridad es la ejecución." },
+    ],
+  },
+  {
+    number: 2,
+    title: "Controlled Assertion",
+    titleEs: "Afirmación Controlada",
+    why: "Once you remove filler, you need replacement patterns — sentence structures that sound authoritative by default. These stems become your executive foundation: deploy them under pressure and your speech immediately sounds more controlled.",
+    whyEs: "Una vez que eliminas los rellenos, necesitas patrones de reemplazo — estructuras de oración que suenen autoritativas por defecto. Estas bases se convierten en tu fundamento ejecutivo: despliégalas bajo presión y tu discurso inmediatamente suena más controlado.",
+    mechanic: "weak-strong-elite",
+    techniqueFocus: "Each pair shows the same meaning with and without filler. The difference is pure authority.",
+    techniqueFocusEs: "Cada par muestra el mismo significado con y sin relleno. La diferencia es pura autoridad.",
+    rapidRepeat: [
+      { text: "The data indicates a shift.", textEs: "Los datos indican un cambio." },
+      { text: "This creates a constraint.", textEs: "Esto crea una restricción." },
+      { text: "We need to address this immediately.", textEs: "Necesitamos abordar esto inmediatamente." },
+      { text: "This is not aligned with our objectives.", textEs: "Esto no está alineado con nuestros objetivos." },
+    ],
+  },
+  {
+    number: 3,
+    title: "Calibrated Certainty",
+    titleEs: "Certeza Calibrada",
+    why: "The final distinction: too much filler sounds uncertain, but too much directness sounds aggressive. C2 language lives in the calibrated middle — measured, not emotional. This is where 'appears to be' and 'not defensible' replace both 'kind of' and the blunt hammer.",
+    whyEs: "La distinción final: demasiado relleno suena incierto, pero demasiada directividad suena agresiva. El lenguaje C2 vive en el medio calibrado — medido, no emocional. Aquí es donde 'appears to be' y 'not defensible' reemplazan tanto 'kind of' como el martillo directo.",
+    mechanic: "weak-strong-elite",
+    techniqueFocus: "The Elite tier is not louder — it is more analytically precise. 'Demand appears to be slowing' becomes 'Demand is showing early signs of contraction.'",
+    techniqueFocusEs: "El nivel Elite no es más fuerte — es más analíticamente preciso. 'Demand appears to be slowing' se convierte en 'Demand is showing early signs of contraction.'",
+    rapidRepeat: [
+      { text: "Demand is showing early signs of contraction.", textEs: "La demanda muestra señales tempranas de contracción." },
+      { text: "This is not defensible under current conditions.", textEs: "Esto no es defendible bajo las condiciones actuales." },
+      { text: "We are operating behind the planned timeline.", textEs: "Estamos operando por detrás de la línea de tiempo planeada." },
+    ],
+  },
+];
+
+// ─── Section 2.1 — Filler Elimination (WeakStrongElite) ────────────────────
+
+export const unit2Section1Drills: WeakStrongEliteItem[] = [
+  {
+    weak: "I think we should probably change direction.",
+    weakEs: "Creo que probablemente deberíamos cambiar de dirección.",
+    strong: "We should change direction.",
+    strongEs: "Deberíamos cambiar de dirección.",
+    elite: "We need to change direction.",
+    eliteEs: "Necesitamos cambiar de dirección.",
+  },
+  {
+    weak: "Maybe we can try another option.",
+    weakEs: "Tal vez podamos probar otra opción.",
+    strong: "We should pursue an alternative.",
+    strongEs: "Deberíamos buscar una alternativa.",
+    elite: "We will pursue an alternative approach.",
+    eliteEs: "Buscaremos un enfoque alternativo.",
+  },
+  {
+    weak: "It kind of looks like demand is slowing.",
+    weakEs: "Parece que la demanda está bajando.",
+    strong: "Demand appears to be slowing.",
+    strongEs: "La demanda parece estar desacelerándose.",
+    elite: "Demand is showing early signs of contraction.",
+    eliteEs: "La demanda muestra señales tempranas de contracción.",
+    note: "The Elite version is not louder — it is more analytically precise.",
+    noteEs: "La versión Elite no es más fuerte — es más analíticamente precisa.",
+  },
+  {
+    weak: "I guess the issue is the timeline.",
+    weakEs: "Supongo que el problema es la línea de tiempo.",
+    strong: "The issue is the timeline.",
+    strongEs: "El problema es la línea de tiempo.",
+  },
+  {
+    weak: "We're sort of running behind.",
+    weakEs: "Estamos como que retrasados.",
+    strong: "We are behind schedule.",
+    strongEs: "Estamos atrasados en el calendario.",
+    elite: "We are operating behind the planned timeline.",
+    eliteEs: "Estamos operando por detrás de la línea de tiempo planeada.",
+  },
+  {
+    weak: "It seems like the team is a little confused.",
+    weakEs: "Parece que el equipo está un poco confundido.",
+    strong: "The team lacks clarity.",
+    strongEs: "Al equipo le falta claridad.",
+  },
+  {
+    weak: "I feel like this might create risk.",
+    weakEs: "Siento que esto podría crear riesgo.",
+    strong: "This creates risk.",
+    strongEs: "Esto crea riesgo.",
+  },
+  {
+    weak: "It's a bit difficult to justify.",
+    weakEs: "Es un poco difícil de justificar.",
+    strong: "It is difficult to justify.",
+    strongEs: "Es difícil de justificar.",
+    elite: "This is not defensible under current conditions.",
+    eliteEs: "Esto no es defendible bajo las condiciones actuales.",
+  },
+];
+
+// ─── Section 2.2 — Controlled Assertion (WeakStrongElite) ──────────────────
+
+export const unit2Section2Drills: WeakStrongEliteItem[] = [
+  {
+    weak: "I think we're not aligned yet.",
+    weakEs: "Creo que aún no estamos alineados.",
+    strong: "We are not aligned yet.",
+    strongEs: "Aún no estamos alineados.",
+  },
+  {
+    weak: "It sort of became a bigger issue than expected.",
+    weakEs: "Se convirtió como que en un problema más grande de lo esperado.",
+    strong: "It became a larger issue than expected.",
+    strongEs: "Se convirtió en un problema más grande de lo esperado.",
+  },
+  {
+    weak: "I guess we underestimated the complexity.",
+    weakEs: "Supongo que subestimamos la complejidad.",
+    strong: "We underestimated the complexity.",
+    strongEs: "Subestimamos la complejidad.",
+  },
+  {
+    weak: "We were kind of hoping for better results.",
+    weakEs: "Estábamos como que esperando mejores resultados.",
+    strong: "We expected stronger results.",
+    strongEs: "Esperábamos resultados más fuertes.",
+  },
+  {
+    weak: "It seems like execution has been uneven.",
+    weakEs: "Parece que la ejecución ha sido irregular.",
+    strong: "Execution has been inconsistent.",
+    strongEs: "La ejecución ha sido inconsistente.",
+  },
+  {
+    weak: "Maybe this isn't the best timing.",
+    weakEs: "Tal vez este no sea el mejor momento.",
+    strong: "This is not the right timing.",
+    strongEs: "Este no es el momento correcto.",
+  },
+  {
+    weak: "I think we probably moved too quickly.",
+    weakEs: "Creo que probablemente nos movimos demasiado rápido.",
+    strong: "We moved too quickly.",
+    strongEs: "Nos movimos demasiado rápido.",
+  },
+];
+
+// ─── Section 2.3 — Calibrated Certainty (WeakStrongElite) ──────────────────
+
+export const unit2Section3Drills: WeakStrongEliteItem[] = [
+  {
+    weak: "This is a big problem.",
+    weakEs: "Este es un gran problema.",
+    strong: "This is a significant issue.",
+    strongEs: "Este es un problema significativo.",
+    note: "Replace emotional scale words ('big', 'huge') with measured executive language.",
+    noteEs: "Reemplaza palabras emocionales de escala ('big', 'huge') con lenguaje ejecutivo medido.",
+  },
+  {
+    weak: "This is bad.",
+    weakEs: "Esto está mal.",
+    strong: "This is not acceptable.",
+    strongEs: "Esto no es aceptable.",
+    elite: "This is not acceptable and requires immediate correction.",
+    eliteEs: "Esto no es aceptable y requiere corrección inmediata.",
+  },
+  {
+    weak: "This is frustrating.",
+    weakEs: "Esto es frustrante.",
+    strong: "This is impacting performance.",
+    strongEs: "Esto está impactando el rendimiento.",
+    note: "Replace the emotion with the business consequence. Executives describe impact, not feelings.",
+    noteEs: "Reemplaza la emoción con la consecuencia de negocio. Los ejecutivos describen impacto, no sentimientos.",
+  },
+  {
+    weak: "We're in trouble.",
+    weakEs: "Estamos en problemas.",
+    strong: "We are facing operational risk.",
+    strongEs: "Enfrentamos riesgo operacional.",
+  },
+  {
+    weak: "This is urgent.",
+    weakEs: "Esto es urgente.",
+    strong: "This requires immediate attention.",
+    strongEs: "Esto requiere atención inmediata.",
+  },
+  {
+    weak: "It's a little more serious now.",
+    weakEs: "Ahora es un poco más serio.",
+    strong: "The situation is more serious now.",
+    strongEs: "La situación es más seria ahora.",
+    elite: "The situation has escalated and requires a revised approach.",
+    eliteEs: "La situación se ha escalado y requiere un enfoque revisado.",
+  },
+];
+
+// ─── Final Shift ────────────────────────────────────────────────────────────
+
+export const unit2FinalShift: FinalShift = {
+  before: "You hedged with filler — 'I think', 'maybe', 'kind of' — diluting your authority with every sentence.",
+  beforeEs: "Atenuabas con rellenos — 'I think', 'maybe', 'kind of' — diluyendo tu autoridad con cada oración.",
+  after: "You speak with calibrated certainty — direct without aggressive, measured without uncertain.",
+  afterEs: "Hablas con certeza calibrada — directo sin ser agresivo, medido sin ser incierto.",
+};

--- a/src/data/executive/unit-3.ts
+++ b/src/data/executive/unit-3.ts
@@ -1,0 +1,252 @@
+// Unit 3 — Structured Responses & Connectors
+// "Cause → Action → Outcome. Problem → Impact → Solution → Recommendation."
+//
+// Three sections:
+// 3.1 Cause → Action → Outcome (StructuredResponseBuilder)
+// 3.2 Problem → Impact → Solution → Recommendation (StructuredResponseBuilder)
+// 3.3 Executive Connectors (ConnectorDrill)
+//
+// Content sourced from Robert's real C1 and C2 executive lessons.
+
+import type {
+  StructuredResponseItem,
+  ConnectorDrillItem,
+  UnitSection,
+  FinalShift,
+} from "./types";
+
+// ─── Section metadata ──────────────────────────────────────────────────────
+
+export const unit3Sections: UnitSection[] = [
+  {
+    number: 1,
+    title: "Cause → Action → Outcome",
+    titleEs: "Causa → Acción → Resultado",
+    why: "Unstructured speech forces the listener to interpret, organize, and guess your meaning. Structured speech reduces cognitive load, signals leadership control, and accelerates decision-making. This is the simplest and most powerful framework.",
+    whyEs: "El discurso no estructurado obliga al oyente a interpretar, organizar y adivinar tu significado. El discurso estructurado reduce la carga cognitiva, señala control de liderazgo y acelera la toma de decisiones. Este es el marco más simple y poderoso.",
+    mechanic: "structured-response",
+    techniqueFocus: "Always think in 3 moves: Cause → Action → Outcome. This structure works for 90% of executive updates.",
+    techniqueFocusEs: "Siempre piensa en 3 movimientos: Causa → Acción → Resultado. Esta estructura funciona para el 90% de las actualizaciones ejecutivas.",
+    rapidRepeat: [
+      { text: "The delays are driven by bottlenecks in execution.", textEs: "Los retrasos son causados por cuellos de botella en la ejecución." },
+      { text: "We are reallocating resources to improve throughput.", textEs: "Estamos reasignando recursos para mejorar el rendimiento." },
+      { text: "We expect performance to stabilize within 72 hours.", textEs: "Esperamos que el rendimiento se estabilice en 72 horas." },
+    ],
+  },
+  {
+    number: 2,
+    title: "Problem → Impact → Solution → Recommendation",
+    titleEs: "Problema → Impacto → Solución → Recomendación",
+    why: "When you need leadership approval for a change, you need a four-part structure that makes the decision feel necessary, not optional. This framework builds the business case in under 60 seconds.",
+    whyEs: "Cuando necesitas aprobación del liderazgo para un cambio, necesitas una estructura de cuatro partes que haga que la decisión se sienta necesaria, no opcional. Este marco construye el caso de negocio en menos de 60 segundos.",
+    mechanic: "structured-response",
+    techniqueFocus: "End with a clear recommendation. Leaders respect people who don't just present problems — they present solutions with a stance.",
+    techniqueFocusEs: "Termina con una recomendación clara. Los líderes respetan a las personas que no solo presentan problemas — presentan soluciones con una postura.",
+    rapidRepeat: [
+      { text: "The current process is limiting efficiency.", textEs: "El proceso actual está limitando la eficiencia." },
+      { text: "This is impacting delivery timelines.", textEs: "Esto está impactando los plazos de entrega." },
+      { text: "Based on this, I recommend moving forward.", textEs: "Basado en esto, recomiendo avanzar." },
+    ],
+  },
+  {
+    number: 3,
+    title: "Executive Connectors",
+    titleEs: "Conectores Ejecutivos",
+    why: "Ideas without connectors sound like a list. Ideas with connectors sound like a strategy. Executive connectors reveal logical progression and make your thinking visible to the listener in real time.",
+    whyEs: "Ideas sin conectores suenan como una lista. Ideas con conectores suenan como una estrategia. Los conectores ejecutivos revelan progresión lógica y hacen visible tu pensamiento al oyente en tiempo real.",
+    mechanic: "connector",
+    techniqueFocus: "Connect your ideas = sound more intelligent instantly. One connector transforms two fragments into a strategic narrative.",
+    techniqueFocusEs: "Conecta tus ideas = suena más inteligente al instante. Un conector transforma dos fragmentos en una narrativa estratégica.",
+    rapidRepeat: [
+      { text: "As a result, performance improved.", textEs: "Como resultado, el rendimiento mejoró." },
+      { text: "In response, we adjusted the approach.", textEs: "En respuesta, ajustamos el enfoque." },
+      { text: "Accordingly, we revised the timeline.", textEs: "En consecuencia, revisamos la línea de tiempo." },
+      { text: "This indicates a deeper issue.", textEs: "Esto indica un problema más profundo." },
+      { text: "From a strategic standpoint, this is the right move.", textEs: "Desde una perspectiva estratégica, este es el movimiento correcto." },
+    ],
+  },
+];
+
+// ─── Section 3.1 — Cause → Action → Outcome (StructuredResponseBuilder) ────
+
+export const unit3Section1Drills: StructuredResponseItem[] = [
+  {
+    prompt: "We are experiencing delays in fulfillment. Explain why.",
+    promptEs: "Estamos experimentando retrasos en los despachos. Explica por qué.",
+    weak: "We had some issues in the warehouse and things got slow.",
+    weakEs: "Tuvimos algunos problemas en el almacén y las cosas se pusieron lentas.",
+    framework: "Cause → Action → Outcome",
+    frameworkEs: "Causa → Acción → Resultado",
+    parts: [
+      { label: "Cause", labelEs: "Causa", sentence: "The delays are driven by bottlenecks in the picking process.", sentenceEs: "Los retrasos son causados por cuellos de botella en el proceso de selección." },
+      { label: "Action", labelEs: "Acción", sentence: "We are reallocating staff and adjusting workflows to improve throughput.", sentenceEs: "Estamos reasignando personal y ajustando flujos de trabajo para mejorar el rendimiento." },
+      { label: "Outcome", labelEs: "Resultado", sentence: "We expect fulfillment speed to stabilize within the next 72 hours.", sentenceEs: "Esperamos que la velocidad de despacho se estabilice dentro de las próximas 72 horas." },
+    ],
+    whyItWorks: "Clear cause, clear action, clear timeline. The listener knows exactly what happened, what you're doing, and when it will be fixed.",
+    whyItWorksEs: "Causa clara, acción clara, línea de tiempo clara. El oyente sabe exactamente qué pasó, qué estás haciendo y cuándo se arreglará.",
+  },
+  {
+    prompt: "Why are there discrepancies in inventory?",
+    promptEs: "¿Por qué hay discrepancias en el inventario?",
+    weak: "There were some mistakes and the system wasn't accurate.",
+    weakEs: "Hubo algunos errores y el sistema no era preciso.",
+    framework: "Cause → Action → Outcome",
+    frameworkEs: "Causa → Acción → Resultado",
+    parts: [
+      { label: "Cause", labelEs: "Causa", sentence: "The discrepancies are the result of inconsistent scanning during receiving.", sentenceEs: "Las discrepancias son el resultado de escaneo inconsistente durante la recepción." },
+      { label: "Action", labelEs: "Acción", sentence: "We are reinforcing process controls and retraining the team on standard procedures.", sentenceEs: "Estamos reforzando los controles de proceso y reentrenando al equipo en procedimientos estándar." },
+      { label: "Outcome", labelEs: "Resultado", sentence: "This will restore inventory accuracy and reduce future variance.", sentenceEs: "Esto restaurará la precisión del inventario y reducirá la varianza futura." },
+    ],
+    whyItWorks: "Specific cause (not vague), action that shows control, outcome that shows confidence.",
+    whyItWorksEs: "Causa específica (no vaga), acción que muestra control, resultado que muestra confianza.",
+  },
+  {
+    prompt: "Why did operational costs increase this quarter?",
+    promptEs: "¿Por qué aumentaron los costos operativos este trimestre?",
+    weak: "Costs went up because of demand and some inefficiencies.",
+    weakEs: "Los costos subieron por la demanda y algunas ineficiencias.",
+    framework: "Cause → Action → Outcome",
+    frameworkEs: "Causa → Acción → Resultado",
+    parts: [
+      { label: "Cause", labelEs: "Causa", sentence: "The increase is driven by higher labor costs and inefficiencies in order processing.", sentenceEs: "El aumento es causado por mayores costos laborales e ineficiencias en el procesamiento de pedidos." },
+      { label: "Action", labelEs: "Acción", sentence: "We are optimizing staffing allocation and improving workflow efficiency.", sentenceEs: "Estamos optimizando la asignación de personal y mejorando la eficiencia de los flujos de trabajo." },
+      { label: "Outcome", labelEs: "Resultado", sentence: "This will reduce cost pressure over the next cycle.", sentenceEs: "Esto reducirá la presión de costos en el próximo ciclo." },
+    ],
+    whyItWorks: "Names two specific cost drivers, not a vague 'costs went up'. The listener trusts you understand what happened.",
+    whyItWorksEs: "Nombra dos impulsores de costos específicos, no un vago 'los costos subieron'. El oyente confía en que entiendes lo que pasó.",
+  },
+  {
+    prompt: "Why is team performance inconsistent?",
+    promptEs: "¿Por qué el rendimiento del equipo es inconsistente?",
+    weak: "The team is not fully aligned yet.",
+    weakEs: "El equipo aún no está completamente alineado.",
+    framework: "Cause → Action → Outcome",
+    frameworkEs: "Causa → Acción → Resultado",
+    parts: [
+      { label: "Cause", labelEs: "Causa", sentence: "The inconsistency is due to unclear process ownership across shifts.", sentenceEs: "La inconsistencia se debe a la falta de claridad en la titularidad de procesos entre turnos." },
+      { label: "Action", labelEs: "Acción", sentence: "We are defining roles more clearly and standardizing execution protocols.", sentenceEs: "Estamos definiendo los roles con más claridad y estandarizando los protocolos de ejecución." },
+      { label: "Outcome", labelEs: "Resultado", sentence: "This will improve consistency and accountability across the operation.", sentenceEs: "Esto mejorará la consistencia y la rendición de cuentas en toda la operación." },
+    ],
+    whyItWorks: "The cause is structural (process ownership), not personal (the team is bad). Leaders diagnose systems, not blame people.",
+    whyItWorksEs: "La causa es estructural (titularidad de procesos), no personal (el equipo es malo). Los líderes diagnostican sistemas, no culpan personas.",
+  },
+];
+
+// ─── Section 3.2 — Problem → Impact → Solution → Recommendation ────────────
+
+export const unit3Section2Drills: StructuredResponseItem[] = [
+  {
+    prompt: "Why should we move forward with this change?",
+    promptEs: "¿Por qué deberíamos avanzar con este cambio?",
+    weak: "I think it's a good idea and we should do it.",
+    weakEs: "Creo que es una buena idea y deberíamos hacerlo.",
+    framework: "Problem → Impact → Solution → Recommendation",
+    frameworkEs: "Problema → Impacto → Solución → Recomendación",
+    parts: [
+      { label: "Problem", labelEs: "Problema", sentence: "The current process is limiting efficiency and increasing operational cost.", sentenceEs: "El proceso actual está limitando la eficiencia y aumentando el costo operacional." },
+      { label: "Impact", labelEs: "Impacto", sentence: "This is impacting fulfillment speed and overall performance.", sentenceEs: "Esto está impactando la velocidad de despacho y el rendimiento general." },
+      { label: "Solution", labelEs: "Solución", sentence: "We are proposing a streamlined workflow that reduces complexity and improves execution.", sentenceEs: "Estamos proponiendo un flujo de trabajo simplificado que reduce la complejidad y mejora la ejecución." },
+      { label: "Recommendation", labelEs: "Recomendación", sentence: "Based on this, I recommend moving forward with the change.", sentenceEs: "Basado en esto, recomiendo avanzar con el cambio." },
+    ],
+    whyItWorks: "Logical flow from problem to recommendation. The decision feels necessary, not optional.",
+    whyItWorksEs: "Flujo lógico del problema a la recomendación. La decisión se siente necesaria, no opcional.",
+  },
+  {
+    prompt: "Why are we proposing to restructure the regional team?",
+    promptEs: "¿Por qué estamos proponiendo reestructurar el equipo regional?",
+    weak: "The team isn't working well and we need to make changes.",
+    weakEs: "El equipo no está funcionando bien y necesitamos hacer cambios.",
+    framework: "Problem → Impact → Solution → Recommendation",
+    frameworkEs: "Problema → Impacto → Solución → Recomendación",
+    parts: [
+      { label: "Problem", labelEs: "Problema", sentence: "The current structure creates overlapping responsibilities and unclear accountability.", sentenceEs: "La estructura actual crea responsabilidades superpuestas y rendición de cuentas poco clara." },
+      { label: "Impact", labelEs: "Impacto", sentence: "This is causing execution delays and inconsistent decision-making across the region.", sentenceEs: "Esto está causando retrasos en la ejecución y toma de decisiones inconsistente en toda la región." },
+      { label: "Solution", labelEs: "Solución", sentence: "We are proposing a realignment that consolidates ownership and clarifies reporting lines.", sentenceEs: "Estamos proponiendo una realineación que consolida la titularidad y clarifica las líneas de reporte." },
+      { label: "Recommendation", labelEs: "Recomendación", sentence: "I recommend we implement this in Q2 to capture the efficiency gains before the peak period.", sentenceEs: "Recomiendo que implementemos esto en el Q2 para capturar las ganancias de eficiencia antes del período pico." },
+    ],
+    whyItWorks: "Adds a specific timeline to the recommendation — signals urgency without panic.",
+    whyItWorksEs: "Agrega una línea de tiempo específica a la recomendación — señala urgencia sin pánico.",
+  },
+  {
+    prompt: "Should we invest in upgrading our reporting tools?",
+    promptEs: "¿Deberíamos invertir en mejorar nuestras herramientas de reporteo?",
+    weak: "Yes, our reporting tools are old and we need better ones.",
+    weakEs: "Sí, nuestras herramientas de reporteo son viejas y necesitamos mejores.",
+    framework: "Problem → Impact → Solution → Recommendation",
+    frameworkEs: "Problema → Impacto → Solución → Recomendación",
+    parts: [
+      { label: "Problem", labelEs: "Problema", sentence: "Our current reporting tools are manual-intensive and produce inconsistent outputs.", sentenceEs: "Nuestras herramientas de reporteo actuales son intensivas en trabajo manual y producen resultados inconsistentes." },
+      { label: "Impact", labelEs: "Impacto", sentence: "This is slowing decision-making and increasing the risk of data errors in executive reviews.", sentenceEs: "Esto está desacelerando la toma de decisiones y aumentando el riesgo de errores de datos en las revisiones ejecutivas." },
+      { label: "Solution", labelEs: "Solución", sentence: "A platform upgrade would automate reporting, improve consistency, and reduce preparation time by an estimated 40%.", sentenceEs: "Una actualización de plataforma automatizaría el reporteo, mejoraría la consistencia y reduciría el tiempo de preparación en un estimado de 40%." },
+      { label: "Recommendation", labelEs: "Recomendación", sentence: "I recommend approving the investment and targeting a Q3 rollout.", sentenceEs: "Recomiendo aprobar la inversión y apuntar a un despliegue en Q3." },
+    ],
+    whyItWorks: "Quantifies the benefit ('40%') and specifies a timeline ('Q3'). Makes it easy to say yes.",
+    whyItWorksEs: "Cuantifica el beneficio ('40%') y especifica una línea de tiempo ('Q3'). Facilita decir que sí.",
+  },
+];
+
+// ─── Section 3.3 — Executive Connectors (ConnectorDrill) ────────────────────
+
+export const unit3Section3Drills: ConnectorDrillItem[] = [
+  {
+    weak: "We had delays. We are fixing it.",
+    weakEs: "Tuvimos retrasos. Lo estamos arreglando.",
+    strong: "We experienced delays. As a result, we are implementing corrective actions.",
+    strongEs: "Experimentamos retrasos. Como resultado, estamos implementando acciones correctivas.",
+    connector: "As a result",
+    connectorEs: "Como resultado",
+    elite: "We experienced delays driven by execution bottlenecks. As a result, we are implementing targeted corrective measures to restore delivery timelines.",
+    eliteEs: "Experimentamos retrasos causados por cuellos de botella en la ejecución. Como resultado, estamos implementando medidas correctivas específicas para restaurar los plazos de entrega.",
+  },
+  {
+    weak: "There were issues. We changed the process.",
+    weakEs: "Hubo problemas. Cambiamos el proceso.",
+    strong: "We identified issues. In response, we adjusted the process.",
+    strongEs: "Identificamos problemas. En respuesta, ajustamos el proceso.",
+    connector: "In response",
+    connectorEs: "En respuesta",
+  },
+  {
+    weak: "The team struggled. We added resources.",
+    weakEs: "El equipo tuvo dificultades. Agregamos recursos.",
+    strong: "The team struggled with capacity constraints. To address this, we added resources.",
+    strongEs: "El equipo tuvo dificultades con restricciones de capacidad. Para abordar esto, agregamos recursos.",
+    connector: "To address this",
+    connectorEs: "Para abordar esto",
+  },
+  {
+    weak: "Costs increased. We are reviewing it.",
+    weakEs: "Los costos aumentaron. Lo estamos revisando.",
+    strong: "Costs increased beyond plan. As a result, we are reviewing cost drivers and identifying areas for optimization.",
+    strongEs: "Los costos aumentaron más allá del plan. Como resultado, estamos revisando los impulsores de costos e identificando áreas de optimización.",
+    connector: "As a result",
+    connectorEs: "Como resultado",
+  },
+  {
+    weak: "Demand changed. We updated the plan.",
+    weakEs: "La demanda cambió. Actualizamos el plan.",
+    strong: "Demand shifted significantly. Accordingly, we revised the plan.",
+    strongEs: "La demanda cambió significativamente. En consecuencia, revisamos el plan.",
+    connector: "Accordingly",
+    connectorEs: "En consecuencia",
+    elite: "Demand shifted significantly in the second half of the quarter. Accordingly, we revised the plan to prioritize high-impact initiatives and defer lower-priority items.",
+    eliteEs: "La demanda cambió significativamente en la segunda mitad del trimestre. En consecuencia, revisamos el plan para priorizar iniciativas de alto impacto y diferir elementos de menor prioridad.",
+  },
+  {
+    weak: "The data showed problems. We need to take action.",
+    weakEs: "Los datos mostraron problemas. Necesitamos tomar acción.",
+    strong: "The data reveals a downward trend. This indicates that corrective action is needed.",
+    strongEs: "Los datos revelan una tendencia a la baja. Esto indica que se necesita acción correctiva.",
+    connector: "This indicates",
+    connectorEs: "Esto indica",
+  },
+];
+
+// ─── Final Shift ────────────────────────────────────────────────────────────
+
+export const unit3FinalShift: FinalShift = {
+  before: "You listed ideas in fragments — the listener had to organize your thinking for you.",
+  beforeEs: "Enumerabas ideas en fragmentos — el oyente tenía que organizar tu pensamiento por ti.",
+  after: "You structure your thinking in real time using named frameworks. Your speech guides the listener instead of burdening them.",
+  afterEs: "Estructuras tu pensamiento en tiempo real usando marcos con nombre. Tu discurso guía al oyente en lugar de cargarlo.",
+};

--- a/src/data/executive/units.ts
+++ b/src/data/executive/units.ts
@@ -62,7 +62,7 @@ export const executiveUnits: ExecutiveUnit[] = [
     outcomeEs:
       "Reemplazarás los verbos genéricos con el lenguaje preciso y estratégico que los ejecutivos esperan.",
     icon: "Target",
-    published: false,
+    published: true,
   },
   {
     id: 2,
@@ -81,7 +81,7 @@ export const executiveUnits: ExecutiveUnit[] = [
     outcomeEs:
       "Hablarás con certeza calibrada — directo, pero nunca tenso.",
     icon: "Zap",
-    published: false,
+    published: true,
   },
   {
     id: 3,
@@ -100,7 +100,7 @@ export const executiveUnits: ExecutiveUnit[] = [
     outcomeEs:
       "Organizarás tu pensamiento en voz alta usando marcos con nombre, bajo presión.",
     icon: "Layers",
-    published: false,
+    published: true,
   },
   {
     id: 4,

--- a/src/pages/en/course/executive/unit-1.astro
+++ b/src/pages/en/course/executive/unit-1.astro
@@ -1,0 +1,153 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import VerbUpgradeLab from "@components/course/VerbUpgradeLab";
+import WeakStrongElite from "@components/course/WeakStrongElite";
+import RapidRepeat from "@components/course/RapidRepeat";
+import FinalShiftCard from "@components/course/FinalShiftCard";
+import { executiveUnits } from "@data/executive/units";
+import {
+  unit1Sections,
+  unit1Section1Drills,
+  unit1Section2Drills,
+  unit1Section3Drills,
+  unit1FinalShift,
+} from "@data/executive/unit-1";
+import { ArrowRight, ArrowLeft, Target } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/executive/unit-1" as const;
+const unit = executiveUnits[0];
+
+const progressUnits = executiveUnits
+  .filter((u) => u.published)
+  .map((u) => ({ id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title={`Unit 1: ${unit.title} | Executive English Course`}
+  description={unit.description}
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={1}
+    basePath="/en/course/executive"
+    lang="en"
+    courseId="executive"
+  />
+
+  <!-- Unit hero -->
+  <section class="bg-gradient-to-b from-slate-950 to-slate-900 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Target class="w-4 h-4" />
+          Unit 1
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          {unit.title}
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          {unit.description}
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 1: Verb Precision -->
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit1Sections[0].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit1Sections[0].why}</p>
+        <div class="ml-11">
+          <VerbUpgradeLab client:visible items={unit1Section1Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit1Sections[0].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit1Sections[0].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2: Progressive Discovery -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit1Sections[1].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit1Sections[1].why}</p>
+        <div class="ml-11">
+          <VerbUpgradeLab client:visible items={unit1Section2Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit1Sections[1].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit1Sections[1].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3: Integrated Executive Phrasing -->
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit1Sections[2].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit1Sections[2].why}</p>
+        <div class="ml-11">
+          <WeakStrongElite client:visible items={unit1Section3Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit1Sections[2].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit1Sections[2].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Final Shift -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <FinalShiftCard client:visible shift={unit1FinalShift} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/en/course/executive/"
+          class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          <ArrowLeft class="w-4 h-4" />
+          Course Overview
+        </a>
+        <Button href="/en/course/executive/unit-2/" variant="primary" size="md">
+          Unit 2: Eliminating Weak Language
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/en/course/executive/unit-2.astro
+++ b/src/pages/en/course/executive/unit-2.astro
@@ -1,0 +1,152 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WeakStrongElite from "@components/course/WeakStrongElite";
+import RapidRepeat from "@components/course/RapidRepeat";
+import FinalShiftCard from "@components/course/FinalShiftCard";
+import { executiveUnits } from "@data/executive/units";
+import {
+  unit2Sections,
+  unit2Section1Drills,
+  unit2Section2Drills,
+  unit2Section3Drills,
+  unit2FinalShift,
+} from "@data/executive/unit-2";
+import { ArrowRight, ArrowLeft, Zap } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/executive/unit-2" as const;
+const unit = executiveUnits[1];
+
+const progressUnits = executiveUnits
+  .filter((u) => u.published)
+  .map((u) => ({ id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title={`Unit 2: ${unit.title} | Executive English Course`}
+  description={unit.description}
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={2}
+    basePath="/en/course/executive"
+    lang="en"
+    courseId="executive"
+  />
+
+  <!-- Unit hero -->
+  <section class="bg-gradient-to-b from-slate-950 to-slate-900 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Zap class="w-4 h-4" />
+          Unit 2
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          {unit.title}
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          {unit.description}
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 1: Filler Elimination -->
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit2Sections[0].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit2Sections[0].why}</p>
+        <div class="ml-11">
+          <WeakStrongElite client:visible items={unit2Section1Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit2Sections[0].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit2Sections[0].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2: Controlled Assertion -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit2Sections[1].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit2Sections[1].why}</p>
+        <div class="ml-11">
+          <WeakStrongElite client:visible items={unit2Section2Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit2Sections[1].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit2Sections[1].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3: Calibrated Certainty -->
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit2Sections[2].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit2Sections[2].why}</p>
+        <div class="ml-11">
+          <WeakStrongElite client:visible items={unit2Section3Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit2Sections[2].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit2Sections[2].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Final Shift -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <FinalShiftCard client:visible shift={unit2FinalShift} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/en/course/executive/unit-1/"
+          class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          <ArrowLeft class="w-4 h-4" />
+          Unit 1: Executive Word Choice
+        </a>
+        <Button href="/en/course/executive/unit-3/" variant="primary" size="md">
+          Unit 3: Structured Responses
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/en/course/executive/unit-3.astro
+++ b/src/pages/en/course/executive/unit-3.astro
@@ -1,0 +1,153 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import StructuredResponseBuilder from "@components/course/StructuredResponseBuilder";
+import ConnectorDrill from "@components/course/ConnectorDrill";
+import RapidRepeat from "@components/course/RapidRepeat";
+import FinalShiftCard from "@components/course/FinalShiftCard";
+import { executiveUnits } from "@data/executive/units";
+import {
+  unit3Sections,
+  unit3Section1Drills,
+  unit3Section2Drills,
+  unit3Section3Drills,
+  unit3FinalShift,
+} from "@data/executive/unit-3";
+import { ArrowRight, ArrowLeft, Layers } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/executive/unit-3" as const;
+const unit = executiveUnits[2];
+
+const progressUnits = executiveUnits
+  .filter((u) => u.published)
+  .map((u) => ({ id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title={`Unit 3: ${unit.title} | Executive English Course`}
+  description={unit.description}
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={3}
+    basePath="/en/course/executive"
+    lang="en"
+    courseId="executive"
+  />
+
+  <!-- Unit hero -->
+  <section class="bg-gradient-to-b from-slate-950 to-slate-900 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Layers class="w-4 h-4" />
+          Unit 3
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          {unit.title}
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          {unit.description}
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 1: Cause → Action → Outcome -->
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit3Sections[0].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit3Sections[0].why}</p>
+        <div class="ml-11">
+          <StructuredResponseBuilder client:visible items={unit3Section1Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit3Sections[0].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit3Sections[0].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2: Problem → Impact → Solution → Recommendation -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit3Sections[1].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit3Sections[1].why}</p>
+        <div class="ml-11">
+          <StructuredResponseBuilder client:visible items={unit3Section2Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit3Sections[1].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit3Sections[1].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3: Executive Connectors -->
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit3Sections[2].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit3Sections[2].why}</p>
+        <div class="ml-11">
+          <ConnectorDrill client:visible items={unit3Section3Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit3Sections[2].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit3Sections[2].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Final Shift -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <FinalShiftCard client:visible shift={unit3FinalShift} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/en/course/executive/unit-2/"
+          class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          <ArrowLeft class="w-4 h-4" />
+          Unit 2: Eliminating Weak Language
+        </a>
+        <Button href="/en/course/executive/" variant="primary" size="md">
+          Course Overview
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/ejecutivo/unidad-1.astro
+++ b/src/pages/es/curso/ejecutivo/unidad-1.astro
@@ -1,0 +1,153 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import VerbUpgradeLab from "@components/course/VerbUpgradeLab";
+import WeakStrongElite from "@components/course/WeakStrongElite";
+import RapidRepeat from "@components/course/RapidRepeat";
+import FinalShiftCard from "@components/course/FinalShiftCard";
+import { executiveUnits } from "@data/executive/units";
+import {
+  unit1Sections,
+  unit1Section1Drills,
+  unit1Section2Drills,
+  unit1Section3Drills,
+  unit1FinalShift,
+} from "@data/executive/unit-1";
+import { ArrowRight, ArrowLeft, Target } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/executive/unit-1" as const;
+const unit = executiveUnits[0];
+
+const progressUnits = executiveUnits
+  .filter((u) => u.published)
+  .map((u) => ({ id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title={`Unidad 1: ${unit.titleEs} | Curso Ejecutivo de Inglés`}
+  description={unit.descriptionEs}
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={1}
+    basePath="/es/curso/ejecutivo"
+    lang="es"
+    courseId="executive"
+  />
+
+  <!-- Unit hero -->
+  <section class="bg-gradient-to-b from-slate-950 to-slate-900 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Target class="w-4 h-4" />
+          Unidad 1
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          {unit.titleEs}
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          {unit.descriptionEs}
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 1: Verb Precision -->
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit1Sections[0].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit1Sections[0].whyEs}</p>
+        <div class="ml-11">
+          <VerbUpgradeLab client:visible items={unit1Section1Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit1Sections[0].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit1Sections[0].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2: Progressive Discovery -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit1Sections[1].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit1Sections[1].whyEs}</p>
+        <div class="ml-11">
+          <VerbUpgradeLab client:visible items={unit1Section2Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit1Sections[1].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit1Sections[1].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3: Integrated Executive Phrasing -->
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit1Sections[2].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit1Sections[2].whyEs}</p>
+        <div class="ml-11">
+          <WeakStrongElite client:visible items={unit1Section3Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit1Sections[2].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit1Sections[2].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Final Shift -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <FinalShiftCard client:visible shift={unit1FinalShift} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/es/curso/ejecutivo/"
+          class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          <ArrowLeft class="w-4 h-4" />
+          Resumen del Curso
+        </a>
+        <Button href="/es/curso/ejecutivo/unidad-2/" variant="primary" size="md">
+          Unidad 2: Eliminando el Lenguaje Débil
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/ejecutivo/unidad-2.astro
+++ b/src/pages/es/curso/ejecutivo/unidad-2.astro
@@ -1,0 +1,152 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WeakStrongElite from "@components/course/WeakStrongElite";
+import RapidRepeat from "@components/course/RapidRepeat";
+import FinalShiftCard from "@components/course/FinalShiftCard";
+import { executiveUnits } from "@data/executive/units";
+import {
+  unit2Sections,
+  unit2Section1Drills,
+  unit2Section2Drills,
+  unit2Section3Drills,
+  unit2FinalShift,
+} from "@data/executive/unit-2";
+import { ArrowRight, ArrowLeft, Zap } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/executive/unit-2" as const;
+const unit = executiveUnits[1];
+
+const progressUnits = executiveUnits
+  .filter((u) => u.published)
+  .map((u) => ({ id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title={`Unidad 2: ${unit.titleEs} | Curso Ejecutivo de Inglés`}
+  description={unit.descriptionEs}
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={2}
+    basePath="/es/curso/ejecutivo"
+    lang="es"
+    courseId="executive"
+  />
+
+  <!-- Unit hero -->
+  <section class="bg-gradient-to-b from-slate-950 to-slate-900 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Zap class="w-4 h-4" />
+          Unidad 2
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          {unit.titleEs}
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          {unit.descriptionEs}
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 1: Filler Elimination -->
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit2Sections[0].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit2Sections[0].whyEs}</p>
+        <div class="ml-11">
+          <WeakStrongElite client:visible items={unit2Section1Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit2Sections[0].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit2Sections[0].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2: Controlled Assertion -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit2Sections[1].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit2Sections[1].whyEs}</p>
+        <div class="ml-11">
+          <WeakStrongElite client:visible items={unit2Section2Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit2Sections[1].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit2Sections[1].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3: Calibrated Certainty -->
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit2Sections[2].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit2Sections[2].whyEs}</p>
+        <div class="ml-11">
+          <WeakStrongElite client:visible items={unit2Section3Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit2Sections[2].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit2Sections[2].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Final Shift -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <FinalShiftCard client:visible shift={unit2FinalShift} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/es/curso/ejecutivo/unidad-1/"
+          class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          <ArrowLeft class="w-4 h-4" />
+          Unidad 1: Elección Ejecutiva de Palabras
+        </a>
+        <Button href="/es/curso/ejecutivo/unidad-3/" variant="primary" size="md">
+          Unidad 3: Respuestas Estructuradas y Conectores
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/ejecutivo/unidad-3.astro
+++ b/src/pages/es/curso/ejecutivo/unidad-3.astro
@@ -1,0 +1,153 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import StructuredResponseBuilder from "@components/course/StructuredResponseBuilder";
+import ConnectorDrill from "@components/course/ConnectorDrill";
+import RapidRepeat from "@components/course/RapidRepeat";
+import FinalShiftCard from "@components/course/FinalShiftCard";
+import { executiveUnits } from "@data/executive/units";
+import {
+  unit3Sections,
+  unit3Section1Drills,
+  unit3Section2Drills,
+  unit3Section3Drills,
+  unit3FinalShift,
+} from "@data/executive/unit-3";
+import { ArrowRight, ArrowLeft, Layers } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/executive/unit-3" as const;
+const unit = executiveUnits[2];
+
+const progressUnits = executiveUnits
+  .filter((u) => u.published)
+  .map((u) => ({ id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title={`Unidad 3: ${unit.titleEs} | Curso Ejecutivo de Inglés`}
+  description={unit.descriptionEs}
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={3}
+    basePath="/es/curso/ejecutivo"
+    lang="es"
+    courseId="executive"
+  />
+
+  <!-- Unit hero -->
+  <section class="bg-gradient-to-b from-slate-950 to-slate-900 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Layers class="w-4 h-4" />
+          Unidad 3
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          {unit.titleEs}
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          {unit.descriptionEs}
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 1: Cause → Action → Outcome -->
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit3Sections[0].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit3Sections[0].whyEs}</p>
+        <div class="ml-11">
+          <StructuredResponseBuilder client:visible items={unit3Section1Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit3Sections[0].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit3Sections[0].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2: Problem → Impact → Solution → Recommendation -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit3Sections[1].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit3Sections[1].whyEs}</p>
+        <div class="ml-11">
+          <StructuredResponseBuilder client:visible items={unit3Section2Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit3Sections[1].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit3Sections[1].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3: Executive Connectors -->
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit3Sections[2].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit3Sections[2].whyEs}</p>
+        <div class="ml-11">
+          <ConnectorDrill client:visible items={unit3Section3Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit3Sections[2].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit3Sections[2].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Final Shift -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <FinalShiftCard client:visible shift={unit3FinalShift} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/es/curso/ejecutivo/unidad-2/"
+          class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          <ArrowLeft class="w-4 h-4" />
+          Unidad 2: Eliminando el Lenguaje Débil
+        </a>
+        <Button href="/es/curso/ejecutivo/" variant="primary" size="md">
+          Resumen del Curso
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary
Second of five PRs for the Executive Communication course. Ships the first 3 live units plus 3 new drill components.

**New components (3):**
- `WeakStrongElite` — 3-tier ladder drill for filler elimination and defensive reframing
- `StructuredResponseBuilder` — prompt → model reply in labeled framework parts → "why it works" reveal
- `ConnectorDrill` — weak sentence pair → connected version with labeled executive connector

**Component fix:**
- All drill components (VerbUpgradeLab, WeakStrongElite, StructuredResponseBuilder, ConnectorDrill, RapidRepeat) now always show English content as primary with Spanish as translation caption — matches the advanced course pattern (WordPairLab)

**Unit 1 — Executive Word Choice** (6 + 5 + 5 drills):
Verb precision, progressive discovery, integrated executive phrasing. Sourced from Robert's real C1/C2 lessons.

**Unit 2 — Eliminating Weak Language** (8 + 7 + 6 drills):
Filler elimination, controlled assertion, calibrated certainty. The Weak→Strong→Elite progression.

**Unit 3 — Structured Responses & Connectors** (4 + 3 + 6 drills):
Cause→Action→Outcome, Problem→Impact→Solution→Recommendation, executive connectors.

All bilingual (EN + ES). Each unit has Rapid Repeat blocks, technique focus callouts, and Final Shift cards. Build: 401 pages, 0 warnings.

## Test plan
- [ ] Walk through Unit 1 at `/en/course/executive/unit-1/` — reveal drills, play audio, check C2 Elite tiers
- [ ] Walk through Unit 2 — verify filler elimination drills, check Elite upgrade on items that have one
- [ ] Walk through Unit 3 — verify StructuredResponseBuilder shows framework labels, ConnectorDrill shows connector badges
- [ ] Check ES mirrors at `/es/curso/ejecutivo/unidad-{1,2,3}/` — Spanish UI labels, English content with Spanish captions
- [ ] Verify landing page unit grid now shows Units 1-3 as clickable (amber, not grayed)
- [ ] CourseProgress bar renders correctly with 3 published units
- [ ] No regressions on advanced/intermediate/beginner course pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)