### PR TITLE
feat(seo): retarget corporate pages to business english coaching keywords

### DIFF
--- a/scripts/seo/gsc-page-queries.mjs
+++ b/scripts/seo/gsc-page-queries.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import { getWebmasters, detectSiteProperty } from './gsc-client.mjs';
+
+const endDate = new Date();
+const startDate = new Date();
+startDate.setDate(endDate.getDate() - 90);
+const fmt = (d) => d.toISOString().split('T')[0];
+
+const siteUrl = await detectSiteProperty();
+const webmasters = await getWebmasters();
+
+const pages = process.argv.slice(2);
+if (!pages.length) {
+  console.log('Usage: node gsc-page-queries.mjs <url1> [url2...]');
+  process.exit(1);
+}
+
+for (const page of pages) {
+  console.log('\n=== Queries for: ' + page + ' ===');
+  const res = await webmasters.searchanalytics.query({
+    siteUrl,
+    requestBody: {
+      startDate: fmt(startDate),
+      endDate: fmt(endDate),
+      dimensions: ['query'],
+      rowLimit: 50,
+      dataState: 'all',
+      dimensionFilterGroups: [{
+        filters: [{ dimension: 'page', operator: 'equals', expression: page }],
+      }],
+    },
+  });
+  const rows = res.data.rows || [];
+  if (!rows.length) { console.log('No queries.'); continue; }
+  for (const r of rows) {
+    console.log(`  ${r.keys[0].padEnd(55)} ${String(r.impressions).padStart(4)} impr  pos ${r.position.toFixed(1)}`);
+  }
+}

--- a/src/pages/en/services/corporate-package.astro
+++ b/src/pages/en/services/corporate-package.astro
@@ -10,14 +10,14 @@ import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
 import { serviceFaqs } from "@data/service-faqs";
 import { corporatePackage as serviceData } from "@data/services";
 
-const title = "Corporate English Training for Teams | NY English Teacher";
+const title = "Business English Coaching for Teams | NY English Teacher";
 const seoDescription =
