### PR TITLE
feat(blog): add Corporate Audit callouts to 4 corporate posts

### DIFF
--- a/src/content/blog/en/corporate-english-transformation-case-study.md
+++ b/src/content/blog/en/corporate-english-transformation-case-study.md
@@ -74,6 +74,16 @@ What emerged was surprising. Grammar wasn't the primary issue. The real barriers
 3. **Missing frameworks** — They lacked structured approaches to objection handling, negotiation, and executive presence
 4. **Isolation** — Each leader thought they were the only one struggling
 
+<aside class="not-prose my-12 rounded-xl border border-blue-100 bg-blue-50 p-6 sm:p-8">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div class="flex-1">
+      <p class="mb-1.5 text-xs font-semibold uppercase tracking-wide text-blue-700">Want to run a quick diagnostic on your own team?</p>
+      <p class="m-0 text-base leading-snug text-gray-800">The Corporate English Training Audit is a self-service version of the Phase 1 diagnostic process — 7 vendor questions plus warning signs and success metrics.</p>
+    </div>
+    <a href="/en/for-hr-managers/?utm_source=blog&utm_medium=callout&utm_campaign=audit&utm_content=case-study-mid#download-the-guide" class="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white no-underline shadow-sm transition hover:bg-blue-700">Get the free guide <span aria-hidden="true">→</span></a>
+  </div>
+</aside>
+
 ### Phase 2: Individual Coaching (Ongoing)
 
 Each executive received weekly one-on-one sessions tailored to their specific challenges:
@@ -208,6 +218,16 @@ If your organization is considering similar development for leadership teams, co
 **Address the full executive toolkit.** Language skills matter, but they're insufficient without the underlying communication frameworks. The best English in the world won't help an executive who doesn't know how to handle an objection or structure a persuasive argument. For a look at what this costs when left unaddressed, see [The Real Cost of Weak English: Lost Deals, Blocked Promotions](/en/blog/real-cost-weak-english-mexican-companies/).
 
 **Start at the top.** When senior leaders participate visibly, they create permission for everyone else. When they hide in private coaching while sending junior staff to group classes, they signal that struggling with English is shameful. The former accelerates development; the latter inhibits it.
+
+<aside class="not-prose my-12 rounded-xl border border-blue-100 bg-blue-50 p-6 sm:p-8">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div class="flex-1">
+      <p class="mb-1.5 text-xs font-semibold uppercase tracking-wide text-blue-700">Evaluating providers for your own leadership team?</p>
+      <p class="m-0 text-base leading-snug text-gray-800">Use The Corporate English Training Audit as a structured checklist before you commit — 7 vendor questions, the warning signs, and how to define success.</p>
+    </div>
+    <a href="/en/for-hr-managers/?utm_source=blog&utm_medium=callout&utm_campaign=audit&utm_content=case-study-end#download-the-guide" class="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white no-underline shadow-sm transition hover:bg-blue-700">Download the audit <span aria-hidden="true">→</span></a>
+  </div>
+</aside>
 
 ## What's Next for This Team
 

--- a/src/content/blog/en/why-corporate-english-training-fails-mexico.md
+++ b/src/content/blog/en/why-corporate-english-training-fails-mexico.md
@@ -72,6 +72,16 @@ The discomfort of speaking English in front of colleagues who might notice your 
 
 ---
 
+<aside class="not-prose my-12 rounded-xl border border-blue-100 bg-blue-50 p-6 sm:p-8">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div class="flex-1">
+      <p class="mb-1.5 text-xs font-semibold uppercase tracking-wide text-blue-700">Researching providers right now?</p>
+      <p class="m-0 text-base leading-snug text-gray-800">Download The Corporate English Training Audit — the 7 questions that separate real programs from glossy proposals, plus the warning signs and how to define success.</p>
+    </div>
+    <a href="/en/for-hr-managers/?utm_source=blog&utm_medium=callout&utm_campaign=audit&utm_content=why-fails-mid#download-the-guide" class="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white no-underline shadow-sm transition hover:bg-blue-700">Get the free guide <span aria-hidden="true">→</span></a>
+  </div>
+</aside>
+
 ## What Actually Works
 
 The programs that produce real, observable performance change have three things in common.
