### PR TITLE
fix: add online-only location framing to knowledge base

### DIFF
--- a/rag-chatbot/en/knowledge-base.en.txt
+++ b/rag-chatbot/en/knowledge-base.en.txt
@@ -9,6 +9,8 @@ SECTION 1 — WHO WE ARE (THE SHORT VERSION)
 
 New York English Teacher is the private English coaching practice of Robert Cushman, an executive communication coach based in Guadalajara, Mexico (UTC-6). Robert spent 20 years in IT — 17 of them at a Fortune 500 company — climbing from developer to Senior Manager. He has led global teams, presented to boardrooms, and navigated corporate politics at scale. He now coaches international professionals to do the same in English.
 
+There is no physical school or classroom. All coaching is conducted 100% online via Google Meet — individual sessions, corporate programs, everything. Robert is based in Guadalajara but students join from wherever they work best: their home, their office, anywhere with a stable connection. No commute, no travel, no scheduling around logistics. This is a feature, not a limitation.
+
 This is not a language school. It is a 1-on-1 coaching practice for working professionals who already lead in their native language and need their English to match.
 
 The core promise: "You already lead. Now sound like it — in English."

--- a/rag-chatbot/es/knowledge-base.es.txt
+++ b/rag-chatbot/es/knowledge-base.es.txt
@@ -9,6 +9,8 @@ SECCIÓN 1 — QUIÉNES SOMOS (VERSIÓN CORTA)
 
 New York English Teacher es la práctica privada de coaching de inglés de Robert Cushman, coach de comunicación ejecutiva con sede en Guadalajara, México (UTC-6). Robert pasó 20 años en TI — 17 de ellos en una empresa Fortune 500 — escalando desde desarrollador hasta Senior Manager. Ha liderado equipos globales, presentado ante salas de juntas y navegado la política corporativa a gran escala. Hoy entrena a profesionales internacionales para hacer lo mismo en inglés.
 
+No existe escuela física ni salón de clases. Todo el coaching se realiza 100% en línea por Google Meet — sesiones individuales, programas corporativos, todo. Robert está en Guadalajara pero los estudiantes se conectan desde donde trabajan mejor: su casa, su oficina, donde tengan buena conexión. Sin traslados, sin viajes, sin coordinar logística. Eso es una ventaja, no una limitación.
+
 Esto no es una escuela de idiomas. Es una práctica de coaching 1-a-1 para profesionales que ya lideran en su idioma nativo y necesitan que su inglés esté a la altura.
 
 La promesa central: "Ya lideras. Ahora suena como tal — en inglés."


### PR DESCRIPTION
## Summary
- Added explicit paragraph to Section 1 of both EN/ES knowledge bases: no physical school, 100% online via Google Meet, Robert is in Guadalajara, no commute required
- Ensures RAG fires correctly on questions like "where is the school" or "do you have classes in Monterrey"
- Aligns with system prompt fix already merged in ny-ai-chatbot (PR #49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)