### PR TITLE
fix(blog): align 7-questions post with the actual audit PDF

### DIFF
--- a/content-marketing/7-questions-corporate-english-vendor-social.md
+++ b/content-marketing/7-questions-corporate-english-vendor-social.md
@@ -9,20 +9,20 @@
 
 You're sitting on three corporate English training proposals. They all look reasonable — polished decks, comparable pricing, glossy case studies featuring brands you recognize. There's no obvious basis for choice.
 
-After years of watching Mexican companies invest in corporate English training only to receive certificates instead of performance, I wrote down the 7 questions that separate substance from polish.
+Most corporate English programs in Mexico don't fail because employees aren't trying. They fail because the program was never designed to produce business results. Employees attend sessions, finish the curriculum, get a certificate, and the budget is approved for next year — because no one measured anything that actually mattered.
 
-Asked sincerely, they surface a vendor's actual approach within 15 minutes. The answers reveal whether you're looking at a program designed to change how your team communicates, or a program designed to produce something measurable in an L&D report.
+For companies with international teams or global clients, English isn't a soft skill. It's operational infrastructure.
 
-A few of them:
+I wrote down the 7 questions that separate substance from polish. Asked sincerely, they surface a vendor's actual approach within 15 minutes. A few of them:
 
-→ "What does success actually look like for our team — and how will we measure it?"
-   Vendors who answer "improved fluency" or "higher CEFR scores" are telling you that they think in completion metrics, not behavior change.
+→ "Is the program built for our team, or is it generic?"
+   The diagnostic that cuts through every polished proposal: *"How would you structure sessions differently for a developer versus a director?"* If the answer is the same for every role, the program is generic.
 
-→ "What's the actual professional background of the coach assigned to my team — and will the same coach work with us throughout the program?"
-   Many providers in Mexico operate on a staffing-agency model. Sales closes the deal; rotating contract teachers deliver the work. That model produces inconsistent results.
+→ "Does the instructor understand business, not just language?"
+   There's a meaningful difference between a certified language teacher and a business communication coach. Knowing how to explain the past perfect tense doesn't qualify someone to coach a CFO through a supplier negotiation.
 
-→ "What's your policy on participants who attend sessions but don't engage outside of them?"
-   The question vendors expect least and that reveals the most. Most programs have no policy at all — and that's the answer.
+→ "Does the program use real work, or simulated exercises?"
+   The single biggest predictor of whether English training transfers to job performance is whether sessions use the participant's actual emails, presentations, and meeting recordings.
 
 The full breakdown of all 7 questions, with concrete "right answer / wrong answer" examples, is in the post:
 
@@ -37,34 +37,35 @@ If you're evaluating proposals right now, this is the framework I wish every HR 
 ## Twitter/X Thread
 
 **Tweet 1 (Hook):**
-Most corporate English training in Mexico is sold to HR managers using the same playbook.
+Most corporate English programs in Mexico don't fail because employees aren't trying.
 
-Polished proposals. Comparable pricing. Identical underlying methodology.
+They fail because the program was never designed to produce business results.
 
 7 questions that surface a vendor's real approach in 15 minutes (thread):
 
 **Tweet 2:**
-Q1: "What does success actually look like for our team — and how will we measure it?"
+Q1: "Is the program built for our team, or is it generic?"
 
-Wrong answer: "Improved fluency."
-Right answer: "Tell me what your team needs to do in English that they currently can't — we'll work backwards from there."
+The diagnostic: *"How would you structure sessions differently for a developer versus a director?"*
+
+If the answer is the same for every role, the program is generic. Generic programs produce generic results.
 
 **Tweet 3:**
-Q4: "What's the actual professional background of the coach assigned to my team — and will the same coach work with us throughout the program?"
+Q5: "Does the instructor understand business, not just language?"
 
-Many providers run on a staffing-agency model. Sales closes the deal. Rotating contract teachers deliver the work.
+A certified language teacher has training in linguistics. A business communication coach has worked at a senior level in industry.
 
-That's why results vary.
+Knowing the past perfect tense doesn't qualify someone to coach a CFO.
 
 **Tweet 4:**
-Q7: "What's your policy on participants who attend but don't engage outside sessions?"
+Q6: "Does the program use real work, or simulated exercises?"
 
-The question vendors expect least.
+Generic programs use textbook case studies. Real programs use the participant's actual emails, presentations, and meeting recordings.
 
-Most programs have no policy at all — they want retention, not results. They'd rather keep an unengaged seat filled for the full contract than have an honest conversation.
+The first improves classroom skills. The second improves on-the-job skills.
 
 **Tweet 5 (CTA):**
-The other 4 questions, plus warning signs to watch for in vendor proposals, are in the full post:
+The other 4 questions, plus the efficiency-vs-effectiveness red-flag matrix, are in the full post:
 
 https://www.nyenglishteacher.com/en/blog/7-questions-corporate-english-vendor/
 
@@ -78,7 +79,9 @@ If you're evaluating proposals right now, this is the framework to use.
 
 If you're an HR manager or L&D director evaluating corporate English training proposals in Mexico, this one's for you.
 
-I just published the 7 questions that separate real performance programs from glossy proposals — questions like "what does success actually look like for our team" and "will the same coach be there in week 1, week 6, and week 12, or are you sending whoever is available?" Asked in a vendor call, they surface a provider's real methodology within 15 minutes.
+For companies with international teams or global clients, English isn't a soft skill — it's operational infrastructure. Unclear communication delays decisions, damages client relationships, and quietly closes off opportunities. The right training investment produces visible results within months. The wrong investment produces completed attendance records and nothing else.
+
+I just published the 7 questions that separate real performance programs from glossy proposals — questions like *"How would you structure sessions differently for a developer versus a director?"* and *"Will sessions use my team's actual emails and presentations, or are you working from a standard curriculum?"* Asked in a vendor call, they surface a provider's real methodology within 15 minutes.
 
 If a vendor can't answer them comfortably, that's information.
 

--- a/src/content/blog/en/7-questions-corporate-english-vendor.md
+++ b/src/content/blog/en/7-questions-corporate-english-vendor.md
@@ -24,53 +24,57 @@ They all look reasonable. Polished decks. Comparable pricing. Glossy case studie
 
 And yet, something feels off. Maybe you've been here before — invested in training that produced certificates but no real performance change. Maybe a peer at another company recently mentioned that their last vendor relationship ended in quiet disappointment. Maybe you're just experienced enough to know that polished proposals don't always translate into results.
 
