### PR TITLE
fix: clarify no-assessment boundary + cross-link corporate pages

### DIFF
--- a/src/pages/en/services/corporate-package.astro
+++ b/src/pages/en/services/corporate-package.astro
@@ -186,6 +186,22 @@ const faqs = serviceFaqs["corporate-package"]?.en || [];
     </div>
   </section>
 
+  <!-- Cross-link — Flexible Coaching Option -->
+  <section class="bg-white py-12 px-8 border-t border-gray-100">
+    <div class="site-container--small mx-auto max-w-3xl">
+      <div class="border-l-4 border-primary pl-8">
+        <p class="text-sm font-semibold text-primary uppercase tracking-wide mb-2">Also Available</p>
+        <h2 class="text-xl font-bold mb-3">Need something more flexible, without the formal assessment structure?</h2>
+        <p class="text-gray-600 mb-4 text-sm">
+          Some teams aren't ready for a structured sprint — or don't need the reporting layer. For companies that want ongoing, immersive English coaching focused on meetings, small talk, presentations, and everyday professional communication, I offer a flexible alternative with no fixed timeline and no HR documentation.
+        </p>
+        <a href="/en/services/ongoing-coaching/" class="inline-flex items-center gap-2 text-primary font-semibold text-sm hover:underline">
+          Explore flexible ongoing coaching <span aria-hidden="true">→</span>
+        </a>
+      </div>
+    </div>
+  </section>
+
   <!-- CTA -->
   <CtaSection content={ctaContent} />
 

--- a/src/pages/en/services/ongoing-coaching.astro
+++ b/src/pages/en/services/ongoing-coaching.astro
@@ -142,6 +142,14 @@ const faqs = serviceFaqs["ongoing-coaching"]?.en || [];
               <span class="text-red-400 font-bold shrink-0">✗</span>
               A beginner or foundational language program
             </li>
+            <li class="flex gap-2">
+              <span class="text-red-400 font-bold shrink-0">✗</span>
+              Formal baseline assessments or individual performance evaluations
+            </li>
+            <li class="flex gap-2">
+              <span class="text-red-400 font-bold shrink-0">✗</span>
+              Written progress reports or HR documentation
+            </li>
           </ul>
         </div>
       </div>
@@ -213,6 +221,10 @@ const faqs = serviceFaqs["ongoing-coaching"]?.en || [];
             Sessions are conducted online via Google Meet. In-person group sessions may be possible depending on location and logistics, but online is the standard format.
           </p>
         </div>
+      </div>
+
+      <div class="mt-10 bg-amber-50 border border-amber-200 rounded-xl p-6 text-sm text-amber-900">
+        <strong>No formal assessments. No HR reports.</strong> This format does not include baseline testing, individual performance evaluations, or written documentation for HR or management review. Improvement happens through coaching — not through measurement and reporting. If your company needs that level of structure and documentation, the <a href="/en/services/corporate-package/" class="underline font-semibold">Corporate English Training Program</a> is the right fit.
       </div>
     </div>
   </section>

--- a/src/pages/es/servicios/coaching-continuo.astro
+++ b/src/pages/es/servicios/coaching-continuo.astro
@@ -142,6 +142,14 @@ const faqs = serviceFaqs["ongoing-coaching"]?.es || [];
               <span class="text-red-400 font-bold shrink-0">✗</span>
               Un programa de inglés básico para principiantes
             </li>
+            <li class="flex gap-2">
+              <span class="text-red-400 font-bold shrink-0">✗</span>
+              Evaluaciones formales o calificaciones de desempeño individual
+            </li>
+            <li class="flex gap-2">
+              <span class="text-red-400 font-bold shrink-0">✗</span>
+              Reportes de progreso escritos ni documentación para RH
+            </li>
           </ul>
         </div>
       </div>
@@ -213,6 +221,10 @@ const faqs = serviceFaqs["ongoing-coaching"]?.es || [];
             Las sesiones se realizan en línea por Google Meet. Las sesiones grupales presenciales pueden ser posibles según la ubicación y la logística, pero el formato estándar es en línea.
           </p>
         </div>
+      </div>
+
+      <div class="mt-10 bg-amber-50 border border-amber-200 rounded-xl p-6 text-sm text-amber-900">
+        <strong>Sin evaluaciones formales. Sin reportes para RH.</strong> Este formato no incluye pruebas de nivel inicial, evaluaciones de desempeño individual ni documentación escrita para recursos humanos o dirección. La mejora se da a través del coaching — no a través de medición y reportes. Si tu empresa necesita ese nivel de estructura y documentación, el <a href="/es/servicios/paquete-corporativo/" class="underline font-semibold">Programa Corporativo de Inglés</a> es la opción indicada.
       </div>
     </div>
   </section>

--- a/src/pages/es/servicios/paquete-corporativo.astro
+++ b/src/pages/es/servicios/paquete-corporativo.astro
@@ -186,6 +186,22 @@ const faqs = serviceFaqs["corporate-package"]?.es || [];
     </div>
   </section>
 
+  <!-- Enlace cruzado — Opción de Coaching Flexible -->
+  <section class="bg-white py-12 px-8 border-t border-gray-100">
+    <div class="site-container--small mx-auto max-w-3xl">
+      <div class="border-l-4 border-primary pl-8">
+        <p class="text-sm font-semibold text-primary uppercase tracking-wide mb-2">También Disponible</p>
+        <h2 class="text-xl font-bold mb-3">¿Necesitas algo más flexible, sin la estructura de evaluación formal?</h2>
+        <p class="text-gray-600 mb-4 text-sm">
+          Algunos equipos no están listos para un sprint estructurado — o simplemente no necesitan la capa de reporteo. Para empresas que quieren coaching continuo e inmersivo enfocado en reuniones, small talk, presentaciones y comunicación profesional cotidiana, ofrezco una alternativa flexible sin plazos fijos ni documentación para RH.
+        </p>
+        <a href="/es/servicios/coaching-continuo/" class="inline-flex items-center gap-2 text-primary font-semibold text-sm hover:underline">
+          Explorar coaching continuo flexible <span aria-hidden="true">→</span>
+        </a>
+      </div>
+    </div>
+  </section>
+
   <!-- CTA -->
   <CtaSection content={ctaContent} />
 


### PR DESCRIPTION
## Summary

- **ongoing-coaching** (EN + ES): Two new "What this is not" items — no formal assessments, no HR reports. Plus an amber callout in the "Who it's for" section that says explicitly: no baseline testing, no performance evaluations, no written documentation for HR. Redirects to the Corporate Package for teams that need that structure.
- **corporate-package** (EN + ES): Cross-link section added before the CTA, pointing to ongoing-coaching for teams that want flexibility without the formal assessment layer.

## Test plan

- [ ] Ongoing coaching pages show the two new "✗" items in the list
- [ ] Amber callout renders correctly on both EN and ES ongoing coaching pages
- [ ] Corporate package pages show the cross-link section before the CTA
- [ ] All internal links resolve correctly
- [ ] `astro check` passes: 0 errors ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)