### PR TITLE
fix: switch all OG images to 800×800 square for WhatsApp thumbnails

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -138,9 +138,9 @@ if (ogImage?.src) {
   // If it's an Astro image object with .src property, extract the path
   const srcValue =
     typeof ogImage.src === "string" ? ogImage.src : (ogImage.src as any)?.src;
-  ogImgPath = srcValue ?? "/images/logos/new-york-english-og.jpg";
+  ogImgPath = srcValue ?? "/images/logos/new-york-english-sq-og.jpg";
 } else {
-  ogImgPath = "/images/logos/new-york-english-og.jpg";
+  ogImgPath = "/images/logos/new-york-english-sq-og.jpg";
 }
 
 // Convert relative paths to absolute URLs, but avoid processing Astro's @fs paths
@@ -149,7 +149,7 @@ const ogImg = ogImgPath.startsWith("http")
   : ogImgPath.startsWith("/@fs") ||
       ogImgPath.includes("C:/") ||
       ogImgPath.includes("C:\\")
-    ? SITE + "/images/logos/new-york-english-og.jpg" // Fallback for dev paths
+    ? SITE + "/images/logos/new-york-english-sq-og.jpg" // Fallback for dev paths
     : SITE + (ogImgPath.startsWith("/") ? ogImgPath : "/" + ogImgPath);
 
 const ogAlt =
@@ -158,9 +158,9 @@ const ogAlt =
     ? "New York English Teacher (ES)"
     : "New York English Teacher (EN)");
 
-// OG image dimensions
-const ogImgWidth = ogImage?.width ?? 1200;
-const ogImgHeight = ogImage?.height ?? 675;
+// OG image dimensions — square (800×800) renders correctly in WhatsApp thumbnails
+const ogImgWidth = ogImage?.width ?? 800;
+const ogImgHeight = ogImage?.height ?? 800;
 
 // Convert dates to ISO 8601 format with timezone (Mexico City: UTC-6)
 // Using timezone-aware format prevents date confusion across regions

--- a/src/pages/en/resources.astro
+++ b/src/pages/en/resources.astro
@@ -46,7 +46,7 @@ const resources: FreeAsset[] = allAssets
   lang="en"
   tkey="resources"
   ogImage={{
-    src: "/images/logos/new-york-english-og.jpg",
+    src: "/images/logos/new-york-english-sq-og.jpg",
     alt: "Executive English Resource Library - New York English Teacher",
   }}
   hideCta={true}

--- a/src/pages/en/resources/[slug].astro
+++ b/src/pages/en/resources/[slug].astro
@@ -65,7 +65,7 @@ const bookingUrl = "/en/book/";
   lang="en"
   tkey={`resources/${slug}` as TKey}
   ogImage={{
-    src: "/images/logos/new-york-english-og.jpg",
+    src: "/images/logos/new-york-english-sq-og.jpg",
     alt: `${enContent.title} - Executive Resource`,
   }}
   hideCta={true}

--- a/src/pages/en/services/executive-english.astro
+++ b/src/pages/en/services/executive-english.astro
@@ -91,7 +91,7 @@ const faqs = serviceFaqs["executive-english"]?.en || [];
     src:
       typeof serviceData.backgroundImage === "string"
         ? serviceData.backgroundImage