-The truth is that most corporate English training in Mexico is sold to HR managers using the same playbook: assessment, curriculum, weekly sessions, completion certificates. The differences between vendors are often surface-level — branding, packaging, salesperson polish — while the underlying methodology is nearly identical, and nearly identically generic.
+Most corporate English programs in Mexico don't fail because employees aren't trying. They fail because the program was never designed to produce business results. That's the illusion: employees attend sessions, finish the curriculum, get a certificate, and the budget is approved for next year — because no one measured anything that actually mattered. The reality, on the manager's side, is unchanged behavior in the meetings, calls, and written exchanges that the training was supposed to fix.
 
-The seven questions below cut through that. Asked sincerely, they'll surface a vendor's actual approach within fifteen minutes of conversation. The answers reveal whether you're looking at a program designed to change how your team communicates, or a program designed to produce something measurable in an L&D report.
+For companies with international teams or global clients, English is not a soft skill. It's operational infrastructure. Unclear communication delays decisions, damages client relationships, drives rework, and quietly closes off opportunities. The right investment produces visible results within months. The wrong investment produces completed attendance records and nothing else.
 
-If a vendor can't answer these comfortably, that's the answer.
-
----
-
-## 1. What does success actually look like for our team — and how will we measure it?
-
-This is the question that frames everything else.
-
-A real corporate English program defines success in terms of behavior change. Specific situations your team will handle differently after the program. Specific frameworks they'll deploy. Specific moments where the bottleneck of "my English isn't good enough" will no longer apply.
-
-Vendors who can't answer this question — or who answer it with "improved fluency" or "higher CEFR scores" — are telling you that they don't think in terms of performance. They think in terms of completion metrics. The certificate is the deliverable. Your team's actual ability to lead a US client call without rehearsing every sentence is incidental.
-
-Listen carefully to how a vendor responds. The right answer sounds like: *"Tell me what your management team needs to do in English that they currently can't do well — and we'll work backwards from there. Your success metrics should be tied to those specific situations."*
-
-The wrong answer sounds like: *"We have a comprehensive assessment system that tracks progress across multiple linguistic competencies."*
+The seven questions below are the structured way to tell which one you're being sold. Asked sincerely, they surface a vendor's actual approach within fifteen minutes of conversation. If a vendor can't answer them comfortably, that's the answer.
 
 ---
 
-## 2. What does a typical session actually look like — performance simulation, conversation practice, or grammar instruction?
+## 1. Is the program built for your team, or is it generic?
 
-The honest answer to this question separates real coaching from glorified tutoring.
+"Business English" is a category, not a program.
 
-Generic programs run sessions that look like classes: vocabulary drills, grammar review, structured exercises from a textbook or app. Conversation practice happens, but it's loosely structured — talk about your weekend, describe your job, discuss this article.
+A real corporate English program treats your team as a set of distinct roles with distinct communication needs. A software engineer's job is to write clear technical documentation, navigate asynchronous discussions, and explain technical issues in live conversations — system errors and delayed sprints are the cost of failure. A sales director's job is to lead high-stakes client calls and deliver persuasive presentations — lost revenue and damaged trust are the cost of failure.
 
-Real corporate English coaching looks different. Sessions are built around performance simulation: rehearsing the actual scenarios your team will face. Mock executive presentations. Role-played client calls. Live practice of objection handling. Real materials from your team's actual work — emails they need to send, decks they need to deliver, meetings they need to lead.
+Those are not the same skill set. The communication gaps are different. The risk profile is different. The training that closes those gaps cannot be the same content delivered with a different cover sheet.
 
-If a vendor describes their sessions in textbook-curriculum terms, that's what your team will get. If a vendor describes their sessions in performance-rehearsal terms, you're looking at something different.
+The diagnostic question is direct: *"How would you structure sessions differently for a developer versus a director?"*
 
-Either approach can be valuable. But you should know which one you're buying — and whether it matches what your team actually needs.
+If the provider gives the same answer for every role — same materials, same exercises, same approach with surface-level adjustments — the program is generic. Generic programs produce generic results.
+
+What you should hear instead is something specific: that the developer's sessions will lean toward technical-discussion practice, asynchronous-text clarity, and explaining-without-jargon drills, while the director's sessions will lean toward live-pressure simulation, persuasive structure, and recovery-from-objection rehearsal. If a vendor can't explain that difference in detail, they don't have it.
 
 ---
 
-## 3. How is the content personalized to each participant's role, industry, and actual communication gaps?
+## 2. How does the program measure progress?
 
-Every vendor will say their content is personalized.
+The trap is grammar test scores.
 
-The right follow-up question is: *show me what that means in practice.*
+The trap works because tests are easy to administer, easy to score, easy to put in an L&D report. They produce numbers that go up. They give the impression of progress. And they have almost nothing to do with whether your team can actually function in English when it counts.
 
-Generic personalization looks like a placement test that sorts participants into A1, A2, B1, B2, C1 levels — and then assigns each level a different version of the same standardized curriculum. That's not personalization. That's stratification.
+The standard is demonstrated business outcomes — specific capabilities tied to real situations, documented before the program starts and re-evaluated when it ends. Not "Lucia's CEFR level improved from B2 to B2+." Instead: *"By week 8, this manager can lead a client call independently."* *"This engineer can explain technical issues live without needing follow-up clarification."* *"This director can present quarterly results without preparation anxiety."*
 
-Real personalization looks like this: each participant has a customized communication profile based on their role, the audiences they communicate with, and the specific situations where their English breaks down. The materials in their sessions are drawn from their actual work — their emails, their decks, their negotiation scripts. Their coaching addresses their specific weaknesses, not a generic curriculum's idea of where someone at their level should improve next.
+These are the kinds of statements an HR sponsor can read, immediately understand, and present to a CFO.
 
