### PR TITLE
fix: update USD pricing 5→0 per session, 00→60 package

### DIFF
--- a/PORTFOLIO.md
+++ b/PORTFOLIO.md
@@ -173,7 +173,7 @@ In the Guadalajara market specifically, the local English tutoring market is sat
 
 - Platform serves as the sole sales and marketing operation for a solo coaching business generating revenue from day one
 - Automated qualification eliminates 10-15 hours/week of administrative overhead that would otherwise require a virtual assistant or SDR hire
-- Premium pricing (500 MXN / $25 USD per session) sustained at 3-5x local market rate, validated by executive-level client roster
+- Premium pricing (500 MXN / $30 USD per session) sustained at 3-5x local market rate, validated by executive-level client roster
 - Bilingual system captures both English-language searches (higher purchase intent) and Spanish-language searches (higher volume) across the Guadalajara market
 
 ## The Fifth Digital Employee: A Free University

--- a/docs/BUSINESS-CASE.md
+++ b/docs/BUSINESS-CASE.md
@@ -100,8 +100,8 @@ Robert Cushman III operates NY English Teacher as a solo business from Guadalaja
 6. **Interview & Presentation Coaching** — For professionals preparing for high-stakes English-language moments
 
 **Pricing model:**
-- 500 MXN (~$25 USD) per session
-- 6,000 MXN (~$300 USD) for a 12-session executive roadmap
+- 500 MXN (~$30 USD) per session
+- 6,000 MXN (~$360 USD) for a 12-session executive roadmap
 - Custom corporate training quotes
 
 ### The Guadalajara Market Opportunity
@@ -171,9 +171,9 @@ Robert already has all of this live and compounding. The longer the platform run
 
 | Revenue Stream | Calculation | Monthly |
 |---|---|---|
-| 12-session packages | 6 clients x $300 USD | $1,800 |
-| Single sessions | 4 clients x 4 sessions x $25 | $400 |
-| **Total revenue** | | **$2,200** |
+| 12-session packages | 6 clients x $360 USD | $2,160 |
+| Single sessions | 4 clients x 4 sessions x $30 | $480 |
+| **Total revenue** | | **$2,640** |
 | Infrastructure cost | Free tiers | $0 |
 | **Gross margin** | | **100%** |
 
@@ -181,10 +181,10 @@ Robert already has all of this live and compounding. The longer the platform run
 
 | Revenue Stream | Calculation | Monthly |
 |---|---|---|
-| 12-session packages | 12 clients x $300 USD | $3,600 |
-| Single sessions | 8 clients x 4 sessions x $25 | $800 |
+| 12-session packages | 12 clients x $360 USD | $4,320 |
+| Single sessions | 8 clients x 4 sessions x $30 | $960 |
 | Corporate workshops | 1 engagement x $500 | $500 |
-| **Total revenue** | | **$4,900** |
+| **Total revenue** | | **$5,780** |
 | Infrastructure cost | Free tiers | $0 |
 | **Gross margin** | | **100%** |
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -146,7 +146,7 @@ A 2-minute self-assessment that identifies specific communication gaps costing p
 ## Frequently Asked Questions
 
 **How much does coaching cost?**
-$25 USD per session, or $300 USD for a 12-session package. Corporate packages available.
+$30 USD per session, or $360 USD for a 12-session package. Corporate packages available.
 
 **What level do I need to start?**
 Intermediate to advanced. We don't teach basic English — we refine professionals who already communicate but want to command.
@@ -179,8 +179,8 @@ Our approach is **performance coaching**, not language instruction:
 
 ## Pricing
 
-- Individual sessions: $25 USD
-- 12-session package: $300 USD ($25/session)
+- Individual sessions: $30 USD
+- 12-session package: $360 USD ($30/session)
 - Price range: 500-6,000 MXN depending on package
 - Corporate packages: Custom pricing
 - Free initial consultation available

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -45,7 +45,7 @@ NY English Teacher is a professional English coaching practice founded by Robert
 
 ## Pricing
 
-Sessions range from $25 USD per session to $300 USD for a 12-session package. Corporate packages available.
+Sessions range from $30 USD per session to $360 USD for a 12-session package. Corporate packages available.
 
 ## Languages
 

--- a/rag-chatbot/en/faqs.txt
+++ b/rag-chatbot/en/faqs.txt
@@ -19,7 +19,7 @@ Q: I work for a Mexican company expanding into the US market. Can you help our t
 A: Yes. I offer corporate packages for teams making the leap into US markets. I focus on the communication skills that determine success — client-facing English, partnership negotiations, and the cultural fluency that builds trust with American business partners.
 
 Q: Do you accept payment in Mexican pesos?
