### PR TITLE
feat: executive course units 4-6 + StoryBuilder + ImpromptuScenario (PR 3/5)

### DIFF
--- a/src/components/course/ImpromptuScenario.tsx
+++ b/src/components/course/ImpromptuScenario.tsx
@@ -1,0 +1,210 @@
+// ImpromptuScenario — the 60-second impromptu reply drill.
+//
+// Shows an executive scenario (e.g., "Give us a quick update on
+// operations"), the named framework to use, a weak attempt, and a
+// model 60-second reply with audio. Used in Unit 6 (The Impromptu
+// Toolkit) and Unit 9 (Negotiation / Decision-Driving).
+
+import { useState } from "react";
+import { ArrowDown, Clock, RotateCcw, Sparkles, Zap } from "lucide-react";
+import AudioButton from "./AudioButton";
+import type { ImpromptuScenarioItem } from "@data/executive/types";
+
+interface Props {
+  items: ImpromptuScenarioItem[];
+  lang: "en" | "es";
+}
+
+export default function ImpromptuScenario({ items, lang }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [revealed, setRevealed] = useState(false);
+  const [whyShown, setWhyShown] = useState(false);
+
+  const current = items[currentIndex];
+  const isLast = currentIndex === items.length - 1;
+
+  const framework = lang === "es" ? current.frameworkEs : current.framework;
+  const frameworkSteps =
+    lang === "es" ? current.frameworkStepsEs : current.frameworkSteps;
+  const why = lang === "es" ? current.whyItWorksEs : current.whyItWorks;
+
+  const handleReveal = () => setRevealed(true);
+  const handleShowWhy = () => setWhyShown(true);
+
+  const handleNext = () => {
+    if (isLast) return;
+    setCurrentIndex(currentIndex + 1);
+    setRevealed(false);
+    setWhyShown(false);
+  };
+
+  const handleRestart = () => {
+    setCurrentIndex(0);
+    setRevealed(false);
+    setWhyShown(false);
+  };
+
+  return (
+    <section className="space-y-6">
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-slate-500">
+          {lang === "es" ? "Escenario" : "Scenario"} {currentIndex + 1} /{" "}
+          {items.length}
+        </span>
+        <button
+          onClick={handleRestart}
+          className="text-xs text-slate-400 hover:text-amber-600 inline-flex items-center gap-1 transition-colors"
+        >
+          <RotateCcw size={12} />
+          {lang === "es" ? "Reiniciar" : "Restart"}
+        </button>
+      </div>
+
+      <div className="w-full h-1.5 bg-slate-100 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-amber-500 rounded-full transition-all duration-300"
+          style={{ width: `${((currentIndex + 1) / items.length) * 100}%` }}
+        />
+      </div>
+
+      <div className="bg-white rounded-2xl border-2 border-slate-200 overflow-hidden">
+        {/* Scenario prompt */}
+        <div className="px-6 pt-6">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-2">
+            {lang === "es" ? "Te preguntan:" : "You are asked:"}
+          </p>
+          <div className="bg-slate-900 text-white rounded-xl p-4">
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-base font-medium leading-relaxed flex-1">
+                "{current.prompt}"
+              </p>
+              <div className="shrink-0 mt-1">
+                <AudioButton text={current.prompt} size="sm" />
+              </div>
+            </div>
+            <p className="text-sm text-slate-400 mt-1">{current.promptEs}</p>
+          </div>
+        </div>
+
+        {/* Framework */}
+        <div className="px-6 pt-4">
+          <div className="bg-amber-50 border border-amber-200 rounded-xl p-4">
+            <div className="flex items-center gap-2 mb-2">
+              <Clock size={14} className="text-amber-600" />
+              <span className="text-xs font-semibold uppercase tracking-wider text-amber-700">
+                {lang === "es" ? "Tu marco (60 segundos):" : "Your framework (60 seconds):"}
+              </span>
+            </div>
+            <p className="text-sm font-bold text-slate-900 mb-2">{framework}</p>
+            <ol className="space-y-1">
+              {frameworkSteps.map((step, idx) => (
+                <li
+                  key={idx}
+                  className="flex items-center gap-2 text-sm text-slate-700"
+                >
+                  <span className="shrink-0 w-5 h-5 rounded-full bg-amber-500 text-white text-[10px] font-bold flex items-center justify-center">
+                    {idx + 1}
+                  </span>
+                  {step}
+                </li>
+              ))}
+            </ol>
+          </div>
+        </div>
+
+        {/* Weak attempt */}
+        <div className="px-6 pt-4">
+          <p className="text-xs font-semibold uppercase tracking-wider text-red-500 mb-2">
+            {lang === "es" ? "Respuesta débil:" : "Weak attempt:"}
+          </p>
+          <div className="bg-red-50 border border-red-200 rounded-xl p-3">
+            <p className="text-sm text-red-900 italic leading-relaxed">
+              "{current.weak}"
+            </p>
+            <p className="text-xs text-red-700/70 mt-1">{current.weakEs}</p>
+          </div>
+        </div>
+
+        <div className="flex justify-center py-4">
+          <ArrowDown className="w-5 h-5 text-slate-300" />
+        </div>
+
+        {/* Model reply */}
+        <div className="px-6 pb-6">
+          <p className="text-xs font-semibold uppercase tracking-wider text-amber-600 mb-2 flex items-center gap-1">
+            <Zap size={12} />
+            {lang === "es" ? "Respuesta modelo (60 seg):" : "Model reply (60 sec):"}
+          </p>
+
+          {!revealed ? (
+            <button
+              onClick={handleReveal}
+              className="w-full py-4 rounded-xl border-2 border-dashed border-amber-300 text-amber-600 font-medium hover:bg-amber-50 transition-colors"
+            >
+              {lang === "es"
+                ? "Toca para revelar la respuesta modelo"
+                : "Tap to reveal the model reply"}
+            </button>
+          ) : (
+            <div className="space-y-3">
+              <div className="bg-gradient-to-br from-amber-50 to-amber-100 border-2 border-amber-300 rounded-xl p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <p className="text-base text-slate-900 font-medium leading-relaxed flex-1">
+                    "{current.modelReply}"
+                  </p>
+                  <div className="shrink-0 mt-1">
+                    <AudioButton text={current.modelReply} size="sm" />
+                  </div>
+                </div>
+                <p className="text-sm text-slate-500 mt-2">
+                  {current.modelReplyEs}
+                </p>
+              </div>
+
+              {!whyShown ? (
+                <button
+                  onClick={handleShowWhy}
+                  className="w-full py-3 rounded-xl border border-dashed border-slate-300 text-slate-500 text-sm hover:bg-slate-50 transition-colors inline-flex items-center justify-center gap-2"
+                >
+                  <Sparkles size={12} />
+                  {lang === "es" ? "¿Por qué funciona?" : "Why it works"}
+                </button>
+              ) : (
+                <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
+                  <p className="text-sm text-slate-700 leading-relaxed flex items-start gap-2">
+                    <Sparkles
+                      size={12}
+                      className="text-amber-500 shrink-0 mt-0.5"
+                    />
+                    <span>{why}</span>
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {revealed && !isLast && (
+        <div className="flex justify-end">
+          <button
+            onClick={handleNext}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-500 text-white font-medium hover:bg-amber-400 transition-colors shadow-sm"
+          >
+            {lang === "es" ? "Siguiente escenario" : "Next scenario"}
+          </button>
+        </div>
+      )}
+
+      {revealed && isLast && (
+        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 text-center">
+          <p className="text-emerald-800 font-medium text-sm">
+            {lang === "es"
+              ? "Has practicado los marcos de respuesta impromptu. La próxima vez que te pregunten, tienes la estructura."
+              : "You've drilled the impromptu frameworks. Next time you're put on the spot, you have the structure."}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/course/StoryBuilder.tsx
+++ b/src/components/course/StoryBuilder.tsx
@@ -1,0 +1,214 @@
+// StoryBuilder — the 5-step executive narrative drill.
+//
+// Shows a prompt, a flat/fact-only attempt, then reveals the strategic
+// narrative step by step: Context → Tension → Insight → Action → Outcome.
+// The learner sees each step labeled and can play the full integrated
+// story as one audio clip.
+//
+// Used in Unit 5 (Strategic Storytelling).
+
+import { useState } from "react";
+import { ArrowDown, BookOpen, RotateCcw, Sparkles } from "lucide-react";
+import AudioButton from "./AudioButton";
+import type { StoryBuilderItem } from "@data/executive/types";
+
+interface Props {
+  items: StoryBuilderItem[];
+  lang: "en" | "es";
+}
+
+const stepColors: Record<string, string> = {
+  Context: "bg-slate-600",
+  Tension: "bg-red-600",
+  Insight: "bg-violet-600",
+  Action: "bg-amber-600",
+  Outcome: "bg-emerald-600",
+};
+
+export default function StoryBuilder({ items, lang }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [revealed, setRevealed] = useState(false);
+  const [whyShown, setWhyShown] = useState(false);
+
+  const current = items[currentIndex];
+  const isLast = currentIndex === items.length - 1;
+
+  const why = lang === "es" ? current.whyItWorksEs : current.whyItWorks;
+  const fullStory = current.steps.map((s) => s.sentence).join(" ");
+
+  const handleReveal = () => setRevealed(true);
+  const handleShowWhy = () => setWhyShown(true);
+
+  const handleNext = () => {
+    if (isLast) return;
+    setCurrentIndex(currentIndex + 1);
+    setRevealed(false);
+    setWhyShown(false);
+  };
+
+  const handleRestart = () => {
+    setCurrentIndex(0);
+    setRevealed(false);
+    setWhyShown(false);
+  };
+
+  return (
+    <section className="space-y-6">
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-slate-500">
+          {lang === "es" ? "Narrativa" : "Narrative"} {currentIndex + 1} /{" "}
+          {items.length}
+        </span>
+        <button
+          onClick={handleRestart}
+          className="text-xs text-slate-400 hover:text-amber-600 inline-flex items-center gap-1 transition-colors"
+        >
+          <RotateCcw size={12} />
+          {lang === "es" ? "Reiniciar" : "Restart"}
+        </button>
+      </div>
+
+      <div className="w-full h-1.5 bg-slate-100 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-amber-500 rounded-full transition-all duration-300"
+          style={{ width: `${((currentIndex + 1) / items.length) * 100}%` }}
+        />
+      </div>
+
+      <div className="bg-white rounded-2xl border-2 border-slate-200 overflow-hidden">
+        {/* Prompt */}
+        <div className="px-6 pt-6">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-2">
+            {lang === "es" ? "La situación:" : "The situation:"}
+          </p>
+          <div className="bg-slate-900 text-white rounded-xl p-4">
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-base font-medium leading-relaxed flex-1">
+                "{current.prompt}"
+              </p>
+              <div className="shrink-0 mt-1">
+                <AudioButton text={current.prompt} size="sm" />
+              </div>
+            </div>
+            <p className="text-sm text-slate-400 mt-1">{current.promptEs}</p>
+          </div>
+        </div>
+
+        {/* Flat attempt */}
+        <div className="px-6 pt-4">
+          <p className="text-xs font-semibold uppercase tracking-wider text-red-500 mb-2">
+            {lang === "es" ? "La versión plana:" : "The flat version:"}
+          </p>
+          <div className="bg-red-50 border border-red-200 rounded-xl p-3">
+            <p className="text-sm text-red-900 italic leading-relaxed">
+              "{current.flat}"
+            </p>
+            <p className="text-xs text-red-700/70 mt-1">{current.flatEs}</p>
+          </div>
+        </div>
+
+        <div className="flex justify-center py-4">
+          <ArrowDown className="w-5 h-5 text-slate-300" />
+        </div>
+
+        {/* Strategic narrative */}
+        <div className="px-6 pb-6">
+          <div className="flex items-center justify-between mb-3">
+            <p className="text-xs font-semibold uppercase tracking-wider text-amber-600 flex items-center gap-1">
+              <BookOpen size={12} />
+              {lang === "es" ? "La narrativa estratégica:" : "The strategic narrative:"}
+            </p>
+            <span className="text-[10px] font-mono uppercase tracking-wider px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200">
+              5-Step Story
+            </span>
+          </div>
+
+          {!revealed ? (
+            <button
+              onClick={handleReveal}
+              className="w-full py-4 rounded-xl border-2 border-dashed border-amber-300 text-amber-600 font-medium hover:bg-amber-50 transition-colors"
+            >
+              {lang === "es"
+                ? "Toca para revelar la narrativa estratégica"
+                : "Tap to reveal the strategic narrative"}
+            </button>
+          ) : (
+            <div className="space-y-3">
+              <div className="bg-gradient-to-br from-amber-50 to-amber-100 border-2 border-amber-300 rounded-xl overflow-hidden">
+                <ul className="divide-y divide-amber-200">
+                  {current.steps.map((step, idx) => (
+                    <li key={idx} className="p-4">
+                      <div className="flex items-center gap-2 mb-1.5">
+                        <span
+                          className={`text-[10px] font-mono uppercase tracking-wider px-2 py-0.5 rounded text-white ${stepColors[step.label] || "bg-slate-500"}`}
+                        >
+                          {step.label}
+                        </span>
+                      </div>
+                      <p className="text-sm text-slate-900 leading-relaxed">
+                        {step.sentence}
+                      </p>
+                      <p className="text-xs text-slate-500 mt-1 leading-relaxed">
+                        {step.sentenceEs}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+                <div className="px-4 py-3 bg-amber-100 border-t-2 border-amber-300 flex items-center justify-between gap-3">
+                  <p className="text-xs font-medium text-amber-800">
+                    {lang === "es"
+                      ? "Escucha toda la narrativa integrada:"
+                      : "Listen to the full integrated narrative:"}
+                  </p>
+                  <AudioButton text={fullStory} size="sm" />
+                </div>
+              </div>
+
+              {/* Why it works */}
+              {!whyShown ? (
+                <button
+                  onClick={handleShowWhy}
+                  className="w-full py-3 rounded-xl border border-dashed border-slate-300 text-slate-500 text-sm hover:bg-slate-50 transition-colors inline-flex items-center justify-center gap-2"
+                >
+                  <Sparkles size={12} />
+                  {lang === "es" ? "¿Por qué funciona?" : "Why it works"}
+                </button>
+              ) : (
+                <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
+                  <p className="text-sm text-slate-700 leading-relaxed flex items-start gap-2">
+                    <Sparkles
+                      size={12}
+                      className="text-amber-500 shrink-0 mt-0.5"
+                    />
+                    <span>{why}</span>
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {revealed && !isLast && (
+        <div className="flex justify-end">
+          <button
+            onClick={handleNext}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-500 text-white font-medium hover:bg-amber-400 transition-colors shadow-sm"
+          >
+            {lang === "es" ? "Siguiente narrativa" : "Next narrative"}
+          </button>
+        </div>
+      )}
+
+      {revealed && isLast && (
+        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 text-center">
+          <p className="text-emerald-800 font-medium text-sm">
+            {lang === "es"
+              ? "Has trabajado las narrativas. Ya no solo reportas — moldeas decisiones."
+              : "You've worked the narratives. You no longer just report — you shape decisions."}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/data/executive/unit-4.ts
+++ b/src/data/executive/unit-4.ts
@@ -1,0 +1,246 @@
+// Unit 4 — Controlled Tone Under Pressure
+// "Defensive → Executive → Strategic. Never defend. Always reframe."
+//
+// Three sections:
+// 4.1 Defensive → Executive Reframing (WeakStrongElite)
+// 4.2 Downgrade Emotion, Upgrade Control (WeakStrongElite)
+// 4.3 Reframe Language Under Challenge (WeakStrongElite)
+//
+// Content sourced from Robert's real C1 and C2 executive lessons.
+
+import type {
+  WeakStrongEliteItem,
+  UnitSection,
+  FinalShift,
+} from "./types";
+
+// ─── Section metadata ──────────────────────────────────────────────────────
+
+export const unit4Sections: UnitSection[] = [
+  {
+    number: 1,
+    title: "Defensive → Executive Reframing",
+    titleEs: "De Defensivo → Reformulación Ejecutiva",
+    why: "When challenged, the instinct is to defend. But defense signals weakness — it tells the room you feel attacked. Executives never defend. They acknowledge, redirect, and reassert direction. The shift from 'That's not our fault' to 'We are addressing the impact' changes your entire positioning.",
+    whyEs: "Cuando te desafían, el instinto es defenderse. Pero la defensa señala debilidad — le dice a la sala que te sientes atacado. Los ejecutivos nunca se defienden. Reconocen, redirigen y reafirman la dirección. El cambio de 'That's not our fault' a 'We are addressing the impact' cambia todo tu posicionamiento.",
+    mechanic: "weak-strong-elite",
+    techniqueFocus: "Never deny. Never deflect. Acknowledge the situation, then pivot immediately to what you are doing about it.",
+    techniqueFocusEs: "Nunca niegues. Nunca desvíes. Reconoce la situación, luego pivotea inmediatamente a lo que estás haciendo al respecto.",
+    rapidRepeat: [
+      { text: "The focus now is…", textEs: "El enfoque ahora es…" },
+      { text: "What matters is…", textEs: "Lo que importa es…" },
+      { text: "The priority is…", textEs: "La prioridad es…" },
+      { text: "We are addressing this by…", textEs: "Estamos abordando esto mediante…" },
+    ],
+  },
+  {
+    number: 2,
+    title: "Downgrade Emotion, Upgrade Control",
+    titleEs: "Reduce la Emoción, Aumenta el Control",
+    why: "Emotional language in executive settings signals that you have lost control. 'This is a big problem' tells people you are overwhelmed. 'This is a significant issue' tells people you have assessed the situation. Replace every emotion with its business consequence and you immediately sound like the person who should be managing the situation.",
+    whyEs: "El lenguaje emocional en entornos ejecutivos señala que has perdido el control. 'This is a big problem' le dice a la gente que estás abrumado. 'This is a significant issue' les dice que has evaluado la situación. Reemplaza cada emoción con su consecuencia de negocio e inmediatamente suenas como la persona que debería estar gestionando la situación.",
+    mechanic: "weak-strong-elite",
+    techniqueFocus: "Replace emotion with business consequence. Executives describe impact, not feelings.",
+    techniqueFocusEs: "Reemplaza la emoción con la consecuencia de negocio. Los ejecutivos describen impacto, no sentimientos.",
+    rapidRepeat: [
+      { text: "This creates risk.", textEs: "Esto crea riesgo." },
+      { text: "This is not acceptable.", textEs: "Esto no es aceptable." },
+      { text: "This requires immediate attention.", textEs: "Esto requiere atención inmediata." },
+      { text: "This is impacting performance.", textEs: "Esto está impactando el rendimiento." },
+    ],
+  },
+  {
+    number: 3,
+    title: "Reframe Language Under Challenge",
+    titleEs: "Reformular Bajo Desafío",
+    why: "When leadership pushes back with pointed questions — 'Why wasn't this identified earlier?', 'Who is responsible?' — the stakes are highest. These are the moments where executives are tested. Your response must be calm, structured, and forward-looking. Never match the energy of the challenge. Redirect it.",
+    whyEs: "Cuando el liderazgo responde con preguntas incisivas — '¿Por qué no se identificó antes?', '¿Quién es responsable?' — las apuestas son las más altas. Estos son los momentos donde los ejecutivos son evaluados. Tu respuesta debe ser calmada, estructurada y orientada al futuro. Nunca iguales la energía del desafío. Redirigela.",
+    mechanic: "weak-strong-elite",
+    techniqueFocus: "The 'weak' here is the challenge itself — the pressure prompt from leadership. Your job is to respond with the executive reframe, not to match the intensity.",
+    techniqueFocusEs: "El 'débil' aquí es el desafío en sí — la pregunta de presión del liderazgo. Tu trabajo es responder con la reformulación ejecutiva, no igualar la intensidad.",
+    rapidRepeat: [
+      { text: "We have identified the root cause.", textEs: "Hemos identificado la causa raíz." },
+      { text: "We are implementing controls.", textEs: "Estamos implementando controles." },
+      { text: "This will allow us to detect issues earlier.", textEs: "Esto nos permitirá detectar problemas más temprano." },
+      { text: "We have a targeted action plan.", textEs: "Tenemos un plan de acción específico." },
+    ],
+  },
+];
+
+// ─── Section 4.1 — Defensive → Executive Reframing (WeakStrongElite) ──────
+
+export const unit4Section1Drills: WeakStrongEliteItem[] = [
+  {
+    weak: "That's not our fault.",
+    weakEs: "Eso no es culpa nuestra.",
+    strong: "The issue originated outside our control, but we are addressing the impact.",
+    strongEs: "El problema se originó fuera de nuestro control, pero estamos abordando el impacto.",
+    elite: "The issue originated externally, and we are managing the impact proactively.",
+    eliteEs: "El problema se originó externamente y estamos gestionando el impacto de manera proactiva.",
+  },
+  {
+    weak: "We did everything we could.",
+    weakEs: "Hicimos todo lo que pudimos.",
+    strong: "We executed according to plan, and we are now strengthening the approach.",
+    strongEs: "Ejecutamos según el plan y ahora estamos fortaleciendo el enfoque.",
+    elite: "We executed according to plan and are refining our approach based on new information.",
+    eliteEs: "Ejecutamos según el plan y estamos refinando nuestro enfoque basándonos en nueva información.",
+  },
+  {
+    weak: "The team tried their best.",
+    weakEs: "El equipo hizo su mejor esfuerzo.",
+    strong: "The team executed under constraints, and we are improving conditions to support better performance.",
+    strongEs: "El equipo ejecutó bajo restricciones y estamos mejorando las condiciones para apoyar un mejor rendimiento.",
+  },
+  {
+    weak: "We didn't expect this.",
+    weakEs: "No esperábamos esto.",
+    strong: "This was not anticipated, and we are adjusting accordingly.",
+    strongEs: "Esto no fue anticipado y estamos ajustándonos en consecuencia.",
+    elite: "This was not anticipated. We are adapting our approach to address the new conditions.",
+    eliteEs: "Esto no fue anticipado. Estamos adaptando nuestro enfoque para abordar las nuevas condiciones.",
+  },
+  {
+    weak: "This is a difficult situation.",
+    weakEs: "Esta es una situación difícil.",
+    strong: "This is a complex situation, and we are managing it with a structured approach.",
+    strongEs: "Esta es una situación compleja y la estamos gestionando con un enfoque estructurado.",
+  },
+  {
+    weak: "It wasn't our decision.",
+    weakEs: "No fue nuestra decisión.",
+    strong: "The decision was made at a different level, and we are executing within those parameters.",
+    strongEs: "La decisión se tomó a un nivel diferente y estamos ejecutando dentro de esos parámetros.",
+    elite: "The decision was made upstream. We are executing within those parameters and have flagged our recommendations.",
+    eliteEs: "La decisión se tomó a un nivel superior. Estamos ejecutando dentro de esos parámetros y hemos señalado nuestras recomendaciones.",
+  },
+];
+
+// ─── Section 4.2 — Downgrade Emotion, Upgrade Control (WeakStrongElite) ───
+
+export const unit4Section2Drills: WeakStrongEliteItem[] = [
+  {
+    weak: "This is a big problem.",
+    weakEs: "Este es un gran problema.",
+    strong: "This is a significant issue.",
+    strongEs: "Este es un problema significativo.",
+    elite: "This is a significant issue that requires a structured response.",
+    eliteEs: "Este es un problema significativo que requiere una respuesta estructurada.",
+    note: "Replace emotional scale words ('big', 'huge') with measured executive language.",
+    noteEs: "Reemplaza palabras emocionales de escala ('big', 'huge') con lenguaje ejecutivo medido.",
+  },
+  {
+    weak: "This is bad.",
+    weakEs: "Esto está mal.",
+    strong: "This is not acceptable.",
+    strongEs: "Esto no es aceptable.",
+    elite: "This is not acceptable and requires immediate correction.",
+    eliteEs: "Esto no es aceptable y requiere corrección inmediata.",
+    note: "Replace the judgment with a standard and an action requirement.",
+    noteEs: "Reemplaza el juicio con un estándar y un requerimiento de acción.",
+  },
+  {
+    weak: "This is frustrating.",
+    weakEs: "Esto es frustrante.",
+    strong: "This is impacting performance.",
+    strongEs: "Esto está impactando el rendimiento.",
+    elite: "This is creating measurable impact on performance and needs to be addressed.",
+    eliteEs: "Esto está creando un impacto medible en el rendimiento y necesita ser abordado.",
+    note: "Replace the emotion with the business consequence. Executives describe impact, not feelings.",
+    noteEs: "Reemplaza la emoción con la consecuencia de negocio. Los ejecutivos describen impacto, no sentimientos.",
+  },
+  {
+    weak: "We're in trouble.",
+    weakEs: "Estamos en problemas.",
+    strong: "We are facing operational risk.",
+    strongEs: "Enfrentamos riesgo operacional.",
+    elite: "We are facing operational risk that requires immediate attention.",
+    eliteEs: "Enfrentamos riesgo operacional que requiere atención inmediata.",
+    note: "Replace the panic with a risk category. 'Trouble' is vague; 'operational risk' is actionable.",
+    noteEs: "Reemplaza el pánico con una categoría de riesgo. 'Trouble' es vago; 'operational risk' es accionable.",
+  },
+  {
+    weak: "This is urgent.",
+    weakEs: "Esto es urgente.",
+    strong: "This requires immediate attention.",
+    strongEs: "Esto requiere atención inmediata.",
+    elite: "This requires immediate attention and a clear action plan.",
+    eliteEs: "Esto requiere atención inmediata y un plan de acción claro.",
+    note: "Replace the alarm with a directive. 'Urgent' creates anxiety; 'requires immediate attention' creates action.",
+    noteEs: "Reemplaza la alarma con una directiva. 'Urgent' crea ansiedad; 'requires immediate attention' crea acción.",
+  },
+  {
+    weak: "I'm worried about this.",
+    weakEs: "Me preocupa esto.",
+    strong: "This creates concern.",
+    strongEs: "Esto genera preocupación.",
+    elite: "This creates risk exposure that we need to quantify and address.",
+    eliteEs: "Esto crea exposición al riesgo que necesitamos cuantificar y abordar.",
+    note: "Replace personal worry with organizational risk language. 'I'm worried' is personal; 'risk exposure' is strategic.",
+    noteEs: "Reemplaza la preocupación personal con lenguaje de riesgo organizacional. 'I'm worried' es personal; 'risk exposure' es estratégico.",
+  },
+];
+
+// ─── Section 4.3 — Reframe Language Under Challenge (WeakStrongElite) ──────
+
+export const unit4Section3Drills: WeakStrongEliteItem[] = [
+  {
+    weak: "Why wasn't this identified earlier?",
+    weakEs: "¿Por qué no se identificó esto antes?",
+    strong: "The issue was not fully visible earlier due to gaps in reporting. We have now identified the root cause and are implementing stronger monitoring controls.",
+    strongEs: "El problema no fue completamente visible antes debido a brechas en los reportes. Ahora hemos identificado la causa raíz y estamos implementando controles de monitoreo más fuertes.",
+    elite: "The issue was not fully visible earlier due to gaps in reporting. We have now identified the root cause and are implementing stronger monitoring controls. This will allow us to detect and address similar issues earlier going forward.",
+    eliteEs: "El problema no fue completamente visible antes debido a brechas en los reportes. Ahora hemos identificado la causa raíz y estamos implementando controles de monitoreo más fuertes. Esto nos permitirá detectar y abordar problemas similares más temprano en el futuro.",
+    note: "The 'weak' here is the challenging question from leadership — not a weak phrase. Your job is to respond without defensiveness.",
+    noteEs: "El 'débil' aquí es la pregunta desafiante del liderazgo — no una frase débil. Tu trabajo es responder sin ponerte a la defensiva.",
+  },
+  {
+    weak: "Who is responsible for this?",
+    weakEs: "¿Quién es responsable de esto?",
+    strong: "Responsibility sits with the execution team. We are strengthening oversight to prevent recurrence.",
+    strongEs: "La responsabilidad recae en el equipo de ejecución. Estamos fortaleciendo la supervisión para prevenir recurrencia.",
+    elite: "We have clarified ownership and are implementing controls to prevent recurrence.",
+    eliteEs: "Hemos clarificado la responsabilidad y estamos implementando controles para prevenir recurrencia.",
+    note: "The 'weak' here is the challenging question from leadership — not a weak phrase. Accept accountability, then pivot to prevention.",
+    noteEs: "El 'débil' aquí es la pregunta desafiante del liderazgo — no una frase débil. Acepta la responsabilidad, luego pivotea a la prevención.",
+  },
+  {
+    weak: "This should have been handled differently.",
+    weakEs: "Esto debería haberse manejado de otra manera.",
+    strong: "We acknowledge the outcome was not ideal. We are applying the lessons learned to strengthen our approach.",
+    strongEs: "Reconocemos que el resultado no fue ideal. Estamos aplicando las lecciones aprendidas para fortalecer nuestro enfoque.",
+    elite: "The outcome was not ideal. We have documented the learnings and integrated them into our revised process.",
+    eliteEs: "El resultado no fue ideal. Hemos documentado las lecciones y las hemos integrado en nuestro proceso revisado.",
+    note: "The 'weak' here is the challenging statement from leadership — not a weak phrase. Acknowledge without excusing, then show the corrective action.",
+    noteEs: "El 'débil' aquí es la declaración desafiante del liderazgo — no una frase débil. Reconoce sin excusar, luego muestra la acción correctiva.",
+  },
+  {
+    weak: "Are you sure about these numbers?",
+    weakEs: "¿Estás seguro de estos números?",
+    strong: "We have verified the data through multiple sources. I'm confident in the accuracy of the figures presented.",
+    strongEs: "Hemos verificado los datos a través de múltiples fuentes. Confío en la precisión de las cifras presentadas.",
+    elite: "The data has been verified, validated, and reconciled across multiple sources.",
+    eliteEs: "Los datos han sido verificados, validados y reconciliados a través de múltiples fuentes.",
+    note: "The 'weak' here is the challenging question from leadership — not a weak phrase. Respond with methodology, not emotion.",
+    noteEs: "El 'débil' aquí es la pregunta desafiante del liderazgo — no una frase débil. Responde con metodología, no con emoción.",
+  },
+  {
+    weak: "This isn't good enough.",
+    weakEs: "Esto no es suficiente.",
+    strong: "We understand the expectation is higher. We are taking specific steps to close the gap.",
+    strongEs: "Entendemos que la expectativa es más alta. Estamos tomando pasos específicos para cerrar la brecha.",
+    elite: "We recognize the gap. We have a targeted action plan to reach the expected standard by the agreed timeline.",
+    eliteEs: "Reconocemos la brecha. Tenemos un plan de acción específico para alcanzar el estándar esperado dentro del plazo acordado.",
+    note: "The 'weak' here is the challenging statement from leadership — not a weak phrase. Accept the standard, then show the path to meeting it.",
+    noteEs: "El 'débil' aquí es la declaración desafiante del liderazgo — no una frase débil. Acepta el estándar, luego muestra el camino para cumplirlo.",
+  },
+];
+
+// ─── Final Shift ────────────────────────────────────────────────────────────
+
+export const unit4FinalShift: FinalShift = {
+  before: "You responded to pressure with defensiveness — 'That's not our fault', 'We tried our best' — losing credibility with every word.",
+  beforeEs: "Respondías a la presión con defensividad — 'That's not our fault', 'We tried our best' — perdiendo credibilidad con cada palabra.",
+  after: "You reframe under pressure with calm authority. You never defend. You acknowledge, redirect, and reassert direction.",
+  afterEs: "Reformulas bajo presión con autoridad calmada. Nunca te defiendes. Reconoces, rediriges y reafirmas la dirección.",
+};

--- a/src/data/executive/unit-5.ts
+++ b/src/data/executive/unit-5.ts
@@ -1,0 +1,373 @@
+// Unit 5 — Strategic Storytelling
+// "Context → Tension → Insight → Action → Outcome. Facts inform. Stories influence."
+//
+// Three sections:
+// 5.1 Build the Story (Guided) — full 5-step narrative construction (StoryBuilder)
+// 5.2 Story Upgrade (Flat → Strategic) — transform flat reports into narratives (StoryBuilder)
+// 5.3 Reusable Executive Story Patterns — complex board-level scenarios (StoryBuilder)
+//
+// Content sourced from Robert's real C1 and C2 executive lessons.
+
+import type {
+  StoryBuilderItem,
+  UnitSection,
+  FinalShift,
+} from "./types";
+
+// ─── Section metadata ──────────────────────────────────────────────────────
+
+export const unit5Sections: UnitSection[] = [
+  {
+    number: 1,
+    title: "Build the Story (Guided)",
+    titleEs: "Construye la Historia (Guiado)",
+    why: "Most professionals report facts — what happened, then what they did. But executives who influence decisions tell stories with structure. In this section, you learn the five-step narrative arc that transforms flat updates into strategic communication.",
+    whyEs: "La mayoría de los profesionales reportan hechos — qué pasó, luego qué hicieron. Pero los ejecutivos que influyen en decisiones cuentan historias con estructura. En esta sección, aprendes el arco narrativo de cinco pasos que transforma actualizaciones planas en comunicación estratégica.",
+    mechanic: "story",
+    techniqueFocus: "Each step builds on the previous one. Context sets the stage, Tension creates urgency, Insight shows understanding, Action demonstrates control, Outcome projects confidence.",
+    techniqueFocusEs: "Cada paso se construye sobre el anterior. Contexto establece el escenario, Tensión crea urgencia, Insight muestra comprensión, Acción demuestra control, Resultado proyecta confianza.",
+    rapidRepeat: [
+      { text: "We are currently seeing…", textEs: "Actualmente estamos viendo…" },
+      { text: "This is driven by…", textEs: "Esto es impulsado por…" },
+      { text: "What this indicates is…", textEs: "Lo que esto indica es…" },
+      { text: "In response, we are…", textEs: "En respuesta, estamos…" },
+      { text: "As a result, we expect…", textEs: "Como resultado, esperamos…" },
+    ],
+  },
+  {
+    number: 2,
+    title: "Story Upgrade (Flat → Strategic)",
+    titleEs: "Mejora de Historia (Plana → Estratégica)",
+    why: "Flat communication kills credibility. When you say 'we had delays and fixed them,' the listener fills in the gaps with their own assumptions — usually worse than reality. A structured story controls the narrative and builds trust.",
+    whyEs: "La comunicación plana mata la credibilidad. Cuando dices 'tuvimos retrasos y los arreglamos,' el oyente llena los vacíos con sus propias suposiciones — generalmente peores que la realidad. Una historia estructurada controla la narrativa y construye confianza.",
+    mechanic: "story",
+    techniqueFocus: "Compare the flat version to the structured version. Notice how the same information becomes dramatically more persuasive when organized into five steps.",
+    techniqueFocusEs: "Compara la versión plana con la versión estructurada. Observa cómo la misma información se vuelve dramáticamente más persuasiva cuando se organiza en cinco pasos.",
+    rapidRepeat: [
+      { text: "What this shows is…", textEs: "Lo que esto muestra es…" },
+      { text: "This highlights a gap in…", textEs: "Esto resalta una brecha en…" },
+      { text: "We addressed this by…", textEs: "Abordamos esto al…" },
+      { text: "As a result, performance is improving.", textEs: "Como resultado, el rendimiento está mejorando." },
+    ],
+  },
+  {
+    number: 3,
+    title: "Reusable Executive Story Patterns",
+    titleEs: "Patrones de Historia Ejecutiva Reutilizables",
+    why: "Board rooms and leadership meetings demand narratives that blend structure, diagnosis, and direction. These patterns are reusable frameworks you can adapt to any high-stakes situation — from operational issues to market shifts.",
+    whyEs: "Las salas de juntas y reuniones de liderazgo demandan narrativas que combinan estructura, diagnóstico y dirección. Estos patrones son marcos reutilizables que puedes adaptar a cualquier situación de alto riesgo — desde problemas operativos hasta cambios de mercado.",
+    mechanic: "story",
+    techniqueFocus: "These are complete executive narratives. Practice delivering them end-to-end as if you were standing in front of the board. Fluency comes from repetition.",
+    techniqueFocusEs: "Estas son narrativas ejecutivas completas. Practica entregarlas de principio a fin como si estuvieras frente a la junta directiva. La fluidez viene de la repetición.",
+    rapidRepeat: [
+      { text: "This indicates a deeper issue.", textEs: "Esto indica un problema más profundo." },
+      { text: "What this means is…", textEs: "Lo que esto significa es…" },
+      { text: "We are proposing a revised approach.", textEs: "Estamos proponiendo un enfoque revisado." },
+      { text: "As a result, we expect to maintain positioning.", textEs: "Como resultado, esperamos mantener el posicionamiento." },
+    ],
+  },
+];
+
+// ─── Section 5.1 — Build the Story (Guided) (StoryBuilder) ────────────────
+
+export const unit5Section1Drills: StoryBuilderItem[] = [
+  {
+    prompt: "Performance has declined over the last month. Explain what's happening.",
+    promptEs: "El rendimiento ha disminuido durante el último mes. Explica qué está pasando.",
+    flat: "Performance dropped because there were some issues and we're working on it.",
+    flatEs: "El rendimiento cayó porque hubo algunos problemas y estamos trabajando en ello.",
+    steps: [
+      {
+        label: "Context",
+        sentence: "Over the past month, we've seen a noticeable decline in performance across key metrics.",
+        sentenceEs: "Durante el último mes, hemos visto una disminución notable en el rendimiento en métricas clave.",
+      },
+      {
+        label: "Tension",
+        sentence: "This is primarily driven by changes in demand patterns and gaps in execution consistency.",
+        sentenceEs: "Esto es impulsado principalmente por cambios en los patrones de demanda y brechas en la consistencia de ejecución.",
+      },
+      {
+        label: "Insight",
+        sentence: "What this tells us is that our current operating model is not adapting quickly enough to shifting conditions.",
+        sentenceEs: "Lo que esto nos dice es que nuestro modelo operativo actual no se está adaptando lo suficientemente rápido a las condiciones cambiantes.",
+      },
+      {
+        label: "Action",
+        sentence: "In response, we are tightening execution standards and adjusting our approach to better match demand variability.",
+        sentenceEs: "En respuesta, estamos ajustando los estándares de ejecución y modificando nuestro enfoque para adaptarnos mejor a la variabilidad de la demanda.",
+      },
+      {
+        label: "Outcome",
+        sentence: "As a result, we expect to stabilize performance in the short term and improve consistency going forward.",
+        sentenceEs: "Como resultado, esperamos estabilizar el rendimiento a corto plazo y mejorar la consistencia en el futuro.",
+      },
+    ],
+    whyItWorks: "You don't just report — you interpret. You create a narrative arc. You sound in control of the situation.",
+    whyItWorksEs: "No solo reportas — interpretas. Creas un arco narrativo. Suenas en control de la situación.",
+  },
+  {
+    prompt: "Why did we miss the quarterly target?",
+    promptEs: "¿Por qué no alcanzamos el objetivo trimestral?",
+    flat: "We didn't hit the numbers because things didn't go as planned.",
+    flatEs: "No alcanzamos los números porque las cosas no salieron como se planeó.",
+    steps: [
+      {
+        label: "Context",
+        sentence: "We entered the quarter with strong momentum, but performance slowed in the final phase.",
+        sentenceEs: "Entramos al trimestre con un fuerte impulso, pero el rendimiento se desaceleró en la fase final.",
+      },
+      {
+        label: "Tension",
+        sentence: "The primary issue was a misalignment between our forecast assumptions and actual demand behavior.",
+        sentenceEs: "El problema principal fue una desalineación entre nuestros supuestos de pronóstico y el comportamiento real de la demanda.",
+      },
+      {
+        label: "Insight",
+        sentence: "This highlights a gap in how we translate market signals into execution decisions.",
+        sentenceEs: "Esto resalta una brecha en cómo traducimos las señales del mercado en decisiones de ejecución.",
+      },
+      {
+        label: "Action",
+        sentence: "We are now refining our forecasting approach and strengthening coordination between planning and execution teams.",
+        sentenceEs: "Ahora estamos refinando nuestro enfoque de pronóstico y fortaleciendo la coordinación entre los equipos de planificación y ejecución.",
+      },
+      {
+        label: "Outcome",
+        sentence: "This will allow us to improve accuracy and deliver more consistent results in the next cycle.",
+        sentenceEs: "Esto nos permitirá mejorar la precisión y entregar resultados más consistentes en el próximo ciclo.",
+      },
+    ],
+    whyItWorks: "You elevate from excuse to diagnosis. You show learning, not failure. You move the conversation forward.",
+    whyItWorksEs: "Elevas de excusa a diagnóstico. Muestras aprendizaje, no fracaso. Mueves la conversación hacia adelante.",
+  },
+  {
+    prompt: "Explain why this new initiative matters.",
+    promptEs: "Explica por qué esta nueva iniciativa importa.",
+    flat: "It's a good opportunity and it will help us improve.",
+    flatEs: "Es una buena oportunidad y nos ayudará a mejorar.",
+    steps: [
+      {
+        label: "Context",
+        sentence: "Currently, our process is creating inefficiencies that limit both speed and scalability.",
+        sentenceEs: "Actualmente, nuestro proceso está creando ineficiencias que limitan tanto la velocidad como la escalabilidad.",
+      },
+      {
+        label: "Tension",
+        sentence: "As demand increases, those limitations become more visible and more costly.",
+        sentenceEs: "A medida que aumenta la demanda, esas limitaciones se vuelven más visibles y más costosas.",
+      },
+      {
+        label: "Insight",
+        sentence: "What this means is that without change, we will struggle to maintain performance at scale.",
+        sentenceEs: "Lo que esto significa es que sin cambio, tendremos dificultades para mantener el rendimiento a escala.",
+      },
+      {
+        label: "Action",
+        sentence: "This initiative addresses that by simplifying workflows and improving execution efficiency.",
+        sentenceEs: "Esta iniciativa aborda eso simplificando los flujos de trabajo y mejorando la eficiencia de ejecución.",
+      },
+      {
+        label: "Outcome",
+        sentence: "As a result, we expect faster delivery, lower operational friction, and stronger overall performance.",
+        sentenceEs: "Como resultado, esperamos una entrega más rápida, menor fricción operativa y un rendimiento general más fuerte.",
+      },
+    ],
+    whyItWorks: "You connect problem → impact → solution. You make the decision feel necessary, not optional.",
+    whyItWorksEs: "Conectas problema → impacto → solución. Haces que la decisión se sienta necesaria, no opcional.",
+  },
+];
+
+// ─── Section 5.2 — Story Upgrade (Flat → Strategic) (StoryBuilder) ────────
+
+export const unit5Section2Drills: StoryBuilderItem[] = [
+  {
+    prompt: "Your team experienced delays. Explain what happened.",
+    promptEs: "Tu equipo experimentó retrasos. Explica qué pasó.",
+    flat: "We had delays and fixed them.",
+    flatEs: "Tuvimos retrasos y los arreglamos.",
+    steps: [
+      {
+        label: "Context",
+        sentence: "We began experiencing delays due to bottlenecks in execution.",
+        sentenceEs: "Comenzamos a experimentar retrasos debido a cuellos de botella en la ejecución.",
+      },
+      {
+        label: "Tension",
+        sentence: "These delays started to impact overall performance and delivery timelines.",
+        sentenceEs: "Estos retrasos comenzaron a impactar el rendimiento general y los plazos de entrega.",
+      },
+      {
+        label: "Insight",
+        sentence: "This made it clear that our current process lacked the flexibility needed under pressure.",
+        sentenceEs: "Esto dejó claro que nuestro proceso actual carecía de la flexibilidad necesaria bajo presión.",
+      },
+      {
+        label: "Action",
+        sentence: "We addressed this by restructuring workflows and reallocating resources.",
+        sentenceEs: "Abordamos esto reestructurando los flujos de trabajo y reasignando recursos.",
+      },
+      {
+        label: "Outcome",
+        sentence: "As a result, delivery speed has improved and the operation is now more stable.",
+        sentenceEs: "Como resultado, la velocidad de entrega ha mejorado y la operación ahora es más estable.",
+      },
+    ],
+    whyItWorks: "Every sentence connects to the next. The listener follows your logic without effort.",
+    whyItWorksEs: "Cada oración se conecta con la siguiente. El oyente sigue tu lógica sin esfuerzo.",
+  },
+  {
+    prompt: "The team had a rough quarter. Explain to leadership.",
+    promptEs: "El equipo tuvo un trimestre difícil. Explica al liderazgo.",
+    flat: "The team had problems but it's better now.",
+    flatEs: "El equipo tuvo problemas pero ya está mejor.",
+    steps: [
+      {
+        label: "Context",
+        sentence: "The team initially faced challenges due to unclear priorities and coordination gaps.",
+        sentenceEs: "El equipo inicialmente enfrentó desafíos debido a prioridades poco claras y brechas de coordinación.",
+      },
+      {
+        label: "Tension",
+        sentence: "This created inconsistency in execution and impacted overall performance.",
+        sentenceEs: "Esto creó inconsistencia en la ejecución e impactó el rendimiento general.",
+      },
+      {
+        label: "Insight",
+        sentence: "What this showed us is that alignment was not strong enough at the operational level.",
+        sentenceEs: "Lo que esto nos mostró es que la alineación no era lo suficientemente fuerte a nivel operativo.",
+      },
+      {
+        label: "Action",
+        sentence: "We responded by clarifying priorities and strengthening communication across teams.",
+        sentenceEs: "Respondimos clarificando prioridades y fortaleciendo la comunicación entre equipos.",
+      },
+      {
+        label: "Outcome",
+        sentence: "As a result, execution is now more consistent and performance is improving.",
+        sentenceEs: "Como resultado, la ejecución ahora es más consistente y el rendimiento está mejorando.",
+      },
+    ],
+    whyItWorks: "You name the systemic issue ('alignment was not strong enough'), not just the symptom.",
+    whyItWorksEs: "Nombras el problema sistémico ('la alineación no era lo suficientemente fuerte'), no solo el síntoma.",
+  },
+  {
+    prompt: "You changed the plan mid-quarter. Justify the change.",
+    promptEs: "Cambiaste el plan a mitad del trimestre. Justifica el cambio.",
+    flat: "We changed the plan and things improved.",
+    flatEs: "Cambiamos el plan y las cosas mejoraron.",
+    steps: [
+      {
+        label: "Context",
+        sentence: "We started with a plan based on initial assumptions that no longer held true.",
+        sentenceEs: "Comenzamos con un plan basado en supuestos iniciales que ya no eran válidos.",
+      },
+      {
+        label: "Tension",
+        sentence: "As conditions changed, performance began to decline.",
+        sentenceEs: "A medida que las condiciones cambiaron, el rendimiento comenzó a disminuir.",
+      },
+      {
+        label: "Insight",
+        sentence: "This indicated that the strategy needed to evolve to remain effective.",
+        sentenceEs: "Esto indicó que la estrategia necesitaba evolucionar para seguir siendo efectiva.",
+      },
+      {
+        label: "Action",
+        sentence: "We revised the plan to better align with current conditions and priorities.",
+        sentenceEs: "Revisamos el plan para alinearlo mejor con las condiciones y prioridades actuales.",
+      },
+      {
+        label: "Outcome",
+        sentence: "As a result, we are now seeing improved outcomes and stronger alignment.",
+        sentenceEs: "Como resultado, ahora estamos viendo resultados mejorados y una alineación más fuerte.",
+      },
+    ],
+    whyItWorks: "You frame the change as strategic adaptation, not reactive scrambling.",
+    whyItWorksEs: "Enmarcas el cambio como adaptación estratégica, no como reacción desordenada.",
+  },
+];
+
+// ─── Section 5.3 — Reusable Executive Story Patterns (StoryBuilder) ───────
+
+export const unit5Section3Drills: StoryBuilderItem[] = [
+  {
+    prompt: "Explain a recent operational issue to the board.",
+    promptEs: "Explica un problema operativo reciente a la junta directiva.",
+    flat: "We had issues and worked on them.",
+    flatEs: "Tuvimos problemas y trabajamos en ellos.",
+    steps: [
+      {
+        label: "Context",
+        sentence: "We began seeing inconsistencies in execution across key areas.",
+        sentenceEs: "Comenzamos a ver inconsistencias en la ejecución en áreas clave.",
+      },
+      {
+        label: "Tension",
+        sentence: "This was driven by misalignment in priorities and a lack of clarity in ownership.",
+        sentenceEs: "Esto fue impulsado por una desalineación en prioridades y una falta de claridad en la responsabilidad.",
+      },
+      {
+        label: "Insight",
+        sentence: "What this indicated was a structural gap in coordination, not just isolated performance issues.",
+        sentenceEs: "Lo que esto indicó fue una brecha estructural en la coordinación, no solo problemas de rendimiento aislados.",
+      },
+      {
+        label: "Action",
+        sentence: "In response, we clarified accountability and standardized execution protocols.",
+        sentenceEs: "En respuesta, clarificamos la responsabilidad y estandarizamos los protocolos de ejecución.",
+      },
+      {
+        label: "Outcome",
+        sentence: "As a result, performance is stabilizing and consistency is improving.",
+        sentenceEs: "Como resultado, el rendimiento se está estabilizando y la consistencia está mejorando.",
+      },
+    ],
+    whyItWorks: "It blends structure, diagnosis, storytelling, and direction into one cohesive narrative.",
+    whyItWorksEs: "Combina estructura, diagnóstico, narrativa y dirección en una narrativa cohesiva.",
+  },
+  {
+    prompt: "The market shifted and your strategy needs to change. Brief leadership.",
+    promptEs: "El mercado cambió y tu estrategia necesita cambiar. Informa al liderazgo.",
+    flat: "The market changed so we need to do something different.",
+    flatEs: "El mercado cambió así que necesitamos hacer algo diferente.",
+    steps: [
+      {
+        label: "Context",
+        sentence: "Over the past quarter, we've observed a significant shift in market conditions.",
+        sentenceEs: "Durante el último trimestre, hemos observado un cambio significativo en las condiciones del mercado.",
+      },
+      {
+        label: "Tension",
+        sentence: "This shift has created a gap between our current strategy and the emerging reality.",
+        sentenceEs: "Este cambio ha creado una brecha entre nuestra estrategia actual y la realidad emergente.",
+      },
+      {
+        label: "Insight",
+        sentence: "What this means is that our original approach, while sound at the time, no longer addresses the current environment.",
+        sentenceEs: "Lo que esto significa es que nuestro enfoque original, aunque sólido en su momento, ya no aborda el entorno actual.",
+      },
+      {
+        label: "Action",
+        sentence: "We are proposing a revised strategy that accounts for the new conditions and positions us for the next phase.",
+        sentenceEs: "Estamos proponiendo una estrategia revisada que tiene en cuenta las nuevas condiciones y nos posiciona para la próxima fase.",
+      },
+      {
+        label: "Outcome",
+        sentence: "As a result, we expect to maintain competitive positioning and capture emerging opportunities.",
+        sentenceEs: "Como resultado, esperamos mantener el posicionamiento competitivo y capturar oportunidades emergentes.",
+      },
+    ],
+    whyItWorks: "You show that the strategy change is proactive, not reactive — you saw it coming and you're ahead of it.",
+    whyItWorksEs: "Muestras que el cambio de estrategia es proactivo, no reactivo — lo viste venir y estás adelante.",
+  },
+];
+
+// ─── Final Shift ────────────────────────────────────────────────────────────
+
+export const unit5FinalShift: FinalShift = {
+  before: "You reported facts — what happened, then what you did. The listener had to figure out what it meant.",
+  beforeEs: "Reportabas hechos — qué pasó, luego qué hiciste. El oyente tenía que descifrar qué significaba.",
+  after: "You tell strategic stories — context, tension, insight, action, outcome. You control how others understand what happened.",
+  afterEs: "Cuentas historias estratégicas — contexto, tensión, insight, acción, resultado. Controlas cómo otros entienden lo que pasó.",
+};

--- a/src/data/executive/unit-6.ts
+++ b/src/data/executive/unit-6.ts
@@ -1,0 +1,236 @@
+// Unit 6 — The Impromptu Toolkit
+// "Four named frameworks for the moments you can't prepare."
+//
+// Three sections:
+// 6.1 Board Updates & Status Reports (ImpromptuScenario)
+// 6.2 Handling Tough Questions (ImpromptuScenario)
+// 6.3 Driving Decisions (ImpromptuScenario)
+//
+// Content sourced from Robert's real C1 and C2 executive lessons.
+
+import type {
+  ImpromptuScenarioItem,
+  UnitSection,
+  FinalShift,
+} from "./types";
+
+// ─── Section metadata ──────────────────────────────────────────────────────
+
+export const unit6Sections: UnitSection[] = [
+  {
+    number: 1,
+    title: "Board Updates & Status Reports",
+    titleEs: "Actualizaciones de Junta e Informes de Estado",
+    why: "When someone says 'give us a quick update,' most people ramble. The executives who command a room deliver a complete picture in under 30 seconds using a repeatable structure. This section gives you that structure.",
+    whyEs: "Cuando alguien dice 'danos una actualización rápida,' la mayoría divaga. Los ejecutivos que dominan una sala entregan un panorama completo en menos de 30 segundos usando una estructura repetible. Esta sección te da esa estructura.",
+    mechanic: "impromptu",
+    techniqueFocus: "State → Issue → Action → Timeline. Four beats, under 30 seconds. Practice until the framework fires automatically.",
+    techniqueFocusEs: "Estado → Problema → Acción → Plazo. Cuatro tiempos, menos de 30 segundos. Practica hasta que el marco se active automáticamente.",
+    rapidRepeat: [
+      { text: "Operations are stable overall.", textEs: "Las operaciones están estables en general." },
+      { text: "We are addressing this by…", textEs: "Estamos abordando esto mediante…" },
+      { text: "We expect performance to stabilize within…", textEs: "Esperamos que el rendimiento se estabilice en…" },
+      { text: "The revised strategy will deliver results in…", textEs: "La estrategia revisada entregará resultados en…" },
+    ],
+  },
+  {
+    number: 2,
+    title: "Handling Tough Questions",
+    titleEs: "Manejar Preguntas Difíciles",
+    why: "Tough questions are designed to test your composure, not just your knowledge. If you get defensive or vague, you lose credibility instantly. A framework lets you absorb the question, show ownership, and redirect to solutions — all in one breath.",
+    whyEs: "Las preguntas difíciles están diseñadas para probar tu compostura, no solo tu conocimiento. Si te pones a la defensiva o eres vago, pierdes credibilidad al instante. Un marco te permite absorber la pregunta, mostrar responsabilidad y redirigir hacia soluciones — todo en una sola respuesta.",
+    mechanic: "impromptu",
+    techniqueFocus: "Acknowledge → Explain → Action → Prevention. Never defend. Always redirect to what you're doing and how you'll prevent recurrence.",
+    techniqueFocusEs: "Reconocer → Explicar → Acción → Prevención. Nunca te defiendas. Siempre redirige hacia lo que estás haciendo y cómo prevenirás la recurrencia.",
+    rapidRepeat: [
+      { text: "The issue was not fully visible earlier.", textEs: "El problema no era completamente visible antes." },
+      { text: "We have identified the root cause.", textEs: "Hemos identificado la causa raíz." },
+      { text: "This will allow us to detect issues earlier.", textEs: "Esto nos permitirá detectar problemas más temprano." },
+      { text: "We have contingency plans in place.", textEs: "Tenemos planes de contingencia establecidos." },
+    ],
+  },
+  {
+    number: 3,
+    title: "Driving Decisions",
+    titleEs: "Impulsar Decisiones",
+    why: "Most people present information and hope the decision happens. Executives who drive decisions build a logical case that makes 'yes' the only rational response. This framework moves from problem to recommendation in four steps — ending with a clear stance.",
+    whyEs: "La mayoría presenta información y espera que la decisión suceda. Los ejecutivos que impulsan decisiones construyen un caso lógico que hace que 'sí' sea la única respuesta racional. Este marco va del problema a la recomendación en cuatro pasos — terminando con una postura clara.",
+    mechanic: "impromptu",
+    techniqueFocus: "Problem → Impact → Solution → Recommendation. Always end with your recommendation. Leaders respect people who take a stance.",
+    techniqueFocusEs: "Problema → Impacto → Solución → Recomendación. Siempre termina con tu recomendación. Los líderes respetan a quienes toman una postura.",
+    rapidRepeat: [
+      { text: "The current approach is creating inefficiencies.", textEs: "El enfoque actual está creando ineficiencias." },
+      { text: "This is limiting our ability to scale.", textEs: "Esto está limitando nuestra capacidad de escalar." },
+      { text: "Based on this, I recommend moving forward.", textEs: "Basado en esto, recomiendo avanzar." },
+      { text: "The proposed investment would reduce time-to-delivery by…", textEs: "La inversión propuesta reduciría el tiempo de entrega en…" },
+    ],
+  },
+];
+
+// ─── Section 6.1 — Board Updates & Status Reports (ImpromptuScenario) ──────
+
+export const unit6Section1Drills: ImpromptuScenarioItem[] = [
+  {
+    prompt: "Give us a quick update on operations.",
+    promptEs: "Danos una actualización rápida sobre las operaciones.",
+    framework: "State → Issue → Action → Timeline",
+    frameworkEs: "Estado → Problema → Acción → Plazo",
+    frameworkSteps: [
+      "State: Current situation",
+      "Issue: What's not working",
+      "Action: What you're doing",
+      "Timeline: When it will be resolved",
+    ],
+    frameworkStepsEs: [
+      "Estado: Situación actual",
+      "Problema: Qué no está funcionando",
+      "Acción: Qué estás haciendo",
+      "Plazo: Cuándo se resolverá",
+    ],
+    weak: "Things are mostly okay, but we had some issues and we are working on them.",
+    weakEs: "Las cosas están más o menos bien, pero tuvimos algunos problemas y estamos trabajando en ellos.",
+    modelReply: "Operations are stable overall, but we are seeing delays in fulfillment driven by bottlenecks in the picking process. We are addressing this by reallocating resources and adjusting workflows to improve throughput. We expect performance to stabilize within the next 72 hours.",
+    modelReplyEs: "Las operaciones están estables en general, pero estamos viendo retrasos en el despacho causados por cuellos de botella en el proceso de selección. Estamos abordando esto reasignando recursos y ajustando flujos de trabajo para mejorar el rendimiento. Esperamos que el rendimiento se estabilice en las próximas 72 horas.",
+    whyItWorks: "Clear structure, no filler, shows control, gives timeline. The listener gets a complete picture in under 30 seconds.",
+    whyItWorksEs: "Estructura clara, sin relleno, muestra control, da un plazo. El oyente obtiene un panorama completo en menos de 30 segundos.",
+  },
+  {
+    prompt: "Summarize Q3 performance for the leadership team.",
+    promptEs: "Resume el rendimiento del Q3 para el equipo de liderazgo.",
+    framework: "State → Issue → Action → Timeline",
+    frameworkEs: "Estado → Problema → Acción → Plazo",
+    frameworkSteps: [
+      "State: Overall performance",
+      "Issue: Key challenges",
+      "Action: Steps taken",
+      "Timeline: What to expect next",
+    ],
+    frameworkStepsEs: [
+      "Estado: Rendimiento general",
+      "Problema: Desafíos clave",
+      "Acción: Pasos tomados",
+      "Plazo: Qué esperar a continuación",
+    ],
+    weak: "Q3 was okay. We had some highs and lows.",
+    weakEs: "El Q3 estuvo bien. Tuvimos altos y bajos.",
+    modelReply: "Q3 performance was mixed. Revenue targets were met in two of three regions, but the third underperformed due to execution gaps in the new market. We have restructured the regional team and revised the go-to-market approach. We expect the revised strategy to deliver results in Q4.",
+    modelReplyEs: "El rendimiento del Q3 fue mixto. Los objetivos de ingresos se cumplieron en dos de tres regiones, pero la tercera tuvo un rendimiento inferior debido a brechas de ejecución en el nuevo mercado. Hemos reestructurado el equipo regional y revisado el enfoque de salida al mercado. Esperamos que la estrategia revisada entregue resultados en el Q4.",
+    whyItWorks: "Specific, not vague. Names the underperforming area, the cause, and the fix — all in 4 sentences.",
+    whyItWorksEs: "Específico, no vago. Nombra el área de bajo rendimiento, la causa y la solución — todo en 4 oraciones.",
+  },
+];
+
+// ─── Section 6.2 — Handling Tough Questions (ImpromptuScenario) ────────────
+
+export const unit6Section2Drills: ImpromptuScenarioItem[] = [
+  {
+    prompt: "Why wasn't this identified earlier?",
+    promptEs: "¿Por qué no se identificó esto antes?",
+    framework: "Acknowledge → Explain → Action → Prevention",
+    frameworkEs: "Reconocer → Explicar → Acción → Prevención",
+    frameworkSteps: [
+      "Acknowledge: Accept the question",
+      "Explain: Why it happened",
+      "Action: What you're doing now",
+      "Prevention: How you'll prevent it",
+    ],
+    frameworkStepsEs: [
+      "Reconocer: Acepta la pregunta",
+      "Explicar: Por qué sucedió",
+      "Acción: Qué estás haciendo ahora",
+      "Prevención: Cómo lo prevenirás",
+    ],
+    weak: "We didn't see it before.",
+    weakEs: "No lo vimos antes.",
+    modelReply: "The issue was not fully visible earlier due to gaps in reporting. We have now identified the root cause and are implementing stronger monitoring controls. This will allow us to detect and address similar issues earlier going forward.",
+    modelReplyEs: "El problema no era completamente visible antes debido a brechas en el reporteo. Ahora hemos identificado la causa raíz y estamos implementando controles de monitoreo más fuertes. Esto nos permitirá detectar y abordar problemas similares más temprano en el futuro.",
+    whyItWorks: "No defensiveness, shows ownership, focuses on solution and prevention.",
+    whyItWorksEs: "Sin actitud defensiva, muestra responsabilidad, se enfoca en la solución y la prevención.",
+  },
+  {
+    prompt: "Are you confident in these projections?",
+    promptEs: "¿Estás seguro de estas proyecciones?",
+    framework: "Acknowledge → Explain → Action → Prevention",
+    frameworkEs: "Reconocer → Explicar → Acción → Prevención",
+    frameworkSteps: [
+      "Acknowledge: Take the question seriously",
+      "Explain: Your basis for confidence",
+      "Action: What you've verified",
+      "Prevention: What safeguards are in place",
+    ],
+    frameworkStepsEs: [
+      "Reconocer: Toma la pregunta en serio",
+      "Explicar: Tu base de confianza",
+      "Acción: Qué has verificado",
+      "Prevención: Qué salvaguardas están establecidas",
+    ],
+    weak: "Yes, I think so.",
+    weakEs: "Sí, creo que sí.",
+    modelReply: "The projections are based on validated data from three independent sources. We have stress-tested the assumptions against historical variance. If conditions shift beyond our baseline scenario, we have contingency plans in place and will adjust proactively.",
+    modelReplyEs: "Las proyecciones están basadas en datos validados de tres fuentes independientes. Hemos sometido los supuestos a pruebas de estrés contra la varianza histórica. Si las condiciones cambian más allá de nuestro escenario base, tenemos planes de contingencia establecidos y ajustaremos de manera proactiva.",
+    whyItWorks: "Three layers of confidence: data quality, stress testing, contingency. The listener feels safe.",
+    whyItWorksEs: "Tres capas de confianza: calidad de datos, pruebas de estrés, contingencia. El oyente se siente seguro.",
+  },
+];
+
+// ─── Section 6.3 — Driving Decisions (ImpromptuScenario) ───────────────────
+
+export const unit6Section3Drills: ImpromptuScenarioItem[] = [
+  {
+    prompt: "Why should we move forward with this change?",
+    promptEs: "¿Por qué deberíamos avanzar con este cambio?",
+    framework: "Problem → Impact → Solution → Recommendation",
+    frameworkEs: "Problema → Impacto → Solución → Recomendación",
+    frameworkSteps: [
+      "Problem: What's broken",
+      "Impact: What it costs",
+      "Solution: What you propose",
+      "Recommendation: Your clear stance",
+    ],
+    frameworkStepsEs: [
+      "Problema: Qué está roto",
+      "Impacto: Qué cuesta",
+      "Solución: Qué propones",
+      "Recomendación: Tu postura clara",
+    ],
+    weak: "I think it's a good idea and we should do it.",
+    weakEs: "Creo que es una buena idea y deberíamos hacerlo.",
+    modelReply: "The current approach is creating inefficiencies that are impacting overall performance. This is limiting our ability to scale effectively. We are proposing a more streamlined model that reduces complexity and improves execution. Based on this, I recommend moving forward with the change.",
+    modelReplyEs: "El enfoque actual está creando ineficiencias que están impactando el rendimiento general. Esto está limitando nuestra capacidad de escalar de manera efectiva. Estamos proponiendo un modelo más simplificado que reduce la complejidad y mejora la ejecución. Basado en esto, recomiendo avanzar con el cambio.",
+    whyItWorks: "Logical flow from problem to recommendation. Business-focused. Clear recommendation at the end — you take a stance.",
+    whyItWorksEs: "Flujo lógico del problema a la recomendación. Enfocado en el negocio. Recomendación clara al final — tomas una postura.",
+  },
+  {
+    prompt: "Why should we approve this budget increase?",
+    promptEs: "¿Por qué deberíamos aprobar este aumento de presupuesto?",
+    framework: "Problem → Impact → Solution → Recommendation",
+    frameworkEs: "Problema → Impacto → Solución → Recomendación",
+    frameworkSteps: [
+      "Problem: Current constraint",
+      "Impact: Business consequence",
+      "Solution: What the investment enables",
+      "Recommendation: Your ask",
+    ],
+    frameworkStepsEs: [
+      "Problema: Restricción actual",
+      "Impacto: Consecuencia de negocio",
+      "Solución: Qué permite la inversión",
+      "Recomendación: Tu solicitud",
+    ],
+    weak: "We need more money because things are getting expensive.",
+    weakEs: "Necesitamos más dinero porque las cosas se están poniendo caras.",
+    modelReply: "Our current resource allocation is not keeping pace with demand growth. This is creating delivery bottlenecks and increasing the risk of missed commitments. The proposed investment would add capacity where it's needed most and reduce time-to-delivery by an estimated 25%. I recommend approving the increase effective next quarter.",
+    modelReplyEs: "Nuestra asignación actual de recursos no está al ritmo del crecimiento de la demanda. Esto está creando cuellos de botella en la entrega y aumentando el riesgo de compromisos incumplidos. La inversión propuesta agregaría capacidad donde más se necesita y reduciría el tiempo de entrega en un estimado de 25%. Recomiendo aprobar el aumento con efecto el próximo trimestre.",
+    whyItWorks: "Quantifies the benefit ('25%'), anchors to a timeline ('next quarter'), and ends with a clear recommendation.",
+    whyItWorksEs: "Cuantifica el beneficio ('25%'), ancla a una línea de tiempo ('próximo trimestre') y termina con una recomendación clara.",
+  },
+];
+
+// ─── Final Shift ────────────────────────────────────────────────────────────
+
+export const unit6FinalShift: FinalShift = {
+  before: "When put on the spot, you froze, rambled, or defaulted to 'I think we should probably...' — losing the room in the first sentence.",
+  beforeEs: "Cuando te ponían en aprietos, te congelabas, divagabas o recurrías a 'Creo que deberíamos probablemente...' — perdiendo la sala en la primera oración.",
+  after: "You deploy a named framework in under 60 seconds. Board update. Tough question. Drive decision. You always have a structure.",
+  afterEs: "Despliegas un marco con nombre en menos de 60 segundos. Actualización de junta. Pregunta difícil. Impulsar decisión. Siempre tienes una estructura.",
+};

--- a/src/data/executive/units.ts
+++ b/src/data/executive/units.ts
@@ -119,7 +119,7 @@ export const executiveUnits: ExecutiveUnit[] = [
     outcomeEs:
       "Responderás a la presión con autoridad, no con emoción.",
     icon: "Shield",
-    published: false,
+    published: true,
   },
   {
     id: 5,
@@ -138,7 +138,7 @@ export const executiveUnits: ExecutiveUnit[] = [
     outcomeEs:
       "Transformarás las actualizaciones en narrativas que moldean decisiones.",
     icon: "BookOpen",
-    published: false,
+    published: true,
   },
   {
     id: 6,
@@ -157,7 +157,7 @@ export const executiveUnits: ExecutiveUnit[] = [
     outcomeEs:
       "Responderás a cualquier pregunta improvisada con un marco con nombre.",
     icon: "Clock",
-    published: false,
+    published: true,
   },
   {
     id: 7,

--- a/src/pages/en/course/executive/unit-4.astro
+++ b/src/pages/en/course/executive/unit-4.astro
@@ -1,0 +1,152 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WeakStrongElite from "@components/course/WeakStrongElite";
+import RapidRepeat from "@components/course/RapidRepeat";
+import FinalShiftCard from "@components/course/FinalShiftCard";
+import { executiveUnits } from "@data/executive/units";
+import {
+  unit4Sections,
+  unit4Section1Drills,
+  unit4Section2Drills,
+  unit4Section3Drills,
+  unit4FinalShift,
+} from "@data/executive/unit-4";
+import { ArrowRight, ArrowLeft, Shield } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/executive/unit-4" as const;
+const unit = executiveUnits[3];
+
+const progressUnits = executiveUnits
+  .filter((u) => u.published)
+  .map((u) => ({ id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title={`Unit 4: ${unit.title} | Executive English Course`}
+  description={unit.description}
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={4}
+    basePath="/en/course/executive"
+    lang="en"
+    courseId="executive"
+  />
+
+  <!-- Unit hero -->
+  <section class="bg-gradient-to-b from-slate-950 to-slate-900 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Shield class="w-4 h-4" />
+          Unit 4
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          {unit.title}
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          {unit.description}
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 1 -->
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit4Sections[0].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit4Sections[0].why}</p>
+        <div class="ml-11">
+          <WeakStrongElite client:visible items={unit4Section1Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit4Sections[0].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit4Sections[0].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2 -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit4Sections[1].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit4Sections[1].why}</p>
+        <div class="ml-11">
+          <WeakStrongElite client:visible items={unit4Section2Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit4Sections[1].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit4Sections[1].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3 -->
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit4Sections[2].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit4Sections[2].why}</p>
+        <div class="ml-11">
+          <WeakStrongElite client:visible items={unit4Section3Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit4Sections[2].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit4Sections[2].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Final Shift -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <FinalShiftCard client:visible shift={unit4FinalShift} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/en/course/executive/unit-3/"
+          class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          <ArrowLeft class="w-4 h-4" />
+          Unit 3: Structured Responses
+        </a>
+        <Button href="/en/course/executive/unit-5/" variant="primary" size="md">
+          Unit 5: Strategic Storytelling
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/en/course/executive/unit-5.astro
+++ b/src/pages/en/course/executive/unit-5.astro
@@ -1,0 +1,152 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import StoryBuilder from "@components/course/StoryBuilder";
+import RapidRepeat from "@components/course/RapidRepeat";
+import FinalShiftCard from "@components/course/FinalShiftCard";
+import { executiveUnits } from "@data/executive/units";
+import {
+  unit5Sections,
+  unit5Section1Drills,
+  unit5Section2Drills,
+  unit5Section3Drills,
+  unit5FinalShift,
+} from "@data/executive/unit-5";
+import { ArrowRight, ArrowLeft, BookOpen } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/executive/unit-5" as const;
+const unit = executiveUnits[4];
+
+const progressUnits = executiveUnits
+  .filter((u) => u.published)
+  .map((u) => ({ id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title={`Unit 5: ${unit.title} | Executive English Course`}
+  description={unit.description}
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={5}
+    basePath="/en/course/executive"
+    lang="en"
+    courseId="executive"
+  />
+
+  <!-- Unit hero -->
+  <section class="bg-gradient-to-b from-slate-950 to-slate-900 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <BookOpen class="w-4 h-4" />
+          Unit 5
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          {unit.title}
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          {unit.description}
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 1 -->
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit5Sections[0].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit5Sections[0].why}</p>
+        <div class="ml-11">
+          <StoryBuilder client:visible items={unit5Section1Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit5Sections[0].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit5Sections[0].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2 -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit5Sections[1].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit5Sections[1].why}</p>
+        <div class="ml-11">
+          <StoryBuilder client:visible items={unit5Section2Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit5Sections[1].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit5Sections[1].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3 -->
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit5Sections[2].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit5Sections[2].why}</p>
+        <div class="ml-11">
+          <StoryBuilder client:visible items={unit5Section3Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit5Sections[2].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit5Sections[2].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Final Shift -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <FinalShiftCard client:visible shift={unit5FinalShift} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/en/course/executive/unit-4/"
+          class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          <ArrowLeft class="w-4 h-4" />
+          Unit 4: Controlled Tone
+        </a>
+        <Button href="/en/course/executive/unit-6/" variant="primary" size="md">
+          Unit 6: The Impromptu Toolkit
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/en/course/executive/unit-6.astro
+++ b/src/pages/en/course/executive/unit-6.astro
@@ -1,0 +1,152 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import ImpromptuScenario from "@components/course/ImpromptuScenario";
+import RapidRepeat from "@components/course/RapidRepeat";
+import FinalShiftCard from "@components/course/FinalShiftCard";
+import { executiveUnits } from "@data/executive/units";
+import {
+  unit6Sections,
+  unit6Section1Drills,
+  unit6Section2Drills,
+  unit6Section3Drills,
+  unit6FinalShift,
+} from "@data/executive/unit-6";
+import { ArrowRight, ArrowLeft, Clock } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/executive/unit-6" as const;
+const unit = executiveUnits[5];
+
+const progressUnits = executiveUnits
+  .filter((u) => u.published)
+  .map((u) => ({ id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title={`Unit 6: ${unit.title} | Executive English Course`}
+  description={unit.description}
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={6}
+    basePath="/en/course/executive"
+    lang="en"
+    courseId="executive"
+  />
+
+  <!-- Unit hero -->
+  <section class="bg-gradient-to-b from-slate-950 to-slate-900 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Clock class="w-4 h-4" />
+          Unit 6
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          {unit.title}
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          {unit.description}
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 1 -->
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit6Sections[0].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit6Sections[0].why}</p>
+        <div class="ml-11">
+          <ImpromptuScenario client:visible items={unit6Section1Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit6Sections[0].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit6Sections[0].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2 -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit6Sections[1].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit6Sections[1].why}</p>
+        <div class="ml-11">
+          <ImpromptuScenario client:visible items={unit6Section2Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit6Sections[1].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit6Sections[1].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3 -->
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit6Sections[2].title}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit6Sections[2].why}</p>
+        <div class="ml-11">
+          <ImpromptuScenario client:visible items={unit6Section3Drills} lang="en" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit6Sections[2].techniqueFocus}</p>
+          <RapidRepeat client:visible stems={unit6Sections[2].rapidRepeat} lang="en" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Final Shift -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <FinalShiftCard client:visible shift={unit6FinalShift} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/en/course/executive/unit-5/"
+          class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          <ArrowLeft class="w-4 h-4" />
+          Unit 5: Strategic Storytelling
+        </a>
+        <Button href="/en/course/executive/" variant="primary" size="md">
+          Course Overview
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/ejecutivo/unidad-4.astro
+++ b/src/pages/es/curso/ejecutivo/unidad-4.astro
@@ -1,0 +1,152 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import WeakStrongElite from "@components/course/WeakStrongElite";
+import RapidRepeat from "@components/course/RapidRepeat";
+import FinalShiftCard from "@components/course/FinalShiftCard";
+import { executiveUnits } from "@data/executive/units";
+import {
+  unit4Sections,
+  unit4Section1Drills,
+  unit4Section2Drills,
+  unit4Section3Drills,
+  unit4FinalShift,
+} from "@data/executive/unit-4";
+import { ArrowRight, ArrowLeft, Shield } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/executive/unit-4" as const;
+const unit = executiveUnits[3];
+
+const progressUnits = executiveUnits
+  .filter((u) => u.published)
+  .map((u) => ({ id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title={`Unidad 4: ${unit.titleEs} | Curso Ejecutivo de Inglés`}
+  description={unit.descriptionEs}
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={4}
+    basePath="/es/curso/ejecutivo"
+    lang="es"
+    courseId="executive"
+  />
+
+  <!-- Unit hero -->
+  <section class="bg-gradient-to-b from-slate-950 to-slate-900 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Shield class="w-4 h-4" />
+          Unidad 4
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          {unit.titleEs}
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          {unit.descriptionEs}
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 1 -->
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit4Sections[0].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit4Sections[0].whyEs}</p>
+        <div class="ml-11">
+          <WeakStrongElite client:visible items={unit4Section1Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit4Sections[0].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit4Sections[0].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2 -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit4Sections[1].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit4Sections[1].whyEs}</p>
+        <div class="ml-11">
+          <WeakStrongElite client:visible items={unit4Section2Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit4Sections[1].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit4Sections[1].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3 -->
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit4Sections[2].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit4Sections[2].whyEs}</p>
+        <div class="ml-11">
+          <WeakStrongElite client:visible items={unit4Section3Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit4Sections[2].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit4Sections[2].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Final Shift -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <FinalShiftCard client:visible shift={unit4FinalShift} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/es/curso/ejecutivo/unidad-3/"
+          class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          <ArrowLeft class="w-4 h-4" />
+          Unidad 3: Respuestas Estructuradas
+        </a>
+        <Button href="/es/curso/ejecutivo/unidad-5/" variant="primary" size="md">
+          Unidad 5: Narrativa Estratégica
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/ejecutivo/unidad-5.astro
+++ b/src/pages/es/curso/ejecutivo/unidad-5.astro
@@ -1,0 +1,152 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import StoryBuilder from "@components/course/StoryBuilder";
+import RapidRepeat from "@components/course/RapidRepeat";
+import FinalShiftCard from "@components/course/FinalShiftCard";
+import { executiveUnits } from "@data/executive/units";
+import {
+  unit5Sections,
+  unit5Section1Drills,
+  unit5Section2Drills,
+  unit5Section3Drills,
+  unit5FinalShift,
+} from "@data/executive/unit-5";
+import { ArrowRight, ArrowLeft, BookOpen } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/executive/unit-5" as const;
+const unit = executiveUnits[4];
+
+const progressUnits = executiveUnits
+  .filter((u) => u.published)
+  .map((u) => ({ id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title={`Unidad 5: ${unit.titleEs} | Curso Ejecutivo de Inglés`}
+  description={unit.descriptionEs}
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={5}
+    basePath="/es/curso/ejecutivo"
+    lang="es"
+    courseId="executive"
+  />
+
+  <!-- Unit hero -->
+  <section class="bg-gradient-to-b from-slate-950 to-slate-900 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <BookOpen class="w-4 h-4" />
+          Unidad 5
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          {unit.titleEs}
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          {unit.descriptionEs}
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 1 -->
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit5Sections[0].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit5Sections[0].whyEs}</p>
+        <div class="ml-11">
+          <StoryBuilder client:visible items={unit5Section1Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit5Sections[0].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit5Sections[0].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2 -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit5Sections[1].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit5Sections[1].whyEs}</p>
+        <div class="ml-11">
+          <StoryBuilder client:visible items={unit5Section2Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit5Sections[1].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit5Sections[1].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3 -->
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit5Sections[2].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit5Sections[2].whyEs}</p>
+        <div class="ml-11">
+          <StoryBuilder client:visible items={unit5Section3Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit5Sections[2].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit5Sections[2].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Final Shift -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <FinalShiftCard client:visible shift={unit5FinalShift} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/es/curso/ejecutivo/unidad-4/"
+          class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          <ArrowLeft class="w-4 h-4" />
+          Unidad 4: Tono Controlado
+        </a>
+        <Button href="/es/curso/ejecutivo/unidad-6/" variant="primary" size="md">
+          Unidad 6: Kit Impromptu
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/ejecutivo/unidad-6.astro
+++ b/src/pages/es/curso/ejecutivo/unidad-6.astro
@@ -1,0 +1,152 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import ImpromptuScenario from "@components/course/ImpromptuScenario";
+import RapidRepeat from "@components/course/RapidRepeat";
+import FinalShiftCard from "@components/course/FinalShiftCard";
+import { executiveUnits } from "@data/executive/units";
+import {
+  unit6Sections,
+  unit6Section1Drills,
+  unit6Section2Drills,
+  unit6Section3Drills,
+  unit6FinalShift,
+} from "@data/executive/unit-6";
+import { ArrowRight, ArrowLeft, Clock } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/executive/unit-6" as const;
+const unit = executiveUnits[5];
+
+const progressUnits = executiveUnits
+  .filter((u) => u.published)
+  .map((u) => ({ id: u.id, slug: u.slug, title: u.title, titleEs: u.titleEs }));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title={`Unidad 6: ${unit.titleEs} | Curso Ejecutivo de Inglés`}
+  description={unit.descriptionEs}
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={6}
+    basePath="/es/curso/ejecutivo"
+    lang="es"
+    courseId="executive"
+  />
+
+  <!-- Unit hero -->
+  <section class="bg-gradient-to-b from-slate-950 to-slate-900 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <Clock class="w-4 h-4" />
+          Unidad 6
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          {unit.titleEs}
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          {unit.descriptionEs}
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 1 -->
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit6Sections[0].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit6Sections[0].whyEs}</p>
+        <div class="ml-11">
+          <ImpromptuScenario client:visible items={unit6Section1Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit6Sections[0].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit6Sections[0].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2 -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit6Sections[1].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit6Sections[1].whyEs}</p>
+        <div class="ml-11">
+          <ImpromptuScenario client:visible items={unit6Section2Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit6Sections[1].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit6Sections[1].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3 -->
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{unit6Sections[2].titleEs}</h2>
+        </div>
+        <p class="text-slate-500 mb-4 ml-11">{unit6Sections[2].whyEs}</p>
+        <div class="ml-11">
+          <ImpromptuScenario client:visible items={unit6Section3Drills} lang="es" />
+        </div>
+        <div class="mt-8 ml-11 space-y-4">
+          <p class="text-sm font-semibold text-slate-600">{unit6Sections[2].techniqueFocusEs}</p>
+          <RapidRepeat client:visible stems={unit6Sections[2].rapidRepeat} lang="es" />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Final Shift -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <FinalShiftCard client:visible shift={unit6FinalShift} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex justify-between items-center">
+        <a
+          href="/es/curso/ejecutivo/unidad-5/"
+          class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-amber-600 transition-colors"
+        >
+          <ArrowLeft class="w-4 h-4" />
+          Unidad 5: Narrativa Estratégica
+        </a>
+        <Button href="/es/curso/ejecutivo/" variant="primary" size="md">
+          Resumen del Curso
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary
Third of five PRs. Ships Units 4-6 (completing the mechanics half of the course) plus 2 new drill components.

**New components:**
- `StoryBuilder` — 5-step strategic narrative (Context → Tension → Insight → Action → Outcome) with color-coded step labels
- `ImpromptuScenario` — executive scenario + named framework + 60-second model reply

**Unit 4 — Controlled Tone Under Pressure** (17 drills):
Defensive→Executive reframing, emotion downgrade, reframing under leadership challenge.

**Unit 5 — Strategic Storytelling** (8 scenarios):
Build the story (guided), flat→strategic upgrades, reusable executive story patterns.

**Unit 6 — The Impromptu Toolkit** (6 scenarios):
Board updates (State→Issue→Action→Timeline), tough questions (Acknowledge→Explain→Action→Prevention), driving decisions (Problem→Impact→Solution→Recommendation).

All bilingual. Units 4-6 marked published. Build: 407 pages, 0 warnings.

**Course status after this PR:**
- Units 1-6 (Mechanics): COMPLETE
- Units 7-9 (Applications): PR 4
- Unit 10 + Capstone: PR 5

## Test plan
- [ ] Walk through Unit 4 at `/en/course/executive/unit-4/` — defensive→executive reframing, C2 Elite tiers
- [ ] Walk through Unit 5 — StoryBuilder: verify 5 color-coded steps, full-story audio, "why it works"
- [ ] Walk through Unit 6 — ImpromptuScenario: verify framework steps list, model reply audio
- [ ] Check ES mirrors at `/es/curso/ejecutivo/unidad-{4,5,6}/`
- [ ] Landing page unit grid: Units 1-6 now clickable, 7-10 still "Coming soon"
- [ ] Navigation: unit-3 → unit-4, unit-6 → overview (since U7 not built yet)
- [ ] No regressions on Units 1-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)