-If a vendor's "personalized program" looks identical for your CFO and your Operations Manager, the personalization is cosmetic.
+If a vendor's measurement system produces level-jump claims and percentage-improvement charts but no documented before-and-after of actual job performance, you have nothing to show for the spend when the program ends.
+
+---
+
+## 3. How long until we see results in real business situations?
+
+A serious vendor can describe what changes happen when, and what method produces those changes.
+
+The shape of a real corporate English program looks roughly like this. **Weeks 1 through 4: cleaner communication.** Reduced daily misunderstandings. Confident participation in meetings that participants previously stayed quiet in. **Weeks 5 through 8: more structured responses.** Reduced hesitation. Greater control in discussions, especially when responding to unexpected questions. **Weeks 8 through 12 and beyond: leading conversations.** Handling pressure effectively. Speaking with the kind of clarity that signals authority rather than effort.
+
+That timeline assumes consistent work — both inside and outside sessions — and a structured methodology that targets each phase deliberately. It is not a guarantee. It is a benchmark for what good looks like.
+
+Be cautious of programs that promise faster results without explaining the method. Higher-level communication outcomes — executive presence, negotiation under pressure, persuasive presentation — require two to four months of focused work. Anyone selling those outcomes in four weeks is selling something else: hope, packaging, or a different (lower) definition of "result."
+
+The right answer to this question sounds like: *"Here's what your team will be able to do at week 4, week 8, and week 12 — and here's the work, in and outside sessions, that produces those changes."*
+
+The wrong answer sounds like: *"Every learner is different, but most see significant improvement throughout the program."*
 
 <aside class="not-prose my-12 rounded-xl border border-blue-100 bg-blue-50 p-6 sm:p-8">
   <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -84,65 +88,66 @@ If a vendor's "personalized program" looks identical for your CFO and your Opera
 
 ---
 
-## 4. What's the actual professional background of the coach assigned to my team — and will the same coach work with us throughout the program?
+## 4. What is the instruction format, and why does it matter?
 
-This question reveals more about a vendor than almost any other.
+There are three formats. Each has a different use.
 
-Many providers in Mexico operate on a staffing-agency model: a sales team closes the contract, and then the actual instruction is delivered by a roster of contract teachers who may or may not have business experience, who may or may not be the person who showed up to the sales call, and who may rotate in and out depending on availability.
+**Large group classes** move at the pace of the group. A C1 participant in a B1 class spends most of their session waiting; a B1 participant in a C1 class spends most of their session lost. Large groups cannot address individual weaknesses, and they almost always default to the lowest common denominator.
 
-That model produces inconsistent results. The person teaching your CFO supplier negotiations should understand supplier negotiations. The person coaching your Operations Director on cross-border meetings should have real experience in cross-border meetings. Native English fluency and a TEFL certificate are necessary but nowhere near sufficient for executive-level coaching.
+**Small groups of three or four** are effective when the peers share the same role, the same gaps, and the same need for interactive practice. Four operations managers all preparing for cross-border quarterly reviews will accelerate together — they're rehearsing the same scenarios, hearing each other's mistakes, absorbing each other's improvements. The same group composed of a CFO, an HR director, a developer, and a sales lead will not.
 
-Ask: who specifically will work with my team? What's their professional background outside of English teaching? Have they ever worked at a senior level in industry? Will the same person be there in week 1, week 6, and week 12?
+**One-on-one instruction** is the fastest path to improvement for your highest-priority roles. There's no group pace to match, no peer composition to manage. Every minute is targeted at the participant's specific gaps.
 
-If the answers are vague, you're being sold a brand, not a coach.
+The diagnostic question is: *"How do you determine the format for each employee?"*
 
----
+A provider that offers only one format isn't personalizing the program — they're simplifying their own operations. The right answer accounts for the participant's role, the urgency, the budget, and whether their development needs interactive peer work or focused individual coaching.
 
-## 5. Is there a group component, or is all training done individually in isolation?
-
-Most corporate English programs are delivered one-on-one or in small groups of similar level. That has its place — individual instruction is where the deepest skill-building happens.
-
-But there's a category of professional moment that individual coaching alone cannot prepare for: speaking English in front of peers, leadership, or clients, where the social and performance pressure is real.
-
-Many fluent professionals freeze in group settings even when they're confident in 1:1 conversation. The fear of being judged by colleagues is its own performance challenge — separate from the language itself. Programs that never expose participants to that condition produce graduates who pass tests but freeze in meetings.
-
-Ask whether the program includes monthly or quarterly group simulations — board presentation rehearsals, cross-functional negotiations, mock client calls with team members playing skeptical observers. If everything is individual and remote, your team will improve in isolation but not necessarily in the conditions that actually matter.
+One additional point: even programs that deliver primarily one-on-one instruction benefit from periodic group simulations — board presentation rehearsals, cross-functional negotiations — because there's a category of professional moment that one-on-one alone cannot prepare for. Speaking under social pressure, in front of peers or leadership, is a separate skill from speaking with a coach.
 
 ---
 
-## 6. How do you measure progress — is there a documented baseline assessment and a documented final deliverable?
+## 5. Does the instructor understand business, not just language?
 
-"Trust us, your team is improving" isn't a valid program output for an HR manager who has to defend the spend internally.
+There's a meaningful difference between a certified language teacher and a business communication coach.
 
-A serious program produces two artifacts. First, a baseline assessment — not a placement test that produces a CEFR level, but a documented evaluation of each participant's specific communication strengths and gaps relative to their actual job. Second, a final deliverable — a documented assessment at the end of the program comparing where each participant started to where they finished, with concrete examples of behavior change.
+A certified language teacher has training in linguistics and teaching methods. That's necessary, but it doesn't carry your team's communication into actual business situations. Knowing how to explain the past perfect tense doesn't qualify someone to coach a CFO through a supplier negotiation.
 
-These artifacts should be specific enough that you, as the HR sponsor, can read them and immediately understand what the program produced. Not *"advanced fluency improvement of 1.2 levels,"* but *"Lucia can now lead her quarterly review with US headquarters without preparing scripts in advance — a behavior we documented her struggling with during the baseline assessment."*
+A business communication coach combines strong teaching skills with direct experience in professional contexts. They've worked at a senior level in industry. They know what's at stake when a message is unclear at the wrong moment. They can listen to your operations director rehearse a quarterly review and, alongside any English correction, immediately identify where the structure of the argument is going to lose the room.
 
-If a vendor's measurement system produces vague language and no documented before-and-after, you have nothing to show your CFO when the program ends.
+The diagnostic question is: *"What's the instructor's professional background outside the classroom? Have they coached the specific type of professional our team needs?"*
 