-A: Yes. Pricing is available in both MXN and USD. Single sessions are 500 MXN ($25 USD), and 12-session packages are 6,000 MXN ($300 USD). I can also issue Mexican corporate invoices (facturas) for company billing.
+A: Yes. Pricing is available in both MXN and USD. Single sessions are 500 MXN ($30 USD), and 12-session packages are 6,000 MXN ($360 USD). I can also issue Mexican corporate invoices (facturas) for company billing.
 
 Section: Getting Started
 
@@ -30,7 +30,7 @@ Q: What happens in the first coaching session?
 A: The first session is a diagnostic. I identify your specific communication gaps, understand your professional context, and create a prioritized roadmap. You'll leave with 2-3 immediate action items you can start using that same week.
 
 Q: Do I need to commit to a long-term package, or can I try a single session?
-A: You can absolutely start with a single session at 500 MXN / $25 USD. Many clients try one session and then choose to continue because they see immediate value. There's no pressure to commit — results speak for themselves.
+A: You can absolutely start with a single session at 500 MXN / $30 USD. Many clients try one session and then choose to continue because they see immediate value. There's no pressure to commit — results speak for themselves.
 
 Q: What technology do I need for online sessions?
 A: Just a computer or phone with a camera, microphone, and stable internet connection. Sessions are conducted via Google Meet — no special software needed. A quiet space where you can speak freely is ideal.
@@ -38,7 +38,7 @@ A: Just a computer or phone with a camera, microphone, and stable internet conne
 Section: Investment & Value
 
 Q: What is the cost of your coaching?
-A: Current Rate: 500 MXN ($25 USD) per session. 12-Session Executive Roadmap: 6,000 MXN / $300 USD. Every session is custom-built around your specific industry, upcoming presentations, and professional goals. I work directly on your real-world challenges: your upcoming board presentation, your salary negotiation, or your client emails. This isn't a curriculum you follow — it's a strategy built around your calendar.
+A: Current Rate: 500 MXN ($30 USD) per session. 12-Session Executive Roadmap: 6,000 MXN / $360 USD. Every session is custom-built around your specific industry, upcoming presentations, and professional goals. I work directly on your real-world challenges: your upcoming board presentation, your salary negotiation, or your client emails. This isn't a curriculum you follow — it's a strategy built around your calendar.
 
 Q: How is this different from a traditional ESL course?
 A: Traditional ESL courses focus on grammar rules and vocabulary lists. I focus on real-time performance under pressure—handling Q&A, negotiating in English, and projecting authority in high-stakes meetings. You won't be memorizing verb tenses; you'll be practicing the exact scenarios you face at work.

--- a/rag-chatbot/en/home.txt
+++ b/rag-chatbot/en/home.txt
@@ -45,7 +45,7 @@ Common Questions
 Everything you need to know before we talk
 
 Q: What is the investment for coaching?
-A: The current rate is 500 MXN ($25 USD) per session or 6,000 MXN ($300 USD) for a 12-session executive roadmap. Every session is custom-built around your specific industry, upcoming presentations, and professional goals. This isn't a curriculum you follow — it's a strategy built around your calendar.
+A: The current rate is 500 MXN ($30 USD) per session or 6,000 MXN ($360 USD) for a 12-session executive roadmap. Every session is custom-built around your specific industry, upcoming presentations, and professional goals. This isn't a curriculum you follow — it's a strategy built around your calendar.
 
 Q: How long does it take to see results?
 A: You'll feel a shift in confidence and clarity immediately after your first strategy session. For measurable changes in fluency and executive presence, most clients see significant ROI within the 12-session roadmap. I don't aim for 'perfect grammar' in 5 years — I aim for 'effective leadership communication' in 3 months.

--- a/rag-chatbot/en/knowledge-base.en.txt
+++ b/rag-chatbot/en/knowledge-base.en.txt
@@ -36,8 +36,8 @@ Not the right fit:
 SECTION 3 — PRICING (VERIFIED, CURRENT)
 ================================================================
 
-- Single session: 500 MXN / $25 USD
-- 12-Session Executive Roadmap: 6,000 MXN / $300 USD
+- Single session: 500 MXN / $30 USD
+- 12-Session Executive Roadmap: 6,000 MXN / $360 USD
 - Free strategy session: 30 minutes, no pressure, no sales pitch — diagnostic only
 - Payment: due before each session for individuals; monthly invoicing for companies
 - Mexican facturas (corporate invoices) available for company billing and reimbursement