-  "Corporate English coaching for management teams in Mexico. 12 weeks of individual prep, peer-pressure group sessions, and measurable outcomes — not just certificates.";
+  "Business English coaching 1-on-1 online for leadership teams in Mexico. A 12-week structured program with a New York native executive coach. Measurable outcomes.";
 
 const heroContent = {
   title: "Your management team is ready. Their English isn't keeping up.",
   description:
-    "A 12-week program that uses peer pressure — not a classroom — to close the gap between preparation and performance.",
+    "Business English coaching 1-on-1 with a native New Yorker. A 12-week program using peer pressure to close the gap between preparation and performance.",
   backgroundImage: serviceData.backgroundImage,
   overlayOpacity: 0.75,
   imageAlt: "Management team in a business English coaching session",
@@ -78,7 +78,7 @@ const faqs = serviceFaqs["corporate-package"]?.en || [];
   <section class="bg-light py-16 px-8">
     <div class="site-container--small mx-auto">
       <h2 class="text-3xl font-bold mb-2 text-center">How the Program Works</h2>
-      <p class="text-center text-gray-600 mb-12">12 weeks. 3 phases. One goal: your team leads in English.</p>
+      <p class="text-center text-gray-600 mb-12">Business English coaching in 3 phases. 12 weeks. One goal: your team leads in English.</p>
 
       <div class="grid gap-8 md:grid-cols-3">
         <!-- Phase 1 -->
@@ -293,22 +293,22 @@ const faqs = serviceFaqs["corporate-package"]?.en || [];
   <BreadcrumbSchema items={[
     { name: "Home", url: "https://www.nyenglishteacher.com/en/" },
     { name: "Services", url: "https://www.nyenglishteacher.com/en/services/" },
-    { name: "Corporate English Training for Leadership Teams", url: "https://www.nyenglishteacher.com/en/services/corporate-package/" }
+    { name: "Business English Coaching for Leadership Teams", url: "https://www.nyenglishteacher.com/en/services/corporate-package/" }
   ]} />
 
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@type": "Service",
-    "name": "Corporate English Training for Leadership Teams",
-    "alternateName": "Courage While Leading in English",
-    "description": "A 12-week structured English coaching program for management teams. Individual preparation, peer-pressure group presentations, and a final assessment — designed to close the gap between private fluency and public performance.",
+    "name": "Business English Coaching for Leadership Teams",
+    "alternateName": ["Corporate English Training for Leadership Teams", "Executive English Coaching", "Courage While Leading in English"],
+    "description": "Business English coaching 1-on-1 online for leadership teams in Mexico. A 12-week structured program that combines individual preparation, peer-pressure group presentations, and a final assessment — designed to close the gap between private fluency and public performance.",
     "provider": {
       "@type": "Person",
       "name": "Robert Cushman",
       "jobTitle": "English Coach",
       "url": "https://www.nyenglishteacher.com/en/about/"
     },
-    "serviceType": "Corporate English Coaching",
+    "serviceType": "Business English Coaching",
     "areaServed": {
       "@type": "Country",
       "name": "Mexico"

--- a/src/pages/es/servicios/paquete-corporativo.astro
+++ b/src/pages/es/servicios/paquete-corporativo.astro
@@ -10,14 +10,14 @@ import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
 import { serviceFaqs } from "@data/service-faqs";
 import { paqueteCorporativo as serviceData } from "@data/services";
 
-const title = "Inglés Corporativo para Equipos | NY English Teacher";
+const title = "Coaching de Inglés de Negocios | NY English Teacher";
 const seoDescription =
-  "Capacitación de inglés corporativo para equipos directivos en México. 12 semanas de preparación individual, presión de pares y resultados medibles — no solo certificados.";
+  "Coaching de inglés de negocios 1-a-1 en línea para equipos directivos en México. Programa de 12 semanas con coach nativo de Nueva York.";
 
 const heroContent = {
   title: "Tu equipo de gestión está listo. Su inglés no les está siguiendo el ritmo.",
   description:
-    "Un programa de 12 semanas que usa la presión de pares — no un salón de clases — para cerrar la brecha entre preparación y desempeño.",
+    "Coaching de inglés de negocios 1-a-1 con coach nativo de Nueva York. Programa de 12 semanas que usa la presión de pares para construir desempeño real.",
   backgroundImage: serviceData.backgroundImage,
   overlayOpacity: 0.75,
   imageAlt: "Equipo de gestión en una sesión de coaching de inglés empresarial",
@@ -78,7 +78,7 @@ const faqs = serviceFaqs["corporate-package"]?.es || [];
   <section class="bg-light py-16 px-8">
     <div class="site-container--small mx-auto">
       <h2 class="text-3xl font-bold mb-2 text-center">Cómo Funciona el Programa</h2>
-      <p class="text-center text-gray-600 mb-12">12 semanas. 3 fases. Un objetivo: tu equipo lidera en inglés.</p>
+      <p class="text-center text-gray-600 mb-12">Coaching de inglés de negocios en 3 fases. 12 semanas. Un objetivo: tu equipo lidera en inglés.</p>
 
       <div class="grid gap-8 md:grid-cols-3">
         <!-- Fase 1 -->
@@ -229,22 +229,22 @@ const faqs = serviceFaqs["corporate-package"]?.es || [];
   <BreadcrumbSchema items={[
     { name: "Inicio", url: "https://www.nyenglishteacher.com/es/" },
     { name: "Servicios", url: "https://www.nyenglishteacher.com/es/servicios/" },
-    { name: "Inglés Corporativo para Equipos Directivos", url: "https://www.nyenglishteacher.com/es/servicios/paquete-corporativo/" }
+    { name: "Coaching de Inglés de Negocios para Equipos Directivos", url: "https://www.nyenglishteacher.com/es/servicios/paquete-corporativo/" }
   ]} />
 
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@type": "Service",
-    "name": "Inglés Corporativo para Equipos Directivos",
-    "alternateName": "Valentía al Liderar en Inglés",
-    "description": "Un programa estructurado de 12 semanas para equipos de gestión. Preparación individual, presentaciones grupales bajo presión de pares y evaluación final — diseñado para cerrar la brecha entre la fluidez privada y el desempeño público.",
+    "name": "Coaching de Inglés de Negocios para Equipos Directivos",
+    "alternateName": ["Inglés Corporativo para Equipos Directivos", "Valentía al Liderar en Inglés"],
+    "description": "Coaching de inglés de negocios 1-a-1 en línea para equipos directivos en México. Programa estructurado de 12 semanas que combina preparación individual, presentaciones grupales bajo presión de pares y evaluación final — diseñado para cerrar la brecha entre la fluidez privada y el desempeño público.",
     "provider": {
       "@type": "Person",
       "name": "Robert Cushman",
       "jobTitle": "Coach de Inglés",
       "url": "https://www.nyenglishteacher.com/es/about/"
     },
-    "serviceType": "Coaching de Inglés Corporativo",
+    "serviceType": "Coaching de Inglés de Negocios",
     "areaServed": {
       "@type": "Country",
       "name": "México"


### PR DESCRIPTION
## Summary

GSC analysis (Jan 22 – Apr 22, 90 days) shows both corporate pages indexed but generating **zero** search impressions — Google sees no keyword relevance despite the pages being crawled recently.

Meanwhile, the site is already showing up for higher-volume adjacent keywords it's not optimized for:

| Keyword | Impressions | Position |
|---|---|---|
| coaching de inglés de negocios | 140 | 39 |
| business english tutor | 57 | 89 |
| executive english coaching | 13 | 74 |
| business english coaches | 12 | 78 |

The corporate pages previously targeted "paquete corporativo" / "corporate english training" — neither matches the phrases buyers actually search. This PR retargets them to the primary keywords already bringing impressions.

## Changes

Both EN and ES corporate-package pages:
- **Title tag** leads with primary keyword (≤60 chars, passes seo-audit)
- **Meta description** rewritten around the keyword + online 1-on-1 framing (≤155 chars)
- **Hero subtitle** weaves the keyword into the existing peer-pressure hook
- **"How the Program Works" subtitle** carries keyword signal
- **Schema.org** `name`, `alternateName` (array of variants), `description`, `serviceType`, and breadcrumb label aligned with new positioning
- **Emotional H1s preserved unchanged** — no copywriting destruction

Plus: `scripts/seo/gsc-page-queries.mjs` — small helper to pull query-level GSC data scoped to specific URLs. Used during this analysis; retained for future SEO work.

## Why this matters

Zero corporate-page impressions in 90 days means Google considers these pages irrelevant for any search. Moving `coaching de inglés de negocios` from page 4 to page 2 would add more traffic than all current site impressions combined. The EN equivalents are deeper but same principle.

## Test plan

- [x] `node scripts/seo/seo-audit.mjs` — both pages pass (title ≤60, description in 80-155 range)
- [x] `npm run build:check` — 423 pages built, no errors
- [x] Verified rendered `<title>`, `<meta name="description">`, OG, and Twitter tags in `dist/` output
- [ ] After merge: submit updated URLs to Google (GSC) and Bing (IndexNow + Bing API) via the repo's SEO scripts
- [ ] Monitor GSC over 4-6 weeks for position changes on the target keywords

🤖 Generated with [Claude Code](https://claude.com/claude-code)