### PR TITLE
feat: add Ongoing Business English Coaching page

### DIFF
--- a/src/data/service-faqs.ts
+++ b/src/data/service-faqs.ts
@@ -405,6 +405,52 @@ export const serviceFaqs: Record<string, ServiceFaqSet> = {
       }
     ]
   },
+  "ongoing-coaching": {
+    en: [
+      {
+        question: "How is this different from the Executive Communication Program?",
+        answer: "The Executive Communication Program is a structured, performance-based sprint — formal assessments, a defined timeline, and a group presentation designed to surface gaps under pressure. This ongoing coaching format is more flexible and open-ended: no fixed structure, no performance milestones, and built around steady improvement in everyday professional communication."
+      },
+      {
+        question: "What level of English do participants need?",
+        answer: "Participants should be at intermediate level (B1) or above. The coaching is conducted entirely in English and is built around real professional communication — it's not a foundational language program. If someone is still building basic vocabulary and grammar, they aren't the right fit."
+      },
+      {
+        question: "Why is small talk included? That sounds informal.",
+        answer: "Small talk is a professional skill. It's how you open a business relationship before the agenda starts, build rapport with a client or colleague you've never met, and signal cultural fluency to the people around you. Professionals who can't engage naturally in informal English in a business setting often struggle to close deals, build trust, or be seen as full participants in meetings. We treat it as a real communication skill, not a social nicety."
+      },
+      {
+        question: "How are sessions scheduled?",
+        answer: "Scheduling is flexible and designed to work around professional calendars. Sessions are primarily conducted online via Google Meet. We'll coordinate timing based on your team's availability — there's no fixed weekly schedule that has to be adhered to rigidly."
+      },
+      {
+        question: "Can I mix 1:1 and group sessions for my team?",
+        answer: "Yes. Most teams benefit from a combination of both. Individual sessions address each person's specific gaps in a direct, private setting. Group sessions create the kind of dynamic, real-time communication pressure that individual sessions alone can't replicate. Robert will recommend a balance based on your team's size and goals."
+      }
+    ],
+    es: [
+      {
+        question: "¿En qué se diferencia del Programa de Comunicación Ejecutiva?",
+        answer: "El Programa de Comunicación Ejecutiva es un sprint estructurado y basado en desempeño — evaluaciones formales, una línea de tiempo definida y una presentación grupal diseñada para exponer brechas bajo presión. Este formato de coaching continuo es más flexible y abierto: sin estructura fija, sin hitos de desempeño, enfocado en la mejora constante de la comunicación profesional cotidiana."
+      },
+      {
+        question: "¿Qué nivel de inglés necesitan los participantes?",
+        answer: "Los participantes deben tener nivel intermedio (B1) o superior. El coaching se realiza íntegramente en inglés y está construido alrededor de la comunicación profesional real — no es un programa de inglés desde cero. Si alguien todavía está construyendo vocabulario y gramática básicos, no es el candidato adecuado."
+      },
+      {
+        question: "¿Por qué incluyen small talk? Eso suena informal.",
+        answer: "El small talk es una habilidad profesional. Es cómo se abre una relación de negocios antes de que empiece la agenda, cómo se construye rapport con un cliente o colega nuevo, y cómo se muestra fluidez cultural a quienes te rodean. Los profesionales que no pueden desenvolverse naturalmente en inglés informal en contextos de negocios con frecuencia tienen dificultades para cerrar tratos, generar confianza o ser percibidos como participantes plenos en reuniones. Lo tratamos como una habilidad de comunicación real, no como un detalle social."
+      },
+      {
+        question: "¿Cómo se programan las sesiones?",
+        answer: "La programación es flexible y está diseñada para adaptarse a las agendas profesionales. Las sesiones se realizan principalmente en línea por Google Meet. Coordinamos los horarios según la disponibilidad de tu equipo — no hay un horario semanal fijo que deba seguirse de manera rígida."
+      },
+      {
+        question: "¿Puedo combinar sesiones individuales y grupales para mi equipo?",
+        answer: "Sí. La mayoría de los equipos se benefician de una combinación de ambas. Las sesiones individuales abordan las brechas específicas de cada persona en un entorno directo y privado. Las sesiones grupales crean el tipo de presión dinámica de comunicación en tiempo real que las sesiones individuales por sí solas no pueden replicar. Robert recomendará un equilibrio basado en el tamaño y los objetivos de tu equipo."
+      }
+    ]
+  },
   "corporate-package": {
     en: [
       {

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -65,6 +65,7 @@ export type TKey =
   | "services/tech-english"
   | "services/technical-sales-english"
   | "services/corporate-package"
+  | "services/ongoing-coaching"
   | `category/${CategorySlug}`
   | "assessments"
   | "quiz"
@@ -194,6 +195,7 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "services/tech-english": "/en/services/tech-english/",
     "services/technical-sales-english": "/en/services/technical-sales-english/",
     "services/corporate-package": "/en/services/corporate-package/",
+    "services/ongoing-coaching": "/en/services/ongoing-coaching/",
     "category/startup-founders": "/en/category/startup-founders/",
     "category/tech-english": "/en/category/tech-english/",
     "category/logistics-english": "/en/category/logistics-english/",
@@ -336,6 +338,7 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "services/technical-sales-english":
       "/es/servicios/ingles-para-ventas-tecnicas/",
     "services/corporate-package": "/es/servicios/paquete-corporativo/",
+    "services/ongoing-coaching": "/es/servicios/coaching-continuo/",
     "category/startup-founders":
       "/es/categoria/ingles-para-fundadores-de-startups/",
     "category/tech-english": "/es/categoria/ingles-para-tecnologia/",

--- a/src/pages/en/services/executive-english.astro
+++ b/src/pages/en/services/executive-english.astro
@@ -126,6 +126,31 @@ const faqs = serviceFaqs["executive-english"]?.en || [];
     )
   }
 
+  <!-- Secondary Path — Ongoing Coaching -->
+  <section class="bg-light py-16 px-8">
+    <div class="site-container--small mx-auto max-w-3xl">
+      <div class="border-l-4 border-primary pl-8">
+        <p class="text-sm font-semibold text-primary uppercase tracking-wide mb-3">Also Available</p>
+        <h2 class="text-2xl font-bold mb-4">Professional English is more than high-stakes moments</h2>
+        <p class="text-gray-600 mb-4">
+          Boardroom presentations and investor meetings matter — but so does every interaction that surrounds them. The small talk before a client call that sets the tone. The meeting where you're following along but not quite contributing at the level you want. The networking lunch where the conversation moves fast and everyone else seems comfortable.
+        </p>
+        <p class="text-gray-600 mb-4">
+          Strong professional English operates at both levels: the obvious high-stakes moments <em>and</em> the everyday communication that builds trust, rapport, and professional presence over time. For teams focused on that second layer — ongoing fluency across meetings, networking, and real business interaction — I offer a more flexible coaching format with no fixed timeline and no performance assessment requirement.
+        </p>
+        <p class="text-gray-600 mb-6">
+          It's a different fit from the Executive Communication Program: less structured, more adaptable, and designed for steady improvement rather than a defined transformation milestone.
+        </p>
+        <a
+          href="/en/services/ongoing-coaching/"
+          class="inline-flex items-center gap-2 text-primary font-semibold hover:underline"
+        >
+          Explore flexible coaching options <span aria-hidden="true">→</span>
+        </a>
+      </div>
+    </div>
+  </section>
+
   <!-- Final CTA -->
   <CtaSection content={ctaContent} />
 

--- a/src/pages/en/services/ongoing-coaching.astro
+++ b/src/pages/en/services/ongoing-coaching.astro
@@ -1,0 +1,293 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import InnerHero from "@components/sections/InnerHero.astro";
+import CtaSection from "@components/sections/CtaSection.astro";
+import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
+import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
+import { serviceFaqs } from "@data/service-faqs";
+import { services } from "@data/services";
+
+const serviceData = services.find((s) => s.slug === "executive-english");
+if (!serviceData) throw new Error("Service data not found");
+
+const title = "Ongoing Business English Coaching for Teams | NY English Teacher";
+const seoDescription =
+  "Flexible English coaching for professional teams in Mexico. Build conversational fluency, stronger meetings, and natural rapport — no fixed curriculum, no generic course.";
+
+const heroContent = {
+  title: "Your team functions in English. Now make it feel natural.",
+  description:
+    "Ongoing coaching for professionals who want stronger communication across every layer of their working day — not just the moments that are obviously high-stakes.",
+  backgroundImage: serviceData.backgroundImage,
+  overlayOpacity: 0.72,
+  imageAlt: "Professional team in a business English coaching session",
+};
+
+const ctaContent = {
+  eyebrow: "Ongoing Coaching",
+  title: "Ready to build real fluency across your team?",
+  description:
+    "Schedule a discovery call. We'll talk about your team's current level, where the gaps are, and what a coaching format that fits your schedule and goals actually looks like.",
+  buttonText: "Schedule a Discovery Call",
+  buttonLink: "/en/book/",
+  whatToExpectTitle: "In Your Discovery Call, We Will:",
+  whatToExpectList: [
+    "Assess your team's current communication baseline",
+    "Identify the scenarios where stronger English would make the biggest difference",
+    "Define a format and schedule that works for your team",
+  ],
+};
+
+const faqs = serviceFaqs["ongoing-coaching"]?.en || [];
+---
+
+<Base
+  title={title}
+  description={seoDescription}
+  lang="en"
+  tkey="services/ongoing-coaching"
+  hideCta={true}
+  customHreflangs={[
+    {
+      lang: "en-US",
+      href: "https://www.nyenglishteacher.com/en/services/ongoing-coaching/",
+    },
+    {
+      lang: "es-MX",
+      href: "https://www.nyenglishteacher.com/es/servicios/coaching-continuo/",
+    },
+  ]}
+  customCanonical="https://www.nyenglishteacher.com/en/services/ongoing-coaching/"
+>
+  <InnerHero content={heroContent} />
+
+  <!-- Problem Section -->
+  <section class="bg-white py-16 px-8">
+    <div class="site-container--small mx-auto max-w-3xl">
+      <h2 class="text-3xl font-bold mb-6">The plateau most professionals don't talk about</h2>
+      <p class="text-gray-600 text-lg mb-5">
+        Many professionals reach a point where their English is functional — they can follow a meeting, answer direct questions, and get through a presentation. But the communication still feels effortful in ways that matter.
+      </p>
+      <p class="text-gray-600 mb-4">
+        The small talk before a client call that sets the tone for everything that follows. A networking lunch where the conversation moves fast and everyone else seems at ease. An unscripted question in the middle of a presentation. The moment after a meeting when colleagues are chatting informally and you feel two steps behind.
+      </p>
+      <p class="text-gray-600 mb-4">
+        These aren't minor inconveniences. Small talk is one of the most underrated skills in professional life. It's how trust gets built before the agenda starts, how business relationships form between meetings, and how you read a room before you need to lead it. The professionals who do it well in English don't just communicate — they connect.
+      </p>
+      <p class="text-gray-600">
+        The gap isn't vocabulary. It's fluency across the full range of professional communication — the kind that happens naturally, without effort, at every level of the working day.
+      </p>
+    </div>
+  </section>
+
+  <!-- Solution Section -->
+  <section class="bg-light py-16 px-8">
+    <div class="site-container--small mx-auto max-w-3xl">
+      <h2 class="text-3xl font-bold mb-4">What this coaching actually looks like</h2>
+      <p class="text-gray-600 mb-4">
+        This isn't a curriculum. There's no fixed syllabus, no grammar workbook, no end-of-module quiz. Sessions are immersive and fully in English. The content is built around your team's actual workplace: real meeting scenarios, the conversations that happen before and after a call, how to handle an unexpected question under pressure, how to build rapport with a new client in the first five minutes.
+      </p>
+      <p class="text-gray-600 mb-8">
+        The work can include conversation and discussion, meetings and Q&A, presentations, small talk and networking practice, and any professional interaction your team finds difficult or unnatural. The goal is to make the full range of English at work feel less like effort and more like instinct.
+      </p>
+
+      <div class="grid gap-4 md:grid-cols-2">
+        <div class="bg-white rounded-xl p-6 border border-gray-100">
+          <h3 class="font-bold mb-3">What sessions cover</h3>
+          <ul class="text-sm text-gray-600 space-y-2">
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span>
+              Meetings — contributing, questioning, leading
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span>
+              Small talk and relationship-building in English
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span>
+              Presentations and unscripted Q&A
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span>
+              Networking and informal business interaction
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span>
+              Everyday workplace communication, done naturally
+            </li>
+          </ul>
+        </div>
+        <div class="bg-white rounded-xl p-6 border border-gray-100">
+          <h3 class="font-bold mb-3">What this is not</h3>
+          <ul class="text-sm text-gray-600 space-y-2">
+            <li class="flex gap-2">
+              <span class="text-red-400 font-bold shrink-0">✗</span>
+              A generic English course with a pre-built syllabus
+            </li>
+            <li class="flex gap-2">
+              <span class="text-red-400 font-bold shrink-0">✗</span>
+              Grammar-focused instruction
+            </li>
+            <li class="flex gap-2">
+              <span class="text-red-400 font-bold shrink-0">✗</span>
+              Certification prep or test practice
+            </li>
+            <li class="flex gap-2">
+              <span class="text-red-400 font-bold shrink-0">✗</span>
+              Classroom-style group teaching
+            </li>
+            <li class="flex gap-2">
+              <span class="text-red-400 font-bold shrink-0">✗</span>
+              A beginner or foundational language program
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- How it Works -->
+  <section class="bg-white py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <h2 class="text-3xl font-bold mb-2 text-center">How it works</h2>
+      <p class="text-center text-gray-600 mb-12 max-w-xl mx-auto">
+        The format combines focused individual sessions with small-group practice. Both are fully in English and built around real professional scenarios.
+      </p>
+      <div class="grid gap-8 md:grid-cols-2 max-w-3xl mx-auto">
+        <div class="bg-light rounded-xl p-8 border border-gray-100">
+          <div class="text-sm font-semibold text-primary uppercase tracking-wide mb-2">Core development</div>
+          <h3 class="text-xl font-bold mb-3">1:1 Sessions</h3>
+          <p class="text-gray-600 text-sm">
+            Individual sessions are the heart of the work. Each participant gets targeted coaching on their specific gaps — how they structure ideas in English, how they come across under pressure, where natural fluency breaks down. It's direct, private, and adapted to the person.
+          </p>
+        </div>
+        <div class="bg-light rounded-xl p-8 border border-gray-100">
+          <div class="text-sm font-semibold text-primary uppercase tracking-wide mb-2">Applied practice</div>
+          <h3 class="text-xl font-bold mb-3">Small Group Sessions</h3>
+          <p class="text-gray-600 text-sm">
+            Group sessions involve a maximum of 4 participants. They're performance-based — not traditional group English teaching. Participants present, discuss, respond to questions, and communicate in real time with peers. This produces the kind of dynamic fluency that individual sessions alone can't build.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Who It's For -->
+  <section class="bg-light py-16 px-8">
+    <div class="site-container--small mx-auto max-w-3xl">
+      <h2 class="text-3xl font-bold mb-10 text-center">Who this is for</h2>
+      <div class="grid gap-8 md:grid-cols-2">
+        <div>
+          <h3 class="font-semibold mb-4">A good fit if...</h3>
+          <ul class="space-y-3 text-gray-600 text-sm">
+            <li class="flex gap-2">
+              <span class="text-green-500 font-bold shrink-0">✓</span>
+              Your team is at B1 level or above
+            </li>
+            <li class="flex gap-2">
+              <span class="text-green-500 font-bold shrink-0">✓</span>
+              You want practical improvement, not a certificate
+            </li>
+            <li class="flex gap-2">
+              <span class="text-green-500 font-bold shrink-0">✓</span>
+              Meetings, small talk, and everyday interaction matter to your work
+            </li>
+            <li class="flex gap-2">
+              <span class="text-green-500 font-bold shrink-0">✓</span>
+              You want coaching adapted to your real workplace context
+            </li>
+            <li class="flex gap-2">
+              <span class="text-green-500 font-bold shrink-0">✓</span>
+              Steady improvement over time fits your goals better than a one-time sprint
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-semibold mb-4">Who leads sessions</h3>
+          <p class="text-gray-600 text-sm mb-3">
+            Robert Cushman is a native New Yorker with over a decade of experience coaching executives, teams, and professionals across Mexico. He works entirely in English and focuses on communication that performs — not just communication that's technically correct.
+          </p>
+          <p class="text-gray-600 text-sm">
+            Sessions are conducted online via Google Meet. In-person group sessions may be possible depending on location and logistics, but online is the standard format.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Pricing -->
+  <section class="bg-white py-16 px-8">
+    <div class="site-container--small mx-auto max-w-2xl">
+      <h2 class="text-3xl font-bold mb-2 text-center">Investment</h2>
+      <p class="text-center text-gray-600 mb-10">Straightforward pricing. No packages, no minimum commitment.</p>
+      <div class="bg-gray-50 rounded-xl p-8 border border-gray-200 text-center">
+        <div class="text-4xl font-bold mb-2">500 MXN</div>
+        <div class="text-gray-500 mb-6">per hour, per participant</div>
+        <ul class="text-sm text-gray-600 space-y-3 text-left max-w-xs mx-auto">
+          <li class="flex gap-2">
+            <span class="text-green-500 font-bold shrink-0">✓</span>
+            Mexican facturas available
+          </li>
+          <li class="flex gap-2">
+            <span class="text-green-500 font-bold shrink-0">✓</span>
+            Flexible scheduling to fit professional calendars
+          </li>
+          <li class="flex gap-2">
+            <span class="text-green-500 font-bold shrink-0">✓</span>
+            Primarily online — standard format is Google Meet
+          </li>
+          <li class="flex gap-2">
+            <span class="text-green-500 font-bold shrink-0">✓</span>
+            No fixed term or minimum commitment required
+          </li>
+        </ul>
+      </div>
+      <p class="text-xs text-gray-400 text-center mt-4">
+        Group sessions are billed per participant per hour. Individual sessions are billed per hour of coaching time.
+      </p>
+    </div>
+  </section>
+
+  <CtaSection content={ctaContent} />
+  <ServiceFAQ faqs={faqs} lang="en" />
+
+  <BreadcrumbSchema
+    items={[
+      { name: "Home", url: "https://www.nyenglishteacher.com/en/" },
+      { name: "Services", url: "https://www.nyenglishteacher.com/en/services/" },
+      {
+        name: "Ongoing Business English Coaching",
+        url: "https://www.nyenglishteacher.com/en/services/ongoing-coaching/",
+      },
+    ]}
+  />
+
+  <script
+    type="application/ld+json"
+    set:html={JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Service",
+      name: "Ongoing Business English Coaching for Teams",
+      description:
+        "Flexible, immersive English coaching for professional teams. 1:1 sessions and small-group practice focused on meetings, small talk, presentations, and everyday business communication.",
+      provider: {
+        "@type": "Person",
+        name: "Robert Cushman",
+        jobTitle: "English Coach",
+        url: "https://www.nyenglishteacher.com/en/about/",
+      },
+      serviceType: "Business English Coaching",
+      areaServed: { "@type": "Country", name: "Mexico" },
+      offers: {
+        "@type": "Offer",
+        price: "500",
+        priceCurrency: "MXN",
+        description: "500 MXN per hour per participant",
+        eligibleCustomerType: "https://schema.org/BusinessCustomer",
+      },
+      url: "https://www.nyenglishteacher.com/en/services/ongoing-coaching/",
+    })}
+  />
+</Base>

