### PR TITLE
feat: add Vercel Analytics to every page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "titan-core",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "titan-core",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
         "@astrojs/check": "^0.9.4",
@@ -20,6 +20,7 @@
         "@neondatabase/serverless": "^1.0.2",
         "@sentry/astro": "^10.48.0",
         "@types/marked": "^5.0.2",
+        "@vercel/analytics": "^2.0.1",
         "@vercel/blob": "^2.3.3",
         "aos": "^2.3.4",
         "astro": "^5.5.3",
@@ -8829,6 +8830,48 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vercel/blob": {
       "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@neondatabase/serverless": "^1.0.2",
     "@sentry/astro": "^10.48.0",
     "@types/marked": "^5.0.2",
+    "@vercel/analytics": "^2.0.1",
     "@vercel/blob": "^2.3.3",
     "aos": "^2.3.4",
     "astro": "^5.5.3",

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -423,6 +423,7 @@ if (translationSlugEs.includes("/es/blog/es/")) {
         if (e.target.closest(".stop-prop")) e.stopPropagation();
       });
     </script>
+    <script defer src="/_vercel/insights/script.js"></script>
   </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Installs `@vercel/analytics` package
- Injects `/_vercel/insights/script.js` (Vercel edge-served) via `defer` script tag in `Base.astro` — fires on every EN and ES page
- Build passes clean

## Test plan
- [ ] Deploy and visit any page — Vercel Analytics dashboard should show live visitor within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)