### PR TITLE
docs: social content for 7-questions corporate English post

### DIFF
--- a/content-marketing/7-questions-corporate-english-vendor-social.md
+++ b/content-marketing/7-questions-corporate-english-vendor-social.md
@@ -1,0 +1,86 @@
+# Social Media Content — 7 Questions Every HR Manager Should Ask Before Signing a Corporate English Training Contract
+
+**Blog Post URL (EN):** https://www.nyenglishteacher.com/en/blog/7-questions-corporate-english-vendor/
+**Blog Post URL (ES):** https://www.nyenglishteacher.com/es/blog/7-preguntas-proveedor-ingles-corporativo/
+
+---
+
+## LinkedIn Post
+
+You're sitting on three corporate English training proposals. They all look reasonable — polished decks, comparable pricing, glossy case studies featuring brands you recognize. There's no obvious basis for choice.
+
+After years of watching Mexican companies invest in corporate English training only to receive certificates instead of performance, I wrote down the 7 questions that separate substance from polish.
+
+Asked sincerely, they surface a vendor's actual approach within 15 minutes. The answers reveal whether you're looking at a program designed to change how your team communicates, or a program designed to produce something measurable in an L&D report.
+
+A few of them:
+
+→ "What does success actually look like for our team — and how will we measure it?"
+   Vendors who answer "improved fluency" or "higher CEFR scores" are telling you that they think in completion metrics, not behavior change.
+
+→ "What's the actual professional background of the coach assigned to my team — and will the same coach work with us throughout the program?"
+   Many providers in Mexico operate on a staffing-agency model. Sales closes the deal; rotating contract teachers deliver the work. That model produces inconsistent results.
+
+→ "What's your policy on participants who attend sessions but don't engage outside of them?"
+   The question vendors expect least and that reveals the most. Most programs have no policy at all — and that's the answer.
+
+The full breakdown of all 7 questions, with concrete "right answer / wrong answer" examples, is in the post:
+
+https://www.nyenglishteacher.com/en/blog/7-questions-corporate-english-vendor/
+
+If you're evaluating proposals right now, this is the framework I wish every HR manager I worked with had used before they signed their last contract.
+
+#CorporateTraining #HRLeadership #LearningAndDevelopment #BusinessEnglish #VendorEvaluation #MexicoBusiness
+
+---
+
+## Twitter/X Thread
+
+**Tweet 1 (Hook):**
+Most corporate English training in Mexico is sold to HR managers using the same playbook.
+
+Polished proposals. Comparable pricing. Identical underlying methodology.
+
+7 questions that surface a vendor's real approach in 15 minutes (thread):
+
+**Tweet 2:**
+Q1: "What does success actually look like for our team — and how will we measure it?"
+
+Wrong answer: "Improved fluency."
+Right answer: "Tell me what your team needs to do in English that they currently can't — we'll work backwards from there."
+
+**Tweet 3:**
+Q4: "What's the actual professional background of the coach assigned to my team — and will the same coach work with us throughout the program?"
+
+Many providers run on a staffing-agency model. Sales closes the deal. Rotating contract teachers deliver the work.
+
+That's why results vary.
+
+**Tweet 4:**
+Q7: "What's your policy on participants who attend but don't engage outside sessions?"
+
+The question vendors expect least.
+
+Most programs have no policy at all — they want retention, not results. They'd rather keep an unengaged seat filled for the full contract than have an honest conversation.
+
+**Tweet 5 (CTA):**
+The other 4 questions, plus warning signs to watch for in vendor proposals, are in the full post:
+
+https://www.nyenglishteacher.com/en/blog/7-questions-corporate-english-vendor/
+
+If you're evaluating proposals right now, this is the framework to use.
+
+#CorporateTraining #HR #BusinessEnglish
+
+---
+
+## Facebook Post
+
+If you're an HR manager or L&D director evaluating corporate English training proposals in Mexico, this one's for you.
+
+I just published the 7 questions that separate real performance programs from glossy proposals — questions like "what does success actually look like for our team" and "will the same coach be there in week 1, week 6, and week 12, or are you sending whoever is available?" Asked in a vendor call, they surface a provider's real methodology within 15 minutes.
+
+If a vendor can't answer them comfortably, that's information.
+
+English version: https://www.nyenglishteacher.com/en/blog/7-questions-corporate-english-vendor/
+Versión en español: https://www.nyenglishteacher.com/es/blog/7-preguntas-proveedor-ingles-corporativo/


### PR DESCRIPTION
Adds LinkedIn, Twitter thread, and Facebook copy for the new corporate vendor evaluation post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)