### PR TITLE
chore(seo): load dotenv in indexnow-submit.mjs

### DIFF
--- a/scripts/seo/indexnow-submit.mjs
+++ b/scripts/seo/indexnow-submit.mjs
@@ -9,6 +9,15 @@
  *   node scripts/seo/indexnow-submit.mjs --sitemap https://...xml    # Submit URLs from a specific sitemap
  */
 
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import dotenv from 'dotenv';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PROJECT_ROOT = join(__dirname, '..', '..');
+dotenv.config({ path: join(PROJECT_ROOT, '.env') });
+
 if (!process.env.INDEXNOW_KEY) {
   console.error('✗ Missing required environment variable: INDEXNOW_KEY');
   process.exit(1);


### PR DESCRIPTION
## Summary

Brings `scripts/seo/indexnow-submit.mjs` into line with `bing-submit.mjs` by loading env vars from the repo root. Without this, the script fails with \"Missing required environment variable: INDEXNOW_KEY\" even when the key is defined in the project's env file — forcing the operator to pass it inline every run.

This matters because the mandatory post-publish SEO automation (submit updated URLs to Bing/Yandex/DuckDuckGo via IndexNow after any content change) was silently failing that step unless the operator remembered the workaround.

## Test plan

- [x] Ran `node scripts/seo/indexnow-submit.mjs --url https://www.nyenglishteacher.com/en/services/corporate-package/` without any inline env — got HTTP 200 from IndexNow, engines notified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)