### PR TITLE
feat: blog — Why Corporate English Training Fails in Mexico

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -26,6 +26,7 @@ const blogTranslations = {
   "5-practical-ways-to-boost-business-english": "/es/blog/5-formas-practicas-mejorar-ingles-negocios/",
   "boost-eng-confidence": "/es/blog/aumentar-confianza/",
   "corporate-english-transformation-case-study": "/es/blog/caso-estudio-transformacion-ingles-corporativo/",
+  "why-corporate-english-training-fails-mexico": "/es/blog/por-que-fracasa-la-capacitacion-de-ingles-corporativo-en-mexico/",
   "executive-english-coaching": "/es/blog/coaching-ejecutivo/",
   "executive-video-call": "/es/blog/presencia-ejecutiva-en-videollamadas/",
   "managers-lose-millions": "/es/blog/por-que-los-gerentes-de-ti-en-mexico-pierden-clientes/",

--- a/src/content/blog/en/why-corporate-english-training-fails-mexico.md
+++ b/src/content/blog/en/why-corporate-english-training-fails-mexico.md
@@ -1,0 +1,129 @@
+---
+title: "Why Corporate English Training Fails in Mexico (And What Actually Works)"
+excerpt: "Most corporate English programs produce certificates, not performance. Here's why they fail — and what a program that actually changes how your team communicates looks like."
+publishDate: "2026-04-23"
+categories:
+  - "Business English"
+  - "Corporate English Training"
+  - "High-Impact Communication"
+readingTime: "6 min read"
+audience: "For HR directors, L&D managers, and executives evaluating English training for their management teams"
+featuredImage: "./images/operations-csuite-language.webp"
+imageAlt: "Management team in a corporate meeting struggling to communicate in English"
+translations:
+  es: "/es/blog/por-que-fracasa-la-capacitacion-de-ingles-corporativo-en-mexico/"
+publish: true
+seo:
+  title: "Why Corporate English Training Fails in Mexico"
+  description: "Most corporate English programs produce certificates, not real performance. Learn why they fail and what actually works for management teams in Mexico."
+---
+
+Your company has invested in English training before.
+
+Maybe it was a group class. Maybe a language app license. Maybe a program from one of the big training providers — the ones with the polished proposal and the glossy case studies.
+
+And your managers completed it. Attended the sessions. Passed the assessments. Received their certificates.
+
+Then walked into the next meeting with US headquarters and froze anyway.
+
+If that sounds familiar, you're not alone. It's one of the most common frustrations I hear from HR directors and executives across Mexico: *we've done English training before and nobody actually improved.* Not in the ways that count.
+
+The problem isn't your team. And it isn't a lack of effort.
+
+The problem is that most corporate English programs are designed to produce the wrong outcome.
+
+---
+
+## What Most Programs Are Actually Measuring
+
+Here's the uncomfortable truth about the corporate English training industry: most programs are optimized for completion, not performance.
+
+Certificates are measurable. Test scores are measurable. Attendance is measurable. These are easy things to put in an L&D report and present to leadership.
+
+What's harder to measure — and what most programs don't even try to measure — is whether someone can hold their own in an unscripted conversation with a VP from Chicago, or navigate a tense negotiation call without switching to Spanish the moment pressure builds.
+
+Generic curricula teach grammar rules and vocabulary lists. Apps teach recognition. Neither prepares anyone for the moment that actually matters: an unexpected question in the middle of a presentation, in front of people who are judging whether you're credible.
+
+That gap — between English you *have* and English you *perform* — is where corporate programs consistently fail.
+
+---
+
+## The Three Reasons Corporate English Programs Don't Transfer
+
+**1. The content has nothing to do with the actual job.**
+
+If your supply chain manager is working through a unit on "ordering at a restaurant" or "making small talk at the airport," the training is disconnected from the performance you need. Real improvement comes from rehearsing the actual scenarios your team faces: status updates to US leadership, cross-functional project calls, quarterly reviews with international clients.
+
+Generic content produces generic improvement. Your team's specific context — their industry, their role, their actual communication gaps — has to be the starting point, not an afterthought.
+
+**2. There's no performance pressure.**
+
+Most English training happens in conditions that are nothing like the real environment. One-on-one sessions in a comfortable setting. Group classes where everyone is at a similar level and no one is really watching. Low-stakes practice that builds a false sense of readiness.
+
+Then the real moment arrives — and it's in front of peers, or in front of leadership, or on a call where something important is at stake — and everything a person "knows" in practice disappears under pressure.
+
+Fluency is not just knowledge. It's performance. And performance has to be trained under conditions that resemble performance. The pressure in the room during a real meeting is not something you can simulate by studying alone.
+
+**3. Individual coaching, no group accountability.**
+
+Most programs build skill in isolation. Each person works on their own, in private. The problem is that the professional moments your managers are preparing for are inherently social — they involve peers watching, leadership evaluating, clients judging.
+
+The discomfort of speaking English in front of colleagues who might notice your mistakes is real. It's one of the most common reasons professionals who are perfectly functional in 1:1 settings freeze in group situations. If training never puts them in that position, they never build the specific confidence that group settings require.
+
+---
+
+## What Actually Works
+
+The programs that produce real, observable performance change have three things in common.
+
+**Individual preparation built around real content.** Not a textbook. Not a generic curriculum. Each participant works on their own communication gaps — their presentation, their vocabulary, their specific performance breakdowns — with coaching that uses the actual materials they work with every day.
+
+**Group presentation under real peer pressure.** At some point in the program, every participant has to deliver something in English in front of the full group. This is where the real breakthroughs happen. Not because the content is harder, but because the conditions finally match the real environment. Peers watching, stakes feeling real, no option to switch to Spanish. Most professionals who have never done this find it significantly harder than they expected — and significantly more effective.
+
+**Honest measurement.** A baseline assessment at the start. A final evaluation at the end. Not a test with a score — a documented assessment of specific communication gaps, progress made, and what still needs work. Something concrete that HR and management can review, not just a certificate that says "completed."
+
+---
+
+## The Question Worth Asking Before You Invest
+
+Before any company commits to a corporate English program, one question cuts through most of the noise:
+
+*"What does success actually look like — and how will we know when we've achieved it?"*
+
+If the answer is "more certificates" or "higher test scores," you're about to repeat the cycle.
+
+If the answer is "my managers can hold their own on a call with US leadership without switching to Spanish and without needing three days to prepare a script" — then you're looking for something different from what most providers offer.
+
+That's what a 12-week structured program should actually produce. Not as a promise. As a result that's measured from week one and documented at week twelve.
+
+---
+
+## The Honest Reality About Timelines
+
+Three months is the minimum to see meaningful, observable change in professional communication. Not because of arbitrary structure, but because of how adult learning actually works.
+
+Progress in a second language after your early twenties requires consistent effort — inside sessions and outside them. Watching content in English. Reading in English. Finding real situations to practice. One or two hours a week of coaching alone is not enough to produce a step change. What coaching does is direct the effort, surface the specific gaps, and create the performance conditions that accelerate growth.
+
+Companies that see real results from corporate English programs share one characteristic: they treat it like athletic training, not like a course. There's a coach. There's a structure. There's accountability. And the participants are doing work between sessions, not just showing up.
+
+---
+
+## What to Look For When You're Evaluating Programs
+
+If you're responsible for selecting an English training program for your management team, a few things worth asking any provider:
+
+- What does a typical session actually look like — is it conversation practice, grammar instruction, or performance simulation?
+- How is the content personalized to each participant's role and actual communication needs?
+- Is there any group component, or is all training done individually in isolation?
+- What does the final deliverable look like — and is there anything that documents progress against a baseline?
+- What's your policy on participants who attend but don't engage outside sessions?
+
+The answers will tell you quickly whether you're looking at a program built for performance or a program built for completion.
+
+---
+
+The goal isn't English on a certificate. It's a management team that can represent your company in English without a bottleneck — without needing to run everything through the one person who is already fluent, without slowing down decisions because of a communication gap, without showing up to a meeting with your international partners feeling unprepared.
+
+That outcome is achievable. But it requires the right structure and honest expectations about what it takes.
+
+If you're evaluating what that looks like for your team specifically, a 20-minute discovery call is the right starting point. No pitch — just an honest assessment of where your team is, what's realistic, and whether this is the right fit.

--- a/src/content/blog/es/por-que-fracasa-la-capacitacion-de-ingles-corporativo-en-mexico.md
+++ b/src/content/blog/es/por-que-fracasa-la-capacitacion-de-ingles-corporativo-en-mexico.md
@@ -1,0 +1,129 @@
+---
+title: "Por Qué Fracasa la Capacitación de Inglés Corporativo en México (Y Qué Sí Funciona)"
+excerpt: "La mayoría de los programas de inglés corporativo producen certificados, no desempeño. Aquí explicamos por qué fallan — y cómo es un programa que realmente transforma la comunicación de tu equipo."
+publishDate: "2026-04-23"
+categories:
+  - "Inglés para Negocios"
+  - "Capacitación Corporativa en Inglés"
+  - "Comunicación de Alto Impacto"
+readingTime: "6 min de lectura"
+audience: "Para directores de RR.HH., gerentes de L&D y ejecutivos que evalúan capacitación en inglés para sus equipos directivos"
+featuredImage: "../en/images/operations-csuite-language.webp"
+imageAlt: "Equipo directivo en una reunión corporativa con dificultades para comunicarse en inglés"
+translations:
+  en: "/en/blog/why-corporate-english-training-fails-mexico/"
+publish: true
+seo:
+  title: "Por Qué Fracasa la Capacitación de Inglés Corporativo"
+  description: "Los programas de inglés corporativo producen certificados, no desempeño real. Aprende por qué fallan y qué sí funciona para equipos directivos en México."
+---
+
+Tu empresa ya ha invertido en capacitación de inglés antes.
+
+Tal vez fue una clase grupal. Tal vez una licencia de app de idiomas. Tal vez un programa de uno de los grandes proveedores de capacitación — los de la propuesta impecable y los casos de éxito bien presentados.
+
+Y tus gerentes lo completaron. Asistieron a las sesiones. Pasaron las evaluaciones. Recibieron sus certificados.
+
+Y luego entraron a la siguiente reunión con la oficina central en Estados Unidos y se bloquearon de todas formas.
+
+Si eso suena familiar, no estás solo. Es una de las frustraciones más comunes que escucho de directores de RR.HH. y ejecutivos en toda México: *ya hicimos capacitación de inglés y nadie mejoró realmente.* No en lo que importa.
+
+El problema no es tu equipo. Ni tampoco la falta de esfuerzo.
+
+El problema es que la mayoría de los programas de inglés corporativo están diseñados para producir el resultado equivocado.
+
+---
+
+## Lo Que la Mayoría de los Programas Realmente Están Midiendo
+
+La verdad incómoda sobre la industria de capacitación de inglés corporativo: la mayoría de los programas están optimizados para la finalización, no para el desempeño.
+
+Los certificados son medibles. Las calificaciones en exámenes son medibles. La asistencia es medible. Son cosas fáciles de incluir en un reporte de L&D y presentar a la dirección.
+
+Lo que es más difícil de medir — y que la mayoría de los programas ni siquiera intentan medir — es si alguien puede sostener una conversación sin guión con un VP de Chicago, o navegar una negociación tensa por teléfono sin cambiar al español en el momento en que la presión aumenta.
+
+Los currículos genéricos enseñan reglas gramaticales y listas de vocabulario. Las apps enseñan reconocimiento. Ninguno prepara a nadie para el momento que realmente importa: una pregunta inesperada en medio de una presentación, frente a personas que están evaluando si eres creíble.
+
+Esa brecha — entre el inglés que se *tiene* y el inglés que se *ejecuta* — es donde los programas corporativos fallan consistentemente.
+
+---
+
+## Las Tres Razones por las que la Capacitación de Inglés Corporativo No Se Transfiere
+
+**1. El contenido no tiene nada que ver con el trabajo real.**
+
+Si tu gerente de cadena de suministro está trabajando una unidad sobre "cómo ordenar en un restaurante" o "hacer small talk en el aeropuerto", la capacitación está desconectada del desempeño que necesitas. La mejora real viene de ensayar los escenarios concretos que enfrenta tu equipo: actualizaciones de estatus para liderazgo en EE.UU., llamadas de proyectos interfuncionales, revisiones trimestrales con clientes internacionales.
+
+El contenido genérico produce mejora genérica. El contexto específico de tu equipo — su industria, su rol, sus brechas de comunicación reales — tiene que ser el punto de partida, no una ocurrencia tardía.
+
+**2. No hay presión de desempeño.**
+
+La mayoría de la capacitación de inglés ocurre en condiciones que no se parecen en nada al entorno real. Sesiones individuales en un ambiente cómodo. Clases grupales donde todos están en un nivel similar y nadie está realmente observando. Práctica de bajo riesgo que genera una falsa sensación de preparación.
+
+Luego llega el momento real — frente a pares, frente a liderazgo, o en una llamada donde algo importante está en juego — y todo lo que alguien "sabe" en la práctica desaparece bajo presión.
+
+La fluidez no es solo conocimiento. Es desempeño. Y el desempeño tiene que entrenarse bajo condiciones que se asemejen al desempeño. La presión en la sala durante una reunión real no es algo que se pueda simular estudiando solo.
+
+**3. Coaching individual, sin responsabilidad grupal.**
+
+La mayoría de los programas desarrollan habilidades en aislamiento. Cada persona trabaja por su cuenta, en privado. El problema es que los momentos profesionales para los que se preparan tus gerentes son inherentemente sociales — involucran pares que observan, liderazgo que evalúa, clientes que juzgan.
+
+La incomodidad de hablar inglés frente a colegas que podrían notar tus errores es real. Es una de las razones más comunes por las que profesionales que funcionan perfectamente en entornos 1:1 se bloquean en situaciones grupales. Si la capacitación nunca los pone en esa posición, nunca desarrollan la confianza específica que los entornos grupales requieren.
+
+---
+
+## Lo Que Sí Funciona
+
+Los programas que producen cambios reales y observables en el desempeño tienen tres cosas en común.
+
+**Preparación individual construida alrededor de contenido real.** No un libro de texto. No un currículo genérico. Cada participante trabaja en sus propias brechas de comunicación — su presentación, su vocabulario, sus bloqueos específicos — con coaching que usa los materiales reales con los que trabaja cada día.
+
+**Presentación grupal bajo presión real de pares.** En algún momento del programa, cada participante tiene que entregar algo en inglés frente al grupo completo. Aquí es donde ocurren los avances reales. No porque el contenido sea más difícil, sino porque las condiciones finalmente coinciden con el entorno real. Pares observando, algo en juego, sin opción de cambiar al español. La mayoría de los profesionales que nunca han hecho esto descubren que es significativamente más difícil de lo que esperaban — y significativamente más efectivo.
+
+**Medición honesta.** Una evaluación de línea base al inicio. Una evaluación final al cierre. No un examen con calificación — una evaluación documentada de brechas de comunicación específicas, el progreso logrado y lo que aún necesita trabajo. Algo concreto que RR.HH. y la dirección puedan revisar, no solo un certificado que dice "completado".
+
+---
+
+## La Pregunta que Vale la Pena Hacer Antes de Invertir
+
+Antes de que cualquier empresa se comprometa con un programa de inglés corporativo, una pregunta corta elimina la mayor parte del ruido:
+
+*"¿Cómo se ve el éxito realmente — y cómo vamos a saber cuándo lo hemos logrado?"*
+
+Si la respuesta es "más certificados" o "calificaciones más altas en exámenes", estás a punto de repetir el ciclo.
+
+Si la respuesta es "mis gerentes pueden sostener su posición en una llamada con liderazgo en EE.UU. sin cambiar al español y sin necesitar tres días para preparar un guión" — entonces estás buscando algo diferente de lo que ofrece la mayoría de los proveedores.
+
+Eso es lo que un programa estructurado de 12 semanas debería producir realmente. No como promesa. Como resultado que se mide desde la semana uno y se documenta en la semana doce.
+
+---
+
+## La Realidad Honesta sobre los Plazos
+
+Tres meses es el mínimo para ver un cambio significativo y observable en la comunicación profesional. No por una estructura arbitraria, sino por cómo funciona realmente el aprendizaje en adultos.
+
+El progreso en un segundo idioma después de los veinte años requiere esfuerzo consistente — dentro de las sesiones y fuera de ellas. Ver contenido en inglés. Leer en inglés. Encontrar situaciones reales para practicar. Una o dos horas a la semana de coaching solo no es suficiente para producir un cambio de nivel. Lo que hace el coaching es dirigir el esfuerzo, identificar las brechas específicas y crear las condiciones de desempeño que aceleran el crecimiento.
+
+Las empresas que ven resultados reales de los programas de inglés corporativo comparten una característica: lo tratan como entrenamiento atlético, no como un curso. Hay un coach. Hay una estructura. Hay rendición de cuentas. Y los participantes hacen trabajo entre sesiones, no solo se presentan a clase.
+
+---
+
+## Qué Buscar Cuando Evalúas Programas
+
+Si eres responsable de seleccionar un programa de capacitación en inglés para tu equipo directivo, vale la pena preguntar a cualquier proveedor:
+
+- ¿Cómo se ve una sesión típica realmente — es práctica de conversación, instrucción gramatical o simulación de desempeño?
+- ¿Cómo se personaliza el contenido al rol y las necesidades de comunicación reales de cada participante?
+- ¿Hay algún componente grupal, o toda la capacitación se hace individualmente en aislamiento?
+- ¿Cómo es el entregable final — y hay algo que documente el progreso contra una línea base?
+- ¿Cuál es su política con los participantes que asisten pero no se involucran fuera de las sesiones?
+
+Las respuestas te dirán rápidamente si estás evaluando un programa construido para el desempeño o un programa construido para la finalización.
+
+---
+
+El objetivo no es inglés en un certificado. Es un equipo directivo que pueda representar a tu empresa en inglés sin cuellos de botella — sin necesitar canalizar todo a través de la única persona que ya habla con fluidez, sin ralentizar decisiones por una brecha de comunicación, sin llegar a una reunión con sus socios internacionales sintiéndose sin preparación.
+
+Ese resultado es alcanzable. Pero requiere la estructura correcta y expectativas honestas sobre lo que se necesita.
+
+Si estás evaluando cómo se vería eso para tu equipo específicamente, una llamada de descubrimiento de 20 minutos es el punto de partida correcto. Sin presentación de ventas — solo una evaluación honesta de dónde está tu equipo, qué es realista y si esto es el ajuste correcto.


### PR DESCRIPTION
## Summary
- New bilingual blog post targeting HR directors and executives evaluating corporate English programs
- EN: `/en/blog/why-corporate-english-training-fails-mexico/`
- ES: `/es/blog/por-que-fracasa-la-capacitacion-de-ingles-corporativo-en-mexico/`
- Placeholder hero image (`operations-csuite-language.webp`) — Robert will provide final image
- hreflang translation mapping added to `astro.config.mjs`

## Content strategy
Directly addresses the #1 sales objection ("we've tried this before and nobody improved"), targets the HR/L&D buyer, and ends with a soft CTA to the discovery call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)