### PR TITLE
fix: remove stale Qdrant reference from privacy policy

### DIFF
--- a/src/content/legal/en/privacy-policy.md
+++ b/src/content/legal/en/privacy-policy.md
@@ -89,7 +89,6 @@ For the Messenger Assistant specifically, your messages are transmitted to the f
 - **Meta Platforms, Inc.** — delivers messages via the Messenger Platform. [Privacy Policy](https://www.facebook.com/privacy/policy)
 - **Anthropic, PBC** — provides the Claude AI model that generates responses. [Privacy Policy](https://www.anthropic.com/legal/privacy)
 - **Cloudflare, Inc.** — hosts the Worker, provides KV storage and AI Gateway routing. [Privacy Policy](https://www.cloudflare.com/privacypolicy/)
-- **Qdrant Solutions GmbH** — hosts the vector database used to retrieve relevant content. [Privacy Policy](https://qdrant.tech/legal/privacy-policy/)
 - **Functional Software, Inc. (Sentry)** — receives error reports for monitoring purposes. [Privacy Policy](https://sentry.io/privacy/)
 
 ## Your Rights

--- a/src/content/legal/es/privacy-policy.md
+++ b/src/content/legal/es/privacy-policy.md
@@ -89,7 +89,6 @@ Específicamente para el Asistente de Messenger, tus mensajes son transmitidos a
 - **Meta Platforms, Inc.** — entrega mensajes a través de la Plataforma Messenger. [Política de Privacidad](https://www.facebook.com/privacy/policy)
 - **Anthropic, PBC** — proporciona el modelo de IA Claude que genera las respuestas. [Política de Privacidad](https://www.anthropic.com/legal/privacy)
 - **Cloudflare, Inc.** — aloja el Worker y proporciona almacenamiento KV y enrutamiento de AI Gateway. [Política de Privacidad](https://www.cloudflare.com/privacypolicy/)
-- **Qdrant Solutions GmbH** — aloja la base de datos vectorial utilizada para recuperar contenido relevante. [Política de Privacidad](https://qdrant.tech/legal/privacy-policy/)
 - **Functional Software, Inc. (Sentry)** — recibe informes de errores para monitoreo. [Política de Privacidad](https://sentry.io/privacy/)
 
 ## Tus Derechos


### PR DESCRIPTION
## Summary
- Removed Qdrant Solutions GmbH from the third-party data processor list in both EN and ES privacy policies
- Qdrant is no longer in use; listing a vendor that doesn't process user data is a false disclosure

## Note
If a replacement vector database is now processing Messenger user messages, that vendor should be added. Confirm with the chatbot repo session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)