--- a/src/pages/es/servicios/coaching-continuo.astro
+++ b/src/pages/es/servicios/coaching-continuo.astro
@@ -1,0 +1,293 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import InnerHero from "@components/sections/InnerHero.astro";
+import CtaSection from "@components/sections/CtaSection.astro";
+import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
+import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
+import { serviceFaqs } from "@data/service-faqs";
+import { services } from "@data/services";
+
+const serviceData = services.find((s) => s.slug === "executive-english");
+if (!serviceData) throw new Error("Service data not found");
+
+const title = "Coaching Continuo de Inglés para Equipos | NY English Teacher";
+const seoDescription =
+  "Coaching flexible de inglés para equipos profesionales en México. Desarrolla fluidez en conversación, mejora reuniones y construye rapport natural — sin currículo fijo ni curso genérico.";
+
+const heroContent = {
+  title: "Tu equipo funciona en inglés. Ahora haz que fluya con naturalidad.",
+  description:
+    "Coaching continuo para profesionales que quieren comunicarse mejor en todos los niveles de su jornada laboral — no solo en los momentos de alta presión.",
+  backgroundImage: serviceData.backgroundImage,
+  overlayOpacity: 0.72,
+  imageAlt: "Equipo profesional en sesión de coaching de inglés de negocios",
+};
+
+const ctaContent = {
+  eyebrow: "Coaching Continuo",
+  title: "¿Listo para construir fluidez real en tu equipo?",
+  description:
+    "Agenda una llamada de descubrimiento. Hablaremos sobre el nivel actual de tu equipo, dónde están las brechas, y qué formato de coaching se adapta realmente a tu agenda y objetivos.",
+  buttonText: "Agendar Llamada de Descubrimiento",
+  buttonLink: "/es/reservar/",
+  whatToExpectTitle: "En Tu Llamada de Descubrimiento:",
+  whatToExpectList: [
+    "Evaluamos la base de comunicación actual de tu equipo",
+    "Identificamos los escenarios donde un mejor inglés marcaría mayor diferencia",
+    "Definimos un formato y horario que funcione para tu equipo",
+  ],
+};
+
+const faqs = serviceFaqs["ongoing-coaching"]?.es || [];
+---
+
+<Base
+  title={title}
+  description={seoDescription}
+  lang="es"
+  tkey="services/ongoing-coaching"
+  hideCta={true}
+  customHreflangs={[
+    {
+      lang: "en-US",
+      href: "https://www.nyenglishteacher.com/en/services/ongoing-coaching/",
+    },
+    {
+      lang: "es-MX",
+      href: "https://www.nyenglishteacher.com/es/servicios/coaching-continuo/",
+    },
+  ]}
+  customCanonical="https://www.nyenglishteacher.com/es/servicios/coaching-continuo/"
+>
+  <InnerHero content={heroContent} />
+
+  <!-- Sección del Problema -->
+  <section class="bg-white py-16 px-8">
+    <div class="site-container--small mx-auto max-w-3xl">
+      <h2 class="text-3xl font-bold mb-6">El estancamiento del que pocos hablan</h2>
+      <p class="text-gray-600 text-lg mb-5">
+        Muchos profesionales llegan a un punto en el que su inglés ya es funcional — pueden seguir una reunión, responder preguntas directas y salir adelante en una presentación. Pero la comunicación sigue sintiéndose forzada en formas que importan.
+      </p>
+      <p class="text-gray-600 mb-4">
+        El small talk antes de una llamada con un cliente que define el tono de todo lo que sigue. Un almuerzo de networking donde la conversación avanza rápido y todos los demás parecen a gusto. Una pregunta fuera del guión en medio de una presentación. El momento después de una reunión cuando los colegas conversan informalmente y sientes que vas dos pasos atrás.
+      </p>
+      <p class="text-gray-600 mb-4">
+        Estos no son inconvenientes menores. El small talk es una de las habilidades más subestimadas en la vida profesional. Es como se construye confianza antes de que empiece la agenda, como se forman las relaciones de negocios entre reuniones, y como se lee una sala antes de tener que liderarla. Los profesionales que lo hacen bien en inglés no solo se comunican — conectan.
+      </p>
+      <p class="text-gray-600">
+        La brecha no está en el vocabulario. Está en la fluidez a lo largo de toda la gama de comunicación profesional — el tipo que sucede de forma natural, sin esfuerzo, en todos los niveles de la jornada laboral.
+      </p>
+    </div>
+  </section>
+
+  <!-- Sección de Solución -->
+  <section class="bg-light py-16 px-8">
+    <div class="site-container--small mx-auto max-w-3xl">
+      <h2 class="text-3xl font-bold mb-4">Cómo funciona este coaching en la práctica</h2>
+      <p class="text-gray-600 mb-4">
+        Esto no es un currículo. No hay un temario fijo, no hay libro de gramática, no hay examen al final del módulo. Las sesiones son inmersivas y completamente en inglés. El contenido está construido alrededor del entorno laboral real de tu equipo: escenarios de reuniones reales, las conversaciones que ocurren antes y después de una llamada, cómo manejar una pregunta inesperada bajo presión, cómo construir rapport con un nuevo cliente en los primeros cinco minutos.
+      </p>
+      <p class="text-gray-600 mb-8">
+        El trabajo puede incluir conversación y discusión, reuniones y Q&A, presentaciones, práctica de small talk y networking, y cualquier interacción profesional que tu equipo encuentre difícil o poco natural. El objetivo es que toda la gama del inglés en el trabajo se sienta menos como esfuerzo y más como instinto.
+      </p>
+
+      <div class="grid gap-4 md:grid-cols-2">
+        <div class="bg-white rounded-xl p-6 border border-gray-100">
+          <h3 class="font-bold mb-3">Qué cubre cada sesión</h3>
+          <ul class="text-sm text-gray-600 space-y-2">
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span>
+              Reuniones — participar, preguntar, liderar
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span>
+              Small talk y construcción de relaciones en inglés
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span>
+              Presentaciones y Q&A sin guión
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span>
+              Networking e interacción informal de negocios
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span>
+              Comunicación cotidiana en el trabajo, hecha con naturalidad
+            </li>
+          </ul>
+        </div>
+        <div class="bg-white rounded-xl p-6 border border-gray-100">
+          <h3 class="font-bold mb-3">Lo que esto no es</h3>
+          <ul class="text-sm text-gray-600 space-y-2">
+            <li class="flex gap-2">
+              <span class="text-red-400 font-bold shrink-0">✗</span>
+              Un curso de inglés genérico con temario prefabricado
+            </li>
+            <li class="flex gap-2">
+              <span class="text-red-400 font-bold shrink-0">✗</span>
+              Instrucción enfocada en gramática
+            </li>
+            <li class="flex gap-2">
+              <span class="text-red-400 font-bold shrink-0">✗</span>
+              Preparación para certificaciones o exámenes
+            </li>
+            <li class="flex gap-2">
+              <span class="text-red-400 font-bold shrink-0">✗</span>
+              Clase grupal estilo salón de clases
+            </li>
+            <li class="flex gap-2">
+              <span class="text-red-400 font-bold shrink-0">✗</span>
+              Un programa de inglés básico para principiantes
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Cómo Funciona -->
+  <section class="bg-white py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <h2 class="text-3xl font-bold mb-2 text-center">Cómo se estructura</h2>
+      <p class="text-center text-gray-600 mb-12 max-w-xl mx-auto">
+        El formato combina sesiones individuales enfocadas con práctica en grupos pequeños. Ambas son completamente en inglés y construidas alrededor de escenarios profesionales reales.
+      </p>
+      <div class="grid gap-8 md:grid-cols-2 max-w-3xl mx-auto">
+        <div class="bg-light rounded-xl p-8 border border-gray-100">
+          <div class="text-sm font-semibold text-primary uppercase tracking-wide mb-2">Desarrollo central</div>
+          <h3 class="text-xl font-bold mb-3">Sesiones 1:1</h3>
+          <p class="text-gray-600 text-sm">
+            Las sesiones individuales son el núcleo del trabajo. Cada participante recibe coaching dirigido a sus brechas específicas — cómo estructura sus ideas en inglés, cómo proyecta bajo presión, dónde se rompe la fluidez natural. Es directo, privado y adaptado a la persona.
+          </p>
+        </div>
+        <div class="bg-light rounded-xl p-8 border border-gray-100">
+          <div class="text-sm font-semibold text-primary uppercase tracking-wide mb-2">Práctica aplicada</div>
+          <h3 class="text-xl font-bold mb-3">Sesiones en Grupo Pequeño</h3>
+          <p class="text-gray-600 text-sm">
+            Las sesiones grupales tienen un máximo de 4 participantes. Son basadas en desempeño — no es enseñanza de inglés grupal tradicional. Los participantes presentan, discuten, responden preguntas y se comunican en tiempo real con sus pares. Esto genera el tipo de fluidez dinámica que las sesiones individuales por sí solas no pueden producir.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Para Quién Es -->
+  <section class="bg-light py-16 px-8">
+    <div class="site-container--small mx-auto max-w-3xl">
+      <h2 class="text-3xl font-bold mb-10 text-center">Para quién es este programa</h2>
+      <div class="grid gap-8 md:grid-cols-2">
+        <div>
+          <h3 class="font-semibold mb-4">Es un buen ajuste si...</h3>
+          <ul class="space-y-3 text-gray-600 text-sm">
+            <li class="flex gap-2">
+              <span class="text-green-500 font-bold shrink-0">✓</span>
+              Tu equipo está en nivel B1 o superior
+            </li>
+            <li class="flex gap-2">
+              <span class="text-green-500 font-bold shrink-0">✓</span>
+              Quieres mejora práctica, no una certificación
+            </li>
+            <li class="flex gap-2">
+              <span class="text-green-500 font-bold shrink-0">✓</span>
+              Las reuniones, el small talk y la interacción cotidiana importan en tu trabajo
+            </li>
+            <li class="flex gap-2">
+              <span class="text-green-500 font-bold shrink-0">✓</span>
+              Quieres coaching adaptado al contexto real de tu empresa
+            </li>
+            <li class="flex gap-2">
+              <span class="text-green-500 font-bold shrink-0">✓</span>
+              La mejora constante en el tiempo encaja mejor con tus objetivos que un sprint puntual
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-semibold mb-4">Quién dirige las sesiones</h3>
+          <p class="text-gray-600 text-sm mb-3">
+            Robert Cushman es un neoyorquino nativo con más de una década de experiencia trabajando con ejecutivos, equipos y profesionales en México. Trabaja íntegramente en inglés y se enfoca en comunicación que funciona — no solo en comunicación técnicamente correcta.
+          </p>
+          <p class="text-gray-600 text-sm">
+            Las sesiones se realizan en línea por Google Meet. Las sesiones grupales presenciales pueden ser posibles según la ubicación y la logística, pero el formato estándar es en línea.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Inversión -->
+  <section class="bg-white py-16 px-8">
+    <div class="site-container--small mx-auto max-w-2xl">
+      <h2 class="text-3xl font-bold mb-2 text-center">Inversión</h2>
+      <p class="text-center text-gray-600 mb-10">Precio claro. Sin paquetes, sin compromiso mínimo.</p>
+      <div class="bg-gray-50 rounded-xl p-8 border border-gray-200 text-center">
+        <div class="text-4xl font-bold mb-2">$500 MXN</div>
+        <div class="text-gray-500 mb-6">por hora, por participante</div>
+        <ul class="text-sm text-gray-600 space-y-3 text-left max-w-xs mx-auto">
+          <li class="flex gap-2">
+            <span class="text-green-500 font-bold shrink-0">✓</span>
+            Facturas mexicanas disponibles
+          </li>
+          <li class="flex gap-2">
+            <span class="text-green-500 font-bold shrink-0">✓</span>
+            Programación flexible para agendas profesionales
+          </li>
+          <li class="flex gap-2">
+            <span class="text-green-500 font-bold shrink-0">✓</span>
+            Principalmente en línea — formato estándar por Google Meet
+          </li>
+          <li class="flex gap-2">
+            <span class="text-green-500 font-bold shrink-0">✓</span>
+            Sin plazo fijo ni compromiso mínimo requerido
+          </li>
+        </ul>
+      </div>
+      <p class="text-xs text-gray-400 text-center mt-4">
+        Las sesiones grupales se facturan por participante por hora. Las sesiones individuales se facturan por hora de coaching.
+      </p>
+    </div>
+  </section>
+
+  <CtaSection content={ctaContent} />
+  <ServiceFAQ faqs={faqs} lang="es" />
+
+  <BreadcrumbSchema
+    items={[
+      { name: "Inicio", url: "https://www.nyenglishteacher.com/es/" },
+      { name: "Servicios", url: "https://www.nyenglishteacher.com/es/servicios/" },
+      {
+        name: "Coaching Continuo de Inglés para Equipos",
+        url: "https://www.nyenglishteacher.com/es/servicios/coaching-continuo/",
+      },
+    ]}
+  />
+
+  <script
+    type="application/ld+json"
+    set:html={JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Service",
+      name: "Coaching Continuo de Inglés para Equipos",
+      description:
+        "Coaching flexible e inmersivo de inglés para equipos profesionales. Sesiones 1:1 y práctica en grupos pequeños enfocadas en reuniones, small talk, presentaciones y comunicación cotidiana de negocios.",
+      provider: {
+        "@type": "Person",
+        name: "Robert Cushman",
+        jobTitle: "English Coach",
+        url: "https://www.nyenglishteacher.com/es/about/",
+      },
+      serviceType: "Business English Coaching",
+      areaServed: { "@type": "Country", name: "Mexico" },
+      offers: {
+        "@type": "Offer",
+        price: "500",
+        priceCurrency: "MXN",
+        description: "500 MXN por hora por participante",
+        eligibleCustomerType: "https://schema.org/BusinessCustomer",
+      },
+      url: "https://www.nyenglishteacher.com/es/servicios/coaching-continuo/",
+    })}
+  />
+</Base>

