### PR TITLE
feat(cta): add WhatsApp secondary CTA to ongoing-coaching pages

### DIFF
--- a/src/pages/en/services/ongoing-coaching.astro
+++ b/src/pages/en/services/ongoing-coaching.astro
@@ -30,8 +30,11 @@ const ctaContent = {
   title: "Ready to build real fluency across your team?",
   description:
     "Schedule a discovery call. We'll talk about your team's current level, where the gaps are, and what a coaching format that fits your schedule and goals actually looks like.",
+  buttonSubtext: "Most discovery calls take 20 minutes.",
   buttonText: "Schedule a Discovery Call",
   buttonLink: "/en/book/",
+  secondaryButtonText: "Contact Robert on WhatsApp",
+  secondaryButtonLink: "https://wa.me/523315590572",
   whatToExpectTitle: "In Your Discovery Call, We Will:",
   whatToExpectList: [
     "Assess your team's current communication baseline",

--- a/src/pages/es/servicios/coaching-continuo.astro
+++ b/src/pages/es/servicios/coaching-continuo.astro
@@ -30,8 +30,11 @@ const ctaContent = {
   title: "¿Listo para construir fluidez real en tu equipo?",
   description:
     "Agenda una llamada de descubrimiento. Hablaremos sobre el nivel actual de tu equipo, dónde están las brechas, y qué formato de coaching se adapta realmente a tu agenda y objetivos.",
+  buttonSubtext: "La mayoría de las llamadas de descubrimiento duran 20 minutos.",
   buttonText: "Agendar Llamada de Descubrimiento",
   buttonLink: "/es/reservar/",
+  secondaryButtonText: "Contactar a Robert por WhatsApp",
+  secondaryButtonLink: "https://wa.me/523315590572",
   whatToExpectTitle: "En Tu Llamada de Descubrimiento:",
   whatToExpectList: [
     "Evaluamos la base de comunicación actual de tu equipo",


### PR DESCRIPTION
## Summary
- Ongoing Coaching pages (EN + ES) were missing the secondary WhatsApp CTA that Corporate Package already has.
- Added `secondaryButtonText` / `secondaryButtonLink` and matching `buttonSubtext` props — `CtaSection` already supports them, so no component changes.
- Makes the final CTA block visually + behaviorally consistent across the two primary service landing pages.

## Test plan
- [x] `npm run build` — 425 pages, sitemap validation PASS
- [ ] Visually verify the secondary button renders on the Vercel preview for `/en/services/ongoing-coaching/` and `/es/servicios/coaching-continuo/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)