@@ -75,7 +75,7 @@ Robert specifically targets the performance gap — the moment where you know th
 SECTION 6 — SERVICES OFFERED
 ================================================================
 
-All services are delivered as private 1-on-1 coaching. Pricing is the same across services (500 MXN / $25 USD per session, 6,000 MXN / $300 USD per 12-session package).
+All services are delivered as private 1-on-1 coaching. Pricing is the same across services (500 MXN / $30 USD per session, 6,000 MXN / $360 USD per 12-session package).
 
 - Business & Executive English — For C-suite, Directors, and VPs who lead board meetings, deliver strategic updates, and negotiate at the highest level.
 - English for Startup Founders — Pitching US investors, recruiting across borders, leading distributed teams.
@@ -96,7 +96,7 @@ SECTION 7 — COMMON QUESTIONS (CURATED Q&A)
 ================================================================
 
 Q: How much does coaching cost?
-A: 500 MXN / $25 USD per session, or 6,000 MXN / $300 USD for a 12-session executive roadmap. Honest context: this is significantly below market rate for executive communication coaching in the US, where comparable 1-on-1 coaching typically runs $150–$400 per hour. Robert prices for the Mexican and Latin American market.
+A: 500 MXN / $30 USD per session, or 6,000 MXN / $360 USD for a 12-session executive roadmap. Honest context: this is significantly below market rate for executive communication coaching in the US, where comparable 1-on-1 coaching typically runs $150–$400 per hour. Robert prices for the Mexican and Latin American market.
 
 Q: How do I get started?
 A: Book a free 30-minute strategy session at /en/book/. It is a diagnostic, not a sales pitch. You will leave with a 30-day roadmap whether you decide to work with Robert or not.
@@ -153,7 +153,7 @@ SECTION 8 — HONEST ASSESSMENT
 What this service does well:
 - Robert has actually sat in the meetings clients are preparing for. 20 years in corporate IT — 17 at a Fortune 500 — gives him pattern recognition that career English teachers don't have. When he says "this is what a VP sounds like when they're losing the room," he means it from experience.
 - The custom-around-your-calendar approach is genuinely different from standard ESL. You are not working through a textbook; you are rehearsing your actual Thursday board meeting on Wednesday.
-- Pricing is unusually fair. $25 USD per session is well below what comparable executive coaching costs in the US. Mexican and Latin American professionals get the same quality at a regional price.
+- Pricing is unusually fair. $30 USD per session is well below what comparable executive coaching costs in the US. Mexican and Latin American professionals get the same quality at a regional price.
 - The free strategy session is structured as a diagnostic, not a sales funnel. You get a real 30-day roadmap whether you sign up or not.
 - The cultural fluency is real. Robert lives in Mexico, married into the country, and understands the specific gaps Spanish-speaking professionals face when working with US headquarters.
 
@@ -198,8 +198,8 @@ SECTION 10 — KEY FACTS THE CHATBOT SHOULD ALWAYS GET RIGHT
 - Location: Guadalajara, Mexico (UTC-6)
 - Format: Online 1-on-1 via Google Meet
 - Languages: Coaching delivered in English; coach understands Spanish
-- Single session: 500 MXN / $25 USD
-- 12-session package: 6,000 MXN / $300 USD
+- Single session: 500 MXN / $30 USD
+- 12-session package: 6,000 MXN / $360 USD
 - Free strategy session: 30 minutes, no obligation
 - Booking: /en/book/
 - Contact: /en/contact/

--- a/rag-chatbot/es/faqs.txt
+++ b/rag-chatbot/es/faqs.txt
@@ -16,7 +16,7 @@ P: Trabajo para una empresa mexicana que se expande al mercado de EE.UU. ¿Puede
 R: Sí. Ofrecemos paquetes corporativos para equipos que dan el salto a mercados de EE.UU. Nos enfocamos en las habilidades de comunicación que determinan el éxito — inglés para interacción con clientes, negociaciones de partnerships, y la fluidez cultural que construye confianza con socios de negocios americanos.
 
 P: ¿Aceptan pago en pesos mexicanos?
