### PR TITLE
fix: HR page font size, mobile padding, table overflow

### DIFF
--- a/src/pages/en/for-hr-managers/index.astro
+++ b/src/pages/en/for-hr-managers/index.astro
@@ -116,7 +116,7 @@ const hrTestimonials = testimonials.filter((t) =>
   </div>
 
   <!-- Cost of weak English -->
-  <section class="bg-gray-900 text-white py-16 px-8">
+  <section class="bg-gray-900 text-white py-16 px-4 sm:px-8">
     <div class="site-container--small mx-auto">
       <p
         class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
@@ -136,7 +136,7 @@ const hrTestimonials = testimonials.filter((t) =>
           <h3 class="text-lg font-bold mb-3 text-white">
             The "I'll follow up by email" moment
           </h3>
-          <p class="text-gray-300 text-sm leading-relaxed mb-4">
+          <p class="text-gray-300 text-base leading-relaxed mb-4">
             Your manager is on a live call with a US client. They understand the
             question. They know the answer. But they can't find the words fast
             enough under pressure, so they say "I'll follow up by email." The
@@ -152,7 +152,7 @@ const hrTestimonials = testimonials.filter((t) =>
           <h3 class="text-lg font-bold mb-3 text-white">
             The bottlenecked relationship
           </h3>
-          <p class="text-gray-300 text-sm leading-relaxed mb-4">
+          <p class="text-gray-300 text-base leading-relaxed mb-4">
             Your team can't escalate directly to US or European leadership
             without routing every important message through the one bilingual
             person in the room. That person becomes the bottleneck. Decisions
@@ -169,7 +169,7 @@ const hrTestimonials = testimonials.filter((t) =>
           <h3 class="text-lg font-bold mb-3 text-white">
             The negotiation that drags
           </h3>
-          <p class="text-gray-300 text-sm leading-relaxed mb-4">
+          <p class="text-gray-300 text-base leading-relaxed mb-4">
             A 30-minute negotiation with a US supplier becomes a 90-minute call
             because your team needs extra time to process, confirm, and respond
             in English. The supplier notices. The dynamic shifts. Deals that
@@ -185,7 +185,7 @@ const hrTestimonials = testimonials.filter((t) =>
           <h3 class="text-lg font-bold mb-3 text-white">
             The talent you're about to lose
           </h3>
-          <p class="text-gray-300 text-sm leading-relaxed mb-4">
+          <p class="text-gray-300 text-base leading-relaxed mb-4">
             Your best managers are ambitious. They see the cross-border roles,
             the international projects, the leadership tracks that require
             strong English. They know their English is the ceiling. If your
@@ -202,7 +202,7 @@ const hrTestimonials = testimonials.filter((t) =>
   </section>
 
   <!-- What HR receives -->
-  <section class="bg-white py-16 px-8">
+  <section class="bg-white py-16 px-4 sm:px-8">
     <div class="site-container--small mx-auto">
       <p
         class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
@@ -226,13 +226,13 @@ const hrTestimonials = testimonials.filter((t) =>
             Delivered after Week 1–2
           </div>
           <h3 class="text-xl font-bold mb-3">Initial Student Profile</h3>
-          <p class="text-gray-600 text-sm mb-4">
+          <p class="text-gray-600 text-base mb-4">
             A written baseline document for each participant. Covers their
             current English level, job role, communication gaps, and priority
             focus areas. This is the document Phase 3 measures progress
             against.
           </p>
-          <ul class="text-sm text-gray-600 space-y-2">
+          <ul class="text-base text-gray-600 space-y-2">
             <li class="flex gap-2">
               <span class="text-primary font-bold shrink-0">→</span> Current
               level and observable communication patterns
@@ -255,11 +255,11 @@ const hrTestimonials = testimonials.filter((t) =>
             Delivered monthly throughout the program
           </div>
           <h3 class="text-xl font-bold mb-3">Monthly Assessments</h3>
-          <p class="text-gray-600 text-sm mb-4">
+          <p class="text-gray-600 text-base mb-4">
             One written assessment per participant per month, covering five
             areas:
           </p>
-          <ul class="text-sm text-gray-600 space-y-2">
+          <ul class="text-base text-gray-600 space-y-2">
             <li class="flex gap-2">
               <span class="text-primary font-bold shrink-0">→</span> Ongoing
               communication gaps
@@ -290,10 +290,10 @@ const hrTestimonials = testimonials.filter((t) =>
             Delivered at program close — per participant
           </div>
           <h3 class="text-xl font-bold mb-3">Written Individual Roadmap</h3>
-          <p class="text-gray-600 text-sm mb-4">
+          <p class="text-gray-600 text-base mb-4">
             A personalized written document for each participant:
           </p>
-          <ul class="text-sm text-gray-600 space-y-2">
+          <ul class="text-base text-gray-600 space-y-2">
             <li class="flex gap-2">
               <span class="text-primary font-bold shrink-0">→</span> Progress
               measured against the Week 1 baseline
@@ -316,10 +316,10 @@ const hrTestimonials = testimonials.filter((t) =>
             Delivered at program close — for the company
           </div>
           <h3 class="text-xl font-bold mb-3">Consolidated Company Report</h3>
-          <p class="text-gray-600 text-sm mb-4">
+          <p class="text-gray-600 text-base mb-4">
             A summary-level document for internal review and reporting:
           </p>
-          <ul class="text-sm text-gray-600 space-y-2">
+          <ul class="text-base text-gray-600 space-y-2">
             <li class="flex gap-2">
               <span class="text-primary font-bold shrink-0">→</span> Team-level
               progress and collective patterns
@@ -347,7 +347,7 @@ const hrTestimonials = testimonials.filter((t) =>
   </section>
 
   <!-- Program Structure -->
-  <section class="bg-light py-16 px-8">
+  <section class="bg-light py-16 px-4 sm:px-8">
     <div class="site-container--small mx-auto">
       <p
         class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
@@ -369,7 +369,7 @@ const hrTestimonials = testimonials.filter((t) =>
             Weeks 1–8
           </div>
           <h3 class="text-xl font-bold mb-3">Individual Preparation</h3>
-          <p class="text-gray-600 mb-4 text-sm">
+          <p class="text-gray-600 mb-4 text-base">
             Each participant works privately with Robert. The first two weeks
             establish an honest baseline. The remaining weeks build preparation
             around their real role, actual presentations, and specific
@@ -384,7 +384,7 @@ const hrTestimonials = testimonials.filter((t) =>
             Weeks 9–10
           </div>
           <h3 class="text-xl font-bold mb-3">Group Presentation</h3>
-          <p class="text-gray-600 mb-4 text-sm">
+          <p class="text-gray-600 mb-4 text-base">
             Every participant delivers their prepared presentation in English to
             the full leadership group — often for the first time. The pressure
             is real, deliberate, and productive. This is where the program
@@ -399,7 +399,7 @@ const hrTestimonials = testimonials.filter((t) =>
             Weeks 11–12
           </div>
           <h3 class="text-xl font-bold mb-3">Assessment & Debrief</h3>
-          <p class="text-gray-600 mb-4 text-sm">
+          <p class="text-gray-600 mb-4 text-base">
             Individual debrief sessions with direct feedback. Final assessment
             measures progress against the Week 1 baseline. Individual roadmaps
             and the consolidated company report are delivered at close.
@@ -420,7 +420,7 @@ const hrTestimonials = testimonials.filter((t) =>
   </section>
 
   <!-- What you bring back to leadership -->
-  <section class="bg-white py-16 px-8">
+  <section class="bg-white py-16 px-4 sm:px-8">
     <div class="site-container--small mx-auto max-w-4xl">
       <p
         class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
@@ -444,7 +444,7 @@ const hrTestimonials = testimonials.filter((t) =>
             <p class="font-semibold text-gray-900 mb-1">
               Progress measured against a documented baseline
             </p>
-            <p class="text-sm text-gray-600">
+            <p class="text-base text-gray-600">
               Not "they improved" — the Initial Student Profile and final
               roadmap show specifically where each participant started and where
               they finished.
@@ -459,7 +459,7 @@ const hrTestimonials = testimonials.filter((t) =>
             <p class="font-semibold text-gray-900 mb-1">
               A deliverable you can show — not just describe
             </p>
-            <p class="text-sm text-gray-600">
+            <p class="text-base text-gray-600">
               The Consolidated Company Report is a formal document. You can
               attach it to an internal review, a budget justification, or a
               follow-up proposal for the next program cycle.
@@ -474,7 +474,7 @@ const hrTestimonials = testimonials.filter((t) =>
             <p class="font-semibold text-gray-900 mb-1">
               Engagement and effort tracked throughout
             </p>
-            <p class="text-sm text-gray-600">
+            <p class="text-base text-gray-600">
               Monthly assessments document each participant's preparation
               quality and engagement — so results are honest, not inflated.
             </p>
@@ -488,7 +488,7 @@ const hrTestimonials = testimonials.filter((t) =>
             <p class="font-semibold text-gray-900 mb-1">
               A recommendation for what comes next
             </p>
-            <p class="text-sm text-gray-600">
+            <p class="text-base text-gray-600">
               Every company report includes Robert's recommendation for
               continued development — whether that's another program cycle,
               individual follow-up coaching, or a specific focus area for the
@@ -501,7 +501,7 @@ const hrTestimonials = testimonials.filter((t) =>
   </section>
 
   <!-- Testimonials -->
-  <section class="bg-light py-16 px-8">
+  <section class="bg-light py-16 px-4 sm:px-8">
     <div class="site-container--small mx-auto">
       <p
         class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
@@ -520,7 +520,7 @@ const hrTestimonials = testimonials.filter((t) =>
         {
           hrTestimonials.map((t) => (
             <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100 flex flex-col gap-4">
-              <p class="text-gray-700 text-sm leading-relaxed italic">
+              <p class="text-gray-700 text-base leading-relaxed italic">
                 "{t.content}"
               </p>
               <div class="flex items-center gap-4 mt-auto pt-4 border-t border-gray-100">
@@ -548,7 +548,7 @@ const hrTestimonials = testimonials.filter((t) =>
   </section>
 
   <!-- Investment -->
-  <section class="bg-white py-16 px-8">
+  <section class="bg-white py-16 px-4 sm:px-8">
     <div class="site-container--small mx-auto">
       <p
         class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
@@ -562,8 +562,8 @@ const hrTestimonials = testimonials.filter((t) =>
         >
       </p>
 
-      <div class="max-w-2xl mx-auto bg-gray-50 rounded-xl p-8 border border-gray-200">
-        <table class="w-full text-sm">
+      <div class="max-w-2xl mx-auto bg-gray-50 rounded-xl p-4 sm:p-8 border border-gray-200 overflow-x-auto">
+        <table class="w-full text-sm min-w-[320px]">
           <thead>
             <tr class="border-b border-gray-200">
               <th class="text-left pb-3 font-semibold">Scenario</th>
@@ -608,7 +608,7 @@ const hrTestimonials = testimonials.filter((t) =>
   </section>
 
   <!-- FAQ -->
-  <section class="bg-light py-16 px-8">
+  <section class="bg-light py-16 px-4 sm:px-8">
     <div class="site-container--small mx-auto max-w-3xl">
       <h2 class="text-3xl font-bold mb-2 text-center">Common Questions</h2>
       <p class="text-center text-gray-600 mb-12">
@@ -620,7 +620,7 @@ const hrTestimonials = testimonials.filter((t) =>
           hrFaqs.map((faq) => (
             <div class="bg-white rounded-xl p-8 border border-gray-100">
               <h3 class="font-bold text-gray-900 mb-3">{faq.question}</h3>
-              <p class="text-gray-600 text-sm leading-relaxed">{faq.answer}</p>
+              <p class="text-gray-600 text-base leading-relaxed">{faq.answer}</p>
             </div>
           ))
         }

--- a/src/pages/es/para-rh/index.astro
+++ b/src/pages/es/para-rh/index.astro
@@ -120,7 +120,7 @@ const hrTestimonials = testimonials.filter((t) =>
   </div>
 
   <!-- Costo del inglés débil -->
-  <section class="bg-gray-900 text-white py-16 px-8">
+  <section class="bg-gray-900 text-white py-16 px-4 sm:px-8">
     <div class="site-container--small mx-auto">
       <p
         class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
@@ -140,7 +140,7 @@ const hrTestimonials = testimonials.filter((t) =>
           <h3 class="text-lg font-bold mb-3 text-white">
             El momento del "te lo mando por correo"
           </h3>
-          <p class="text-gray-300 text-sm leading-relaxed mb-4">
+          <p class="text-gray-300 text-base leading-relaxed mb-4">
             Tu gerente está en una llamada en vivo con un cliente de EE.UU.
             Entiende la pregunta. Sabe la respuesta. Pero no encuentra las
             palabras con suficiente rapidez bajo presión, entonces dice "te lo
@@ -157,7 +157,7 @@ const hrTestimonials = testimonials.filter((t) =>
           <h3 class="text-lg font-bold mb-3 text-white">
             La relación que se atasca
           </h3>
-          <p class="text-gray-300 text-sm leading-relaxed mb-4">
+          <p class="text-gray-300 text-base leading-relaxed mb-4">
             Tu equipo no puede escalar directamente al liderazgo en EE.UU. o
             Europa sin pasar cada mensaje importante por la única persona
             bilingüe en la sala. Esa persona se convierte en el cuello de
@@ -175,7 +175,7 @@ const hrTestimonials = testimonials.filter((t) =>
           <h3 class="text-lg font-bold mb-3 text-white">
             La negociación que se alarga
           </h3>
-          <p class="text-gray-300 text-sm leading-relaxed mb-4">
+          <p class="text-gray-300 text-base leading-relaxed mb-4">
             Una negociación de 30 minutos con un proveedor de EE.UU. se
             convierte en una llamada de 90 minutos porque tu equipo necesita
             tiempo extra para procesar, confirmar y responder en inglés. El
@@ -192,7 +192,7 @@ const hrTestimonials = testimonials.filter((t) =>
           <h3 class="text-lg font-bold mb-3 text-white">
             El talento que estás a punto de perder
           </h3>
-          <p class="text-gray-300 text-sm leading-relaxed mb-4">
+          <p class="text-gray-300 text-base leading-relaxed mb-4">
             Tus mejores gerentes son ambiciosos. Ven los roles internacionales,
             los proyectos transfronterizos, las trayectorias de liderazgo que
             requieren inglés sólido. Saben que su inglés es el techo. Si tu
@@ -210,7 +210,7 @@ const hrTestimonials = testimonials.filter((t) =>
   </section>
 
   <!-- Lo que RH recibe -->
-  <section class="bg-white py-16 px-8">
+  <section class="bg-white py-16 px-4 sm:px-8">
     <div class="site-container--small mx-auto">
       <p
         class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
@@ -234,13 +234,13 @@ const hrTestimonials = testimonials.filter((t) =>
             Entregado después de la Semana 1–2
           </div>
           <h3 class="text-xl font-bold mb-3">Perfil Inicial del Estudiante</h3>
-          <p class="text-gray-600 text-sm mb-4">
+          <p class="text-gray-600 text-base mb-4">
             Un documento base escrito para cada participante. Cubre su nivel
             actual de inglés, rol laboral, brechas de comunicación y áreas
             prioritarias. Este es el documento contra el cual la Fase 3 mide
             el progreso.
           </p>
-          <ul class="text-sm text-gray-600 space-y-2">
+          <ul class="text-base text-gray-600 space-y-2">
             <li class="flex gap-2">
               <span class="text-primary font-bold shrink-0">→</span> Nivel
               actual y patrones de comunicación observables
@@ -263,11 +263,11 @@ const hrTestimonials = testimonials.filter((t) =>
             Entregado mensualmente durante el programa
           </div>
           <h3 class="text-xl font-bold mb-3">Evaluaciones Mensuales</h3>
-          <p class="text-gray-600 text-sm mb-4">
+          <p class="text-gray-600 text-base mb-4">
             Una evaluación escrita por participante al mes, cubriendo cinco
             áreas:
           </p>
-          <ul class="text-sm text-gray-600 space-y-2">
+          <ul class="text-base text-gray-600 space-y-2">
             <li class="flex gap-2">
               <span class="text-primary font-bold shrink-0">→</span> Brechas
               de comunicación persistentes
@@ -298,10 +298,10 @@ const hrTestimonials = testimonials.filter((t) =>
             Entregado al cierre del programa — por participante
           </div>
           <h3 class="text-xl font-bold mb-3">Plan de Ruta Individual Escrito</h3>
-          <p class="text-gray-600 text-sm mb-4">
+          <p class="text-gray-600 text-base mb-4">
             Un documento escrito personalizado para cada participante:
           </p>
-          <ul class="text-sm text-gray-600 space-y-2">
+          <ul class="text-base text-gray-600 space-y-2">
             <li class="flex gap-2">
               <span class="text-primary font-bold shrink-0">→</span> Progreso
               medido contra la línea base de la Semana 1
@@ -324,10 +324,10 @@ const hrTestimonials = testimonials.filter((t) =>
             Entregado al cierre del programa — para la empresa
           </div>
           <h3 class="text-xl font-bold mb-3">Reporte Consolidado de la Empresa</h3>
-          <p class="text-gray-600 text-sm mb-4">
+          <p class="text-gray-600 text-base mb-4">
             Un documento de resumen para revisión interna y reporte:
           </p>
-          <ul class="text-sm text-gray-600 space-y-2">
+          <ul class="text-base text-gray-600 space-y-2">
             <li class="flex gap-2">
               <span class="text-primary font-bold shrink-0">→</span> Progreso
               a nivel equipo y patrones colectivos observados
@@ -355,7 +355,7 @@ const hrTestimonials = testimonials.filter((t) =>
   </section>
 
   <!-- Estructura del programa -->
-  <section class="bg-light py-16 px-8">
+  <section class="bg-light py-16 px-4 sm:px-8">
     <div class="site-container--small mx-auto">
       <p
         class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
@@ -377,7 +377,7 @@ const hrTestimonials = testimonials.filter((t) =>
             Semanas 1–8
           </div>
           <h3 class="text-xl font-bold mb-3">Preparación Individual</h3>
-          <p class="text-gray-600 mb-4 text-sm">
+          <p class="text-gray-600 mb-4 text-base">
             Cada participante trabaja en privado con Robert. Las primeras dos
             semanas establecen una línea base honesta. Las semanas restantes
             construyen preparación alrededor de su rol real, sus presentaciones
@@ -394,7 +394,7 @@ const hrTestimonials = testimonials.filter((t) =>
             Semanas 9–10
           </div>
           <h3 class="text-xl font-bold mb-3">Presentación Grupal</h3>
-          <p class="text-gray-600 mb-4 text-sm">
+          <p class="text-gray-600 mb-4 text-base">
             Cada participante entrega su presentación preparada en inglés frente
             al grupo completo de liderazgo — muchas veces por primera vez. La
             presión es real, deliberada y productiva. Aquí es donde el programa
@@ -409,7 +409,7 @@ const hrTestimonials = testimonials.filter((t) =>
             Semanas 11–12
           </div>
           <h3 class="text-xl font-bold mb-3">Evaluación y Debrief</h3>
-          <p class="text-gray-600 mb-4 text-sm">
+          <p class="text-gray-600 mb-4 text-base">
             Sesiones individuales de debrief con retroalimentación directa. La
             evaluación final mide el progreso contra la línea base de la
             Semana 1. Los planes de ruta individuales y el reporte consolidado
@@ -433,7 +433,7 @@ const hrTestimonials = testimonials.filter((t) =>
   </section>
 
   <!-- Lo que presentas a tu dirección -->
-  <section class="bg-white py-16 px-8">
+  <section class="bg-white py-16 px-4 sm:px-8">
     <div class="site-container--small mx-auto max-w-4xl">
       <p
         class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
@@ -457,7 +457,7 @@ const hrTestimonials = testimonials.filter((t) =>
             <p class="font-semibold text-gray-900 mb-1">
               Progreso medido contra una línea base documentada
             </p>
-            <p class="text-sm text-gray-600">
+            <p class="text-base text-gray-600">
               No "mejoró" — el Perfil Inicial y el plan de ruta final muestran
               específicamente dónde comenzó cada participante y dónde terminó.
             </p>
@@ -471,7 +471,7 @@ const hrTestimonials = testimonials.filter((t) =>
             <p class="font-semibold text-gray-900 mb-1">
               Un entregable que puedes mostrar — no solo describir
             </p>
-            <p class="text-sm text-gray-600">
+            <p class="text-base text-gray-600">
               El Reporte Consolidado de la Empresa es un documento formal. Puedes
               adjuntarlo a una revisión interna, una justificación de
               presupuesto o una propuesta de siguiente ciclo.
@@ -486,7 +486,7 @@ const hrTestimonials = testimonials.filter((t) =>
             <p class="font-semibold text-gray-900 mb-1">
               Esfuerzo y participación registrados durante todo el programa
             </p>
-            <p class="text-sm text-gray-600">
+            <p class="text-base text-gray-600">
               Las evaluaciones mensuales documentan la calidad de preparación y
               participación de cada persona — para que los resultados sean
               honestos, no inflados.
@@ -501,7 +501,7 @@ const hrTestimonials = testimonials.filter((t) =>
             <p class="font-semibold text-gray-900 mb-1">
               Una recomendación clara sobre qué sigue
             </p>
-            <p class="text-sm text-gray-600">
+            <p class="text-base text-gray-600">
               Cada reporte de empresa incluye la recomendación de Robert para el
               desarrollo continuo — ya sea otro ciclo del programa, coaching
               individual de seguimiento o un área de enfoque específica para el
@@ -514,7 +514,7 @@ const hrTestimonials = testimonials.filter((t) =>
   </section>
 
   <!-- Testimonios -->
-  <section class="bg-light py-16 px-8">
+  <section class="bg-light py-16 px-4 sm:px-8">
     <div class="site-container--small mx-auto">
       <p
         class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
@@ -533,7 +533,7 @@ const hrTestimonials = testimonials.filter((t) =>
         {
           hrTestimonials.map((t) => (
             <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100 flex flex-col gap-4">
-              <p class="text-gray-700 text-sm leading-relaxed italic">
+              <p class="text-gray-700 text-base leading-relaxed italic">
                 "{t.content}"
               </p>
               <div class="flex items-center gap-4 mt-auto pt-4 border-t border-gray-100">
@@ -561,7 +561,7 @@ const hrTestimonials = testimonials.filter((t) =>
   </section>
 
   <!-- Inversión -->
-  <section class="bg-white py-16 px-8">
+  <section class="bg-white py-16 px-4 sm:px-8">
     <div class="site-container--small mx-auto">
       <p
         class="text-sm font-semibold text-primary uppercase tracking-wide mb-3 text-center"
@@ -576,9 +576,9 @@ const hrTestimonials = testimonials.filter((t) =>
       </p>
 
       <div
-        class="max-w-2xl mx-auto bg-gray-50 rounded-xl p-8 border border-gray-200"
+        class="max-w-2xl mx-auto bg-gray-50 rounded-xl p-4 sm:p-8 border border-gray-200 overflow-x-auto"
       >
-        <table class="w-full text-sm">
+        <table class="w-full text-sm min-w-[320px]">
           <thead>
             <tr class="border-b border-gray-200">
               <th class="text-left pb-3 font-semibold">Escenario</th>
@@ -623,7 +623,7 @@ const hrTestimonials = testimonials.filter((t) =>
   </section>
 
   <!-- Preguntas frecuentes -->
-  <section class="bg-light py-16 px-8">
+  <section class="bg-light py-16 px-4 sm:px-8">
     <div class="site-container--small mx-auto max-w-3xl">
       <h2 class="text-3xl font-bold mb-2 text-center">Preguntas Frecuentes</h2>
       <p class="text-center text-gray-600 mb-12">
@@ -635,7 +635,7 @@ const hrTestimonials = testimonials.filter((t) =>
           hrFaqs.map((faq) => (
             <div class="bg-white rounded-xl p-8 border border-gray-100">
               <h3 class="font-bold text-gray-900 mb-3">{faq.question}</h3>
-              <p class="text-gray-600 text-sm leading-relaxed">{faq.answer}</p>
+              <p class="text-gray-600 text-base leading-relaxed">{faq.answer}</p>
             </div>
           ))
         }


### PR DESCRIPTION
## Summary

- All body paragraph text, list items, FAQ answers, and testimonial quotes bumped from `text-sm` to `text-base` (16px) — copy is meant to be read, not skimmed
- `text-sm` kept only on: badge labels, session counts, metadata lines, pricing table cells, kicker italics
- `text-xs` kept only on: footnotes inside cards, pricing table note
- All section padding changed from `px-8` to `px-4 sm:px-8` for proper mobile breathing room
- Pricing table gets `overflow-x-auto` + `min-w-[320px]` so it scrolls cleanly on narrow screens instead of overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)