----
-
-## 7. What's your policy on participants who attend sessions but don't engage outside of them?
-
-This is the question that vendors expect least and that reveals the most.
-
-Real adult language acquisition requires effort outside of sessions. Watching content in English. Reading in English. Practicing in real situations. One or two hours of weekly coaching is not enough on its own — it directs the work, but the work has to happen.
-
-Most programs have no policy at all. Participants attend, complete enough exercises to earn a certificate, and the program produces certificates regardless of whether anyone actually changed their behavior. The vendor gets paid. HR gets a clean L&D report. Nothing changes.
-
-A serious program has accountability built into the structure. Pre-session preparation that the coach reviews. Between-session work the coach references. A clear conversation early in the program that addresses what happens if a participant repeatedly attends but doesn't engage — including the option to pause their participation and reallocate the seat to someone who will use it.
-
-Vendors who don't have an answer to this are signaling that they're optimized for retention, not results. They'd rather keep an unengaged participant in the program for the full contract than have an honest conversation about what's not working.
+If the answer is vague, or if the instructor is generic ("an experienced ESL professional with native fluency"), you're being sold a teacher. For executive coaching, that's not enough. Your team's coach should be someone whose own résumé, in any language, would be credible to your team.
 
 ---
 
-## A note on warning signs
+## 6. Does the program use real work, or simulated exercises?
 
-The questions above will reveal a lot. So will *how* a vendor responds to them.
+The single biggest predictor of whether English training transfers to job performance is whether sessions use the participant's actual work materials.
 
-The vendors who have a real methodology will answer specifically and confidently. They've thought about these questions before. They'll likely have asked you a few of their own — about your team, your industry, your specific situations — by the end of the conversation.
+Generic programs use fictional business situations: textbook case studies, standardized exercises, made-up companies in made-up industries. Improvements happen in the classroom. Then participants leave the classroom and discover that their improvements don't transfer at speed or depth — because the gap between the simulated material and their real work is exactly where their breakdown happens.
 
-The vendors who don't have a real methodology will respond with marketing language. *"We follow industry best practices."* *"Our methodology is based on the latest pedagogical research."* *"Our coaches are highly qualified professionals with extensive international experience."* This kind of language is its own warning sign — it sounds substantive, but it answers nothing concrete.
+Real-work programs use the participant's actual materials. The email they need to send tomorrow. The presentation they're preparing for next month's board meeting. The client scenario that fell apart last week. The negotiation transcript they want to redo. Improvements made on this material transfer immediately, because the material *is* the job.
+
+The diagnostic question is: *"Will sessions use my team's actual emails, presentations, and meeting recordings — or are you working from a standard curriculum?"*
+
+If the answer is anything other than yes — if there's any version of "we have an extensive library of business scenarios that closely mirror real work" — you're getting classroom improvement, not on-the-job improvement.
+
+---
+
+## 7. What does success look like, and who is responsible?
+
+A real program operates on a three-way accountability structure.
+
+**The learner** practices consistently and applies corrections in real conversations. Without that, no methodology works. **The instructor** diagnoses gaps, provides real-time correction under pressure, and adjusts the trajectory based on what's working. **The organization** prioritizes training time, aligns the development with actual job demands, and treats the program as an investment rather than a benefit.
+
+Success is measured along three dimensions. **Execution quality**: clarity, structure, faster response time. **Risk reduction**: fewer misunderstandings, faster decision cycles, fewer mis-routed conversations through a single bilingual bottleneck person. **Support reduction**: less prompting from peers, fewer corrections, more autonomous handling of high-stakes situations.
+
+Underneath all three is a single, simpler measurement: the curve from dependency to autonomy. Participants come in needing support — help finding words, external correction, time to organize thoughts. They leave handling conversations independently and at speed.
+
+Before: *"I think maybe the issue is... something with the system."*
+After: *"The issue is in the integration layer."*
+
+That's not a CEFR jump. It's a person who can now do their job in English. Programs that deliver real outcomes can articulate exactly who is responsible for what, and exactly how progress will be visible at every stage. Programs that frame success in any other terms — completion percentages, satisfaction scores, level-jump certificates — don't have the accountability structure to produce that change.
 
 <aside class="not-prose my-12 rounded-xl border border-blue-100 bg-blue-50 p-6 sm:p-8">
   <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -153,6 +158,28 @@ The vendors who don't have a real methodology will respond with marketing langua
     <a href="/en/for-hr-managers/?utm_source=blog&utm_medium=callout&utm_campaign=audit&utm_content=7-questions-end#download-the-guide" class="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white no-underline shadow-sm transition hover:bg-blue-700">Download the audit <span aria-hidden="true">→</span></a>
   </div>
 </aside>
+
+---
+
+## Efficiency vs. effectiveness — the final filter
+
+If you're still unsure after asking the seven questions, hold each proposal up against this binary.
+
+**Signs of an efficiency-driven program** (warning signs):
+
+- "All levels welcome" with no role segmentation
+- No baseline assessment tied to real job demands
+- Price is the primary differentiator
+- Fixed, generic curriculum regardless of industry
+
+**Signs of an outcome-driven program**:
+
+- Custom-built content based on level, role, and professional goals
+- Progress tracked via execution quality, not just language proficiency
+- Format and intensity adjust dynamically as the learner develops
+- Performance measured under real business conditions
+
+Efficiency-driven programs optimize for the vendor's operating costs. Outcome-driven programs optimize for your team's results. They cost more. They're worth more. And they're rarer than the proposals on your desk would suggest.
 
 ---
 

--- a/src/content/blog/es/7-preguntas-proveedor-ingles-corporativo.md
+++ b/src/content/blog/es/7-preguntas-proveedor-ingles-corporativo.md
@@ -24,53 +24,57 @@ Todas se ven razonables. Presentaciones pulidas. Precios comparables. Estudios d
 
 Y aun así, algo no termina de cuadrar. Quizás ya has estado aquí antes — invertiste en capacitación que produjo certificados pero ningún cambio real en el desempeño. Quizás un colega de otra empresa te mencionó recientemente que su última relación con un proveedor terminó en decepción silenciosa. Quizás simplemente tienes la experiencia suficiente para saber que las propuestas pulidas no siempre se traducen en resultados.
 
-La verdad es que la mayoría de la capacitación de inglés corporativo en México se vende a gerentes de RH usando el mismo manual: evaluación, currículo, sesiones semanales, certificados de finalización. Las diferencias entre proveedores suelen ser superficiales — marca, empaque, pulido del vendedor — mientras que la metodología subyacente es casi idéntica, y casi idénticamente genérica.
+La mayoría de los programas de inglés corporativo en México no fracasan porque los empleados no se esfuercen. Fracasan porque el programa nunca fue diseñado para producir resultados de negocio. Esa es la ilusión: los empleados asisten a las sesiones, terminan el currículo, reciben un certificado, y se aprueba el presupuesto para el próximo año — porque nadie midió nada que realmente importara. La realidad, del lado del gerente, es comportamiento sin cambios en las reuniones, llamadas e intercambios escritos que la capacitación supuestamente iba a arreglar.
 