-R: Sí. Los precios están disponibles tanto en MXN como en USD. Las sesiones individuales son de 500 MXN ($25 USD), y los paquetes de 12 sesiones son de 6,000 MXN ($300 USD). También podemos emitir facturas corporativas mexicanas para facturación empresarial.
+R: Sí. Los precios están disponibles tanto en MXN como en USD. Las sesiones individuales son de 500 MXN ($30 USD), y los paquetes de 12 sesiones son de 6,000 MXN ($360 USD). También podemos emitir facturas corporativas mexicanas para facturación empresarial.
 
 Sección: Cómo Empezar
 
@@ -27,7 +27,7 @@ P: ¿Qué pasa en la primera sesión de coaching?
 R: La primera sesión es un diagnóstico. Identificamos tus brechas específicas de comunicación, entendemos tu contexto profesional y creamos una hoja de ruta priorizada. Te irás con 2-3 acciones inmediatas que puedes empezar a usar esa misma semana.
 
 P: ¿Necesito comprometerme con un paquete a largo plazo, o puedo probar una sola sesión?
-R: Puedes comenzar con una sola sesión a 500 MXN / $25 USD. Muchos clientes prueban una sesión y luego eligen continuar porque ven valor inmediato. No hay presión para comprometerte — los resultados hablan por sí mismos.
+R: Puedes comenzar con una sola sesión a 500 MXN / $30 USD. Muchos clientes prueban una sesión y luego eligen continuar porque ven valor inmediato. No hay presión para comprometerte — los resultados hablan por sí mismos.
 
 P: ¿Qué tecnología necesito para las sesiones en línea?
 R: Solo una computadora o teléfono con cámara, micrófono y conexión a internet estable. Las sesiones se realizan por Google Meet — no se necesita software especial. Un espacio tranquilo donde puedas hablar libremente es ideal.
@@ -35,7 +35,7 @@ R: Solo una computadora o teléfono con cámara, micrófono y conexión a intern
 Sección: Inversión y Valor
 
 P: ¿Cuál es el costo de tu coaching?
-R: Tarifa Actual: 500 MXN ($25 USD) por sesión. Paquete de 12 Sesiones: 6,000 MXN / $300 USD. La mayoría de las clases de inglés se enfocan en gramática genérica y escenarios de libros de texto. Yo opero como tu socio estratégico de comunicación. Trabajamos directamente en tus desafíos del mundo real: tu próxima presentación ante la junta, tu negociación salarial o tus correos con clientes. Cada sesión está completamente personalizada para tu industria y tus KPIs específicos. Debido al alto nivel de personalización requerido, no ofrezco descuentos por volumen.
+R: Tarifa Actual: 500 MXN ($30 USD) por sesión. Paquete de 12 Sesiones: 6,000 MXN / $360 USD. La mayoría de las clases de inglés se enfocan en gramática genérica y escenarios de libros de texto. Yo opero como tu socio estratégico de comunicación. Trabajamos directamente en tus desafíos del mundo real: tu próxima presentación ante la junta, tu negociación salarial o tus correos con clientes. Cada sesión está completamente personalizada para tu industria y tus KPIs específicos. Debido al alto nivel de personalización requerido, no ofrezco descuentos por volumen.
 
 P: ¿En qué se diferencia esto de un curso de ESL tradicional?
 R: Los cursos de ESL tradicionales se enfocan en reglas gramaticales y listas de vocabulario. Yo me enfoco en el desempeño en tiempo real bajo presión — manejar preguntas y respuestas, negociar en inglés y proyectar autoridad en reuniones de alto riesgo. No memorizarás tiempos verbales; practicarás los escenarios exactos que enfrentas en el trabajo.

--- a/rag-chatbot/es/home.txt
+++ b/rag-chatbot/es/home.txt
@@ -44,7 +44,7 @@ CTA: Explorar El Marco — /es/about
 Preguntas Frecuentes
 
 P: ¿Cuál es la inversión para el coaching?
-R: La tarifa actual es de 500 MXN ($25 USD) por sesión o 6,000 MXN ($300 USD) por un plan ejecutivo de 12 sesiones. Cada sesión está diseñada a medida en torno a tu industria específica, tus próximas presentaciones y tus objetivos profesionales. Esto no es un plan de estudios que sigues — es una estrategia construida en torno a tu calendario.
+R: La tarifa actual es de 500 MXN ($30 USD) por sesión o 6,000 MXN ($360 USD) por un plan ejecutivo de 12 sesiones. Cada sesión está diseñada a medida en torno a tu industria específica, tus próximas presentaciones y tus objetivos profesionales. Esto no es un plan de estudios que sigues — es una estrategia construida en torno a tu calendario.
 
 P: ¿Cuánto tiempo toma ver resultados?
 R: Sentirás un cambio en confianza y claridad inmediatamente después de tu primera sesión estratégica. Para cambios medibles en fluidez y presencia ejecutiva, la mayoría de los clientes ven un ROI significativo dentro del plan de 12 sesiones. No apunto a 'gramática perfecta' en 5 años — apunto a 'comunicación de liderazgo efectiva' en 3 meses.