--- a/src/pages/es/servicios/ingles-para-ejecutivos.astro
+++ b/src/pages/es/servicios/ingles-para-ejecutivos.astro
@@ -153,6 +153,31 @@ const faqs = serviceFaqs["executive-english"]?.es || [];
     )
   }
 
+  <!-- Opción Secundaria — Coaching Continuo -->
+  <section class="bg-light py-16 px-8">
+    <div class="site-container--small mx-auto max-w-3xl">
+      <div class="border-l-4 border-primary pl-8">
+        <p class="text-sm font-semibold text-primary uppercase tracking-wide mb-3">También Disponible</p>
+        <h2 class="text-2xl font-bold mb-4">El inglés profesional va más allá de los momentos de alta presión</h2>
+        <p class="text-gray-600 mb-4">
+          Las presentaciones en sala de juntas y las reuniones con inversionistas importan — pero también importa todo lo que las rodea. El small talk antes de una llamada con un cliente que define el tono. La reunión en la que estás siguiendo la conversación pero no participas al nivel que quisieras. El almuerzo de networking donde la conversación avanza rápido y todos los demás parecen cómodos.
+        </p>
+        <p class="text-gray-600 mb-4">
+          El inglés profesional sólido opera en ambos niveles: los momentos de alta presión más evidentes <em>y</em> la comunicación cotidiana que construye confianza, rapport y presencia profesional a lo largo del tiempo. Para equipos enfocados en esa segunda capa — fluidez continua en reuniones, networking e interacción real de negocios — ofrezco un formato de coaching más flexible, sin plazos fijos y sin requisitos de evaluación de desempeño.
+        </p>
+        <p class="text-gray-600 mb-6">
+          Es un ajuste diferente al Programa de Comunicación Ejecutiva: menos estructurado, más adaptable, y diseñado para la mejora constante en lugar de un hito de transformación definido.
+        </p>
+        <a
+          href="/es/servicios/coaching-continuo/"
+          class="inline-flex items-center gap-2 text-primary font-semibold hover:underline"
+        >
+          Explorar opciones de coaching flexible <span aria-hidden="true">→</span>
+        </a>
+      </div>
+    </div>
+  </section>
+
   <!-- Final CTA -->
   <CtaSection content={ctaContent} />
 


### PR DESCRIPTION
## Summary

- New standalone page `/en/services/ongoing-coaching/` (+ ES mirror `/es/servicios/coaching-continuo/`) for the flexible team coaching offer
- Secondary-path section added to both EN and ES Executive Communication Program pages, introducing the offer as a different fit without weakening the flagship
- 5-question FAQ set in both languages covering: difference from executive program, required level, why small talk matters, scheduling, and 1:1 vs group mix
- i18n routing and TKey registered for both locales
- Pricing: 500 MXN/hr per participant, facturas available

## Test plan

- [ ] `/en/services/ongoing-coaching/` loads and renders all sections
- [ ] `/es/servicios/coaching-continuo/` loads and renders Spanish content correctly
- [ ] Executive English pages (EN + ES) show the secondary section above the final CTA
- [ ] "Explore flexible coaching options →" link navigates to the new page
- [ ] FAQ accordion expands correctly on both pages
- [ ] No TypeScript errors (`astro check` passed: 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)