-Las siete preguntas que siguen atraviesan eso. Hechas con sinceridad, revelan el enfoque real de un proveedor en quince minutos de conversación. Las respuestas muestran si estás viendo un programa diseñado para cambiar cómo se comunica tu equipo, o un programa diseñado para producir algo medible en un reporte de L&D.
+Para empresas con equipos internacionales o clientes globales, el inglés no es una habilidad blanda. Es infraestructura operativa. La comunicación poco clara retrasa decisiones, daña relaciones con clientes, genera retrabajo y silenciosamente cierra oportunidades. La inversión correcta produce resultados visibles en meses. La inversión equivocada produce registros de asistencia completos y nada más.
 
-Si un proveedor no puede responderlas con comodidad, esa es la respuesta.
-
----
-
-## 1. ¿Cómo se ve realmente el éxito para nuestro equipo — y cómo lo mediremos?
-
-Esta es la pregunta que enmarca todo lo demás.
-
-Un programa real de inglés corporativo define el éxito en términos de cambio de comportamiento. Situaciones específicas que tu equipo manejará de manera diferente después del programa. Marcos específicos que utilizarán. Momentos específicos donde el cuello de botella de "mi inglés no es suficiente" ya no aplicará.
-
-Los proveedores que no pueden responder esta pregunta — o que la responden con "fluidez mejorada" o "calificaciones más altas en CEFR" — te están diciendo que no piensan en términos de desempeño. Piensan en términos de métricas de finalización. El certificado es el entregable. La capacidad real de tu equipo para liderar una llamada con un cliente estadounidense sin ensayar cada frase es incidental.
-
-Escucha cuidadosamente cómo responde un proveedor. La respuesta correcta suena así: *"Cuéntame qué necesita hacer tu equipo directivo en inglés que actualmente no puede hacer bien — y trabajaremos hacia atrás desde ahí. Tus métricas de éxito deberían estar atadas a esas situaciones específicas."*
-
-La respuesta equivocada suena así: *"Tenemos un sistema integral de evaluación que rastrea el progreso a través de múltiples competencias lingüísticas."*
+Las siete preguntas que siguen son la manera estructurada de saber cuál te están vendiendo. Hechas con sinceridad, revelan el enfoque real de un proveedor en quince minutos de conversación. Si un proveedor no puede responderlas con comodidad, esa es la respuesta.
 
 ---
 
-## 2. ¿Cómo se ve realmente una sesión típica — simulación de desempeño, práctica de conversación o instrucción de gramática?
+## 1. ¿El programa está construido para tu equipo, o es genérico?
 
-La respuesta honesta a esta pregunta separa el coaching real de las clases particulares con barniz corporativo.
+"Inglés de negocios" es una categoría, no un programa.
 
-Los programas genéricos corren sesiones que parecen clases: ejercicios de vocabulario, repaso de gramática, ejercicios estructurados de un libro de texto o una aplicación. La práctica de conversación ocurre, pero está poco estructurada — habla de tu fin de semana, describe tu trabajo, comenta este artículo.
+Un programa real de inglés corporativo trata a tu equipo como un conjunto de roles distintos con necesidades de comunicación distintas. El trabajo de un ingeniero de software es escribir documentación técnica clara, navegar discusiones asíncronas, y explicar problemas técnicos en conversaciones en vivo — los errores de sistema y los sprints retrasados son el costo del fracaso. El trabajo de un director de ventas es liderar llamadas con clientes de alto riesgo y entregar presentaciones persuasivas — los ingresos perdidos y la confianza dañada son el costo del fracaso.
 
-El coaching real de inglés corporativo se ve diferente. Las sesiones están construidas alrededor de la simulación de desempeño: ensayando los escenarios reales que tu equipo enfrentará. Presentaciones ejecutivas simuladas. Llamadas con clientes en formato de juego de roles. Práctica en vivo de manejo de objeciones. Materiales reales del trabajo real de tu equipo — correos que necesitan enviar, presentaciones que necesitan entregar, reuniones que necesitan liderar.
+Eso no es el mismo conjunto de habilidades. Las brechas de comunicación son diferentes. El perfil de riesgo es diferente. La capacitación que cierra esas brechas no puede ser el mismo contenido entregado con una portada diferente.
 
-Si un proveedor describe sus sesiones en términos de currículo de libro de texto, eso es lo que tu equipo recibirá. Si un proveedor describe sus sesiones en términos de ensayo de desempeño, estás viendo algo diferente.
+La pregunta diagnóstica es directa: *"¿Cómo estructurarían sesiones diferentes para un desarrollador versus un director?"*
 
-Cualquiera de los dos enfoques puede ser valioso. Pero deberías saber cuál estás comprando — y si coincide con lo que tu equipo realmente necesita.
+Si el proveedor da la misma respuesta para cada rol — los mismos materiales, los mismos ejercicios, el mismo enfoque con ajustes superficiales — el programa es genérico. Los programas genéricos producen resultados genéricos.
+
+Lo que deberías escuchar en cambio es algo específico: que las sesiones del desarrollador se inclinarán hacia la práctica de discusión técnica, claridad en texto asíncrono, y ejercicios de explicar-sin-jerga, mientras que las sesiones del director se inclinarán hacia la simulación bajo presión en vivo, estructura persuasiva y ensayo de recuperación-tras-objeciones. Si un proveedor no puede explicar esa diferencia en detalle, no la tiene.
 
 ---
 
-## 3. ¿Cómo se personaliza el contenido al rol, industria y brechas de comunicación reales de cada participante?
+## 2. ¿Cómo mide el progreso el programa?
 
-Cada proveedor dirá que su contenido es personalizado.
+La trampa son las calificaciones de exámenes de gramática.
 
-La pregunta de seguimiento correcta es: *muéstrame qué significa eso en la práctica.*
+La trampa funciona porque los exámenes son fáciles de administrar, fáciles de calificar, fáciles de meter en un reporte de L&D. Producen números que suben. Dan la impresión de progreso. Y tienen casi nada que ver con si tu equipo realmente puede funcionar en inglés cuando importa.
 
-La personalización genérica se ve así: una prueba de ubicación que clasifica a los participantes en niveles A1, A2, B1, B2, C1 — y luego asigna a cada nivel una versión diferente del mismo currículo estandarizado. Eso no es personalización. Eso es estratificación.
+El estándar son los resultados de negocio demostrados — capacidades específicas atadas a situaciones reales, documentadas antes de que comience el programa y re-evaluadas cuando termina. No "el nivel CEFR de Lucía mejoró de B2 a B2+." Sino: *"Para la semana 8, este gerente puede liderar una llamada con un cliente de manera independiente."* *"Este ingeniero puede explicar problemas técnicos en vivo sin necesitar aclaración de seguimiento."* *"Esta directora puede presentar resultados trimestrales sin ansiedad de preparación."*
 
