### PR TITLE
fix(seo): trim 27 meta descriptions to 120-160 chars + add build gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "astro dev",
     "start": "astro dev",
     "prebuild": "node scripts/prebuild.js",
-    "build": "npm run prebuild && cross-env NODE_OPTIONS=--max-old-space-size=7168 astro build && node scripts/pre-deploy/audits/sitemap-validator.js",
+    "build": "npm run prebuild && cross-env NODE_OPTIONS=--max-old-space-size=7168 astro build && node scripts/pre-deploy/audits/sitemap-validator.js && node scripts/pre-deploy/audits/meta-description-gate.mjs",
     "build:hostinger": "npm run prebuild && powershell -ExecutionPolicy Bypass -File ./scripts/build-for-hostinger.ps1",
     "build:check": "npm run prebuild && astro check && astro build",
     "preview": "astro preview",

--- a/scripts/pre-deploy/audits/meta-description-gate.mjs
+++ b/scripts/pre-deploy/audits/meta-description-gate.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DIST = path.resolve(__dirname, "../../../dist");
+const MIN = 120;
+const MAX = 160;
+
+const EXCLUDE_PREFIXES = [
+  "dev/docs/",
+  "en/chat-test/",
+];
+const EXCLUDE_FILES = new Set([
+  "index.html",
+]);
+
+const META_RE =
+  /<meta\s+[^>]*name=["']description["'][^>]*content=(?:"([^"]*)"|'([^']*)')[^>]*>/i;
+
+function walk(dir) {
+  const out = [];
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...walk(full));
+    else if (e.isFile() && e.name.endsWith(".html")) out.push(full);
+  }
+  return out;
+}
+
+if (!fs.existsSync(DIST)) {
+  console.error(`meta-description-gate: dist/ not found at ${DIST}`);
+  process.exit(1);
+}
+
+const files = walk(DIST);
+const tooLong = [];
+const tooShort = [];
+let checked = 0;
+let missing = 0;
+let excluded = 0;
+
+for (const file of files) {
+  const rel = path.relative(DIST, file).replace(/\\/g, "/");
+  if (EXCLUDE_FILES.has(rel) || EXCLUDE_PREFIXES.some((p) => rel.startsWith(p))) {
+    excluded++;
+    continue;
+  }
+  const html = fs.readFileSync(file, "utf8");
+  const m = html.match(META_RE);
+  if (!m) {
+    missing++;
+    continue;
+  }
+  const desc = (m[1] ?? m[2] ?? "").trim();
+  const len = desc.length;
+  checked++;
+  if (len > MAX) tooLong.push({ rel, len, desc });
+  else if (len < MIN) tooShort.push({ rel, len, desc });
+}
+
+console.log(
+  `meta-description-gate: ${checked} pages checked, ${tooShort.length} too short (warn), ${tooLong.length} too long (FAIL), ${missing} missing meta, ${excluded} excluded`,
+);
+
+if (tooShort.length > 0) {
+  console.warn(`\nWARN — ${tooShort.length} pages with description < ${MIN} chars (Ahrefs flags but not blocking):`);
+  for (const v of tooShort) {
+    console.warn(`  /${v.rel} (${v.len} chars) "${v.desc.slice(0, 80)}${v.desc.length > 80 ? "..." : ""}"`);
+  }
+}
+
+if (tooLong.length === 0) {
+  console.log(`\nPASS — no descriptions exceed ${MAX} chars`);
+  process.exit(0);
+}
+
+console.error(`\nFAIL — ${tooLong.length} descriptions exceed ${MAX} chars:\n`);
+for (const v of tooLong) {
+  console.error(`  /${v.rel} (${v.len} chars)`);
+  console.error(`    "${v.desc}"`);
+}
+console.error(`\nFix descriptions to be ${MIN}-${MAX} characters.`);
+process.exit(1);

