### PR TITLE
feat: add corporate program detail, FAQs, and chatbot knowledge base

### DIFF
--- a/rag-chatbot/en/knowledge-base.en.txt
+++ b/rag-chatbot/en/knowledge-base.en.txt
@@ -208,3 +208,195 @@ SECTION 10 — KEY FACTS THE CHATBOT SHOULD ALWAYS GET RIGHT
 - Facturas: Available for Mexican corporate clients
 - Specialties: Executive English, Tech English, Logistics English, Medical/Legal English, Interview Prep, Public Speaking, Startup Founders
 - Free self-study courses: Beginner ("First Steps Into English") and Intermediate ("Building Fluency") and Advanced ("Advanced Fluency") and Business English ("Business Fluency") coming soon
+
+================================================================
+SECTION 11 — CORPORATE PROGRAMS (VERIFIED, CURRENT)
+================================================================
+
+There are two corporate coaching formats. They serve different needs
+and include different levels of structure and documentation.
+
+QUICK COMPARISON:
+- Ongoing Coaching (Standard): 500 MXN / ~$30 USD per person per session. No formal assessments. No HR reports.
+- Corporate Training Program (Premium): 600 MXN / ~$35 USD per person per session. Full formal reviews, monthly assessments, written roadmaps, consolidated company report.
+- Individual (private clients): 500 MXN / $30 USD per session.
+
+Both corporate programs: no minimum commitment, no minimum team size,
+Mexican SAT facturas issued monthly, formal proposals available on request.
+
+================================================================
+CORPORATE PROGRAM 1: ONGOING COACHING — STANDARD (500 MXN/HR)
+================================================================
+
+Page: /en/services/ongoing-coaching/
+
+What it is: Flexible, immersive English coaching for professional
+teams. No fixed syllabus, no grammar workbook, no formal reporting.
+Sessions are built around the team's real workplace — actual meeting
+scenarios, client calls, small talk with international partners, and
+everyday professional English. The goal is to make communication feel
+natural, not just technically correct.
+
+Session formats:
+- 1:1 sessions (private, targeted to each participant's specific gaps)
+- Small group sessions (maximum 4 participants per group session,
+  performance-based — participants present, discuss, respond in real
+  time to peers)
+
+What sessions cover: meetings, small talk and relationship-building,
+presentations and unscripted Q&A, networking and informal business
+interaction, everyday workplace communication.
+
+What it does NOT include: formal baseline assessments, monthly
+performance evaluations, individual written feedback reports,
+consolidated HR reports, grammar instruction, fixed syllabus,
+certification or exam preparation.
+
+Pricing: 500 MXN per person per session (~$30 USD).
+No minimum commitment. No minimum team size.
+Mexican facturas issued monthly.
+
+================================================================
+CORPORATE PROGRAM 2: CORPORATE TRAINING PROGRAM — PREMIUM (600 MXN/HR)
+================================================================
+
+Page: /en/services/corporate-package/
+
+What it is: A structured 12-week program for senior leadership teams.
+Includes formal written reviews, monthly assessments, and a
+consolidated company progress report. Designed to close the gap
+between private preparation and public performance under peer pressure.
+
+Program structure — 3 phases:
+
+PHASE 1 (Weeks 1–8): Individual Assessment & Preparation
+Each participant works 1:1 with Robert. Weeks 1–2 establish a formal
+baseline. Weeks 3–8 are targeted preparation around each
+participant's real role and presentations. 8–12 sessions per
+participant (4,800–7,200 MXN per participant).
+
+PHASE 2 (Weeks 9–10): Group Presentation
+Every participant delivers their prepared presentation in English to
+the full leadership group — most for the first time in front of
+peers. 1–2 group sessions (600–1,200 MXN per participant).
+
+PHASE 3 (Weeks 11–12): Lessons Learned & Final Assessment
+Individual debrief sessions. Final assessment against the Week 1–2
+baseline. Each participant receives a written roadmap. The company
+receives a consolidated progress report. 2–3 sessions per participant
+(1,200–1,800 MXN per participant).
+
+What formal reviews include (this is what separates the 600 MXN
+program from the 500 MXN program):
+
+1. Initial Student Profile (written, per participant, after session 1–2)
+   - Current English level and observable communication patterns
+   - Job role, responsibilities, and team context
+   - Job-related English goals and high-stakes communication moments
+   - Priority focus areas — this is the program baseline
+
+2. Monthly Assessments (per participant, ongoing throughout program)
+   - Ongoing communication gaps still relevant
+   - Level of effort outside sessions (preparation quality, practice
+     between sessions — effort is assessed honestly because it is one
+     of the strongest predictors of outcomes)
+   - Enthusiasm and engagement during sessions
+   - In-session performance: fluency, clarity, confidence under pressure
+   - Updated priority areas based on recent work
+
+3. Written Individual Roadmap (per participant, at program close)
+   - Progress against the initial baseline
+   - Remaining priority gaps and how to address them
+   - Recommended focus areas and practice approaches going forward
+   - Honest summary of where they stand after the program
+
+4. Consolidated Company Report (for HR and executive review, at close)
+   - Team-level progress and collective patterns observed
+   - Notable achievements and breakthroughs
+   - Recommendations for continued team development
+   - Program outcomes against original goals
+   (Note: individual performance details stay in personal roadmaps,
+   not in the company report)
+
+IMPORTANT: Sessions are never AI-recorded. All assessment content
+comes from Robert's direct observation. This is intentional — recording
+is intrusive to the coaching relationship.
+
+Pricing: 600 MXN per person per session (~$35 USD for US companies).
+This rate applies to all session types — individual and group sessions
+are both billed at 600 MXN per participant per hour.
+
+Full program estimates for a 5-person team:
+- Conservative (12 sessions/participant): ~36,000 MXN total
+- Moderate (14–15 sessions/participant): ~42,000–45,000 MXN total
+- Intensive (17 sessions/participant): ~51,000 MXN total
+
+No minimum commitment. Typically 4–6 participants but as few as 2 is
+fine. HR usually initiates but procurement or business leaders can too.
+
+================================================================
+CORPORATE FAQ — KEY QUESTIONS THE CHATBOT SHOULD HANDLE
+================================================================
+
+Q: What is the difference between the two corporate programs?
+A: The Ongoing Coaching program (500 MXN/hr) is flexible coaching
+with no formal reporting — practical fluency for meetings, small talk,
+and everyday communication. No assessments, no HR paperwork. The
+Corporate Training Program (600 MXN/hr) is a 12-week structured
+sprint with formal student profiles, monthly assessments, written
+individual roadmaps, and a consolidated company progress report. If
+HR or L&D needs documentation, the 600 MXN program is the right
+choice. If you just want the team to communicate better without the
+reporting layer, 500 MXN is simpler and works well for many teams.
+
+Q: How does the session structure work — individual, group, or both?
+A: Both programs combine individual and group sessions. In the
+Corporate Training Program, Phases 1 and 3 are almost entirely 1:1,
+and the group presentation happens in Phase 2 — this is the high-
+pressure moment where participants present to their full peer group,
+often for the first time. In Ongoing Coaching, 1:1 sessions address
+personal gaps and group sessions (max 4 people) build applied
+fluency. The balance is set in the discovery call.
+
+Q: We have 4–6 people on the middle management team. Can you accommodate that?
+A: Yes — that is an ideal size for both programs. For the Corporate
+Training Program, having 4–6 peers in the group presentation phase
+creates exactly the productive pressure the program is built around.
+For Ongoing Coaching, if the group exceeds 4, it splits into smaller
+groups for group sessions while individual sessions continue in
+parallel.
+
+Q: Is there a minimum commitment or team size?
+A: No minimum commitment and no strict minimum. Two people is
+workable. Most teams are 3–8 people. Billing is per session per
+participant throughout.
+
+Q: How are group sessions billed?
+A: 600 MXN per person per session for the premium program. A group
+session with 5 participants = 3,000 MXN total. Individual and group
+sessions are billed at the same per-person rate.
+
+Q: Do you record sessions?
+A: No. Never. Not by AI, not by Robert, not by any software. All
+assessment content comes from Robert's direct observation.
+
+Q: Can you send a formal proposal?
+A: Yes — once the corporate contact is ready, Robert sends a formal
+proposal with full scope, program structure, investment summary, and
+timeline. A discovery call usually comes first. Reach out via
+WhatsApp at +52 33 1559 0572 or through the contact form.
+
+Q: Do you issue SAT invoices (facturas)?
+A: Yes. Robert is a registered business in good standing with Mexico's
+SAT and issues proper facturas monthly for all corporate engagements.
+
+Q: What level does the team need to be?
+A: B1 (intermediate) or above. These programs are not for beginners.
+If a team member is below B1, Robert can advise on the right starting
+point before they join a corporate program.
+
+Q: We are a US-based company. What is the pricing in USD?
+A: Approximately $30 USD per person per session for Ongoing Coaching
+and approximately $35 USD per person per session for the Corporate
+Training Program. All current clients are Mexico-based, but USD
+invoices are available. Contact Robert directly to discuss.

--- a/rag-chatbot/en/knowledge-base.en.txt
+++ b/rag-chatbot/en/knowledge-base.en.txt
@@ -262,7 +262,7 @@ CORPORATE PROGRAM 2: CORPORATE TRAINING PROGRAM — PREMIUM (600 MXN/HR)
 
 Page: /en/services/corporate-package/
 
-What it is: A structured 12-week program for senior leadership teams.
+What it is: A structured 12-week program for management teams.
 Includes formal written reviews, monthly assessments, and a
 consolidated company progress report. Designed to close the gap
 between private preparation and public performance under peer pressure.

--- a/rag-chatbot/es/knowledge-base.es.txt
+++ b/rag-chatbot/es/knowledge-base.es.txt
@@ -208,3 +208,193 @@ SECCIÓN 10 — DATOS CLAVE QUE EL CHATBOT SIEMPRE DEBE ACERTAR
 - Facturas: Disponibles para clientes corporativos mexicanos
 - Especialidades: Inglés Ejecutivo, Inglés para Tecnología, Inglés para Logística, Inglés Médico/Legal, Preparación para Entrevistas, Hablar en Público, Fundadores de Startups
 - Cursos gratuitos de autoestudio: Principiantes ("Primeros Pasos al Inglés") e Intermedio ("Construyendo Fluidez")
+
+================================================================
+SECCIÓN 11 — PROGRAMAS CORPORATIVOS (VERIFICADOS, ACTUALES)
+================================================================
+
+Existen dos formatos de coaching corporativo. Sirven necesidades
+distintas e incluyen diferentes niveles de estructura y documentación.
+
+COMPARACIÓN RÁPIDA:
+- Coaching Continuo (Estándar): 500 MXN / ~$30 USD por persona por sesión. Sin evaluaciones formales. Sin reportes para RH.
+- Programa de Capacitación Corporativa (Premium): 600 MXN / ~$35 USD por persona por sesión. Revisiones formales completas, evaluaciones mensuales, hojas de ruta escritas, reporte consolidado para la empresa.
+- Individual (clientes privados): 500 MXN / $30 USD por sesión.
+
+Ambos programas corporativos: sin compromiso mínimo, sin tamaño
+mínimo de equipo, facturas SAT emitidas mensualmente, propuestas
+formales disponibles bajo petición.
+
+================================================================
+PROGRAMA CORPORATIVO 1: COACHING CONTINUO — ESTÁNDAR (500 MXN/HR)
+================================================================
+
+Página: /es/servicios/coaching-continuo/
+
+Qué es: Coaching de inglés flexible e inmersivo para equipos
+profesionales. Sin temario fijo, sin libro de gramática, sin reportes
+formales. Las sesiones se construyen alrededor del lugar de trabajo
+real del equipo — escenarios reales de reuniones, llamadas con
+clientes, small talk con socios internacionales, y comunicación
+profesional cotidiana. El objetivo es que la comunicación se sienta
+natural, no solo técnicamente correcta.
+
+Formatos de sesión:
+- Sesiones 1:1 (privadas, enfocadas en las brechas específicas de
+  cada participante)
+- Sesiones grupales pequeñas (máximo 4 participantes por sesión,
+  basadas en desempeño — los participantes presentan, discuten y
+  responden a sus pares en tiempo real)
+
+Qué cubren las sesiones: reuniones, small talk y construcción de
+relaciones, presentaciones y sesiones de preguntas improvisadas,
+networking e interacción informal de negocios, comunicación
+cotidiana en el lugar de trabajo.
+
+Qué NO incluye: evaluaciones formales de línea base, evaluaciones
+mensuales de desempeño, reportes escritos individuales, reportes
+consolidados para RH, instrucción gramatical, temario fijo,
+preparación para certificaciones o exámenes.
+
+Precio: 500 MXN por persona por sesión (~$30 USD).
+Sin compromiso mínimo. Sin tamaño mínimo de equipo.
+Facturas mexicanas emitidas mensualmente.
+
+================================================================
+PROGRAMA CORPORATIVO 2: PROGRAMA DE CAPACITACIÓN — PREMIUM (600 MXN/HR)
+================================================================
+
+Página: /es/servicios/paquete-corporativo/
+
+Qué es: Un programa estructurado de 12 semanas para equipos de
+liderazgo senior. Incluye revisiones escritas formales, evaluaciones
+mensuales y un reporte consolidado de progreso para la empresa.
+Diseñado para cerrar la brecha entre la preparación privada y el
+desempeño público bajo presión de pares.
+
+Estructura del programa — 3 fases:
+
+FASE 1 (Semanas 1–8): Evaluación Individual y Preparación
+Cada participante trabaja 1:1 con Robert. Las semanas 1–2 establecen
+una línea base formal. Las semanas 3–8 son preparación específica
+alrededor del rol real y presentaciones de cada participante.
+8–12 sesiones por participante (4,800–7,200 MXN por participante).
+
+FASE 2 (Semanas 9–10): Presentación Grupal
+Cada participante entrega su presentación preparada en inglés frente
+al grupo completo de liderazgo — la mayoría por primera vez frente
+a sus pares. 1–2 sesiones grupales (600–1,200 MXN por participante).
+
+FASE 3 (Semanas 11–12): Lecciones Aprendidas y Evaluación Final
+Sesiones de debrief individual. Evaluación final contra la línea
+base de las semanas 1–2. Cada participante recibe una hoja de ruta
+escrita. La empresa recibe un reporte consolidado de progreso.
+2–3 sesiones por participante (1,200–1,800 MXN por participante).
+
+Qué incluyen las revisiones formales (esto es lo que diferencia el
+programa de 600 MXN del de 500 MXN):
+
+1. Perfil Inicial del Estudiante (escrito, por participante, tras sesión 1–2)
+   - Nivel actual de inglés y patrones de comunicación observados
+   - Puesto, responsabilidades y contexto del equipo
+   - Objetivos en inglés y momentos de comunicación de alto riesgo
+   - Áreas de enfoque prioritarias — esta es la línea base del programa
+
+2. Evaluaciones Mensuales (por participante, durante todo el programa)
+   - Brechas de comunicación actuales aún relevantes
+   - Nivel de esfuerzo fuera de sesiones (calidad de preparación,
+     práctica entre sesiones — el esfuerzo se evalúa honestamente
+     porque es uno de los predictores más fuertes de resultados)
+   - Entusiasmo y participación durante las sesiones
+   - Desempeño en sesión: fluidez, claridad, confianza bajo presión
+   - Áreas prioritarias actualizadas según el trabajo reciente
+
+3. Hoja de Ruta Individual Escrita (por participante, al cierre)
+   - Progreso contra la línea base inicial
+   - Brechas prioritarias restantes y cómo abordarlas
+   - Áreas de enfoque y enfoques de práctica recomendados
+   - Resumen honesto de dónde se encuentra tras el programa
+
+4. Reporte Consolidado para la Empresa (para RH y liderazgo, al cierre)
+   - Progreso a nivel de equipo y patrones colectivos observados
+   - Logros y avances notables
+   - Recomendaciones para el desarrollo continuo del equipo
+   - Resultados del programa contra los objetivos originales
+   (Nota: los detalles de desempeño individual se mantienen en las
+   hojas de ruta personales, no en el reporte empresarial)
+
+IMPORTANTE: Las sesiones nunca se graban con IA. Todo el contenido
+de evaluación proviene de la observación directa de Robert.
+
+Precio: 600 MXN por persona por sesión (~$35 USD para empresas en EE.UU.).
+Esta tarifa aplica a todos los tipos de sesión — individuales y
+grupales se cobran igual, a 600 MXN por participante por hora.
+
+Estimados del programa completo para un equipo de 5 personas:
+- Conservador (12 sesiones/participante): ~36,000 MXN en total
+- Moderado (14–15 sesiones/participante): ~42,000–45,000 MXN en total
+- Intensivo (17 sesiones/participante): ~51,000 MXN en total
+
+================================================================
+PREGUNTAS FRECUENTES CORPORATIVAS
+================================================================
+
+P: ¿Cuál es la diferencia entre los dos programas corporativos?
+R: El Coaching Continuo (500 MXN/hr) es coaching flexible sin
+reportes formales — fluidez práctica para reuniones, small talk y
+comunicación cotidiana. Sin evaluaciones, sin papeleo para RH. El
+Programa de Capacitación Corporativa (600 MXN/hr) es un sprint
+estructurado de 12 semanas con perfiles iniciales, evaluaciones
+mensuales, hojas de ruta escritas individuales y un reporte
+consolidado para la empresa. Si RH o L&D necesita documentación,
+el programa de 600 MXN es la opción correcta.
+
+P: ¿Cómo funciona la estructura de sesiones — individual, grupal o ambas?
+R: Ambos programas combinan sesiones individuales y grupales. En el
+Programa de Capacitación, las Fases 1 y 3 son casi enteramente 1:1,
+y la presentación grupal ocurre en la Fase 2 — este es el momento
+de alta presión donde los participantes presentan frente a todo el
+equipo, generalmente por primera vez. En el Coaching Continuo, las
+sesiones 1:1 abordan las brechas personales y las sesiones grupales
+(máx. 4 personas) desarrollan la fluidez aplicada.
+
+P: Tenemos entre 4 y 6 personas en el equipo de mandos medios. ¿Pueden trabajar con ese tamaño?
+R: Sí — ese es un tamaño ideal para ambos programas. Para el
+Programa de Capacitación, tener 4–6 pares en la fase de presentación
+grupal crea exactamente la presión productiva que el programa busca.
+Para el Coaching Continuo, si el grupo supera 4, se divide en grupos
+más pequeños para las sesiones grupales mientras las sesiones
+individuales continúan en paralelo.
+
+P: ¿Hay un compromiso mínimo o tamaño mínimo de equipo?
+R: Sin compromiso mínimo y sin mínimo estricto. Con dos personas
+funciona. La mayoría de los equipos son de 3–8 personas. La
+facturación es por sesión por participante en todo momento.
+
+P: ¿Graban las sesiones?
+R: No. Nunca. Ni con IA, ni por Robert, ni con ningún software. Todo
+el contenido de evaluación proviene de la observación directa de Robert.
+
+P: ¿Pueden enviar una propuesta formal?
+R: Sí — una vez que el contacto corporativo está listo, Robert envía
+una propuesta formal con alcance completo, estructura del programa,
+resumen de inversión y cronograma. Generalmente primero hay una
+llamada de descubrimiento. Contáctenos por WhatsApp al +52 33 1559
+0572 o a través del formulario de contacto.
+
+P: ¿Emiten facturas SAT?
+R: Sí. Robert es un negocio registrado en regla con el SAT de México
+y emite facturas correctas mensualmente para todos los compromisos
+corporativos.
+
+P: ¿Qué nivel necesita tener el equipo?
+R: B1 (intermedio) o superior. Estos programas no son para
+principiantes. Si algún miembro del equipo está por debajo de B1,
+Robert puede asesorar sobre el punto de partida correcto.
+
+P: Somos una empresa con sede en EE.UU. ¿Cuál es el precio en USD?
+R: Aproximadamente $30 USD por persona por sesión para el Coaching
+Continuo y aproximadamente $35 USD por persona por sesión para el
+Programa de Capacitación Corporativa. Todos los clientes actuales
+están en México, pero hay facturas en USD disponibles. Contacta a
+Robert directamente para hablar de tu situación.

--- a/rag-chatbot/es/knowledge-base.es.txt
+++ b/rag-chatbot/es/knowledge-base.es.txt
@@ -267,7 +267,7 @@ PROGRAMA CORPORATIVO 2: PROGRAMA DE CAPACITACIÓN — PREMIUM (600 MXN/HR)
 Página: /es/servicios/paquete-corporativo/
 
 Qué es: Un programa estructurado de 12 semanas para equipos de
-liderazgo senior. Incluye revisiones escritas formales, evaluaciones
+gestión. Incluye revisiones escritas formales, evaluaciones
 mensuales y un reporte consolidado de progreso para la empresa.
 Diseñado para cerrar la brecha entre la preparación privada y el
 desempeño público bajo presión de pares.

--- a/src/data/service-faqs.ts
+++ b/src/data/service-faqs.ts
@@ -426,6 +426,14 @@ export const serviceFaqs: Record<string, ServiceFaqSet> = {
       {
         question: "Can I mix 1:1 and group sessions for my team?",
         answer: "Yes. Most teams benefit from a combination of both. Individual sessions address each person's specific gaps in a direct, private setting. Group sessions create the kind of dynamic, real-time communication pressure that individual sessions alone can't replicate. Robert will recommend a balance based on your team's size and goals."
+      },
+      {
+        question: "How does the session structure work day-to-day — individual, group, or both?",
+        answer: "Both, combined. Each participant gets regular 1:1 sessions focused on their specific gaps — how they structure ideas in English, where fluency breaks down, how they perform under pressure. These are private and direct. Group sessions (capped at 4 participants) are layered in for applied practice — participants present, discuss, and respond to peers in real time. The 1:1 sessions build the foundation; the group sessions build the kind of dynamic fluency that private practice alone can't produce. The balance between individual and group is determined based on your team's size, schedule, and goals in the discovery call."
+      },
+      {
+        question: "What if we have more than 4 people on the team?",
+        answer: "Teams larger than 4 are handled by splitting into smaller groups for group sessions while continuing individual sessions in parallel. For example, a team of 6 might have two group-of-3 sessions running alongside individual sessions for each participant. This keeps the group sessions small enough to maintain quality and individual attention."
       }
     ],
     es: [
@@ -448,6 +456,14 @@ export const serviceFaqs: Record<string, ServiceFaqSet> = {
       {
         question: "¿Puedo combinar sesiones individuales y grupales para mi equipo?",
         answer: "Sí. La mayoría de los equipos se benefician de una combinación de ambas. Las sesiones individuales abordan las brechas específicas de cada persona en un entorno directo y privado. Las sesiones grupales crean el tipo de presión dinámica de comunicación en tiempo real que las sesiones individuales por sí solas no pueden replicar. Robert recomendará un equilibrio basado en el tamaño y los objetivos de tu equipo."
+      },
+      {
+        question: "¿Cómo funciona la estructura de sesiones día a día — individual, grupal o ambas?",
+        answer: "Ambas, combinadas. Cada participante tiene sesiones 1:1 regulares enfocadas en sus brechas específicas — cómo estructura ideas en inglés, dónde se quiebra la fluidez, cómo se desempeña bajo presión. Estas son privadas y directas. Las sesiones grupales (máximo 4 participantes) se integran para práctica aplicada — los participantes presentan, discuten y responden a sus pares en tiempo real. Las sesiones individuales construyen la base; las sesiones grupales desarrollan el tipo de fluidez dinámica que la práctica privada sola no puede producir. El equilibrio entre individual y grupal se determina según el tamaño, horario y objetivos de tu equipo en la llamada de descubrimiento."
+      },
+      {
+        question: "¿Qué pasa si tenemos más de 4 personas en el equipo?",
+        answer: "Los equipos de más de 4 personas se manejan dividiendo en grupos más pequeños para las sesiones grupales, mientras se continúan las sesiones individuales en paralelo. Por ejemplo, un equipo de 6 podría tener dos grupos de 3 para las sesiones grupales junto con sesiones individuales para cada participante. Esto mantiene los grupos lo suficientemente pequeños para garantizar calidad y atención individualizada."
       }
     ]
   },
@@ -472,6 +488,14 @@ export const serviceFaqs: Record<string, ServiceFaqSet> = {
       {
         question: "Can we run this program in Spanish?",
         answer: "The program is conducted in English — that's the point. Robert understands Spanish and can provide context or clarification in Spanish when needed, but the coaching sessions and group presentation are in English. The pressure of speaking English in front of peers is the core mechanism of the program."
+      },
+      {
+        question: "How does the session structure actually work — individual sessions, group sessions, or both?",
+        answer: "Mostly individual, with one high-pressure group session at the pivotal moment. Phases 1 and 3 are almost entirely 1:1 — each participant works privately with Robert on their preparation and their personal debrief. Phase 2 is the group session, where every participant delivers their prepared presentation to the full team. Most people have never done this before. The combination is deliberate: individual sessions build the preparation, the group session exposes the gap between private preparation and public performance under peer pressure. That gap is the real target."
+      },
+      {
+        question: "What exactly do the formal reviews include?",
+        answer: "Three written deliverables per participant: (1) An Initial Student Profile after the first session — current level, job role, English goals, and priority focus areas, which becomes the program baseline. (2) Monthly Assessments throughout the program covering ongoing gaps, level of effort outside sessions, enthusiasm, in-session performance, and updated priorities. Sessions are never AI-recorded — all assessment content comes from Robert's direct observation. (3) A Written Individual Roadmap at program close — progress against the baseline, remaining gaps, and a specific development plan for what comes next. The company also receives a Consolidated Progress Report for HR and executive review."
       }
     ],
     es: [
@@ -494,6 +518,14 @@ export const serviceFaqs: Record<string, ServiceFaqSet> = {
       {
         question: "¿Podemos hacer este programa en español?",
         answer: "El programa se realiza en inglés — ese es el punto. Robert entiende español y puede proporcionar contexto o aclaraciones en español cuando sea necesario, pero las sesiones de coaching y la presentación grupal son en inglés. La presión de hablar inglés frente a los pares es el mecanismo central del programa."
+      },
+      {
+        question: "¿Cómo funciona realmente la estructura de sesiones — individuales, grupales o ambas?",
+        answer: "Principalmente individuales, con una sesión grupal de alta presión en el momento crucial. Las Fases 1 y 3 son casi completamente 1:1 — cada participante trabaja en privado con Robert en su preparación y su debrief personal. La Fase 2 es la sesión grupal, donde cada participante entrega su presentación preparada frente a todo el equipo. La mayoría no ha hecho esto antes. La combinación es deliberada: las sesiones individuales construyen la preparación, la sesión grupal expone la brecha entre la preparación privada y el desempeño público bajo presión de pares. Esa brecha es el objetivo real."
+      },
+      {
+        question: "¿Qué incluyen exactamente las revisiones formales?",
+        answer: "Tres entregables escritos por participante: (1) Un Perfil Inicial del Estudiante después de la primera sesión — nivel actual, puesto, objetivos en inglés y áreas de enfoque prioritarias, que se convierte en la línea base del programa. (2) Evaluaciones Mensuales durante todo el programa que cubren brechas actuales, nivel de esfuerzo fuera de sesiones, entusiasmo, desempeño en sesión y prioridades actualizadas. Las sesiones nunca se graban con IA — todo el contenido de evaluación proviene de la observación directa de Robert. (3) Una Hoja de Ruta Individual Escrita al cierre del programa — progreso contra la línea base, brechas restantes y un plan específico para lo que sigue. La empresa también recibe un Reporte Consolidado de Progreso para revisión de RH y liderazgo ejecutivo."
       }
     ]
   }

--- a/src/pages/en/services/corporate-package.astro
+++ b/src/pages/en/services/corporate-package.astro
@@ -115,6 +115,70 @@ const faqs = serviceFaqs["corporate-package"]?.en || [];
     </div>
   </section>
 
+  <!-- Formal Review Deliverables -->
+  <section class="bg-white py-16 px-8 border-t border-gray-100">
+    <div class="site-container--small mx-auto">
+      <h2 class="text-3xl font-bold mb-2 text-center">What the Formal Reviews Include</h2>
+      <p class="text-center text-gray-600 mb-12 max-w-xl mx-auto">This is what separates the structured program from flexible ongoing coaching. Three formal deliverables per participant, plus a company-level report.</p>
+
+      <div class="grid gap-6 md:grid-cols-2 max-w-4xl mx-auto">
+
+        <div class="bg-light rounded-xl p-8 border border-gray-100">
+          <div class="text-sm font-semibold text-primary uppercase tracking-wide mb-2">Delivered after Session 1–2</div>
+          <h3 class="text-xl font-bold mb-3">Initial Student Profile</h3>
+          <p class="text-gray-600 text-sm mb-4">A written baseline document for each participant, produced after the first session. Covers:</p>
+          <ul class="text-sm text-gray-600 space-y-2">
+            <li class="flex gap-2"><span class="text-primary font-bold shrink-0">→</span> Current English level and observable communication patterns</li>
+            <li class="flex gap-2"><span class="text-primary font-bold shrink-0">→</span> Job role, responsibilities, and team context</li>
+            <li class="flex gap-2"><span class="text-primary font-bold shrink-0">→</span> Job-related English goals and high-stakes communication moments</li>
+            <li class="flex gap-2"><span class="text-primary font-bold shrink-0">→</span> Priority focus areas for Phases 1–3</li>
+          </ul>
+          <p class="text-xs text-gray-400 mt-4">This document is the program baseline. Phase 3 measures progress against it.</p>
+        </div>
+
+        <div class="bg-light rounded-xl p-8 border border-gray-100">
+          <div class="text-sm font-semibold text-primary uppercase tracking-wide mb-2">Delivered monthly throughout the program</div>
+          <h3 class="text-xl font-bold mb-3">Monthly Assessments</h3>
+          <p class="text-gray-600 text-sm mb-4">One assessment per participant per month. Each covers five areas:</p>
+          <ul class="text-sm text-gray-600 space-y-2">
+            <li class="flex gap-2"><span class="text-primary font-bold shrink-0">→</span> <span><strong>Ongoing gaps</strong> — the specific communication patterns still showing up that matter most</span></li>
+            <li class="flex gap-2"><span class="text-primary font-bold shrink-0">→</span> <span><strong>Level of effort</strong> — preparation quality and practice outside of sessions, assessed honestly</span></li>
+            <li class="flex gap-2"><span class="text-primary font-bold shrink-0">→</span> <span><strong>Enthusiasm and engagement</strong> during sessions</span></li>
+            <li class="flex gap-2"><span class="text-primary font-bold shrink-0">→</span> <span><strong>In-session performance</strong> — fluency, clarity, confidence under pressure</span></li>
+            <li class="flex gap-2"><span class="text-primary font-bold shrink-0">→</span> <span><strong>Updated priority areas</strong> based on recent work</span></li>
+          </ul>
+          <p class="text-xs text-gray-400 mt-4">Sessions are never AI-recorded. All assessment content comes from Robert's direct observation.</p>
+        </div>
+
+        <div class="bg-light rounded-xl p-8 border border-gray-100">
+          <div class="text-sm font-semibold text-primary uppercase tracking-wide mb-2">Delivered at program close — per participant</div>
+          <h3 class="text-xl font-bold mb-3">Written Individual Roadmap</h3>
+          <p class="text-gray-600 text-sm mb-4">A personalized written document for each participant covering:</p>
+          <ul class="text-sm text-gray-600 space-y-2">
+            <li class="flex gap-2"><span class="text-primary font-bold shrink-0">→</span> Progress measured against the initial baseline</li>
+            <li class="flex gap-2"><span class="text-primary font-bold shrink-0">→</span> Remaining priority gaps and how to address them</li>
+            <li class="flex gap-2"><span class="text-primary font-bold shrink-0">→</span> Recommended focus areas and practice approaches for continued development</li>
+            <li class="flex gap-2"><span class="text-primary font-bold shrink-0">→</span> Honest summary of where they stand after the program</li>
+          </ul>
+        </div>
+
+        <div class="bg-light rounded-xl p-8 border border-gray-100">
+          <div class="text-sm font-semibold text-primary uppercase tracking-wide mb-2">Delivered at program close — for the company</div>
+          <h3 class="text-xl font-bold mb-3">Consolidated Company Report</h3>
+          <p class="text-gray-600 text-sm mb-4">A summary-level document for HR and executive review covering:</p>
+          <ul class="text-sm text-gray-600 space-y-2">
+            <li class="flex gap-2"><span class="text-primary font-bold shrink-0">→</span> Team-level progress and collective patterns observed</li>
+            <li class="flex gap-2"><span class="text-primary font-bold shrink-0">→</span> Notable achievements and breakthroughs across the group</li>
+            <li class="flex gap-2"><span class="text-primary font-bold shrink-0">→</span> Recommendations for continued team development</li>
+            <li class="flex gap-2"><span class="text-primary font-bold shrink-0">→</span> Overview of program outcomes against original goals</li>
+          </ul>
+          <p class="text-xs text-gray-400 mt-4">Individual performance details are kept in the personal roadmap documents, not the company report.</p>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
   <!-- Investment -->
   <section class="bg-white py-16 px-8">
     <div class="site-container--small mx-auto">

--- a/src/pages/en/services/corporate-package.astro
+++ b/src/pages/en/services/corporate-package.astro
@@ -12,21 +12,21 @@ import { corporatePackage as serviceData } from "@data/services";
 
 const title = "Corporate English Training for Teams | NY English Teacher";
 const seoDescription =
-  "Corporate English coaching for senior leadership teams in Mexico. 12 weeks of individual prep, peer-pressure group sessions, and measurable outcomes — not just certificates.";
+  "Corporate English coaching for management teams in Mexico. 12 weeks of individual prep, peer-pressure group sessions, and measurable outcomes — not just certificates.";
 
 const heroContent = {
-  title: "Your leadership team is ready. Their English isn't keeping up.",
+  title: "Your management team is ready. Their English isn't keeping up.",
   description:
     "A 12-week program that uses peer pressure — not a classroom — to close the gap between preparation and performance.",
   backgroundImage: serviceData.backgroundImage,
   overlayOpacity: 0.75,
-  imageAlt: "Senior leadership team in a business English coaching session",
+  imageAlt: "Management team in a business English coaching session",
 };
 
 const challengeContent = {
   headline: "The Problem Most L&D Programs Miss",
   painPoints: [
-    "Your senior leaders communicate well in private English sessions — but freeze, rush, or switch to Spanish the moment their peers are watching.",
+    "Your managers communicate well in private English sessions — but freeze, rush, or switch to Spanish the moment their peers are watching.",
     "Generic English courses produce certificates, not performance. Your team sits through a curriculum built for someone else.",
     "The gap between 'functional English' and 'executive English' shows up in the boardroom, not in a grammar test.",
   ],
@@ -42,7 +42,7 @@ const challengeContent = {
 
 const ctaContent = {
   eyebrow: "Corporate Programs",
-  title: "Ready to build a leadership team that leads in English?",
+  title: "Ready to build a management team that leads in English?",
   description:
     "This program requires a discovery call to scope for your group size, schedule, and goals. Robert is a native New Yorker who has coached senior executives and leadership teams across Mexico for over a decade. He responds within 24 hours.",
   buttonSubtext: "Most discovery calls take 20 minutes.",
@@ -52,7 +52,7 @@ const ctaContent = {
   whatToExpectList: [
     "Assess your team's current English communication baseline",
     "Scope the program for your group size, schedule, and industry context",
-    "Define what a successful outcome looks like for your leadership team",
+    "Define what a successful outcome looks like for your team",
   ],
 };
 
@@ -239,7 +239,7 @@ const faqs = serviceFaqs["corporate-package"]?.en || [];
         <div>
           <h3 class="font-bold text-lg mb-4">For the Company</h3>
           <ul class="space-y-3 text-gray-600">
-            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> A senior team that can represent the company in English without bottlenecks</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> A management team that can represent the company in English without bottlenecks</li>
             <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> A structured L&D investment with observable performance outcomes, not just certificates</li>
             <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> A consolidated progress report for HR and executive review</li>
             <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> The beginning of a culture shift — from avoiding English to preparing for it</li>
@@ -283,7 +283,7 @@ const faqs = serviceFaqs["corporate-package"]?.en || [];
     "@type": "Service",
     "name": "Corporate English Training for Leadership Teams",
     "alternateName": "Courage While Leading in English",
-    "description": "A 12-week structured English coaching program for senior leadership teams. Individual preparation, peer-pressure group presentations, and a final assessment — designed to close the gap between private fluency and public performance.",
+    "description": "A 12-week structured English coaching program for management teams. Individual preparation, peer-pressure group presentations, and a final assessment — designed to close the gap between private fluency and public performance.",
     "provider": {
       "@type": "Person",
       "name": "Robert Cushman",

--- a/src/pages/en/services/ongoing-coaching.astro
+++ b/src/pages/en/services/ongoing-coaching.astro
@@ -235,7 +235,7 @@ const faqs = serviceFaqs["ongoing-coaching"]?.en || [];
       <h2 class="text-3xl font-bold mb-2 text-center">Investment</h2>
       <p class="text-center text-gray-600 mb-10">Straightforward pricing. No packages, no minimum commitment.</p>
       <div class="bg-gray-50 rounded-xl p-8 border border-gray-200 text-center">
-        <div class="text-4xl font-bold mb-2">500 MXN</div>
+        <div class="text-4xl font-bold mb-2">500 MXN <span class="text-2xl font-normal text-gray-400">/ ~$30 USD</span></div>
         <div class="text-gray-500 mb-6">per hour, per participant</div>
         <ul class="text-sm text-gray-600 space-y-3 text-left max-w-xs mx-auto">
           <li class="flex gap-2">

--- a/src/pages/es/servicios/paquete-corporativo.astro
+++ b/src/pages/es/servicios/paquete-corporativo.astro
@@ -15,18 +15,18 @@ const seoDescription =
   "Capacitación de inglés corporativo para equipos directivos en México. 12 semanas de preparación individual, presión de pares y resultados medibles — no solo certificados.";
 
 const heroContent = {
-  title: "Tu equipo directivo está listo. Su inglés no les está siguiendo el ritmo.",
+  title: "Tu equipo de gestión está listo. Su inglés no les está siguiendo el ritmo.",
   description:
     "Un programa de 12 semanas que usa la presión de pares — no un salón de clases — para cerrar la brecha entre preparación y desempeño.",
   backgroundImage: serviceData.backgroundImage,
   overlayOpacity: 0.75,
-  imageAlt: "Equipo directivo senior en una sesión de coaching de inglés empresarial",
+  imageAlt: "Equipo de gestión en una sesión de coaching de inglés empresarial",
 };
 
 const challengeContent = {
   headline: "El Problema que la Mayoría de los Programas de L&D Ignoran",
   painPoints: [
-    "Tus líderes senior se comunican bien en sesiones privadas de inglés — pero se congelan, se apresuran o cambian al español en el momento en que sus pares los están observando.",
+    "Tus gerentes se comunican bien en sesiones privadas de inglés — pero se congelan, se apresuran o cambian al español en el momento en que sus pares los están observando.",
     "Los cursos genéricos de inglés producen certificados, no desempeño. Tu equipo sigue un temario construido para otra persona.",
     "La brecha entre 'inglés funcional' e 'inglés ejecutivo' se muestra en la sala de juntas, no en un examen de gramática.",
   ],
@@ -52,7 +52,7 @@ const ctaContent = {
   whatToExpectList: [
     "Evaluaremos la línea base actual de comunicación en inglés de tu equipo",
     "Definiremos el alcance del programa para tu tamaño de grupo, agenda y contexto de industria",
-    "Estableceremos cómo se ve un resultado exitoso para tu equipo de liderazgo",
+    "Estableceremos cómo se ve un resultado exitoso para tu equipo",
   ],
 };
 


### PR DESCRIPTION
## Summary

- **ongoing-coaching page**: Added `~$30 USD` to the 500 MXN pricing display so international visitors immediately see the USD equivalent
- **corporate-package page**: New "What the Formal Reviews Include" section with 4 cards covering Initial Student Profile, Monthly Assessments, Individual Roadmap, and Consolidated Company Report — answers the question serious corporate buyers always ask
- **service-faqs.ts**: Added 3 new FAQ entries to each corporate program (EN + ES):
  - How does the session structure work (individual vs. group)?
  - What if the team has more than 4 people?
  - What exactly do the formal reviews include? *(corporate-package only)*
- **RAG chatbot knowledge bases** (EN + ES): Full Section 11 covering both corporate programs — pricing, structure, deliverables, all FAQ scenarios the chatbot needs to handle correctly

## Background
Prompted by a live prospect WhatsApp inquiry asking "how would the dynamic work with individual vs. group sessions?" — the site and chatbot had no good answer for this.

## Test plan
- [ ] Build passes
- [ ] `/en/services/ongoing-coaching/` pricing shows `500 MXN / ~$30 USD`
- [ ] `/en/services/corporate-package/` shows the 4-card formal reviews section between program structure and investment
- [ ] FAQ pages for both services show the new questions
- [ ] Chatbot correctly answers corporate program questions in EN and ES

🤖 Generated with [Claude Code](https://claude.com/claude-code)