### PR TITLE
fix: remove L&D jargon from corporate pages

### DIFF
--- a/src/pages/en/services/corporate-package.astro
+++ b/src/pages/en/services/corporate-package.astro
@@ -24,7 +24,7 @@ const heroContent = {
 };
 
 const challengeContent = {
-  headline: "The Problem Most L&D Programs Miss",
+  headline: "The Problem Most Corporate English Programs Miss",
   painPoints: [
     "Your managers communicate well in private English sessions — but freeze, rush, or switch to Spanish the moment their peers are watching.",
     "Generic English courses produce certificates, not performance. Your team sits through a curriculum built for someone else.",
@@ -242,7 +242,7 @@ const faqs = serviceFaqs["corporate-package"]?.en || [];
           <h3 class="font-bold text-lg mb-4">For the Company</h3>
           <ul class="space-y-3 text-gray-600">
             <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> A management team that can represent the company in English without bottlenecks</li>
-            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> A structured L&D investment with observable performance outcomes, not just certificates</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> A training investment with observable performance outcomes — not just certificates</li>
             <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> A consolidated progress report for HR and executive review</li>
             <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> The beginning of a culture shift — from avoiding English to preparing for it</li>
             <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> An unexpected side effect: peers see each other differently, which changes dynamics in real meetings</li>

--- a/src/pages/es/servicios/paquete-corporativo.astro
+++ b/src/pages/es/servicios/paquete-corporativo.astro
@@ -24,7 +24,7 @@ const heroContent = {
 };
 
 const challengeContent = {
-  headline: "El Problema que la Mayoría de los Programas de L&D Ignoran",
+  headline: "El Problema que la Mayoría de los Cursos de Inglés Corporativo Ignoran",
   painPoints: [
     "Tus gerentes se comunican bien en sesiones privadas de inglés — pero se congelan, se apresuran o cambian al español en el momento en que sus pares los están observando.",
     "Los cursos genéricos de inglés producen certificados, no desempeño. Tu equipo sigue un temario construido para otra persona.",
@@ -178,7 +178,7 @@ const faqs = serviceFaqs["corporate-package"]?.es || [];
           <h3 class="font-bold text-lg mb-4">Para la Empresa</h3>
           <ul class="space-y-3 text-gray-600">
             <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Un equipo de gestión que puede representar a la empresa en inglés sin cuellos de botella</li>
-            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Una inversión estructurada en L&D con resultados de desempeño observables, no solo certificados</li>
+            <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Una inversión en capacitación con resultados de desempeño observables — no solo certificados</li>
             <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Un reporte de progreso consolidado para RH y revisión ejecutiva</li>
             <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> El inicio de un cambio cultural — de evitar el inglés a prepararse para él</li>
             <li class="flex gap-3"><span class="text-green-500 font-bold mt-0.5">✓</span> Un efecto secundario inesperado: los pares se ven mutuamente con nuevos ojos, cambiando la dinámica en las reuniones reales</li>


### PR DESCRIPTION
## Summary

- Removes all 4 instances of "L&D" (Learning & Development) from EN and ES corporate-package pages
- Term is North American HR jargon not recognized in Mexico — especially not in family-owned companies or small/mid-size businesses where the decision sits with a director or owner
- EN section headline: "The Problem Most L&D Programs Miss" → "The Problem Most Corporate English Programs Miss"
- EN outcomes bullet: "A structured L&D investment..." → "A training investment..."
- Same two fixes in ES

🤖 Generated with [Claude Code](https://claude.com/claude-code)