### PR TITLE
fix: remove in-person session references — all coaching is online

### DIFF
--- a/rag-chatbot/en/services-public-speaking-english.txt
+++ b/rag-chatbot/en/services-public-speaking-english.txt
@@ -35,8 +35,8 @@ A: Yes. We work on every aspect — opening hooks that grab attention, storytell
 Q: I get nervous speaking English in front of groups. Can coaching help?
 A: Absolutely. Public speaking anxiety multiplies when you're speaking in a second language. Our coaching builds confidence through progressive practice — starting with comfortable scenarios and building to increasingly challenging audiences until presenting feels natural.
 
-Q: Do you coach for virtual presentations too, not just in-person?
-A: Yes. Virtual presentations require different skills — camera presence, slide pacing, voice modulation without physical cues, and engaging an audience you can't see. We practice the specific techniques that make virtual delivery compelling and authoritative.
+Q: Do you coach for virtual presentations — calls, webinars, remote pitches?
+A: Yes, and that's the primary format. All sessions are online via Google Meet. Virtual presentations require different skills — camera presence, slide pacing, voice modulation without physical cues, and engaging an audience you can't see. We practice the specific techniques that make virtual delivery compelling and authoritative.
 
 Q: Can I bring my actual presentation to practice in our sessions?
 A: That's exactly how we work. Every session uses your real content — your slides, your script, your audience context. We refine your delivery until you can present your material with confidence, clarity, and the impact your message deserves.

--- a/rag-chatbot/es/servicios-hablar-en-publico.txt
+++ b/rag-chatbot/es/servicios-hablar-en-publico.txt
@@ -35,8 +35,8 @@ R: Sí. Trabajamos en cada aspecto — ganchos de apertura que capturan atenció
 P: Me pongo nervioso hablando inglés frente a grupos. ¿El coaching puede ayudar?
 R: Por supuesto. La ansiedad de hablar en público se multiplica cuando hablas en un segundo idioma. Nuestro coaching construye confianza a través de práctica progresiva.
 
-P: ¿Dan coaching para presentaciones virtuales también, no solo presenciales?
-R: Sí. Las presentaciones virtuales requieren habilidades diferentes — presencia ante cámara, ritmo de slides, modulación de voz sin señales físicas, y captar una audiencia que no puedes ver.
+P: ¿Dan coaching para presentaciones virtuales — llamadas, webinars, pitches remotos?
+R: Sí, y ese es el formato principal. Todas las sesiones son en línea por Google Meet. Las presentaciones virtuales requieren habilidades diferentes — presencia ante cámara, ritmo de slides, modulación de voz sin señales físicas, y captar una audiencia que no puedes ver.
 
 P: ¿Puedo traer mi presentación real para practicar en las sesiones?
 R: Así es exactamente como trabajamos. Cada sesión usa tu contenido real — tus slides, tu guión, el contexto de tu audiencia. Refinamos tu entrega hasta que puedas presentar tu material con confianza, claridad y el impacto que tu mensaje merece.

--- a/src/data/service-faqs.ts
+++ b/src/data/service-faqs.ts
@@ -340,8 +340,8 @@ export const serviceFaqs: Record<string, ServiceFaqSet> = {
         answer: "Absolutely. Public speaking anxiety multiplies when you're speaking in a second language. Our coaching builds confidence through progressive practice — starting with comfortable scenarios and building to increasingly challenging audiences until presenting feels natural."
       },
       {
-        question: "Do you coach for virtual presentations too, not just in-person?",
-        answer: "Yes. Virtual presentations require different skills — camera presence, slide pacing, voice modulation without physical cues, and engaging an audience you can't see. We practice the specific techniques that make virtual delivery compelling and authoritative."
+        question: "Do you coach for virtual presentations — calls, webinars, remote pitches?",
+        answer: "Yes, and that's the primary format we work in. Virtual presentations require different skills — camera presence, slide pacing, voice modulation without physical cues, and engaging an audience you can't see. We practice the specific techniques that make virtual delivery compelling and authoritative."
       },
       {
         question: "Can I bring my actual presentation to practice in our sessions?",
@@ -358,8 +358,8 @@ export const serviceFaqs: Record<string, ServiceFaqSet> = {
         answer: "Por supuesto. La ansiedad de hablar en público se multiplica cuando hablas en un segundo idioma. Nuestro coaching construye confianza a través de práctica progresiva — comenzando con escenarios cómodos y avanzando a audiencias cada vez más retadoras hasta que presentar se sienta natural."
       },
       {
-        question: "¿Dan coaching para presentaciones virtuales también, no solo presenciales?",
-        answer: "Sí. Las presentaciones virtuales requieren habilidades diferentes — presencia ante cámara, ritmo de slides, modulación de voz sin señales físicas, y captar una audiencia que no puedes ver. Practicamos las técnicas específicas que hacen que la entrega virtual sea convincente y con autoridad."
+        question: "¿Dan coaching para presentaciones virtuales — llamadas, webinars, pitches remotos?",
+        answer: "Sí, y ese es el formato principal con el que trabajamos. Las presentaciones virtuales requieren habilidades diferentes — presencia ante cámara, ritmo de slides, modulación de voz sin señales físicas, y captar una audiencia que no puedes ver. Practicamos las técnicas específicas que hacen que la entrega virtual sea convincente y con autoridad."
       },
       {
         question: "¿Puedo traer mi presentación real para practicar en las sesiones?",

--- a/src/pages/en/services/ongoing-coaching.astro
+++ b/src/pages/en/services/ongoing-coaching.astro
@@ -218,7 +218,7 @@ const faqs = serviceFaqs["ongoing-coaching"]?.en || [];
             Robert Cushman is a native New Yorker with over a decade of experience coaching executives, teams, and professionals across Mexico. He works entirely in English and focuses on communication that performs — not just communication that's technically correct.
           </p>
           <p class="text-gray-600 text-sm">
-            Sessions are conducted online via Google Meet. In-person group sessions may be possible depending on location and logistics, but online is the standard format.
+            All sessions are conducted online via Google Meet.
           </p>
         </div>
       </div>

--- a/src/pages/es/servicios/coaching-continuo.astro
+++ b/src/pages/es/servicios/coaching-continuo.astro
@@ -218,7 +218,7 @@ const faqs = serviceFaqs["ongoing-coaching"]?.es || [];
             Robert Cushman es un neoyorquino nativo con más de una década de experiencia trabajando con ejecutivos, equipos y profesionales en México. Trabaja íntegramente en inglés y se enfoca en comunicación que funciona — no solo en comunicación técnicamente correcta.
           </p>
           <p class="text-gray-600 text-sm">
-            Las sesiones se realizan en línea por Google Meet. Las sesiones grupales presenciales pueden ser posibles según la ubicación y la logística, pero el formato estándar es en línea.
+            Todas las sesiones se realizan en línea por Google Meet.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- `ongoing-coaching.astro` + `coaching-continuo.astro`: removed "In-person group sessions may be possible" sentence — replaced with "All sessions are conducted online via Google Meet"
- `service-faqs.ts`: reframed virtual presentation FAQ question to remove the implication that in-person is an option (EN + ES)
- `rag-chatbot/en/services-public-speaking-english.txt` + ES equivalent: same FAQ update in knowledge base

Robert does not do on-site, home visits, or office visits. All coaching is remote via Google Meet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)