--- a/src/data/free/60-second-self-introduction-template.json
+++ b/src/data/free/60-second-self-introduction-template.json
@@ -169,7 +169,7 @@
   "es": {
     "title": "La Plantilla de Auto-Presentación de 60 Segundos",
     "subtitle": "Una Fórmula para Completar que Crea Presentaciones que Abren Puertas",
-    "description": "Usa esta plantilla para crear una presentación profesional en inglés. Nunca más tropieces con 'cuéntame sobre ti'. Ideal para networking, entrevistas y reuniones.",
+    "description": "Usa esta plantilla para crear una presentación profesional en inglés. Nunca más tropieces con 'cuéntame sobre ti'. Ideal para networking y entrevistas.",
     "headline": "Preséntate Como un Ejecutivo Norteamericano",
     "valueProposition": "Crea una auto-presentación pulida y memorable en menos de 10 minutos usando nuestra fórmula probada de 4 partes. Incluye plantillas para completar para 5 escenarios comunes.",
     "leadCapture": {

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -20,7 +20,7 @@ const content = {
     en: {
         title: "404: Page Not Found",
         description:
-            "The page you were looking for doesn't exist or has been moved. Please check the URL or use the navigation menu to find what you need, or return to the homepage for more resources.",
+            "The page you were looking for doesn't exist or has been moved. Please use the navigation menu or return to the homepage to find what you need.",
         heading: "404",
         subheading: "Page Not Found",
         bodyText:

--- a/src/pages/en/course/beginners/unit-1.astro
+++ b/src/pages/en/course/beginners/unit-1.astro
@@ -47,7 +47,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
   lang={lang}
   tkey={tkey}
   title="Unit 1: You Already Know English | NY English Teacher"
-  description="Discover the 100+ English words hiding in your Spanish. Build your first English sentences — from 'It is possible' to complex structures. Free interactive lesson with audio."
+  description="Discover the 100+ English words hiding in your Spanish. Build your first sentences — from 'It is possible' to complex structures. Free lesson."
 >
   <!-- Course progress bar -->
   <CourseProgress

--- a/src/pages/en/course/beginners/unit-2.astro
+++ b/src/pages/en/course/beginners/unit-2.astro
@@ -46,7 +46,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
   lang={lang}
   tkey={tkey}
   title="Unit 2: What You Like | NY English Teacher"
-  description="Learn to express preferences in English: I like, I don't like, I would like. Talk about food, daily activities, and the past. Free interactive lesson with audio."
+  description="Learn to express preferences: I like, I don't like, I would like. Talk about food, daily activities, and the past. Free lesson for Spanish speakers."
 >
   <CourseProgress
     client:load

--- a/src/pages/en/course/beginners/unit-4.astro
+++ b/src/pages/en/course/beginners/unit-4.astro
@@ -45,7 +45,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
   lang={lang}
   tkey={tkey}
   title="Unit 4: Talking to Someone | NY English Teacher"
-  description="Learn to address someone directly in English: you can, you have to, what happened. Indirect objects and TH pronunciation. Free interactive lesson for Spanish speakers."
+  description="Learn to address someone directly: you can, you have to, what happened. Indirect objects and TH pronunciation. Free lesson for Spanish speakers."
 >
   <CourseProgress
     client:load

--- a/src/pages/en/course/beginners/unit-5.astro
+++ b/src/pages/en/course/beginners/unit-5.astro
@@ -45,7 +45,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
   lang={lang}
   tkey={tkey}
   title="Unit 5: What Just Happened | NY English Teacher"
-  description="Learn to talk about recent events in English using 'just': I just ate, she just told me, he just found out. Past -ed pronunciation. Free interactive lesson for Spanish speakers."
+  description="Learn to talk about recent events in English using 'just': I just ate, she just told me. Past -ed pronunciation. Free lesson for Spanish speakers."
 >
   <CourseProgress
     client:load

--- a/src/pages/en/course/beginners/unit-6.astro
+++ b/src/pages/en/course/beginners/unit-6.astro
@@ -45,7 +45,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
   lang={lang}
   tkey={tkey}
   title="Unit 6: Everyone, Someone, No One | NY English Teacher"
-  description="Learn indefinite pronouns in English: everyone, someone, nobody. Plus should, shouldn't, and initial S pronunciation. Free interactive lesson for Spanish speakers."
+  description="Learn indefinite pronouns: everyone, someone, nobody. Plus should, shouldn't, and initial S pronunciation. Free lesson for Spanish speakers."
 >
   <CourseProgress
     client:load

--- a/src/pages/en/course/beginners/unit-7.astro
+++ b/src/pages/en/course/beginners/unit-7.astro
@@ -45,7 +45,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
   lang={lang}
   tkey={tkey}
   title="Unit 7: Together | NY English Teacher"
-  description="Learn 'we' forms in English: we can, we want, we should, we would like. Plus the -able cognate family and W pronunciation. Free interactive lesson for Spanish speakers."
+  description="Learn 'we' forms: we can, we want, we should, we would like. Plus the -able cognate family and W pronunciation. Free lesson for Spanish speakers."
 >
   <CourseProgress
     client:load

--- a/src/pages/en/course/beginners/unit-8.astro
+++ b/src/pages/en/course/beginners/unit-8.astro
@@ -45,7 +45,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
   lang={lang}
   tkey={tkey}
   title="Unit 8: Feelings and Curiosity | NY English Teacher"
-  description="Learn to express feelings and curiosity in English: I feel like, I wonder, and they forms. Plus -ence/-ance cognates and question intonation. Free interactive lesson."
+  description="Learn to express feelings and curiosity: I feel like, I wonder, and they forms. Plus -ence/-ance cognates and question intonation. Free lesson."
 >
   <CourseProgress
     client:load

--- a/src/pages/en/course/beginners/unit-9.astro
+++ b/src/pages/en/course/beginners/unit-9.astro
@@ -45,7 +45,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
   lang={lang}
   tkey={tkey}
   title="Unit 9: Telling Stories | NY English Teacher"
-  description="Learn past tense storytelling in English: was/were, used to, told me, that's why. Plus story vocabulary, -ous cognates, and R sound pronunciation. Free interactive lesson for Spanish speakers."
+  description="Learn past tense storytelling: was/were, used to, told me, that's why. Plus story vocabulary, -ous cognates, and R sound pronunciation. Free lesson."
 >
   <CourseProgress
     client:load

--- a/src/pages/en/course/intermediate/unit-1.astro
+++ b/src/pages/en/course/intermediate/unit-1.astro
@@ -46,7 +46,7 @@ const progressUnits = intermediateUnits.map((u) => ({
   lang={lang}
   tkey={tkey}
   title="Unit 1: The Phrasal Verb Problem | NY English Teacher"
-  description="Why 'give up' doesn't mean 'dar arriba'. Master 8 essential phrasal verbs and the present perfect tense. Free interactive English lesson for B1-B2 Spanish speakers."
+  description="Why 'give up' doesn't mean 'dar arriba'. Master 8 essential phrasal verbs and the present perfect tense. Free B1-B2 lesson for Spanish speakers."
 >
   <!-- Course progress bar -->
   <CourseProgress

--- a/src/pages/en/course/intermediate/unit-10.astro
+++ b/src/pages/en/course/intermediate/unit-10.astro
@@ -36,7 +36,7 @@ const progressUnits = intermediateUnits.map((u) => ({
   lang={lang}
   tkey={tkey}
   title="Unit 10: Sounding Native | NY English Teacher"
-  description="The capstone unit. Master modals of deduction (must be, can't be, might have been) — reason out loud like a native English speaker. Free B1-B2 lesson for Spanish speakers."
+  description="The capstone unit. Master modals of deduction (must be, can't be, might have been) — reason out loud like a native speaker. Free B1-B2 lesson."
 >
   <CourseProgress
     client:load

--- a/src/pages/en/course/intermediate/unit-2.astro
+++ b/src/pages/en/course/intermediate/unit-2.astro
@@ -36,7 +36,7 @@ const progressUnits = intermediateUnits.map((u) => ({
   lang={lang}
   tkey={tkey}
   title="Unit 2: At the Office | NY English Teacher"
-  description="Master workplace English. Learn 8 office phrasal verbs (follow up, set up, put off) and the present perfect continuous. Free interactive lesson for B1-B2 Spanish speakers."
+  description="Master workplace English: 8 office phrasal verbs (follow up, set up, put off) and the present perfect continuous. Free B1-B2 lesson."
 >
   <CourseProgress
     client:load

--- a/src/pages/en/course/intermediate/unit-3.astro
+++ b/src/pages/en/course/intermediate/unit-3.astro
@@ -36,7 +36,7 @@ const progressUnits = intermediateUnits.map((u) => ({
   lang={lang}
   tkey={tkey}
   title="Unit 3: Getting Around | NY English Teacher"
-  description="Travel English beyond tourist phrases. Master 9 transport phrasal verbs (check in, get on, drop off) and the first conditional. Free B1-B2 English lesson for Spanish speakers."
+  description="Travel English beyond tourist phrases. Master 9 transport phrasal verbs (check in, get on, drop off) and the first conditional. Free B1-B2 lesson."
 >
   <CourseProgress
     client:load

--- a/src/pages/en/course/intermediate/unit-4.astro
+++ b/src/pages/en/course/intermediate/unit-4.astro
@@ -36,7 +36,7 @@ const progressUnits = intermediateUnits.map((u) => ({
   lang={lang}
   tkey={tkey}
   title="Unit 4: Making Plans | Building Fluency | NY English Teacher"
-  description="The polite, sophisticated English of invitations and suggestions. Master 'would' and 'could' — the politeness upgrade that separates B1 from B2 speakers. Free interactive lesson for Spanish speakers."
+  description="The polite English of invitations and suggestions. Master 'would' and 'could' — the politeness upgrade that separates B1 from B2 speakers."
 >
   <CourseProgress
     client:load

--- a/src/pages/en/course/intermediate/unit-5.astro
+++ b/src/pages/en/course/intermediate/unit-5.astro
@@ -36,7 +36,7 @@ const progressUnits = intermediateUnits.map((u) => ({
   lang={lang}
   tkey={tkey}
   title="Unit 5: Telling Stories | NY English Teacher"
-  description="Narrate events like a native speaker. Master past perfect, reported speech, and 'would' for past habits. Free interactive English lesson for B1-B2 Spanish speakers."
+  description="Narrate events like a native speaker. Master past perfect, reported speech, and 'would' for past habits. Free B1-B2 lesson for Spanish speakers."
 >
   <CourseProgress
     client:load

--- a/src/pages/en/course/intermediate/unit-6.astro
+++ b/src/pages/en/course/intermediate/unit-6.astro
@@ -36,7 +36,7 @@ const progressUnits = intermediateUnits.map((u) => ({
   lang={lang}
   tkey={tkey}
   title="Unit 6: Expressing Opinions | NY English Teacher"
-  description="The language of debate, persuasion, and professional disagreement. Master the third conditional and softening modals (might, may, could). Free B1-B2 English lesson for Spanish speakers."
+  description="The language of debate and professional disagreement. Master the third conditional and softening modals (might, may, could). Free B1-B2 lesson."
 >
   <CourseProgress
     client:load

--- a/src/pages/en/course/intermediate/unit-7.astro
+++ b/src/pages/en/course/intermediate/unit-7.astro
@@ -36,7 +36,7 @@ const progressUnits = intermediateUnits.map((u) => ({
   lang={lang}
   tkey={tkey}
   title="Unit 7: Health and Emergencies | NY English Teacher"
-  description="Medical English for real situations. Master passive voice, advice modals (should, ought to), and the phrases you need at the doctor, pharmacy, or hospital. Free B1-B2 lesson."
+  description="Medical English for real situations. Master passive voice, advice modals (should, ought to), and phrases for the doctor, pharmacy, or hospital."
 >
   <CourseProgress
     client:load

--- a/src/pages/en/course/intermediate/unit-8.astro
+++ b/src/pages/en/course/intermediate/unit-8.astro
@@ -36,7 +36,7 @@ const progressUnits = intermediateUnits.map((u) => ({
   lang={lang}
   tkey={tkey}
   title="Unit 8: Money and Shopping | NY English Teacher"
-  description="Consumer English for shopping, banking, and complaints. Master relative clauses and preference modals (would rather, would prefer). Free B1-B2 English lesson for Spanish speakers."
+  description="Consumer English for shopping, banking, and complaints. Master relative clauses and preference modals (would rather, would prefer). B1-B2 lesson."
 >
   <CourseProgress
     client:load

--- a/src/pages/en/course/intermediate/unit-9.astro
+++ b/src/pages/en/course/intermediate/unit-9.astro
@@ -36,7 +36,7 @@ const progressUnits = intermediateUnits.map((u) => ({
   lang={lang}
   tkey={tkey}
   title="Unit 9: Relationships and Feelings | NY English Teacher"
-  description="The emotional vocabulary B1 speakers lack. Master wish/regret structures and 'would' for hypotheticals — express feelings and apologies in English. Free B1-B2 lesson."
+  description="The emotional vocabulary B1 speakers lack. Master wish/regret structures and 'would' for hypotheticals — express feelings in English."
 >
   <CourseProgress
     client:load

--- a/src/pages/en/for-hr-managers/index.astro
+++ b/src/pages/en/for-hr-managers/index.astro
@@ -14,7 +14,7 @@ import { Image } from "astro:assets";
 const title =
   "Corporate English Training for HR Managers | NY English Teacher";
 const seoDescription =
-  "Evaluating English training for your management team? See the formal deliverables you receive, how progress is documented, and what makes this different from a generic language course.";
+  "Evaluating English training for your team? See the formal deliverables, how progress is documented, and how this differs from generic courses.";
 
 const heroContent = {
   title:

--- a/src/pages/en/services/corporate-package.astro
+++ b/src/pages/en/services/corporate-package.astro
@@ -14,7 +14,7 @@ import { corporatePackage as serviceData } from "@data/services";
 
 const title = "Business English Coaching for Teams | NY English Teacher";
 const seoDescription =
-  "Business English coaching 1-on-1 online for leadership teams in Mexico. A 12-week structured program with a New York native executive coach. Measurable outcomes.";
+  "Business English coaching for leadership teams in Mexico. A 12-week structured program with a New York native executive coach. Measurable outcomes.";
 
 const heroContent = {
   title: "Your management team is ready. Their English isn't keeping up.",

--- a/src/pages/en/services/ongoing-coaching.astro
+++ b/src/pages/en/services/ongoing-coaching.astro
@@ -14,7 +14,7 @@ if (!serviceData) throw new Error("Service data not found");
 
 const title = "Ongoing Business English Coaching | NY English Teacher";
 const seoDescription =
-  "Flexible English coaching for professional teams in Mexico. Build conversational fluency, stronger meetings, and natural rapport — no fixed curriculum, no generic course.";
+  "Flexible English coaching for professional teams in Mexico. Build conversational fluency, stronger meetings, and natural rapport — no fixed course.";
 
 const heroContent = {
   title: "Your team functions in English. Now make it feel natural.",

--- a/src/pages/es/curso/principiantes/unidad-1.astro
+++ b/src/pages/es/curso/principiantes/unidad-1.astro
@@ -47,7 +47,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
   lang={lang}
   tkey={tkey}
   title="Unidad 1: Ya Sabes Inglés | NY English Teacher"
-  description="Descubre las más de 100 palabras en inglés escondidas en tu español. Construye tus primeras oraciones en inglés — desde 'It is possible' hasta estructuras complejas. Lección interactiva gratuita con audio."
+  description="Descubre las 100+ palabras en inglés escondidas en tu español. Construye tus primeras oraciones — desde 'It is possible' a estructuras complejas. Gratis."
 >
   <!-- Course progress bar -->
   <CourseProgress

--- a/src/pages/es/curso/principiantes/unidad-9.astro
+++ b/src/pages/es/curso/principiantes/unidad-9.astro
@@ -45,7 +45,7 @@ const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
   lang={lang}
   tkey={tkey}
   title="Unidad 9: Contando Historias | NY English Teacher"
-  description="Aprende a contar historias en pasado en inglés: was/were, used to, told me, that's why. Más vocabulario narrativo, cognados -ous y pronunciación de la R. Lección gratuita interactiva."
+  description="Aprende a contar historias en pasado: was/were, used to, told me, that's why. Vocabulario narrativo, cognados -ous y pronunciación de la R. Lección gratis."
 >
   <CourseProgress
     client:load

--- a/src/pages/es/para-rh/index.astro
+++ b/src/pages/es/para-rh/index.astro
@@ -14,7 +14,7 @@ import { Image } from "astro:assets";
 const title =
   "Capacitación de Inglés Corporativo para Responsables de RH | NY English Teacher";
 const seoDescription =
-  "¿Evaluando un programa de inglés para tu equipo directivo? Conoce los entregables formales que recibes, cómo se documenta el progreso y qué distingue este programa de un curso genérico de idiomas.";
+  "¿Evaluando un programa de inglés para tu equipo directivo? Conoce los entregables formales y cómo se documenta el progreso. Distinto de un curso genérico.";
 
 const heroContent = {
   title:

--- a/src/pages/es/servicios/coaching-continuo.astro
+++ b/src/pages/es/servicios/coaching-continuo.astro
@@ -14,7 +14,7 @@ if (!serviceData) throw new Error("Service data not found");
 
 const title = "Coaching Continuo de Inglés para Equipos | NY English";
 const seoDescription =
-  "Coaching flexible de inglés para equipos profesionales en México. Desarrolla fluidez en conversación, mejora reuniones y construye rapport natural — sin currículo fijo ni curso genérico.";
+  "Coaching flexible de inglés para equipos profesionales en México. Desarrolla fluidez, mejora reuniones y construye rapport natural — sin curso fijo.";
 
 const heroContent = {
   title: "Tu equipo funciona en inglés. Ahora haz que fluya con naturalidad.",


### PR DESCRIPTION
## Summary
- Trims 27 meta descriptions that exceeded Ahrefs' 160-char limit (21 flagged in latest audit + 6 additional found by new gate)
- Adds `scripts/pre-deploy/audits/meta-description-gate.mjs` that scans all emitted HTML in `dist/` and FAILS the build on any description >160 chars (warns on <120)
- Wires the gate into `npm run build` so this class of regression cannot reach production again

## Why this slipped through
The existing `seo-validator.js` only checked a 62-URL whitelist (`CRITICAL-URLS.txt`) and was not wired into the build chain — so it would never have caught these pages even if it ran. The new gate scans **every** built HTML file.

## Test plan
- [x] `npm run build` passes locally with the new gate active
- [x] Verified all 27 trimmed descriptions land in 132-155 char range
- [ ] Vercel preview deploy succeeds
- [ ] Re-run Ahrefs audit after merge to confirm 0 long-description violations