### PR TITLE
feat: dual CTA on corporate pages — booking primary, WhatsApp secondary

### DIFF
--- a/src/components/sections/CtaSection.astro
+++ b/src/components/sections/CtaSection.astro
@@ -10,6 +10,8 @@ export interface Props {
     buttonText: string;
     buttonLink: string;
     buttonSubtext?: string;
+    secondaryButtonText?: string;
+    secondaryButtonLink?: string;
     whatToExpectTitle: string;
     whatToExpectList: string[];
   }
@@ -36,18 +38,28 @@ const { content } = Astro.props;
         <p class="text-lg text-blue-100 mb-8 max-w-xl mx-auto lg:mx-0 leading-relaxed">
           {content.description}
         </p>
-        <div class="flex justify-center lg:justify-start">
+        <div class="flex flex-col sm:flex-row gap-3 justify-center lg:justify-start">
           <a
             href={normalizePath(content.buttonLink)}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="inline-flex items-center px-8 py-4 bg-blue-500 hover:bg-blue-400 text-white font-semibold text-lg rounded-lg shadow-lg transform hover:scale-105 transition-all duration-300 hover:shadow-xl"
+            target={content.buttonLink.startsWith('http') ? '_blank' : undefined}
+            rel={content.buttonLink.startsWith('http') ? 'noopener noreferrer' : undefined}
+            class="inline-flex items-center justify-center px-8 py-4 bg-blue-500 hover:bg-blue-400 text-white font-semibold text-lg rounded-lg shadow-lg transform hover:scale-105 transition-all duration-300 hover:shadow-xl"
           >
             {content.buttonText}
             <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
             </svg>
           </a>
+          {content.secondaryButtonText && content.secondaryButtonLink && (
+            <a
+              href={normalizePath(content.secondaryButtonLink)}
+              target={content.secondaryButtonLink.startsWith('http') ? '_blank' : undefined}
+              rel={content.secondaryButtonLink.startsWith('http') ? 'noopener noreferrer' : undefined}
+              class="inline-flex items-center justify-center px-8 py-4 border border-blue-400/50 hover:border-blue-300 text-blue-100 hover:text-white font-semibold text-lg rounded-lg transition-all duration-300"
+            >
+              {content.secondaryButtonText}
+            </a>
+          )}
         </div>
         {content.buttonSubtext && (
           <p class="mt-3 text-sm text-blue-200 text-center lg:text-left">{content.buttonSubtext}</p>

--- a/src/pages/en/for-hr-managers/index.astro
+++ b/src/pages/en/for-hr-managers/index.astro
@@ -30,8 +30,10 @@ const ctaContent = {
   description:
     "Discovery calls take about 20 minutes. Robert scopes the program to your team size, schedule, and industry context — and answers whatever you need to move it forward internally.",
   buttonSubtext: "Most discovery calls take 20 minutes.",
-  buttonText: "Contact Robert on WhatsApp",
-  buttonLink: "https://wa.me/523315590572",
+  buttonText: "Schedule a Discovery Call",
+  buttonLink: "/en/book/",
+  secondaryButtonText: "Contact Robert on WhatsApp",
+  secondaryButtonLink: "https://wa.me/523315590572",
   whatToExpectTitle: "In Your Discovery Call, We Will:",
   whatToExpectList: [
     "Establish your team's current English communication baseline",

--- a/src/pages/en/services/corporate-package.astro
+++ b/src/pages/en/services/corporate-package.astro
@@ -46,8 +46,10 @@ const ctaContent = {
   description:
     "This program requires a discovery call to scope for your group size, schedule, and goals. Robert is a native New Yorker who has coached senior executives and leadership teams across Mexico for over a decade. He responds within 24 hours.",
   buttonSubtext: "Most discovery calls take 20 minutes.",
-  buttonText: "Contact Robert on WhatsApp",
-  buttonLink: "https://wa.me/523315590572",
+  buttonText: "Schedule a Discovery Call",
+  buttonLink: "/en/book/",
+  secondaryButtonText: "Contact Robert on WhatsApp",
+  secondaryButtonLink: "https://wa.me/523315590572",
   whatToExpectTitle: "In Your Discovery Call, We Will:",
   whatToExpectList: [
     "Assess your team's current English communication baseline",

--- a/src/pages/es/para-rh/index.astro
+++ b/src/pages/es/para-rh/index.astro
@@ -31,8 +31,10 @@ const ctaContent = {
   description:
     "Las llamadas de descubrimiento duran unos 20 minutos. Robert define el alcance del programa según el tamaño de tu equipo, agenda y contexto de industria — y responde lo que necesites para avanzar internamente.",
   buttonSubtext: "La mayoría de las llamadas de descubrimiento duran 20 minutos.",
-  buttonText: "Contactar a Robert por WhatsApp",
-  buttonLink: "https://wa.me/523315590572",
+  buttonText: "Agendar Llamada de Descubrimiento",
+  buttonLink: "/es/reservar/",
+  secondaryButtonText: "Contactar a Robert por WhatsApp",
+  secondaryButtonLink: "https://wa.me/523315590572",
   whatToExpectTitle: "En Tu Llamada de Descubrimiento:",
   whatToExpectList: [
     "Establecemos la línea base actual de comunicación en inglés de tu equipo",

--- a/src/pages/es/servicios/paquete-corporativo.astro
+++ b/src/pages/es/servicios/paquete-corporativo.astro
@@ -46,8 +46,10 @@ const ctaContent = {
   description:
     "Este programa requiere una llamada de descubrimiento para definir el alcance según el tamaño de tu grupo, agenda y objetivos. Robert es neoyorquino de nacimiento y lleva más de una década entrenando ejecutivos y equipos directivos en toda México. Responde en 24 horas.",
   buttonSubtext: "La mayoría de las llamadas de descubrimiento duran 20 minutos.",
-  buttonText: "Contactar a Robert por WhatsApp",
-  buttonLink: "https://wa.me/523315590572",
+  buttonText: "Agendar Llamada de Descubrimiento",
+  buttonLink: "/es/reservar/",
+  secondaryButtonText: "Contactar a Robert por WhatsApp",
+  secondaryButtonLink: "https://wa.me/523315590572",
   whatToExpectTitle: "En Tu Llamada de Descubrimiento:",
   whatToExpectList: [
     "Evaluaremos la línea base actual de comunicación en inglés de tu equipo",


### PR DESCRIPTION
## Summary
- Adds optional `secondaryButtonText` / `secondaryButtonLink` props to `CtaSection` — fully backwards-compatible, no other pages affected
- On all four corporate pages (EN/ES for-hr-managers + corporate-package), the primary CTA is now **Schedule a Discovery Call** → booking page, with **WhatsApp** as a ghost-style secondary button
- Spanish pages use localized button text and `/es/reservar/` as the booking link
- Build passes clean (298 URLs, 0 errors)

## Test plan
- [ ] Visit `/en/for-hr-managers/` — CTA shows two buttons, booking is solid blue, WhatsApp is outlined
- [ ] Visit `/en/services/corporate-package/` — same layout
- [ ] Visit `/es/para-rh/` — Spanish button text, links to `/es/reservar/`
- [ ] Visit `/es/servicios/paquete-corporativo/` — same
- [ ] Verify no other pages using `CtaSection` are affected (secondary props are optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)