-La personalización real se ve así: cada participante tiene un perfil de comunicación personalizado basado en su rol, las audiencias con las que se comunica y las situaciones específicas donde su inglés se quiebra. Los materiales en sus sesiones provienen de su trabajo real — sus correos, sus presentaciones, sus guiones de negociación. Su coaching aborda sus debilidades específicas, no la idea de un currículo genérico sobre dónde alguien de su nivel debería mejorar a continuación.
+Estos son el tipo de afirmaciones que un patrocinador de RH puede leer, entender de inmediato y presentarle a un CFO.
 
-Si el "programa personalizado" de un proveedor se ve idéntico para tu CFO y para tu Gerente de Operaciones, la personalización es cosmética.
+Si el sistema de medición de un proveedor produce afirmaciones de salto de nivel y gráficas de mejora porcentual pero ningún antes-y-después documentado del desempeño real en el trabajo, no tienes nada que mostrar por el gasto cuando el programa termine.
+
+---
+
+## 3. ¿Cuánto tiempo hasta ver resultados en situaciones de negocio reales?
+
+Un proveedor serio puede describir qué cambios ocurren cuándo, y qué método produce esos cambios.
+
+La forma de un programa real de inglés corporativo se ve más o menos así. **Semanas 1 a 4: comunicación más clara.** Reducción de malentendidos diarios. Participación confiada en reuniones donde antes los participantes se quedaban callados. **Semanas 5 a 8: respuestas más estructuradas.** Reducción de la duda. Mayor control en las discusiones, especialmente al responder preguntas inesperadas. **Semanas 8 a 12 y más allá: liderar conversaciones.** Manejar la presión de manera efectiva. Hablar con el tipo de claridad que señala autoridad en lugar de esfuerzo.
+
+Ese cronograma asume trabajo consistente — dentro y fuera de las sesiones — y una metodología estructurada que apunta deliberadamente a cada fase. No es una garantía. Es un punto de referencia de cómo se ve lo bueno.
+
+Ten cuidado con los programas que prometen resultados más rápidos sin explicar el método. Los resultados de comunicación de nivel más alto — presencia ejecutiva, negociación bajo presión, presentación persuasiva — requieren de dos a cuatro meses de trabajo enfocado. Cualquiera que venda esos resultados en cuatro semanas está vendiendo otra cosa: esperanza, empaque o una definición diferente (más baja) de "resultado."
+
+La respuesta correcta a esta pregunta suena así: *"Esto es lo que tu equipo será capaz de hacer en la semana 4, la semana 8 y la semana 12 — y este es el trabajo, dentro y fuera de las sesiones, que produce esos cambios."*
+
+La respuesta equivocada suena así: *"Cada aprendiz es diferente, pero la mayoría ve mejora significativa a lo largo del programa."*
 
 <aside class="not-prose my-12 rounded-xl border border-blue-100 bg-blue-50 p-6 sm:p-8">
   <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -84,65 +88,66 @@ Si el "programa personalizado" de un proveedor se ve idéntico para tu CFO y par
 
 ---
 
-## 4. ¿Cuál es el trasfondo profesional real del coach asignado a mi equipo — y será el mismo coach el que trabaje con nosotros durante todo el programa?
+## 4. ¿Cuál es el formato de instrucción, y por qué importa?
 
-Esta pregunta revela más sobre un proveedor que casi cualquier otra.
+Hay tres formatos. Cada uno tiene un uso diferente.
 
-Muchos proveedores en México operan bajo un modelo de agencia de personal: un equipo de ventas cierra el contrato, y luego la instrucción real es entregada por una nómina de maestros contratados que pueden o no tener experiencia empresarial, que pueden o no ser la persona que se presentó a la llamada de ventas, y que pueden rotar dentro y fuera dependiendo de la disponibilidad.
+**Las clases en grupos grandes** se mueven al ritmo del grupo. Un participante C1 en una clase B1 pasa la mayor parte de su sesión esperando; un participante B1 en una clase C1 pasa la mayor parte de su sesión perdido. Los grupos grandes no pueden abordar debilidades individuales, y casi siempre se ajustan al mínimo común denominador.
 
-Ese modelo produce resultados inconsistentes. La persona que enseña a tu CFO sobre negociaciones con proveedores debería entender de negociaciones con proveedores. La persona que entrena a tu Director de Operaciones en reuniones transfronterizas debería tener experiencia real en reuniones transfronterizas. La fluidez nativa en inglés y un certificado TEFL son necesarios pero están lejos de ser suficientes para coaching a nivel ejecutivo.
+**Los grupos pequeños de tres o cuatro** son efectivos cuando los pares comparten el mismo rol, las mismas brechas y la misma necesidad de práctica interactiva. Cuatro gerentes de operaciones todos preparándose para revisiones trimestrales transfronterizas acelerarán juntos — están ensayando los mismos escenarios, escuchando los errores de los demás, absorbiendo las mejoras de los demás. El mismo grupo compuesto por un CFO, una directora de RH, un desarrollador y un líder de ventas no lo hará.
 
-Pregunta: ¿quién específicamente trabajará con mi equipo? ¿Cuál es su trasfondo profesional fuera de la enseñanza de inglés? ¿Han trabajado alguna vez a nivel senior en la industria? ¿Estará la misma persona en la semana 1, la semana 6 y la semana 12?
+**La instrucción uno a uno** es el camino más rápido a la mejora para tus roles de mayor prioridad. No hay ritmo de grupo que igualar, no hay composición de pares que manejar. Cada minuto está dirigido a las brechas específicas del participante.
 
-Si las respuestas son vagas, te están vendiendo una marca, no un coach.
+La pregunta diagnóstica es: *"¿Cómo determinan el formato para cada empleado?"*
 
----
+Un proveedor que solo ofrece un formato no está personalizando el programa — está simplificando sus propias operaciones. La respuesta correcta toma en cuenta el rol del participante, la urgencia, el presupuesto, y si su desarrollo necesita trabajo interactivo con pares o coaching individual enfocado.
 