-        : "/images/logos/new-york-english-og.jpg",
+        : "/images/logos/new-york-english-sq-og.jpg",
   }}
   hideCta={true}
   customHreflangs={[

--- a/src/pages/en/services/high-stakes-english.astro
+++ b/src/pages/en/services/high-stakes-english.astro
@@ -96,7 +96,7 @@ const faqs = serviceFaqs["high-stakes-english"]?.en || [];
     src:
       typeof highStakesService?.backgroundImage === "string"
         ? highStakesService.backgroundImage
-        : "/images/logos/new-york-english-og.jpg",
+        : "/images/logos/new-york-english-sq-og.jpg",
   }}
   customHreflangs={[
     {

--- a/src/pages/en/services/index.astro
+++ b/src/pages/en/services/index.astro
@@ -63,7 +63,7 @@ const ctaContent = {
   description={seoDescription}
   lang={lang}
   tkey={tkey}
-  ogImage={{ src: "/images/logos/new-york-english-og-wide.jpg" }}
+  ogImage={{ src: "/images/logos/new-york-english-sq-og.jpg" }}
   heroImage={servicesHeroImage}
   hideCta={true}
 >

--- a/src/pages/en/services/interview-prep.astro
+++ b/src/pages/en/services/interview-prep.astro
@@ -81,7 +81,7 @@ const faqs = serviceFaqs["interview-prep"]?.en || [];
   description="Master confident English for job interviews. Clear technical explanations, compelling stories, and executive presence that gets you hired."
   lang="en"
   tkey="services/interview-prep"
-  ogImage={{ src: typeof serviceData?.backgroundImage === 'string' ? serviceData.backgroundImage : "/images/logos/new-york-english-og.jpg" }}
+  ogImage={{ src: typeof serviceData?.backgroundImage === 'string' ? serviceData.backgroundImage : "/images/logos/new-york-english-sq-og.jpg" }}
   customHreflangs={[
     { lang: 'en-US', href: 'https://www.nyenglishteacher.com/en/services/interview-prep/' },
     { lang: 'es-MX', href: 'https://www.nyenglishteacher.com/es/servicios/preparacion-para-entrevistas/' }

--- a/src/pages/en/services/logistics-english.astro
+++ b/src/pages/en/services/logistics-english.astro
@@ -98,7 +98,7 @@ const faqs = serviceFaqs["logistics-english"]?.en || [];
     src:
       typeof logisticsService?.backgroundImage === "string"
         ? logisticsService.backgroundImage
-        : "/images/logos/new-york-english-og.jpg",
+        : "/images/logos/new-york-english-sq-og.jpg",
   }}
   customHreflangs={[
     {

--- a/src/pages/en/services/medical-english.astro
+++ b/src/pages/en/services/medical-english.astro
@@ -85,7 +85,7 @@ const faqs = serviceFaqs["medical-english"]?.en || [];
   lang="en"
   tkey="services/medical-english"
   ogImage={{
-    src: medicalService?.backgroundImage?.src || "/images/logos/new-york-english-og.jpg",
+    src: medicalService?.backgroundImage?.src || "/images/logos/new-york-english-sq-og.jpg",
     alt: `${title} - Featured Image`,
     width: medicalService?.backgroundImage?.width,
     height: medicalService?.backgroundImage?.height

--- a/src/pages/en/services/professional-english.astro
+++ b/src/pages/en/services/professional-english.astro
@@ -92,7 +92,7 @@ const faqs = serviceFaqs["professional-english"]?.en || [];
     src:
       typeof professionalService?.backgroundImage === "string"
         ? professionalService.backgroundImage
-        : "/images/logos/new-york-english-og.jpg",
+        : "/images/logos/new-york-english-sq-og.jpg",
   }}
   customHreflangs={[
     {

--- a/src/pages/en/services/public-speaking-english.astro
+++ b/src/pages/en/services/public-speaking-english.astro
@@ -84,7 +84,7 @@ const faqs = serviceFaqs["public-speaking-english"]?.en || [];
   ogImage={{
     src:
       publicSpeakingService?.backgroundImage?.src ||
-      "/images/logos/new-york-english-og.jpg",
+      "/images/logos/new-york-english-sq-og.jpg",
     alt: `${title} - Featured Image`,
     width: publicSpeakingService?.backgroundImage?.width,
     height: publicSpeakingService?.backgroundImage?.height,

--- a/src/pages/en/services/startup-founders.astro
+++ b/src/pages/en/services/startup-founders.astro
@@ -76,7 +76,7 @@ const faqs = serviceFaqs["startup-founders"]?.en || [];
   description="English coaching for startup founders. Perfect your investor pitch, lead your team, and communicate your vision with confidence and clarity."
   lang="en"
   tkey="services/startup-founders"
-  ogImage={{ src: typeof serviceData?.backgroundImage === 'string' ? serviceData.backgroundImage : "/images/logos/new-york-english-og.jpg" }}
+  ogImage={{ src: typeof serviceData?.backgroundImage === 'string' ? serviceData.backgroundImage : "/images/logos/new-york-english-sq-og.jpg" }}
   customHreflangs={[
     { lang: 'en-US', href: 'https://www.nyenglishteacher.com/en/services/startup-founders/' },
     { lang: 'es-MX', href: 'https://www.nyenglishteacher.com/es/servicios/ingles-para-fundadores-de-startups/' }

--- a/src/pages/en/services/tech-english.astro
+++ b/src/pages/en/services/tech-english.astro
@@ -82,7 +82,7 @@ const faqs = serviceFaqs["tech-english"]?.en || [];
     src:
       typeof serviceData?.backgroundImage === "string"
         ? serviceData.backgroundImage
-        : "/images/logos/new-york-english-og.jpg",
+        : "/images/logos/new-york-english-sq-og.jpg",
   }}
   customHreflangs={[
     {

--- a/src/pages/en/services/technical-sales-english.astro
+++ b/src/pages/en/services/technical-sales-english.astro
@@ -86,7 +86,7 @@ const faqs = serviceFaqs["technical-sales-english"]?.en || [];
   ogImage={{
     src:
       technicalSalesService?.backgroundImage?.src ||
-      "/images/logos/new-york-english-og.jpg",
+      "/images/logos/new-york-english-sq-og.jpg",
     alt: `${title} - Featured Image`,
     width: technicalSalesService?.backgroundImage?.width,
     height: technicalSalesService?.backgroundImage?.height,

--- a/src/pages/en/site-index/index.astro
+++ b/src/pages/en/site-index/index.astro
@@ -83,7 +83,7 @@ const assessments = [
   lang="en"
   tkey="site-index"
   ogImage={{
-    src: "/images/logos/new-york-english-og.jpg",
+    src: "/images/logos/new-york-english-sq-og.jpg",
     alt: "NY English Teacher - Complete Site Index",
   }}
   hideCta={true}

--- a/src/pages/es/indice-del-sitio/index.astro
+++ b/src/pages/es/indice-del-sitio/index.astro
@@ -83,7 +83,7 @@ const assessments = [
   lang="es"
   tkey="site-index"
   ogImage={{
-    src: "/images/logos/new-york-english-og.jpg",
+    src: "/images/logos/new-york-english-sq-og.jpg",
     alt: "NY English Teacher - Índice Completo del Sitio",
   }}
   hideCta={true}

--- a/src/pages/es/recursos.astro
+++ b/src/pages/es/recursos.astro
@@ -46,7 +46,7 @@ const resources: FreeAsset[] = allAssets
   lang="es"
   tkey="resources"
   ogImage={{
-    src: "/images/logos/new-york-english-og.jpg",
+    src: "/images/logos/new-york-english-sq-og.jpg",
     alt: "Biblioteca de Recursos Ejecutivos - New York English Teacher",
   }}
   hideCta={true}

--- a/src/pages/es/recursos/[slug].astro
+++ b/src/pages/es/recursos/[slug].astro
@@ -67,7 +67,7 @@ const bookingUrl = "/es/reservar/";
   lang="es"
   tkey={`resources/${content.slugEn || slug}` as TKey}
   ogImage={{
-    src: "/images/logos/new-york-english-og.jpg",
+    src: "/images/logos/new-york-english-sq-og.jpg",
     alt: `${esContent.title} - Recurso Ejecutivo`,
   }}
   hideCta={true}

--- a/src/pages/es/servicios/hablar-en-publico.astro
+++ b/src/pages/es/servicios/hablar-en-publico.astro
@@ -124,7 +124,7 @@ const faqs = serviceFaqs["public-speaking-english"]?.es || [];
   ogImage={{
     src:
       publicSpeakingService?.backgroundImage?.src ||
-      "/images/logos/new-york-english-og.jpg",
+      "/images/logos/new-york-english-sq-og.jpg",
     alt: `${title} - Featured Image`,
     width: publicSpeakingService?.backgroundImage?.width,
     height: publicSpeakingService?.backgroundImage?.height,

--- a/src/pages/es/servicios/index.astro
+++ b/src/pages/es/servicios/index.astro
@@ -64,7 +64,7 @@ const professionalProfilesContent = {
   description={seoDescription}
   lang={lang}
   tkey={tkey}
-  ogImage={{ src: "/images/logos/new-york-english-og-wide.jpg" }}
+  ogImage={{ src: "/images/logos/new-york-english-sq-og.jpg" }}
   heroImage={servicesHeroImage}
   hideCta={true}
 >

--- a/src/pages/es/servicios/ingles-para-ejecutivos.astro
+++ b/src/pages/es/servicios/ingles-para-ejecutivos.astro
@@ -122,7 +122,7 @@ const faqs = serviceFaqs["executive-english"]?.es || [];
     src:
       typeof executiveService.backgroundImage === "string"
         ? executiveService.backgroundImage
-        : "/images/logos/new-york-english-og.jpg",
+        : "/images/logos/new-york-english-sq-og.jpg",
   }}
   hideCta={true}
   customHreflangs={[

--- a/src/pages/es/servicios/ingles-para-fundadores-de-startups.astro
+++ b/src/pages/es/servicios/ingles-para-fundadores-de-startups.astro
@@ -118,7 +118,7 @@ const faqs = serviceFaqs["startup-founders"]?.es || [];
     src:
       typeof startupFoundersService?.backgroundImage === "string"
         ? startupFoundersService.backgroundImage
-        : "/images/logos/new-york-english-og.jpg",
+        : "/images/logos/new-york-english-sq-og.jpg",
   }}
   customHreflangs={[
     {

--- a/src/pages/es/servicios/ingles-para-logistica.astro
+++ b/src/pages/es/servicios/ingles-para-logistica.astro
@@ -116,7 +116,7 @@ const faqs = serviceFaqs["logistics-english"]?.es || [];
     src:
       typeof logisticsService?.backgroundImage === "string"
         ? logisticsService.backgroundImage
-        : "/images/logos/new-york-english-og.jpg",
+        : "/images/logos/new-york-english-sq-og.jpg",
   }}
   customHreflangs={[
     {

--- a/src/pages/es/servicios/ingles-para-medicos.astro
+++ b/src/pages/es/servicios/ingles-para-medicos.astro
@@ -119,7 +119,7 @@ const faqs = serviceFaqs["medical-english"]?.es || [];
   ogImage={{
     src:
       medicalService?.backgroundImage?.src ||
-      "/images/logos/new-york-english-og.jpg",
+      "/images/logos/new-york-english-sq-og.jpg",
     alt: `${title} - Featured Image`,
     width: medicalService?.backgroundImage?.width,
     height: medicalService?.backgroundImage?.height,

--- a/src/pages/es/servicios/ingles-para-presentaciones.astro
+++ b/src/pages/es/servicios/ingles-para-presentaciones.astro
@@ -118,7 +118,7 @@ const faqs = serviceFaqs["high-stakes-english"]?.es || [];
     src:
       typeof highStakesService?.backgroundImage === "string"
         ? highStakesService.backgroundImage
-        : "/images/logos/new-york-english-og.jpg",
+        : "/images/logos/new-york-english-sq-og.jpg",
   }}
   customHreflangs={[
     {

--- a/src/pages/es/servicios/ingles-para-profesionales.astro
+++ b/src/pages/es/servicios/ingles-para-profesionales.astro
@@ -118,7 +118,7 @@ const faqs = serviceFaqs["professional-english"]?.es || [];
     src:
       typeof professionalService?.backgroundImage === "string"
         ? professionalService.backgroundImage
-        : "/images/logos/new-york-english-og.jpg",
+        : "/images/logos/new-york-english-sq-og.jpg",
   }}
   customHreflangs={[
     {

--- a/src/pages/es/servicios/ingles-para-tecnologia.astro
+++ b/src/pages/es/servicios/ingles-para-tecnologia.astro
@@ -116,7 +116,7 @@ const faqs = serviceFaqs["tech-english"]?.es || [];
     src:
       typeof techService?.backgroundImage === "string"
         ? techService.backgroundImage
-        : "/images/logos/new-york-english-og.jpg",
+        : "/images/logos/new-york-english-sq-og.jpg",
   }}
   customHreflangs={[
     {

--- a/src/pages/es/servicios/ingles-para-ventas-tecnicas.astro
+++ b/src/pages/es/servicios/ingles-para-ventas-tecnicas.astro
@@ -124,7 +124,7 @@ const faqs = serviceFaqs["technical-sales-english"]?.es || [];
   ogImage={{
     src:
       technicalSalesService?.backgroundImage?.src ||
-      "/images/logos/new-york-english-og.jpg",
+      "/images/logos/new-york-english-sq-og.jpg",
     alt: `${title} - Featured Image`,
     width: technicalSalesService?.backgroundImage?.width,
     height: technicalSalesService?.backgroundImage?.height,

--- a/src/pages/es/servicios/preparacion-para-entrevistas.astro
+++ b/src/pages/es/servicios/preparacion-para-entrevistas.astro
@@ -123,7 +123,7 @@ const faqs = serviceFaqs["interview-prep"]?.es || [];
     src:
       typeof interviewPrepService?.backgroundImage === "string"
         ? interviewPrepService.backgroundImage
-        : "/images/logos/new-york-english-og.jpg",
+        : "/images/logos/new-york-english-sq-og.jpg",
   }}
   customHreflangs={[
     {


### PR DESCRIPTION
## Root cause

WhatsApp center-crops the `og:image` to a square thumbnail. The rectangular `new-york-english-og.jpg` (1200×630) was being cropped to its center 630×630, cutting off most of the logo. The square `new-york-english-sq-og.jpg` (800×800) was already used on both homepages and renders correctly — this was the discrepancy visible in the WhatsApp screenshot.

## Changes

- **Base.astro** — default fallback changed from `new-york-english-og.jpg` → `new-york-english-sq-og.jpg`; default declared dimensions updated `1200×675` → `800×800`
- **All EN + ES service pages** (29 files) — rectangular OG fallback reference replaced with square
- **services/index.astro (EN + ES)** — also fixed a broken reference to `new-york-english-og-wide.jpg` which did not exist (would have caused a missing OG image on both services index pages)
- **JSON-LD / schema files** — left unchanged; structured data uses landscape images and is not affected by WhatsApp preview behavior

## Test plan

- [ ] Share any service page URL in WhatsApp — should show full logo, not a cropped corner
- [ ] Homepage still renders correctly (already using square, unchanged)
- [ ] `astro check` passes: 0 errors ✓
- [ ] Services index pages no longer reference the missing `og-wide.jpg` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)