--- a/rag-chatbot/es/knowledge-base.es.txt
+++ b/rag-chatbot/es/knowledge-base.es.txt
@@ -36,8 +36,8 @@ No es el ajuste correcto para:
 SECCIÓN 3 — PRECIOS (VERIFICADOS, ACTUALES)
 ================================================================
 
-- Sesión individual: 500 MXN / $25 USD
-- Paquete Ejecutivo de 12 sesiones: 6,000 MXN / $300 USD
+- Sesión individual: 500 MXN / $30 USD
+- Paquete Ejecutivo de 12 sesiones: 6,000 MXN / $360 USD
 - Sesión de estrategia gratuita: 30 minutos, sin presión, sin venta — solo diagnóstico
 - Pago: requerido antes de cada sesión para individuos; facturación mensual para empresas
 - Facturas mexicanas disponibles para facturación y reembolso corporativo
@@ -75,7 +75,7 @@ Robert ataca específicamente la brecha de desempeño — el momento en que sabe
 SECCIÓN 6 — SERVICIOS OFRECIDOS
 ================================================================
 
-Todos los servicios se imparten como coaching privado 1-a-1. El precio es el mismo para todos los servicios (500 MXN / $25 USD por sesión, 6,000 MXN / $300 USD por paquete de 12 sesiones).
+Todos los servicios se imparten como coaching privado 1-a-1. El precio es el mismo para todos los servicios (500 MXN / $30 USD por sesión, 6,000 MXN / $360 USD por paquete de 12 sesiones).
 
 - Inglés de Negocios y Ejecutivo — Para C-suite, Directores y VPs que lideran juntas, entregan actualizaciones estratégicas y negocian al más alto nivel.
 - Inglés para Fundadores de Startups — Pitchear inversionistas en EE.UU., reclutar internacionalmente, liderar equipos distribuidos.
@@ -96,7 +96,7 @@ SECCIÓN 7 — PREGUNTAS FRECUENTES (Q&A CURADO)
 ================================================================
 
 P: ¿Cuánto cuesta el coaching?
-R: 500 MXN / $25 USD por sesión, o 6,000 MXN / $300 USD por un paquete ejecutivo de 12 sesiones. Contexto honesto: esto está significativamente por debajo del precio de mercado para coaching de comunicación ejecutiva en EE.UU., donde un coaching 1-a-1 comparable cuesta típicamente entre $150 y $400 USD por hora. Robert cobra precios para el mercado mexicano y latinoamericano.
+R: 500 MXN / $30 USD por sesión, o 6,000 MXN / $360 USD por un paquete ejecutivo de 12 sesiones. Contexto honesto: esto está significativamente por debajo del precio de mercado para coaching de comunicación ejecutiva en EE.UU., donde un coaching 1-a-1 comparable cuesta típicamente entre $150 y $400 USD por hora. Robert cobra precios para el mercado mexicano y latinoamericano.
 
 P: ¿Cómo empiezo?
 R: Reserva una sesión de estrategia gratuita de 30 minutos en /es/reservar/. Es un diagnóstico, no una venta. Te vas con una hoja de ruta de 30 días, decidas trabajar con Robert o no.
@@ -153,7 +153,7 @@ SECCIÓN 8 — EVALUACIÓN HONESTA
 Lo que este servicio hace bien:
 - Robert realmente ha estado en las juntas para las que los clientes se preparan. 20 años en TI corporativo — 17 en una Fortune 500 — le dan un reconocimiento de patrones que los maestros de inglés de carrera no tienen. Cuando dice "así suena un VP cuando está perdiendo a la sala," lo dice por experiencia.
 - El enfoque personalizado alrededor de tu calendario es genuinamente diferente del ESL estándar. No estás trabajando en un libro de texto; estás ensayando tu junta directiva del jueves el miércoles.