-## 5. ¿Hay un componente grupal, o toda la capacitación se hace individualmente en aislamiento?
-
-La mayoría de los programas de inglés corporativo se entregan uno a uno o en grupos pequeños del mismo nivel. Eso tiene su lugar — la instrucción individual es donde ocurre la construcción de habilidades más profunda.
-
-Pero hay una categoría de momento profesional para la que el coaching individual por sí solo no puede preparar: hablar inglés frente a colegas, liderazgo o clientes, donde la presión social y de desempeño es real.
-
-Muchos profesionales fluidos se paralizan en entornos grupales incluso cuando están seguros en conversación 1:1. El miedo a ser juzgado por colegas es su propio reto de desempeño — separado del idioma mismo. Los programas que nunca exponen a los participantes a esa condición producen graduados que pasan exámenes pero se paralizan en reuniones.
-
-Pregunta si el programa incluye simulaciones grupales mensuales o trimestrales — ensayos de presentaciones de junta, negociaciones interfuncionales, llamadas simuladas con clientes con miembros del equipo haciendo de observadores escépticos. Si todo es individual y remoto, tu equipo mejorará en aislamiento pero no necesariamente en las condiciones que realmente importan.
+Un punto adicional: incluso los programas que entregan principalmente instrucción uno a uno se benefician de simulaciones grupales periódicas — ensayos de presentaciones de junta, negociaciones interfuncionales — porque hay una categoría de momento profesional para la que el uno a uno por sí solo no puede preparar. Hablar bajo presión social, frente a colegas o liderazgo, es una habilidad separada de hablar con un coach.
 
 ---
 
-## 6. ¿Cómo miden el progreso — hay una evaluación de línea base documentada y un entregable final documentado?
+## 5. ¿Entiende el instructor de negocios, no solo de idiomas?
 
-"Confía en nosotros, tu equipo está mejorando" no es un resultado válido para un gerente de RH que tiene que defender el gasto internamente.
+Hay una diferencia significativa entre un maestro certificado de idiomas y un coach de comunicación de negocios.
 
-Un programa serio produce dos artefactos. Primero, una evaluación de línea base — no una prueba de ubicación que produce un nivel CEFR, sino una evaluación documentada de las fortalezas y brechas específicas de comunicación de cada participante en relación con su trabajo real. Segundo, un entregable final — una evaluación documentada al final del programa comparando dónde empezó cada participante con dónde terminó, con ejemplos concretos de cambio de comportamiento.
+Un maestro certificado de idiomas tiene formación en lingüística y métodos de enseñanza. Eso es necesario, pero no lleva la comunicación de tu equipo a situaciones de negocio reales. Saber explicar el pretérito perfecto no califica a alguien para entrenar a un CFO en una negociación con proveedores.
 
-Estos artefactos deberían ser lo suficientemente específicos como para que tú, como patrocinador de RH, puedas leerlos y entender inmediatamente lo que produjo el programa. No *"mejora de fluidez avanzada de 1.2 niveles,"* sino *"Lucía ahora puede liderar su revisión trimestral con la sede en Estados Unidos sin preparar guiones por adelantado — un comportamiento que documentamos que ella tenía dificultad durante la evaluación de línea base."*
+Un coach de comunicación de negocios combina habilidades sólidas de enseñanza con experiencia directa en contextos profesionales. Han trabajado a nivel senior en la industria. Saben qué está en juego cuando un mensaje no es claro en el momento equivocado. Pueden escuchar a tu director de operaciones ensayar una revisión trimestral y, junto con cualquier corrección de inglés, identificar de inmediato dónde la estructura del argumento va a perder a la sala.
 
-Si el sistema de medición de un proveedor produce lenguaje vago y ningún antes-y-después documentado, no tienes nada que mostrarle a tu CFO cuando termine el programa.
+La pregunta diagnóstica es: *"¿Cuál es el trasfondo profesional del instructor fuera del salón de clases? ¿Han entrenado al tipo específico de profesional que mi equipo necesita?"*
 
----
-
-## 7. ¿Cuál es su política con los participantes que asisten a las sesiones pero no se involucran fuera de ellas?
-
-Esta es la pregunta que los proveedores menos esperan y que más revela.
-
-La adquisición real de un segundo idioma en adultos requiere esfuerzo fuera de las sesiones. Ver contenido en inglés. Leer en inglés. Practicar en situaciones reales. Una o dos horas de coaching semanal no son suficientes por sí solas — dirigen el trabajo, pero el trabajo tiene que ocurrir.
-
-La mayoría de los programas no tienen política alguna. Los participantes asisten, completan ejercicios suficientes para ganar un certificado, y el programa produce certificados independientemente de si alguien realmente cambió su comportamiento. El proveedor cobra. RH obtiene un reporte de L&D limpio. Nada cambia.
-
-Un programa serio tiene la rendición de cuentas integrada en la estructura. Preparación previa a la sesión que el coach revisa. Trabajo entre sesiones al que el coach hace referencia. Una conversación clara temprano en el programa que aborde qué pasa si un participante asiste repetidamente pero no se involucra — incluyendo la opción de pausar su participación y reasignar el lugar a alguien que sí lo aprovechará.
-
-Los proveedores que no tienen una respuesta a esto están señalando que están optimizados para retención, no para resultados. Prefieren mantener a un participante no involucrado en el programa durante todo el contrato que tener una conversación honesta sobre lo que no está funcionando.
+Si la respuesta es vaga, o si el instructor es genérico ("un profesional ESL experimentado con fluidez nativa"), te están vendiendo un maestro. Para coaching ejecutivo, eso no es suficiente. El coach de tu equipo debería ser alguien cuyo propio currículum, en cualquier idioma, sería creíble para tu equipo.
 
 ---
 
-## Una nota sobre las señales de alerta
+## 6. ¿Usa el programa trabajo real, o ejercicios simulados?
 
-Las preguntas anteriores revelarán mucho. También lo hará *cómo* responde un proveedor a ellas.
+El predictor más grande de si la capacitación de inglés se transfiere al desempeño laboral es si las sesiones usan los materiales reales de trabajo del participante.
 
-Los proveedores que tienen una metodología real responderán específica y confiadamente. Han pensado en estas preguntas antes. Probablemente te habrán hecho algunas propias — sobre tu equipo, tu industria, tus situaciones específicas — para el final de la conversación.
+Los programas genéricos usan situaciones de negocio ficticias: estudios de caso de libro de texto, ejercicios estandarizados, empresas inventadas en industrias inventadas. Las mejoras ocurren en el salón de clases. Luego los participantes salen del salón y descubren que sus mejoras no se transfieren a velocidad o profundidad — porque la brecha entre el material simulado y su trabajo real es exactamente donde ocurre su quiebre.
 