@@ -121,6 +131,16 @@ If you're responsible for selecting an English training program for your managem
 The answers will tell you quickly whether you're looking at a program built for performance or a program built for completion.
 
 ---
+
+<aside class="not-prose my-12 rounded-xl border border-blue-100 bg-blue-50 p-6 sm:p-8">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div class="flex-1">
+      <p class="mb-1.5 text-xs font-semibold uppercase tracking-wide text-blue-700">5 questions is a start. The full audit has 7 more.</p>
+      <p class="m-0 text-base leading-snug text-gray-800">Plus the warning signs of a generic program disguised as a tailored solution, and a structured way to define success before you sign a contract.</p>
+    </div>
+    <a href="/en/for-hr-managers/?utm_source=blog&utm_medium=callout&utm_campaign=audit&utm_content=why-fails-end#download-the-guide" class="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white no-underline shadow-sm transition hover:bg-blue-700">Download the audit <span aria-hidden="true">→</span></a>
+  </div>
+</aside>
 
 The goal isn't English on a certificate. It's a management team that can represent your company in English without a bottleneck — without needing to run everything through the one person who is already fluent, without slowing down decisions because of a communication gap, without showing up to a meeting with your international partners feeling unprepared.
 

--- a/src/content/blog/es/caso-estudio-transformacion-ingles-corporativo.md
+++ b/src/content/blog/es/caso-estudio-transformacion-ingles-corporativo.md
@@ -74,6 +74,16 @@ Lo que surgió fue sorprendente. La gramática no era el problema principal. Las
 3. **Falta de marcos de referencia** — Les faltaban enfoques estructurados para manejar objeciones, negociación y presencia ejecutiva
 4. **Aislamiento** — Cada líder pensaba que era el único que estaba luchando
 
+<aside class="not-prose my-12 rounded-xl border border-blue-100 bg-blue-50 p-6 sm:p-8">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div class="flex-1">
+      <p class="mb-1.5 text-xs font-semibold uppercase tracking-wide text-blue-700">¿Quiere hacer un diagnóstico rápido de su propio equipo?</p>
+      <p class="m-0 text-base leading-snug text-gray-800">La Guía de Evaluación de Capacitación de Inglés Corporativo es una versión auto-servicio del proceso de diagnóstico de la Fase 1 — 7 preguntas para proveedores más señales de alerta y métricas de éxito.</p>
+    </div>
+    <a href="/es/para-rh/?utm_source=blog&utm_medium=callout&utm_campaign=audit&utm_content=caso-estudio-mid#descargar-guia" class="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white no-underline shadow-sm transition hover:bg-blue-700">Ver la guía gratuita <span aria-hidden="true">→</span></a>
+  </div>
+</aside>
+
 ### Fase 2: Coaching Individual (Continuo)
 
 Cada ejecutivo recibió sesiones semanales uno a uno adaptadas a sus desafíos específicos:
@@ -208,6 +218,16 @@ Si tu organización está considerando un desarrollo similar para equipos direct
 **Aborda el kit completo de herramientas ejecutivas.** Las habilidades de idioma importan, pero son insuficientes sin los marcos de comunicación subyacentes. El mejor inglés del mundo no ayudará a un ejecutivo que no sabe cómo manejar una objeción o estructurar un argumento persuasivo.
 
 **Empieza desde arriba.** Cuando los líderes senior participan visiblemente, crean permiso para todos los demás. Cuando se esconden en coaching privado mientras envían al personal junior a clases grupales, señalan que luchar con el inglés es vergonzoso. Lo primero acelera el desarrollo; lo segundo lo inhibe.
+
+<aside class="not-prose my-12 rounded-xl border border-blue-100 bg-blue-50 p-6 sm:p-8">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div class="flex-1">
+      <p class="mb-1.5 text-xs font-semibold uppercase tracking-wide text-blue-700">¿Evaluando proveedores para su propio equipo directivo?</p>
+      <p class="m-0 text-base leading-snug text-gray-800">Use La Guía de Evaluación de Capacitación de Inglés Corporativo como una lista de verificación estructurada antes de comprometerse — 7 preguntas para proveedores, las señales de alerta y cómo definir el éxito.</p>
+    </div>
+    <a href="/es/para-rh/?utm_source=blog&utm_medium=callout&utm_campaign=audit&utm_content=caso-estudio-end#descargar-guia" class="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white no-underline shadow-sm transition hover:bg-blue-700">Descargar la guía <span aria-hidden="true">→</span></a>
+  </div>
+</aside>
 
 ## Qué Sigue para Este Equipo
 

