### PR TITLE
fix: remove remaining 'senior' references from ES corporate page

### DIFF
--- a/src/pages/es/servicios/paquete-corporativo.astro
+++ b/src/pages/es/servicios/paquete-corporativo.astro
@@ -175,7 +175,7 @@ const faqs = serviceFaqs["corporate-package"]?.es || [];
         <div>
           <h3 class="font-bold text-lg mb-4">Para la Empresa</h3>
           <ul class="space-y-3 text-gray-600">
-            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Un equipo senior que puede representar a la empresa en inglés sin cuellos de botella</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Un equipo de gestión que puede representar a la empresa en inglés sin cuellos de botella</li>
             <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Una inversión estructurada en L&D con resultados de desempeño observables, no solo certificados</li>
             <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Un reporte de progreso consolidado para RH y revisión ejecutiva</li>
             <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> El inicio de un cambio cultural — de evitar el inglés a prepararse para él</li>
@@ -219,7 +219,7 @@ const faqs = serviceFaqs["corporate-package"]?.es || [];
     "@type": "Service",
     "name": "Inglés Corporativo para Equipos Directivos",
     "alternateName": "Valentía al Liderar en Inglés",
-    "description": "Un programa estructurado de 12 semanas para equipos de liderazgo senior. Preparación individual, presentaciones grupales bajo presión de pares y evaluación final — diseñado para cerrar la brecha entre la fluidez privada y el desempeño público.",
+    "description": "Un programa estructurado de 12 semanas para equipos de gestión. Preparación individual, presentaciones grupales bajo presión de pares y evaluación final — diseñado para cerrar la brecha entre la fluidez privada y el desempeño público.",
     "provider": {
       "@type": "Person",
       "name": "Robert Cushman",


### PR DESCRIPTION
Two spots missed in prior pass on paquete-corporativo.astro: outcomes bullet ('equipo senior' → 'equipo de gestión') and JSON-LD description ('equipos de liderazgo senior' → 'equipos de gestión').