-- El precio es inusualmente justo. $25 USD por sesión está muy por debajo de lo que cuesta un coaching ejecutivo comparable en EE.UU. Los profesionales mexicanos y latinoamericanos obtienen la misma calidad a un precio regional.
+- El precio es inusualmente justo. $30 USD por sesión está muy por debajo de lo que cuesta un coaching ejecutivo comparable en EE.UU. Los profesionales mexicanos y latinoamericanos obtienen la misma calidad a un precio regional.
 - La sesión de estrategia gratuita está estructurada como diagnóstico, no como embudo de ventas. Recibes una hoja de ruta real de 30 días te inscribas o no.
 - La fluidez cultural es real. Robert vive en México, está casado con una mexicana y entiende las brechas específicas que los profesionales hispanohablantes enfrentan al trabajar con casas matrices en EE.UU.
 
@@ -198,8 +198,8 @@ SECCIÓN 10 — DATOS CLAVE QUE EL CHATBOT SIEMPRE DEBE ACERTAR
 - Ubicación: Guadalajara, México (UTC-6)
 - Formato: Online 1-a-1 vía Google Meet
 - Idiomas: Coaching impartido en inglés; el coach entiende español
-- Sesión individual: 500 MXN / $25 USD
-- Paquete de 12 sesiones: 6,000 MXN / $300 USD
+- Sesión individual: 500 MXN / $30 USD
+- Paquete de 12 sesiones: 6,000 MXN / $360 USD
 - Sesión de estrategia gratuita: 30 minutos, sin compromiso
 - Reservaciones: /es/reservar/
 - Contacto: /es/contact/

