### PR TITLE
feat: HR manager page for corporate buyer journey (EN + ES)

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -126,6 +126,7 @@ export type TKey =
   | "course/executive/unit-9"
   | "course/executive/unit-10"
   | "course/executive/capstone"
+  | "corporate/for-hr"
   | "meme-portfolio"
   | "site-index";
 
@@ -266,6 +267,7 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/executive/unit-9": "/en/course/executive/unit-9/",
     "course/executive/unit-10": "/en/course/executive/unit-10/",
     "course/executive/capstone": "/en/course/executive/capstone/",
+    "corporate/for-hr": "/en/for-hr-managers/",
     "meme-portfolio": "/en/meme-portfolio/all/",
     "site-index": "/en/site-index/",
   },
@@ -410,6 +412,7 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/executive/unit-9": "/es/curso/ejecutivo/unidad-9/",
     "course/executive/unit-10": "/es/curso/ejecutivo/unidad-10/",
     "course/executive/capstone": "/es/curso/ejecutivo/reto-final/",
+    "corporate/for-hr": "/es/para-rh/",
     "meme-portfolio": "/es/meme-portfolio/all/",
     "site-index": "/es/indice-del-sitio/",
   },
@@ -514,6 +517,7 @@ export function getAllTKeys(): TKey[] {
     "quiz/executives",
     "quiz/professional-services",
     "quiz/high-stakes",
+    "corporate/for-hr",
     "meme-portfolio",
     "site-index",
   ];