--- a/src/content/blog/es/por-que-fracasa-la-capacitacion-de-ingles-corporativo-en-mexico.md
+++ b/src/content/blog/es/por-que-fracasa-la-capacitacion-de-ingles-corporativo-en-mexico.md
@@ -72,6 +72,16 @@ La incomodidad de hablar inglés frente a colegas que podrían notar tus errores
 
 ---
 
+<aside class="not-prose my-12 rounded-xl border border-blue-100 bg-blue-50 p-6 sm:p-8">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div class="flex-1">
+      <p class="mb-1.5 text-xs font-semibold uppercase tracking-wide text-blue-700">¿Está investigando proveedores en este momento?</p>
+      <p class="m-0 text-base leading-snug text-gray-800">Descargue La Guía de Evaluación de Capacitación de Inglés Corporativo — las 7 preguntas que separan los programas reales de las propuestas brillantes, además de las señales de alerta y cómo definir el éxito.</p>
+    </div>
+    <a href="/es/para-rh/?utm_source=blog&utm_medium=callout&utm_campaign=audit&utm_content=por-que-fracasa-mid#descargar-guia" class="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white no-underline shadow-sm transition hover:bg-blue-700">Ver la guía gratuita <span aria-hidden="true">→</span></a>
+  </div>
+</aside>
+
 ## Lo Que Sí Funciona
 
 Los programas que producen cambios reales y observables en el desempeño tienen tres cosas en común.
@@ -121,6 +131,16 @@ Si eres responsable de seleccionar un programa de capacitación en inglés para 
 Las respuestas te dirán rápidamente si estás evaluando un programa construido para el desempeño o un programa construido para la finalización.
 
 ---
+
+<aside class="not-prose my-12 rounded-xl border border-blue-100 bg-blue-50 p-6 sm:p-8">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div class="flex-1">
+      <p class="mb-1.5 text-xs font-semibold uppercase tracking-wide text-blue-700">5 preguntas son un inicio. La guía completa tiene 7 más.</p>
+      <p class="m-0 text-base leading-snug text-gray-800">Además, las señales de alerta de un programa genérico disfrazado de solución personalizada, y una forma estructurada de definir el éxito antes de firmar un contrato.</p>
+    </div>
+    <a href="/es/para-rh/?utm_source=blog&utm_medium=callout&utm_campaign=audit&utm_content=por-que-fracasa-end#descargar-guia" class="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white no-underline shadow-sm transition hover:bg-blue-700">Descargar la guía <span aria-hidden="true">→</span></a>
+  </div>
+</aside>
 
 El objetivo no es inglés en un certificado. Es un equipo directivo que pueda representar a tu empresa en inglés sin cuellos de botella — sin necesitar canalizar todo a través de la única persona que ya habla con fluidez, sin ralentizar decisiones por una brecha de comunicación, sin llegar a una reunión con sus socios internacionales sintiéndose sin preparación.
 


### PR DESCRIPTION
## Summary
Retrofits the two existing corporate-targeted blog posts (EN + ES mirrors) with two contextual callouts each, linking to the Corporate English Training Audit form on \`/en/for-hr-managers/\` (and \`/es/para-rh/\` for ES).

**Posts updated:**
- \`why-corporate-english-training-fails-mexico\` (EN + ES)
- \`corporate-english-transformation-case-study\` (EN + ES)

**Placement strategy:**
- Mid-post callout — after the strongest pain or method-establishing moment
- Closing callout — right before the wrap-up paragraph

Different copy per placement, same destination URL. UTM params on every link so we can see in Neon which post + position drove each download.

**Tech notes:**
- Inline HTML in markdown using Tailwind classes
- Wrapped in \`<aside class="not-prose">\` to escape the blog's \`prose\` Typography styling
- All 4 callout positions tested via local build — sitemap validation passes

## Test plan
- [x] \`npm run build\` succeeds
- [x] Sitemap validation passes
- [ ] Visual check on preview deployment — callouts render correctly in both EN and ES posts
- [ ] Click-through from each callout lands on the form anchor on \`/en/for-hr-managers/\` / \`/es/para-rh/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)