--- a/src/data/faqs.ts
+++ b/src/data/faqs.ts
@@ -26,7 +26,7 @@ export const faqLists: Record<string, FaqList> = {
       {
         question: "¿Cuánto cuesta el coaching?",
         answer:
-          "Sesión Individual: 500 MXN / $25 USD. Paquete de 12 Sesiones: 6,000 MXN / $300 USD. Nota: No ofrezco descuentos por volumen. Mi enfoque es entregar el máximo valor y personalización en cada hora que trabajamos juntos.",
+          "Sesión Individual: 500 MXN / $30 USD. Paquete de 12 Sesiones: 6,000 MXN / $360 USD. Nota: No ofrezco descuentos por volumen. Mi enfoque es entregar el máximo valor y personalización en cada hora que trabajamos juntos.",
       },
       {
         question: "¿Proporcionas facturas para empresas?",
@@ -81,7 +81,7 @@ export const faqLists: Record<string, FaqList> = {
       {
         question: "¿Cuánto cuesta el coaching?",
         answer:
-          "Sesión Individual: 500 MXN / $25 USD. Paquete de 12 Sesiones: 6,000 MXN / $300 USD. Nota: No ofrezco descuentos por volumen. Mi enfoque es entregar el máximo valor y personalización en cada hora que trabajamos juntos.",
+          "Sesión Individual: 500 MXN / $30 USD. Paquete de 12 Sesiones: 6,000 MXN / $360 USD. Nota: No ofrezco descuentos por volumen. Mi enfoque es entregar el máximo valor y personalización en cada hora que trabajamos juntos.",
       },
       {
         question: "¿Proporcionas facturas para empresas?",
@@ -116,7 +116,7 @@ export const faqLists: Record<string, FaqList> = {
       {
         question: "How much does coaching cost?",
         answer:
-          "Single Session: 500 MXN / $25 USD. 12-Session Executive Roadmap: 6,000 MXN / $300 USD. Every session is custom-built around your specific industry, upcoming presentations, and professional goals. This isn't a curriculum you follow — it's a strategy built around your calendar.",
+          "Single Session: 500 MXN / $30 USD. 12-Session Executive Roadmap: 6,000 MXN / $360 USD. Every session is custom-built around your specific industry, upcoming presentations, and professional goals. This isn't a curriculum you follow — it's a strategy built around your calendar.",
       },
       {
         question: "Do you provide invoices for companies?",
@@ -171,7 +171,7 @@ export const faqLists: Record<string, FaqList> = {
       {
         question: "How much does coaching cost?",
         answer:
-          "Single Session: 500 MXN / $25 USD. 12-Session Executive Roadmap: 6,000 MXN / $300 USD. Every session is custom-built around your specific industry, upcoming presentations, and professional goals. This isn't a curriculum you follow — it's a strategy built around your calendar.",
+          "Single Session: 500 MXN / $30 USD. 12-Session Executive Roadmap: 6,000 MXN / $360 USD. Every session is custom-built around your specific industry, upcoming presentations, and professional goals. This isn't a curriculum you follow — it's a strategy built around your calendar.",
       },
       {
         question: "Do you provide invoices for companies?",
@@ -232,7 +232,7 @@ export const segmentedFaqLists: Record<string, SegmentedFaqList> = {
           {
             question: "Do you accept payment in Mexican pesos?",
             answer:
-              "Yes. Pricing is available in both MXN and USD. Single sessions are 500 MXN ($25 USD), and 12-session packages are 6,000 MXN ($300 USD). I can also issue Mexican corporate invoices (facturas) for company billing.",
+              "Yes. Pricing is available in both MXN and USD. Single sessions are 500 MXN ($30 USD), and 12-session packages are 6,000 MXN ($360 USD). I can also issue Mexican corporate invoices (facturas) for company billing.",
           },
         ],
       },
@@ -255,7 +255,7 @@ export const segmentedFaqLists: Record<string, SegmentedFaqList> = {
             question:
               "Do I need to commit to a long-term package, or can I try a single session?",
             answer:
-              "You can absolutely start with a single session at 500 MXN / $25 USD. Many clients try one session and then choose to continue because they see immediate value. There's no pressure to commit — results speak for themselves.",
+              "You can absolutely start with a single session at 500 MXN / $30 USD. Many clients try one session and then choose to continue because they see immediate value. There's no pressure to commit — results speak for themselves.",
           },
           {
             question: "What technology do I need for online sessions?",
@@ -272,7 +272,7 @@ export const segmentedFaqLists: Record<string, SegmentedFaqList> = {
           {
             question: "What is the cost of your coaching?",
             answer:
-              "Current Rate: 500 MXN ($25 USD) per session. 12-Session Executive Roadmap: 6,000 MXN / $300 USD. Every session is custom-built around your specific industry, upcoming presentations, and professional goals. I work directly on your real-world challenges: your upcoming board presentation, your salary negotiation, or your client emails. This isn't a curriculum you follow — it's a strategy built around your calendar.",
+              "Current Rate: 500 MXN ($30 USD) per session. 12-Session Executive Roadmap: 6,000 MXN / $360 USD. Every session is custom-built around your specific industry, upcoming presentations, and professional goals. I work directly on your real-world challenges: your upcoming board presentation, your salary negotiation, or your client emails. This isn't a curriculum you follow — it's a strategy built around your calendar.",
           },
           {
             question: "How is this different from a traditional ESL course?",
@@ -376,7 +376,7 @@ export const segmentedFaqLists: Record<string, SegmentedFaqList> = {
           {
             question: "¿Aceptan pago en pesos mexicanos?",
             answer:
-              "Sí. Los precios están disponibles tanto en MXN como en USD. Las sesiones individuales son de 500 MXN ($25 USD), y los paquetes de 12 sesiones son de 6,000 MXN ($300 USD). También podemos emitir facturas corporativas mexicanas para facturación empresarial.",
+              "Sí. Los precios están disponibles tanto en MXN como en USD. Las sesiones individuales son de 500 MXN ($30 USD), y los paquetes de 12 sesiones son de 6,000 MXN ($360 USD). También podemos emitir facturas corporativas mexicanas para facturación empresarial.",
           },
         ],
       },
@@ -399,7 +399,7 @@ export const segmentedFaqLists: Record<string, SegmentedFaqList> = {
             question:
               "¿Necesito comprometerme con un paquete a largo plazo, o puedo probar una sola sesión?",
             answer:
-              "Puedes comenzar con una sola sesión a 500 MXN / $25 USD. Muchos clientes prueban una sesión y luego eligen continuar porque ven valor inmediato. No hay presión para comprometerte — los resultados hablan por sí mismos.",
+              "Puedes comenzar con una sola sesión a 500 MXN / $30 USD. Muchos clientes prueban una sesión y luego eligen continuar porque ven valor inmediato. No hay presión para comprometerte — los resultados hablan por sí mismos.",
           },
           {
             question: "¿Qué tecnología necesito para las sesiones en línea?",
@@ -416,7 +416,7 @@ export const segmentedFaqLists: Record<string, SegmentedFaqList> = {
           {
             question: "¿Cuál es el costo de tu coaching?",
             answer:
-              "Tarifa Actual: 500 MXN ($25 USD) por sesión. Paquete de 12 Sesiones: 6,000 MXN / $300 USD. Por qué esto es diferente de las clases de inglés estándar: La mayoría de las clases de inglés se enfocan en gramática genérica y escenarios de libros de texto. Yo opero como tu socio estratégico de comunicación. Trabajamos directamente en tus desafíos del mundo real: tu próxima presentación ante la junta, tu negociación salarial o tus correos con clientes. Cada sesión está completamente personalizada para tu industria y tus KPIs específicos. No solo estás aprendiendo inglés; estás adquiriendo la presencia ejecutiva necesaria para cerrar tratos y avanzar en tu carrera. Debido al alto nivel de personalización y preparación requerido para este nivel de coaching, no ofrezco descuentos por volumen.",
+              "Tarifa Actual: 500 MXN ($30 USD) por sesión. Paquete de 12 Sesiones: 6,000 MXN / $360 USD. Por qué esto es diferente de las clases de inglés estándar: La mayoría de las clases de inglés se enfocan en gramática genérica y escenarios de libros de texto. Yo opero como tu socio estratégico de comunicación. Trabajamos directamente en tus desafíos del mundo real: tu próxima presentación ante la junta, tu negociación salarial o tus correos con clientes. Cada sesión está completamente personalizada para tu industria y tus KPIs específicos. No solo estás aprendiendo inglés; estás adquiriendo la presencia ejecutiva necesaria para cerrar tratos y avanzar en tu carrera. Debido al alto nivel de personalización y preparación requerido para este nivel de coaching, no ofrezco descuentos por volumen.",
           },
           {
             question:

--- a/src/data/homepage-faqs.ts
+++ b/src/data/homepage-faqs.ts
@@ -35,7 +35,7 @@ export const homepageFAQs: HomepageFAQData = {
       {
         question: "What is the investment for coaching?",
         answer:
-          "The current rate is 500 MXN ($25 USD) per session or 6,000 MXN ($300 USD) for a 12-session executive roadmap. Every session is custom-built around your specific industry, upcoming presentations, and professional goals. This isn't a curriculum you follow — it's a strategy built around your calendar.",
+          "The current rate is 500 MXN ($30 USD) per session or 6,000 MXN ($360 USD) for a 12-session executive roadmap. Every session is custom-built around your specific industry, upcoming presentations, and professional goals. This isn't a curriculum you follow — it's a strategy built around your calendar.",
       },
       {
         question: "How long does it take to see results?",
@@ -68,7 +68,7 @@ export const homepageFAQs: HomepageFAQData = {
       {
         question: "¿Cuál es la inversión para el coaching?",
         answer:
-          "La tarifa actual es de 500 MXN ($25 USD) por sesión o 6,000 MXN ($300 USD) por un plan ejecutivo de 12 sesiones. Cada sesión está diseñada a medida en torno a tu industria específica, tus próximas presentaciones y tus objetivos profesionales. Esto no es un plan de estudios que sigues — es una estrategia construida en torno a tu calendario.",
+          "La tarifa actual es de 500 MXN ($30 USD) por sesión o 6,000 MXN ($360 USD) por un plan ejecutivo de 12 sesiones. Cada sesión está diseñada a medida en torno a tu industria específica, tus próximas presentaciones y tus objetivos profesionales. Esto no es un plan de estudios que sigues — es una estrategia construida en torno a tu calendario.",
       },
       {
         question: "¿Cuánto tiempo toma ver resultados?",


### PR DESCRIPTION
## Summary

- Per-session price updated: **$25 USD → $30 USD** (weak dollar adjustment)
- 12-session package updated: **$300 USD → $360 USD** (12 × $30)
- Updated across all 12 content surfaces: FAQs (EN/ES), homepage FAQ data, RAG chatbot knowledge base (EN/ES), home.txt, faqs.txt, llms.txt, llms-full.txt, PORTFOLIO.md, BUSINESS-CASE.md financial projections

## Files changed
- `src/data/faqs.ts` — all FAQ lists EN/ES
- `src/data/homepage-faqs.ts` — homepage FAQ component data
- `rag-chatbot/en/` — knowledge base, home, faqs
- `rag-chatbot/es/` — knowledge base, home, faqs
- `public/llms.txt` + `public/llms-full.txt` — AI crawler pricing
- `PORTFOLIO.md` — results metrics
- `docs/BUSINESS-CASE.md` — pricing model + financial projections (totals recalculated)

## Test plan
- [ ] Build passes
- [ ] Grep for `$25` in pricing context returns no results
- [ ] FAQs display $30/$360 on live site after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)