--- a/src/pages/en/for-hr-managers/index.astro
+++ b/src/pages/en/for-hr-managers/index.astro
@@ -1,0 +1,676 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import InnerHero from "@components/sections/InnerHero.astro";
+import CtaSection from "@components/sections/CtaSection.astro";
+import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
+import { corporatePackage as serviceData } from "@data/services";
+import { testimonials } from "@data/testimonials/en";
+import { Image } from "astro:assets";
+
+const title =
+  "Corporate English Training for HR Managers | NY English Teacher";
+const seoDescription =
+  "Evaluating English training for your management team? See the formal deliverables you receive, how progress is documented, and what makes this different from a generic language course.";
+
+const heroContent = {
+  title:
+    "Your team's English is good enough for class. Not good enough for the boardroom.",
+  description:
+    "This page is written for whoever is evaluating the program — not for the people who will attend it.",
+  backgroundImage: serviceData.backgroundImage,
+  overlayOpacity: 0.75,
+  imageAlt: "HR manager evaluating a corporate English training program",
+};
+
+const ctaContent = {
+  eyebrow: "Corporate Programs",
+  title: "Ready to discuss what this would look like for your team?",
+  description:
+    "Discovery calls take about 20 minutes. Robert scopes the program to your team size, schedule, and industry context — and answers whatever you need to move it forward internally.",
+  buttonSubtext: "Most discovery calls take 20 minutes.",
+  buttonText: "Contact Robert on WhatsApp",
+  buttonLink: "https://wa.me/523315590572",
+  whatToExpectTitle: "In Your Discovery Call, We Will:",
+  whatToExpectList: [
+    "Establish your team's current English communication baseline",
+    "Define what success looks like — and how it's measured",
+    "Scope the program for your group size, schedule, and industry context",
+  ],
+};
+
+const hrFaqs = [
+  {
+    question: "What documentation do we receive at the end of the program?",
+    answer:
+      "Four formal deliverables: an Initial Student Profile per participant (baseline document from Week 1), monthly progress assessments throughout the program, a Written Individual Roadmap per participant at program close, and a Consolidated Company Report summarizing team-level outcomes. Individual performance details stay in the personal documents — not the company report.",
+  },
+  {
+    question: "Can we get a factura?",
+    answer: "Yes. Mexican facturas are issued monthly throughout the program.",
+  },
+  {
+    question: "What is the minimum team size?",
+    answer:
+      "The structured program works best with 3–8 participants from the same leadership team. For groups larger than 8, Robert scopes a custom arrangement. For a single participant, the executive coaching program is the better fit.",
+  },
+  {
+    question:
+      "What if an employee doesn't engage or misses sessions?",
+    answer:
+      "That gets documented in the monthly assessments — specifically the level-of-effort and engagement fields. You will see it on paper before the program ends, not as a surprise in the final report. Participants who prepare between sessions see measurable gains. Those who attend but don't prepare will see limited results — and the assessments will reflect that honestly.",
+  },
+  {
+    question: "Is all instruction in English?",
+    answer:
+      "Yes. Sessions can include brief Spanish clarification when something genuinely needs it, but the program is designed for maximum English exposure. Switching to Spanish to avoid discomfort defeats the purpose — and Robert won't do it.",
+  },
+  {
+    question:
+      "How is this different from a language school or generic English course?",
+    answer:
+      "Generic courses follow a preset curriculum built for no one in particular. This program is scoped to your team's actual roles, communication gaps, and real-world English situations: presentations, client calls, cross-border negotiations. Formal assessments track individual progress against a Week 1 baseline. At the end, you have documentation of what changed — not just attendance records and a certificate.",
+  },
+  {
+    question: "Is USD pricing available?",
+    answer:
+      "Yes. For international companies, USD pricing is available. The session rate converts at the exchange rate at program start. Facturas are issued in MXN regardless of how your company settles payment internally.",
+  },
+];
+
+const selectedSlugs = [
+  "julio-smarttie",
+  "hugo-blum-100-ladrillos",
+  "andres-driscolls",
+  "andrea-ceva-logistics",
+];
+const hrTestimonials = testimonials.filter((t) =>
+  selectedSlugs.includes(t.slug)
+);
+---
+
+<Base
+  title={title}
+  description={seoDescription}
+  lang="en"
+  tkey="corporate/for-hr"
+  hideCta={true}
+>
+  <!-- Hero -->
+  <InnerHero content={heroContent} />
+
+  <!-- HR crosslink callout -->
+  <div class="bg-blue-50 border-b border-blue-100 py-4 px-8">
+    <div class="site-container--small mx-auto flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+      <p class="text-sm text-blue-800">
+        <strong>You're on the HR manager page.</strong> Looking for the program details written for participants?
+      </p>
+      <a
+        href="/en/services/corporate-package/"
+        class="text-sm font-semibold text-blue-700 hover:underline whitespace-nowrap shrink-0"
+      >
+        See the full program page →
+      </a>
+    </div>
+  </div>
+
+  <!-- Cost of weak English -->
+  <section class="bg-gray-900 text-white py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <p
+        class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
+      >
+        The Business Case
+      </p>
+      <h2 class="text-3xl font-bold mb-4 text-center">
+        What Weak English Actually Costs Your Business
+      </h2>
+      <p class="text-center text-gray-400 mb-12 max-w-2xl mx-auto">
+        These aren't abstract statistics. They're situations your team has
+        already been in.
+      </p>
+
+      <div class="grid gap-6 md:grid-cols-2">
+        <div class="bg-gray-800 rounded-xl p-8 border border-gray-700">
+          <h3 class="text-lg font-bold mb-3 text-white">
+            The "I'll follow up by email" moment
+          </h3>
+          <p class="text-gray-300 text-sm leading-relaxed mb-4">
+            Your manager is on a live call with a US client. They understand the
+            question. They know the answer. But they can't find the words fast
+            enough under pressure, so they say "I'll follow up by email." The
+            meeting ends. The client moves on. Three days later, an email goes
+            out that should have been a 30-second answer.
+          </p>
+          <p class="text-sm text-gray-500 italic">
+            That's not a communication gap. That's a deal gap.
+          </p>
+        </div>
+
+        <div class="bg-gray-800 rounded-xl p-8 border border-gray-700">
+          <h3 class="text-lg font-bold mb-3 text-white">
+            The bottlenecked relationship
+          </h3>
+          <p class="text-gray-300 text-sm leading-relaxed mb-4">
+            Your team can't escalate directly to US or European leadership
+            without routing every important message through the one bilingual
+            person in the room. That person becomes the bottleneck. Decisions
+            slow down. Your local managers can't build direct relationships with
+            decision-makers. Over time, your office becomes "the team that
+            always needs a translator" — and gets treated accordingly.
+          </p>
+          <p class="text-sm text-gray-500 italic">
+            The gap compounds quietly, until it doesn't.
+          </p>
+        </div>
+
+        <div class="bg-gray-800 rounded-xl p-8 border border-gray-700">
+          <h3 class="text-lg font-bold mb-3 text-white">
+            The negotiation that drags
+          </h3>
+          <p class="text-gray-300 text-sm leading-relaxed mb-4">
+            A 30-minute negotiation with a US supplier becomes a 90-minute call
+            because your team needs extra time to process, confirm, and respond
+            in English. The supplier notices. The dynamic shifts. Deals that
+            should close in two calls take five. Your position weakens — not
+            because of your terms, but because of your pace.
+          </p>
+          <p class="text-sm text-gray-500 italic">
+            Speed signals confidence. Hesitation signals weakness.
+          </p>
+        </div>
+
+        <div class="bg-gray-800 rounded-xl p-8 border border-gray-700">
+          <h3 class="text-lg font-bold mb-3 text-white">
+            The talent you're about to lose
+          </h3>
+          <p class="text-gray-300 text-sm leading-relaxed mb-4">
+            Your best managers are ambitious. They see the cross-border roles,
+            the international projects, the leadership tracks that require
+            strong English. They know their English is the ceiling. If your
+            company doesn't invest in removing that ceiling, they'll find one
+            that does — or they'll plateau, disengage, and coast.
+          </p>
+          <p class="text-sm text-gray-500 italic">
+            Training English is a retention strategy. Not training it is a
+            risk.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- What HR receives -->
+  <section class="bg-white py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <p
+        class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
+      >
+        Formal Deliverables
+      </p>
+      <h2 class="text-3xl font-bold mb-4 text-center">
+        What You Have on Paper When It's Done
+      </h2>
+      <p class="text-center text-gray-600 mb-12 max-w-2xl mx-auto">
+        This is what separates a structured program from ongoing private
+        tutoring. Four formal documents — three per participant, one for the
+        company.
+      </p>
+
+      <div class="grid gap-6 md:grid-cols-2 max-w-4xl mx-auto">
+        <div class="bg-light rounded-xl p-8 border border-gray-100">
+          <div
+            class="text-sm font-semibold text-primary uppercase tracking-wide mb-2"
+          >
+            Delivered after Week 1–2
+          </div>
+          <h3 class="text-xl font-bold mb-3">Initial Student Profile</h3>
+          <p class="text-gray-600 text-sm mb-4">
+            A written baseline document for each participant. Covers their
+            current English level, job role, communication gaps, and priority
+            focus areas. This is the document Phase 3 measures progress
+            against.
+          </p>
+          <ul class="text-sm text-gray-600 space-y-2">
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Current
+              level and observable communication patterns
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Job role
+              and high-stakes communication moments
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Priority
+              focus areas for the program
+            </li>
+          </ul>
+        </div>
+
+        <div class="bg-light rounded-xl p-8 border border-gray-100">
+          <div
+            class="text-sm font-semibold text-primary uppercase tracking-wide mb-2"
+          >
+            Delivered monthly throughout the program
+          </div>
+          <h3 class="text-xl font-bold mb-3">Monthly Assessments</h3>
+          <p class="text-gray-600 text-sm mb-4">
+            One written assessment per participant per month, covering five
+            areas:
+          </p>
+          <ul class="text-sm text-gray-600 space-y-2">
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Ongoing
+              communication gaps
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Level of
+              effort and preparation quality
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Engagement
+              and in-session performance
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Updated
+              priority areas
+            </li>
+          </ul>
+          <p class="text-xs text-gray-400 mt-4">
+            Based on Robert's direct observation — no AI recording or
+            transcription.
+          </p>
+        </div>
+
+        <div class="bg-light rounded-xl p-8 border border-gray-100">
+          <div
+            class="text-sm font-semibold text-primary uppercase tracking-wide mb-2"
+          >
+            Delivered at program close — per participant
+          </div>
+          <h3 class="text-xl font-bold mb-3">Written Individual Roadmap</h3>
+          <p class="text-gray-600 text-sm mb-4">
+            A personalized written document for each participant:
+          </p>
+          <ul class="text-sm text-gray-600 space-y-2">
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Progress
+              measured against the Week 1 baseline
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Remaining
+              gaps and recommended focus areas
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Honest
+              summary of where they stand after the program
+            </li>
+          </ul>
+        </div>
+
+        <div class="bg-light rounded-xl p-8 border border-gray-100">
+          <div
+            class="text-sm font-semibold text-primary uppercase tracking-wide mb-2"
+          >
+            Delivered at program close — for the company
+          </div>
+          <h3 class="text-xl font-bold mb-3">Consolidated Company Report</h3>
+          <p class="text-gray-600 text-sm mb-4">
+            A summary-level document for internal review and reporting:
+          </p>
+          <ul class="text-sm text-gray-600 space-y-2">
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Team-level
+              progress and collective patterns
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Notable
+              achievements across the group
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Program
+              outcomes vs. original goals
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Recommendations
+              for continued team development
+            </li>
+          </ul>
+          <p class="text-xs text-gray-400 mt-4">
+            Individual performance details are kept in the personal roadmaps —
+            not this document.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Program Structure -->
+  <section class="bg-light py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <p
+        class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
+      >
+        How It Works
+      </p>
+      <h2 class="text-3xl font-bold mb-2 text-center">12 Weeks. 3 Phases.</h2>
+      <p class="text-center text-gray-600 mb-12">
+        Not a course that runs indefinitely with no defined outcome. A
+        structured sprint with a clear beginning, a pressure point, and a
+        formal close.
+      </p>
+
+      <div class="grid gap-8 md:grid-cols-3">
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div
+            class="text-sm font-semibold text-primary uppercase tracking-wide mb-2"
+          >
+            Weeks 1–8
+          </div>
+          <h3 class="text-xl font-bold mb-3">Individual Preparation</h3>
+          <p class="text-gray-600 mb-4 text-sm">
+            Each participant works privately with Robert. The first two weeks
+            establish an honest baseline. The remaining weeks build preparation
+            around their real role, actual presentations, and specific
+            communication challenges.
+          </p>
+          <div class="text-sm text-gray-500">8–12 sessions per participant</div>
+        </div>
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div
+            class="text-sm font-semibold text-primary uppercase tracking-wide mb-2"
+          >
+            Weeks 9–10
+          </div>
+          <h3 class="text-xl font-bold mb-3">Group Presentation</h3>
+          <p class="text-gray-600 mb-4 text-sm">
+            Every participant delivers their prepared presentation in English to
+            the full leadership group — often for the first time. The pressure
+            is real, deliberate, and productive. This is where the program
+            earns its results.
+          </p>
+          <div class="text-sm text-gray-500">1–2 group sessions</div>
+        </div>
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div
+            class="text-sm font-semibold text-primary uppercase tracking-wide mb-2"
+          >
+            Weeks 11–12
+          </div>
+          <h3 class="text-xl font-bold mb-3">Assessment & Debrief</h3>
+          <p class="text-gray-600 mb-4 text-sm">
+            Individual debrief sessions with direct feedback. Final assessment
+            measures progress against the Week 1 baseline. Individual roadmaps
+            and the consolidated company report are delivered at close.
+          </p>
+          <div class="text-sm text-gray-500">2–3 sessions per participant</div>
+        </div>
+      </div>
+
+      <div class="mt-8 text-center">
+        <a
+          href="/en/services/corporate-package/"
+          class="inline-flex items-center gap-2 text-primary font-semibold text-sm hover:underline"
+        >
+          See the full program detail <span aria-hidden="true">→</span>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- What you bring back to leadership -->
+  <section class="bg-white py-16 px-8">
+    <div class="site-container--small mx-auto max-w-4xl">
+      <p
+        class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
+      >
+        Reporting Upward
+      </p>
+      <h2 class="text-3xl font-bold mb-4 text-center">
+        What You Bring Back to Leadership
+      </h2>
+      <p class="text-center text-gray-600 mb-12">
+        When the program ends, you're not reporting "everyone felt more
+        confident." You're reporting specific, documented outcomes.
+      </p>
+
+      <div class="grid gap-4 md:grid-cols-2">
+        <div class="flex gap-4 p-6 bg-light rounded-xl border border-gray-100">
+          <span class="text-green-500 font-bold text-lg mt-0.5 shrink-0"
+            >✓</span
+          >
+          <div>
+            <p class="font-semibold text-gray-900 mb-1">
+              Progress measured against a documented baseline
+            </p>
+            <p class="text-sm text-gray-600">
+              Not "they improved" — the Initial Student Profile and final
+              roadmap show specifically where each participant started and where
+              they finished.
+            </p>
+          </div>
+        </div>
+        <div class="flex gap-4 p-6 bg-light rounded-xl border border-gray-100">
+          <span class="text-green-500 font-bold text-lg mt-0.5 shrink-0"
+            >✓</span
+          >
+          <div>
+            <p class="font-semibold text-gray-900 mb-1">
+              A deliverable you can show — not just describe
+            </p>
+            <p class="text-sm text-gray-600">
+              The Consolidated Company Report is a formal document. You can
+              attach it to an internal review, a budget justification, or a
+              follow-up proposal for the next program cycle.
+            </p>
+          </div>
+        </div>
+        <div class="flex gap-4 p-6 bg-light rounded-xl border border-gray-100">
+          <span class="text-green-500 font-bold text-lg mt-0.5 shrink-0"
+            >✓</span
+          >
+          <div>
+            <p class="font-semibold text-gray-900 mb-1">
+              Engagement and effort tracked throughout
+            </p>
+            <p class="text-sm text-gray-600">
+              Monthly assessments document each participant's preparation
+              quality and engagement — so results are honest, not inflated.
+            </p>
+          </div>
+        </div>
+        <div class="flex gap-4 p-6 bg-light rounded-xl border border-gray-100">
+          <span class="text-green-500 font-bold text-lg mt-0.5 shrink-0"
+            >✓</span
+          >
+          <div>
+            <p class="font-semibold text-gray-900 mb-1">
+              A recommendation for what comes next
+            </p>
+            <p class="text-sm text-gray-600">
+              Every company report includes Robert's recommendation for
+              continued development — whether that's another program cycle,
+              individual follow-up coaching, or a specific focus area for the
+              team.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Testimonials -->
+  <section class="bg-light py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <p
+        class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
+      >
+        Program Alumni
+      </p>
+      <h2 class="text-3xl font-bold mb-4 text-center">
+        Who Has Been Through This
+      </h2>
+      <p class="text-center text-gray-600 mb-12 max-w-2xl mx-auto">
+        These are the participants — COOs, CEOs, and directors from companies
+        you know. Their titles are the outcome you're trying to produce.
+      </p>
+
+      <div class="grid gap-6 md:grid-cols-2">
+        {
+          hrTestimonials.map((t) => (
+            <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100 flex flex-col gap-4">
+              <p class="text-gray-700 text-sm leading-relaxed italic">
+                "{t.content}"
+              </p>
+              <div class="flex items-center gap-4 mt-auto pt-4 border-t border-gray-100">
+                {typeof t.avatar !== "string" && (
+                  <Image
+                    src={t.avatar}
+                    alt={t.author}
+                    width={48}
+                    height={48}
+                    class="rounded-full object-cover w-12 h-12 shrink-0"
+                  />
+                )}
+                <div>
+                  <p class="font-bold text-gray-900 text-sm">{t.author}</p>
+                  <p class="text-xs text-gray-500">
+                    {t.position}, {t.company}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
+  <!-- Investment -->
+  <section class="bg-white py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <p
+        class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
+      >
+        Investment
+      </p>
+      <h2 class="text-3xl font-bold mb-2 text-center">Pricing</h2>
+      <p class="text-center text-gray-600 mb-10">
+        600 MXN per session per participant. <strong
+          >Mexican facturas issued monthly.</strong
+        >
+      </p>
+
+      <div class="max-w-2xl mx-auto bg-gray-50 rounded-xl p-8 border border-gray-200">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-gray-200">
+              <th class="text-left pb-3 font-semibold">Scenario</th>
+              <th class="text-right pb-3 font-semibold">Per Participant</th>
+              <th class="text-right pb-3 font-semibold">5-Person Team</th>
+            </tr>
+          </thead>
+          <tbody class="text-gray-600">
+            <tr class="border-b border-gray-100">
+              <td class="py-3">Conservative (12 sessions)</td>
+              <td class="text-right py-3">7,200 MXN</td>
+              <td class="text-right py-3">~36,000 MXN</td>
+            </tr>
+            <tr class="border-b border-gray-100">
+              <td class="py-3">Moderate (14–15 sessions)</td>
+              <td class="text-right py-3">8,400 – 9,000 MXN</td>
+              <td class="text-right py-3">~42,000–45,000 MXN</td>
+            </tr>
+            <tr>
+              <td class="py-3">Intensive (17 sessions)</td>
+              <td class="text-right py-3">10,200 MXN</td>
+              <td class="text-right py-3">~51,000 MXN</td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="text-xs text-gray-400 mt-4">
+          Total varies because schedules vary — not every participant attends
+          every possible session. USD pricing available for international
+          companies.
+        </p>
+      </div>
+
+      <div class="max-w-2xl mx-auto mt-6 text-center">
+        <a
+          href="/en/services/corporate-package/"
+          class="text-sm text-primary font-semibold hover:underline"
+        >
+          See full program detail and FAQ →
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- FAQ -->
+  <section class="bg-light py-16 px-8">
+    <div class="site-container--small mx-auto max-w-3xl">
+      <h2 class="text-3xl font-bold mb-2 text-center">Common Questions</h2>
+      <p class="text-center text-gray-600 mb-12">
+        The things people ask before moving this forward internally.
+      </p>
+
+      <div class="space-y-4">
+        {
+          hrFaqs.map((faq) => (
+            <div class="bg-white rounded-xl p-8 border border-gray-100">
+              <h3 class="font-bold text-gray-900 mb-3">{faq.question}</h3>
+              <p class="text-gray-600 text-sm leading-relaxed">{faq.answer}</p>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <CtaSection content={ctaContent} />
+
+  <BreadcrumbSchema
+    items={[
+      { name: "Home", url: "https://www.nyenglishteacher.com/en/" },
+      {
+        name: "Services",
+        url: "https://www.nyenglishteacher.com/en/services/",
+      },
+      {
+        name: "Corporate English Training for HR Managers",
+        url: "https://www.nyenglishteacher.com/en/for-hr-managers/",
+      },
+    ]}
+  />
+
+  <script
+    type="application/ld+json"
+    set:html={JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Service",
+      name: "Corporate English Training for Management Teams",
+      description:
+        "A 12-week structured English coaching program for management teams in Mexico, with formal documentation for HR managers and training coordinators.",
+      provider: {
+        "@type": "Person",
+        name: "Robert Cushman",
+        jobTitle: "English Coach",
+        url: "https://www.nyenglishteacher.com/en/about/",
+      },
+      serviceType: "Corporate English Coaching",
+      areaServed: {
+        "@type": "Country",
+        name: "Mexico",
+      },
+      offers: {
+        "@type": "Offer",
+        price: "600",
+        priceCurrency: "MXN",
+        eligibleCustomerType: "https://schema.org/BusinessCustomer",
+      },
+      url: "https://www.nyenglishteacher.com/en/for-hr-managers/",
+    })}
+  />
+</Base>

--- a/src/pages/en/services/corporate-package.astro
+++ b/src/pages/en/services/corporate-package.astro
@@ -250,6 +250,22 @@ const faqs = serviceFaqs["corporate-package"]?.en || [];
     </div>
   </section>
 
+  <!-- Cross-link — HR Manager Page -->
+  <section class="bg-white py-12 px-8 border-t border-gray-100">
+    <div class="site-container--small mx-auto max-w-3xl">
+      <div class="border-l-4 border-blue-400 pl-8">
+        <p class="text-sm font-semibold text-blue-600 uppercase tracking-wide mb-2">For HR Managers</p>
+        <h2 class="text-xl font-bold mb-3">Are you evaluating this program for your team?</h2>
+        <p class="text-gray-600 mb-4 text-sm">
+          This page is written for participants. There's a separate page written for whoever is evaluating the program — covering the business case, the formal deliverables HR receives, what you report to leadership, and common questions before moving it forward internally.
+        </p>
+        <a href="/en/for-hr-managers/" class="inline-flex items-center gap-2 text-blue-600 font-semibold text-sm hover:underline">
+          See the HR manager page <span aria-hidden="true">→</span>
+        </a>
+      </div>
+    </div>
+  </section>
+
   <!-- Cross-link — Flexible Coaching Option -->
   <section class="bg-white py-12 px-8 border-t border-gray-100">
     <div class="site-container--small mx-auto max-w-3xl">

--- a/src/pages/es/para-rh/index.astro
+++ b/src/pages/es/para-rh/index.astro
@@ -1,0 +1,691 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import InnerHero from "@components/sections/InnerHero.astro";
+import CtaSection from "@components/sections/CtaSection.astro";
+import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
+import { paqueteCorporativo as serviceData } from "@data/services";
+import { testimonials } from "@data/testimonials/es";
+import { Image } from "astro:assets";
+
+const title =
+  "Capacitación de Inglés Corporativo para Responsables de RH | NY English Teacher";
+const seoDescription =
+  "¿Evaluando un programa de inglés para tu equipo directivo? Conoce los entregables formales que recibes, cómo se documenta el progreso y qué distingue este programa de un curso genérico de idiomas.";
+
+const heroContent = {
+  title:
+    "El inglés de tu equipo es suficiente para un curso. No para la sala de juntas.",
+  description:
+    "Esta página está escrita para quien evalúa el programa — no para quienes lo van a tomar.",
+  backgroundImage: serviceData.backgroundImage,
+  overlayOpacity: 0.75,
+  imageAlt:
+    "Responsable de RH evaluando un programa de inglés corporativo",
+};
+
+const ctaContent = {
+  eyebrow: "Programas Corporativos",
+  title: "¿Listo para conversar sobre lo que esto implicaría para tu equipo?",
+  description:
+    "Las llamadas de descubrimiento duran unos 20 minutos. Robert define el alcance del programa según el tamaño de tu equipo, agenda y contexto de industria — y responde lo que necesites para avanzar internamente.",
+  buttonSubtext: "La mayoría de las llamadas de descubrimiento duran 20 minutos.",
+  buttonText: "Contactar a Robert por WhatsApp",
+  buttonLink: "https://wa.me/523315590572",
+  whatToExpectTitle: "En Tu Llamada de Descubrimiento:",
+  whatToExpectList: [
+    "Establecemos la línea base actual de comunicación en inglés de tu equipo",
+    "Definimos cómo se ve el éxito — y cómo se mide",
+    "Definimos el alcance del programa para tu grupo, agenda y contexto de industria",
+  ],
+};
+
+const hrFaqs = [
+  {
+    question: "¿Qué documentación recibimos al final del programa?",
+    answer:
+      "Cuatro entregables formales: un Perfil Inicial de Estudiante por participante (documento base de la Semana 1), evaluaciones mensuales de progreso a lo largo del programa, un Plan de Ruta Individual Escrito por participante al cierre, y un Reporte Consolidado de la Empresa con los resultados a nivel equipo. Los detalles de desempeño individual se conservan en los documentos personales — no en el reporte de empresa.",
+  },
+  {
+    question: "¿Emiten facturas?",
+    answer:
+      "Sí. Las facturas mexicanas se emiten mensualmente durante el programa.",
+  },
+  {
+    question: "¿Cuál es el tamaño mínimo de equipo?",
+    answer:
+      "El programa estructurado funciona mejor con 3 a 8 participantes del mismo equipo directivo. Para grupos de más de 8 personas, Robert define un esquema personalizado. Para un solo participante, el programa de coaching ejecutivo es la mejor opción.",
+  },
+  {
+    question: "¿Qué pasa si un empleado no se involucra o falta a sesiones?",
+    answer:
+      "Eso queda documentado en las evaluaciones mensuales — específicamente en los campos de nivel de esfuerzo y participación. Lo verás en papel antes de que termine el programa, no como una sorpresa en el reporte final. Los participantes que se preparan entre sesiones logran avances medibles. Los que asisten pero no se preparan verán resultados limitados — y las evaluaciones lo reflejarán con honestidad.",
+  },
+  {
+    question: "¿Toda la instrucción es en inglés?",
+    answer:
+      "Sí. Las sesiones pueden incluir aclaraciones breves en español cuando algo genuinamente lo requiere, pero el programa está diseñado para la máxima exposición al inglés. Cambiar al español para evitar la incomodidad contrarresta el objetivo — y Robert no lo hace.",
+  },
+  {
+    question:
+      "¿En qué se diferencia esto de una escuela de idiomas o un curso genérico de inglés?",
+    answer:
+      "Los cursos genéricos siguen un plan de estudios diseñado para nadie en particular. Este programa se construye alrededor de los roles reales de tu equipo, sus brechas de comunicación y situaciones concretas de inglés: presentaciones, llamadas con clientes, negociaciones internacionales. Las evaluaciones formales rastrean el progreso individual contra una línea base de la Semana 1. Al final, tienes documentación de lo que cambió — no solo registros de asistencia y un certificado.",
+  },
+  {
+    question: "¿Hay precios en dólares disponibles?",
+    answer:
+      "Sí. Para empresas internacionales, los precios en USD están disponibles. La tarifa por sesión se convierte al tipo de cambio al inicio del programa. Las facturas se emiten en MXN independientemente de cómo tu empresa liquide el pago internamente.",
+  },
+];
+
+const selectedSlugs = [
+  "julio-aldana-smarttie",
+  "hugo-blum-100-ladrillos",
+  "andres-guzman-driscolls",
+  "andrea-oliveira-ceva-logistics",
+];
+const hrTestimonials = testimonials.filter((t) =>
+  selectedSlugs.includes(t.slug)
+);
+---
+
+<Base
+  title={title}
+  description={seoDescription}
+  lang="es"
+  tkey="corporate/for-hr"
+  hideCta={true}
+>
+  <!-- Hero -->
+  <InnerHero content={heroContent} />
+
+  <!-- HR crosslink callout -->
+  <div class="bg-blue-50 border-b border-blue-100 py-4 px-8">
+    <div
+      class="site-container--small mx-auto flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3"
+    >
+      <p class="text-sm text-blue-800">
+        <strong>Estás en la página para responsables de RH.</strong> ¿Buscas los
+        detalles del programa para los participantes?
+      </p>
+      <a
+        href="/es/servicios/paquete-corporativo/"
+        class="text-sm font-semibold text-blue-700 hover:underline whitespace-nowrap shrink-0"
+      >
+        Ver la página completa del programa →
+      </a>
+    </div>
+  </div>
+
+  <!-- Costo del inglés débil -->
+  <section class="bg-gray-900 text-white py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <p
+        class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
+      >
+        El Argumento de Negocio
+      </p>
+      <h2 class="text-3xl font-bold mb-4 text-center">
+        Lo que el inglés débil le cuesta realmente a tu empresa
+      </h2>
+      <p class="text-center text-gray-400 mb-12 max-w-2xl mx-auto">
+        No son estadísticas abstractas. Son situaciones en las que tu equipo ya
+        ha estado.
+      </p>
+
+      <div class="grid gap-6 md:grid-cols-2">
+        <div class="bg-gray-800 rounded-xl p-8 border border-gray-700">
+          <h3 class="text-lg font-bold mb-3 text-white">
+            El momento del "te lo mando por correo"
+          </h3>
+          <p class="text-gray-300 text-sm leading-relaxed mb-4">
+            Tu gerente está en una llamada en vivo con un cliente de EE.UU.
+            Entiende la pregunta. Sabe la respuesta. Pero no encuentra las
+            palabras con suficiente rapidez bajo presión, entonces dice "te lo
+            mando por correo." La reunión termina. El cliente sigue adelante.
+            Tres días después sale un email que debió haber sido una respuesta
+            de 30 segundos.
+          </p>
+          <p class="text-sm text-gray-500 italic">
+            Eso no es una brecha de comunicación. Es una brecha de negocio.
+          </p>
+        </div>
+
+        <div class="bg-gray-800 rounded-xl p-8 border border-gray-700">
+          <h3 class="text-lg font-bold mb-3 text-white">
+            La relación que se atasca
+          </h3>
+          <p class="text-gray-300 text-sm leading-relaxed mb-4">
+            Tu equipo no puede escalar directamente al liderazgo en EE.UU. o
+            Europa sin pasar cada mensaje importante por la única persona
+            bilingüe en la sala. Esa persona se convierte en el cuello de
+            botella. Las decisiones se ralentizan. Tus gerentes locales no
+            pueden construir relaciones directas con quienes toman decisiones.
+            Con el tiempo, tu oficina se convierte en "el equipo que siempre
+            necesita un traductor" — y recibe el trato correspondiente.
+          </p>
+          <p class="text-sm text-gray-500 italic">
+            La brecha se acumula silenciosamente, hasta que ya no.
+          </p>
+        </div>
+
+        <div class="bg-gray-800 rounded-xl p-8 border border-gray-700">
+          <h3 class="text-lg font-bold mb-3 text-white">
+            La negociación que se alarga
+          </h3>
+          <p class="text-gray-300 text-sm leading-relaxed mb-4">
+            Una negociación de 30 minutos con un proveedor de EE.UU. se
+            convierte en una llamada de 90 minutos porque tu equipo necesita
+            tiempo extra para procesar, confirmar y responder en inglés. El
+            proveedor lo nota. La dinámica cambia. Acuerdos que deberían cerrar
+            en dos llamadas toman cinco. Tu posición se debilita — no por tus
+            términos, sino por tu ritmo.
+          </p>
+          <p class="text-sm text-gray-500 italic">
+            La velocidad transmite confianza. La duda transmite debilidad.
+          </p>
+        </div>
+
+        <div class="bg-gray-800 rounded-xl p-8 border border-gray-700">
+          <h3 class="text-lg font-bold mb-3 text-white">
+            El talento que estás a punto de perder
+          </h3>
+          <p class="text-gray-300 text-sm leading-relaxed mb-4">
+            Tus mejores gerentes son ambiciosos. Ven los roles internacionales,
+            los proyectos transfronterizos, las trayectorias de liderazgo que
+            requieren inglés sólido. Saben que su inglés es el techo. Si tu
+            empresa no invierte en quitar ese techo, encontrarán una que sí lo
+            haga — o se estancarán, se desmotivarán y seguirán en piloto
+            automático.
+          </p>
+          <p class="text-sm text-gray-500 italic">
+            Capacitar en inglés es una estrategia de retención. No hacerlo es
+            un riesgo.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Lo que RH recibe -->
+  <section class="bg-white py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <p
+        class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
+      >
+        Entregables Formales
+      </p>
+      <h2 class="text-3xl font-bold mb-4 text-center">
+        Lo que tienes en papel cuando termina
+      </h2>
+      <p class="text-center text-gray-600 mb-12 max-w-2xl mx-auto">
+        Esto es lo que distingue un programa estructurado de un tutoraje
+        privado continuo. Cuatro documentos formales — tres por participante,
+        uno para la empresa.
+      </p>
+
+      <div class="grid gap-6 md:grid-cols-2 max-w-4xl mx-auto">
+        <div class="bg-light rounded-xl p-8 border border-gray-100">
+          <div
+            class="text-sm font-semibold text-primary uppercase tracking-wide mb-2"
+          >
+            Entregado después de la Semana 1–2
+          </div>
+          <h3 class="text-xl font-bold mb-3">Perfil Inicial del Estudiante</h3>
+          <p class="text-gray-600 text-sm mb-4">
+            Un documento base escrito para cada participante. Cubre su nivel
+            actual de inglés, rol laboral, brechas de comunicación y áreas
+            prioritarias. Este es el documento contra el cual la Fase 3 mide
+            el progreso.
+          </p>
+          <ul class="text-sm text-gray-600 space-y-2">
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Nivel
+              actual y patrones de comunicación observables
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Rol
+              laboral y momentos de comunicación de alto impacto
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Áreas
+              prioritarias para el programa
+            </li>
+          </ul>
+        </div>
+
+        <div class="bg-light rounded-xl p-8 border border-gray-100">
+          <div
+            class="text-sm font-semibold text-primary uppercase tracking-wide mb-2"
+          >
+            Entregado mensualmente durante el programa
+          </div>
+          <h3 class="text-xl font-bold mb-3">Evaluaciones Mensuales</h3>
+          <p class="text-gray-600 text-sm mb-4">
+            Una evaluación escrita por participante al mes, cubriendo cinco
+            áreas:
+          </p>
+          <ul class="text-sm text-gray-600 space-y-2">
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Brechas
+              de comunicación persistentes
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Nivel de
+              esfuerzo y calidad de preparación
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span>
+              Participación y desempeño en sesión
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Áreas
+              prioritarias actualizadas
+            </li>
+          </ul>
+          <p class="text-xs text-gray-400 mt-4">
+            Basadas en la observación directa de Robert — sin grabación ni
+            transcripción por IA.
+          </p>
+        </div>
+
+        <div class="bg-light rounded-xl p-8 border border-gray-100">
+          <div
+            class="text-sm font-semibold text-primary uppercase tracking-wide mb-2"
+          >
+            Entregado al cierre del programa — por participante
+          </div>
+          <h3 class="text-xl font-bold mb-3">Plan de Ruta Individual Escrito</h3>
+          <p class="text-gray-600 text-sm mb-4">
+            Un documento escrito personalizado para cada participante:
+          </p>
+          <ul class="text-sm text-gray-600 space-y-2">
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Progreso
+              medido contra la línea base de la Semana 1
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Brechas
+              restantes y áreas de enfoque recomendadas
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Resumen
+              honesto de dónde están al finalizar el programa
+            </li>
+          </ul>
+        </div>
+
+        <div class="bg-light rounded-xl p-8 border border-gray-100">
+          <div
+            class="text-sm font-semibold text-primary uppercase tracking-wide mb-2"
+          >
+            Entregado al cierre del programa — para la empresa
+          </div>
+          <h3 class="text-xl font-bold mb-3">Reporte Consolidado de la Empresa</h3>
+          <p class="text-gray-600 text-sm mb-4">
+            Un documento de resumen para revisión interna y reporte:
+          </p>
+          <ul class="text-sm text-gray-600 space-y-2">
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Progreso
+              a nivel equipo y patrones colectivos observados
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Logros
+              destacados del grupo
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span> Resultados
+              del programa vs. objetivos originales
+            </li>
+            <li class="flex gap-2">
+              <span class="text-primary font-bold shrink-0">→</span>
+              Recomendaciones para el desarrollo continuo del equipo
+            </li>
+          </ul>
+          <p class="text-xs text-gray-400 mt-4">
+            Los detalles de desempeño individual se conservan en los planes de
+            ruta personales — no en este documento.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Estructura del programa -->
+  <section class="bg-light py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <p
+        class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
+      >
+        Cómo Funciona
+      </p>
+      <h2 class="text-3xl font-bold mb-2 text-center">12 Semanas. 3 Fases.</h2>
+      <p class="text-center text-gray-600 mb-12">
+        No un curso que corre indefinidamente sin un resultado definido. Un
+        sprint estructurado con un inicio claro, un punto de presión y un
+        cierre formal.
+      </p>
+
+      <div class="grid gap-8 md:grid-cols-3">
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div
+            class="text-sm font-semibold text-primary uppercase tracking-wide mb-2"
+          >
+            Semanas 1–8
+          </div>
+          <h3 class="text-xl font-bold mb-3">Preparación Individual</h3>
+          <p class="text-gray-600 mb-4 text-sm">
+            Cada participante trabaja en privado con Robert. Las primeras dos
+            semanas establecen una línea base honesta. Las semanas restantes
+            construyen preparación alrededor de su rol real, sus presentaciones
+            actuales y sus retos específicos de comunicación.
+          </p>
+          <div class="text-sm text-gray-500">
+            8–12 sesiones por participante
+          </div>
+        </div>
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div
+            class="text-sm font-semibold text-primary uppercase tracking-wide mb-2"
+          >
+            Semanas 9–10
+          </div>
+          <h3 class="text-xl font-bold mb-3">Presentación Grupal</h3>
+          <p class="text-gray-600 mb-4 text-sm">
+            Cada participante entrega su presentación preparada en inglés frente
+            al grupo completo de liderazgo — muchas veces por primera vez. La
+            presión es real, deliberada y productiva. Aquí es donde el programa
+            produce sus resultados.
+          </p>
+          <div class="text-sm text-gray-500">1–2 sesiones grupales</div>
+        </div>
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div
+            class="text-sm font-semibold text-primary uppercase tracking-wide mb-2"
+          >
+            Semanas 11–12
+          </div>
+          <h3 class="text-xl font-bold mb-3">Evaluación y Debrief</h3>
+          <p class="text-gray-600 mb-4 text-sm">
+            Sesiones individuales de debrief con retroalimentación directa. La
+            evaluación final mide el progreso contra la línea base de la
+            Semana 1. Los planes de ruta individuales y el reporte consolidado
+            de empresa se entregan al cierre.
+          </p>
+          <div class="text-sm text-gray-500">
+            2–3 sesiones por participante
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-8 text-center">
+        <a
+          href="/es/servicios/paquete-corporativo/"
+          class="inline-flex items-center gap-2 text-primary font-semibold text-sm hover:underline"
+        >
+          Ver el detalle completo del programa <span aria-hidden="true">→</span>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Lo que presentas a tu dirección -->
+  <section class="bg-white py-16 px-8">
+    <div class="site-container--small mx-auto max-w-4xl">
+      <p
+        class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
+      >
+        Reporte a Tu Dirección
+      </p>
+      <h2 class="text-3xl font-bold mb-4 text-center">
+        Lo que presentas cuando termina
+      </h2>
+      <p class="text-center text-gray-600 mb-12">
+        Cuando el programa concluye, no reportas "todos se sintieron más
+        seguros." Reportas resultados específicos, documentados.
+      </p>
+
+      <div class="grid gap-4 md:grid-cols-2">
+        <div class="flex gap-4 p-6 bg-light rounded-xl border border-gray-100">
+          <span class="text-green-500 font-bold text-lg mt-0.5 shrink-0"
+            >✓</span
+          >
+          <div>
+            <p class="font-semibold text-gray-900 mb-1">
+              Progreso medido contra una línea base documentada
+            </p>
+            <p class="text-sm text-gray-600">
+              No "mejoró" — el Perfil Inicial y el plan de ruta final muestran
+              específicamente dónde comenzó cada participante y dónde terminó.
+            </p>
+          </div>
+        </div>
+        <div class="flex gap-4 p-6 bg-light rounded-xl border border-gray-100">
+          <span class="text-green-500 font-bold text-lg mt-0.5 shrink-0"
+            >✓</span
+          >
+          <div>
+            <p class="font-semibold text-gray-900 mb-1">
+              Un entregable que puedes mostrar — no solo describir
+            </p>
+            <p class="text-sm text-gray-600">
+              El Reporte Consolidado de la Empresa es un documento formal. Puedes
+              adjuntarlo a una revisión interna, una justificación de
+              presupuesto o una propuesta de siguiente ciclo.
+            </p>
+          </div>
+        </div>
+        <div class="flex gap-4 p-6 bg-light rounded-xl border border-gray-100">
+          <span class="text-green-500 font-bold text-lg mt-0.5 shrink-0"
+            >✓</span
+          >
+          <div>
+            <p class="font-semibold text-gray-900 mb-1">
+              Esfuerzo y participación registrados durante todo el programa
+            </p>
+            <p class="text-sm text-gray-600">
+              Las evaluaciones mensuales documentan la calidad de preparación y
+              participación de cada persona — para que los resultados sean
+              honestos, no inflados.
+            </p>
+          </div>
+        </div>
+        <div class="flex gap-4 p-6 bg-light rounded-xl border border-gray-100">
+          <span class="text-green-500 font-bold text-lg mt-0.5 shrink-0"
+            >✓</span
+          >
+          <div>
+            <p class="font-semibold text-gray-900 mb-1">
+              Una recomendación clara sobre qué sigue
+            </p>
+            <p class="text-sm text-gray-600">
+              Cada reporte de empresa incluye la recomendación de Robert para el
+              desarrollo continuo — ya sea otro ciclo del programa, coaching
+              individual de seguimiento o un área de enfoque específica para el
+              equipo.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Testimonios -->
+  <section class="bg-light py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <p
+        class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
+      >
+        Exalumnos del Programa
+      </p>
+      <h2 class="text-3xl font-bold mb-4 text-center">
+        Quién ha pasado por esto
+      </h2>
+      <p class="text-center text-gray-600 mb-12 max-w-2xl mx-auto">
+        Estos son los participantes — COOs, CEOs y directores de empresas que
+        reconocerás. Sus títulos son el resultado que estás buscando producir.
+      </p>
+
+      <div class="grid gap-6 md:grid-cols-2">
+        {
+          hrTestimonials.map((t) => (
+            <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100 flex flex-col gap-4">
+              <p class="text-gray-700 text-sm leading-relaxed italic">
+                "{t.content}"
+              </p>
+              <div class="flex items-center gap-4 mt-auto pt-4 border-t border-gray-100">
+                {typeof t.avatar !== "string" && (
+                  <Image
+                    src={t.avatar}
+                    alt={t.author}
+                    width={48}
+                    height={48}
+                    class="rounded-full object-cover w-12 h-12 shrink-0"
+                  />
+                )}
+                <div>
+                  <p class="font-bold text-gray-900 text-sm">{t.author}</p>
+                  <p class="text-xs text-gray-500">
+                    {t.position}, {t.company}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
+  <!-- Inversión -->
+  <section class="bg-white py-16 px-8">
+    <div class="site-container--small mx-auto">
+      <p
+        class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
+      >
+        Inversión
+      </p>
+      <h2 class="text-3xl font-bold mb-2 text-center">Precios</h2>
+      <p class="text-center text-gray-600 mb-10">
+        600 MXN por sesión por participante. <strong
+          >Facturas mexicanas emitidas mensualmente.</strong
+        >
+      </p>
+
+      <div
+        class="max-w-2xl mx-auto bg-gray-50 rounded-xl p-8 border border-gray-200"
+      >
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-gray-200">
+              <th class="text-left pb-3 font-semibold">Escenario</th>
+              <th class="text-right pb-3 font-semibold">Por Participante</th>
+              <th class="text-right pb-3 font-semibold">Equipo de 5</th>
+            </tr>
+          </thead>
+          <tbody class="text-gray-600">
+            <tr class="border-b border-gray-100">
+              <td class="py-3">Conservador (12 sesiones)</td>
+              <td class="text-right py-3">7,200 MXN</td>
+              <td class="text-right py-3">~36,000 MXN</td>
+            </tr>
+            <tr class="border-b border-gray-100">
+              <td class="py-3">Moderado (14–15 sesiones)</td>
+              <td class="text-right py-3">8,400 – 9,000 MXN</td>
+              <td class="text-right py-3">~42,000–45,000 MXN</td>
+            </tr>
+            <tr>
+              <td class="py-3">Intensivo (17 sesiones)</td>
+              <td class="text-right py-3">10,200 MXN</td>
+              <td class="text-right py-3">~51,000 MXN</td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="text-xs text-gray-400 mt-4">
+          El total varía porque las agendas varían — no todos los participantes
+          asisten a todas las sesiones posibles. Precios en USD disponibles para
+          empresas internacionales.
+        </p>
+      </div>
+
+      <div class="max-w-2xl mx-auto mt-6 text-center">
+        <a
+          href="/es/servicios/paquete-corporativo/"
+          class="text-sm text-primary font-semibold hover:underline"
+        >
+          Ver el detalle completo del programa y preguntas frecuentes →
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Preguntas frecuentes -->
+  <section class="bg-light py-16 px-8">
+    <div class="site-container--small mx-auto max-w-3xl">
+      <h2 class="text-3xl font-bold mb-2 text-center">Preguntas Frecuentes</h2>
+      <p class="text-center text-gray-600 mb-12">
+        Lo que la gente pregunta antes de avanzar internamente.
+      </p>
+
+      <div class="space-y-4">
+        {
+          hrFaqs.map((faq) => (
+            <div class="bg-white rounded-xl p-8 border border-gray-100">
+              <h3 class="font-bold text-gray-900 mb-3">{faq.question}</h3>
+              <p class="text-gray-600 text-sm leading-relaxed">{faq.answer}</p>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <CtaSection content={ctaContent} />
+
+  <BreadcrumbSchema
+    items={[
+      { name: "Inicio", url: "https://www.nyenglishteacher.com/es/" },
+      {
+        name: "Servicios",
+        url: "https://www.nyenglishteacher.com/es/servicios/",
+      },
+      {
+        name: "Capacitación de Inglés Corporativo para RH",
+        url: "https://www.nyenglishteacher.com/es/para-rh/",
+      },
+    ]}
+  />
+
+  <script
+    type="application/ld+json"
+    set:html={JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Service",
+      name: "Capacitación de Inglés Corporativo para Equipos Directivos",
+      description:
+        "Programa estructurado de coaching de inglés de 12 semanas para equipos directivos en México, con documentación formal para responsables de RH.",
+      provider: {
+        "@type": "Person",
+        name: "Robert Cushman",
+        jobTitle: "Coach de Inglés",
+        url: "https://www.nyenglishteacher.com/es/about/",
+      },
+      serviceType: "Coaching de Inglés Corporativo",
+      areaServed: {
+        "@type": "Country",
+        name: "México",
+      },
+      offers: {
+        "@type": "Offer",
+        price: "600",
+        priceCurrency: "MXN",
+        eligibleCustomerType: "https://schema.org/BusinessCustomer",
+      },
+      url: "https://www.nyenglishteacher.com/es/para-rh/",
+    })}
+  />
+</Base>

--- a/src/pages/es/servicios/paquete-corporativo.astro
+++ b/src/pages/es/servicios/paquete-corporativo.astro
@@ -186,6 +186,22 @@ const faqs = serviceFaqs["corporate-package"]?.es || [];
     </div>
   </section>
 
+  <!-- Enlace cruzado — Página para RH -->
+  <section class="bg-white py-12 px-8 border-t border-gray-100">
+    <div class="site-container--small mx-auto max-w-3xl">
+      <div class="border-l-4 border-blue-400 pl-8">
+        <p class="text-sm font-semibold text-blue-600 uppercase tracking-wide mb-2">Para Responsables de RH</p>
+        <h2 class="text-xl font-bold mb-3">¿Estás evaluando este programa para tu equipo?</h2>
+        <p class="text-gray-600 mb-4 text-sm">
+          Esta página está escrita para los participantes. Hay una página separada para quien evalúa el programa — con el argumento de negocio, los entregables formales que recibe RH, lo que presentas a tu dirección y las preguntas frecuentes antes de avanzar internamente.
+        </p>
+        <a href="/es/para-rh/" class="inline-flex items-center gap-2 text-blue-600 font-semibold text-sm hover:underline">
+          Ver la página para responsables de RH <span aria-hidden="true">→</span>
+        </a>
+      </div>
+    </div>
+  </section>
+
   <!-- Enlace cruzado — Opción de Coaching Flexible -->
   <section class="bg-white py-12 px-8 border-t border-gray-100">
     <div class="site-container--small mx-auto max-w-3xl">


### PR DESCRIPTION
## Summary

- New page at `/en/for-hr-managers/` and `/es/para-rh/` written for whoever evaluates the corporate program internally — HR manager, founder, director, whoever holds the budget
- Completely different angle than the corporate-package page: business cost framing, formal deliverables HR receives, what to report to leadership, and HR-specific FAQ
- Crosslinks added to both corporate-package pages so participants who land there can pass it along to their evaluator

## What's on the page

1. **The cost of weak English** — 4 scenario-based cards (dark section), no invented stats: "the follow up by email moment," "the bottlenecked relationship," "the negotiation that drags," "the talent you're about to lose"
2. **Formal deliverables** — Initial Student Profile, Monthly Assessments, Individual Roadmap, Consolidated Company Report — reframed for the HR buyer
3. **Program structure** — condensed 3-phase overview with link to full detail
4. **What you bring back to leadership** — 4 outcome cards framed as reportable results
5. **Testimonials** — 4 senior titles (COO/CEO/Director) from Smarttie, 100 Ladrillos, Driscoll's, CEVA Logistics
6. **Pricing + factura** — same table, factura prominently called out
7. **HR FAQ** — 7 questions: documentation, factura, team size, disengaged participants, language of instruction, vs. generic courses, USD pricing

## Notes

- Zero "L&D" terminology anywhere — plain language throughout
- No CEO framing — "leadership" is generic enough to cover founders and directors
- Both EN and ES build clean (423 pages, 0 errors, sitemap valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)