-Los proveedores que no tienen una metodología real responderán con lenguaje de marketing. *"Seguimos las mejores prácticas de la industria."* *"Nuestra metodología está basada en la última investigación pedagógica."* *"Nuestros coaches son profesionales altamente calificados con amplia experiencia internacional."* Este tipo de lenguaje es su propia señal de alerta — suena sustantivo, pero no responde nada concreto.
+Los programas de trabajo real usan los materiales reales del participante. El correo que necesita enviar mañana. La presentación que está preparando para la junta del próximo mes. El escenario con el cliente que se desmoronó la semana pasada. La transcripción de negociación que quiere rehacer. Las mejoras hechas sobre este material se transfieren de inmediato, porque el material *es* el trabajo.
+
+La pregunta diagnóstica es: *"¿Las sesiones usarán los correos, presentaciones y grabaciones de reuniones reales de mi equipo — o están trabajando desde un currículo estándar?"*
+
+Si la respuesta es cualquier cosa que no sea sí — si hay alguna versión de "tenemos una biblioteca extensa de escenarios de negocio que se asemejan mucho al trabajo real" — estás obteniendo mejora de salón de clases, no mejora en el trabajo.
+
+---
+
+## 7. ¿Cómo se ve el éxito, y quién es responsable?
+
+Un programa real opera sobre una estructura de rendición de cuentas de tres vías.
+
+**El aprendiz** practica consistentemente y aplica las correcciones en conversaciones reales. Sin eso, ninguna metodología funciona. **El instructor** diagnostica brechas, proporciona corrección en tiempo real bajo presión, y ajusta la trayectoria con base en lo que está funcionando. **La organización** prioriza el tiempo de capacitación, alinea el desarrollo con las demandas reales del trabajo, y trata el programa como una inversión en lugar de un beneficio.
+
+El éxito se mide en tres dimensiones. **Calidad de ejecución**: claridad, estructura, tiempo de respuesta más rápido. **Reducción de riesgo**: menos malentendidos, ciclos de decisión más rápidos, menos conversaciones canalizadas a través de una sola persona bilingüe que es cuello de botella. **Reducción de soporte**: menos indicaciones de pares, menos correcciones, manejo más autónomo de situaciones de alto riesgo.
+
+Debajo de las tres hay una medición única, más simple: la curva de dependencia a autonomía. Los participantes llegan necesitando soporte — ayuda para encontrar palabras, corrección externa, tiempo para organizar pensamientos. Salen manejando conversaciones de manera independiente y a velocidad.
+
+Antes: *"Creo que tal vez el problema es... algo con el sistema."*
+Después: *"El problema está en la capa de integración."*
+
+Eso no es un salto de CEFR. Es una persona que ahora puede hacer su trabajo en inglés. Los programas que entregan resultados reales pueden articular exactamente quién es responsable de qué, y exactamente cómo el progreso será visible en cada etapa. Los programas que enmarcan el éxito en cualquier otro término — porcentajes de finalización, calificaciones de satisfacción, certificados de salto de nivel — no tienen la estructura de rendición de cuentas para producir ese cambio.
 
 <aside class="not-prose my-12 rounded-xl border border-blue-100 bg-blue-50 p-6 sm:p-8">
   <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -153,6 +158,28 @@ Los proveedores que no tienen una metodología real responderán con lenguaje de
     <a href="/es/para-rh/?utm_source=blog&utm_medium=callout&utm_campaign=audit&utm_content=7-preguntas-end#descargar-guia" class="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white no-underline shadow-sm transition hover:bg-blue-700">Descargar la guía <span aria-hidden="true">→</span></a>
   </div>
 </aside>
+
+---
+
+## Eficiencia vs. efectividad — el filtro final
+
+Si todavía tienes dudas después de hacer las siete preguntas, contrasta cada propuesta contra este binario.
+
+**Señales de un programa orientado a la eficiencia** (señales de alerta):
+
+- "Todos los niveles bienvenidos" sin segmentación por rol
+- Sin evaluación de línea base atada a las demandas reales del trabajo
+- El precio es el diferenciador principal
+- Currículo fijo y genérico independientemente de la industria
+
+**Señales de un programa orientado a resultados**:
+
+- Contenido construido a la medida con base en nivel, rol y objetivos profesionales
+- Progreso rastreado vía calidad de ejecución, no solo dominio del idioma
+- Formato e intensidad ajustados dinámicamente conforme el aprendiz se desarrolla
+- Desempeño medido bajo condiciones de negocio reales
+
+Los programas orientados a la eficiencia optimizan los costos de operación del proveedor. Los programas orientados a resultados optimizan los resultados de tu equipo. Cuestan más. Valen más. Y son más raros de lo que las propuestas en tu escritorio sugieren.
 
 ---
 


### PR DESCRIPTION
## Summary
Rewrites the body of the \`/blog/7-questions-corporate-english-vendor/\` post so the 7 H2 questions, their order, and their phrasing all match the actual Corporate English Training Audit PDF — so a reader who downloads the audit sees the same 7 questions they just read.

## What changed
**Question order now matches the PDF exactly:**
1. Is the program built for your team, or is it generic?
2. How does the program measure progress?
3. How long until we see results in real business situations?
4. What is the instruction format, and why does it matter?
5. Does the instructor understand business, not just language?
6. Does the program use real work, or simulated exercises?
7. What does success look like, and who is responsible?

**Framing concepts from the PDF that the post was missing:**
- "Operational infrastructure, not a soft skill"
- "Illusion of progress vs reality of impact" intro
- The dependency-to-autonomy curve in Q7 with the *\"I think maybe the issue is...\"* → *\"The issue is in the integration layer\"* before/after
- "Efficiency vs effectiveness" final-filter section

**Preserved:**
- Frontmatter unchanged (slug, URL, hreflang, featured image — full SEO continuity)
- Right-answer/wrong-answer structure (value the post adds beyond the PDF)
- Two audit-download callouts at the same insertion points

**Also updated:**
- ES translation rewritten to match
- \`content-marketing/7-questions-corporate-english-vendor-social.md\` updated to reference new question numbers + copy

## Test plan
- [x] \`npm run build\` clean
- [x] Sitemap validates 302 URLs
- [x] SEO description still 120-160 chars (EN: 159, ES: 146)
- [ ] Post-deploy: re-submit URLs to GSC/Bing/IndexNow

🤖 Generated with [Claude Code](https://claude.com/claude-code)