### PR TITLE
feat(courses): unhide advanced units + sharpen 4 course pitches

### DIFF
--- a/src/pages/en/courses/index.astro
+++ b/src/pages/en/courses/index.astro
@@ -21,7 +21,7 @@ const tkey = "courses" as const;
 
 const beginnerAvailable = units.length;
 const intermediateAvailable = intermediateUnits.length;
-const advancedAvailable = advancedUnits.filter((u) => u.id === 1).length;
+const advancedAvailable = advancedUnits.length;
 const executiveAvailable = executiveUnits.filter((u) => u.published).length;
 ---
 
@@ -29,7 +29,7 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
   lang={lang}
   tkey={tkey}
   title="Free English Courses for Spanish Speakers | NY English"
-  description="Free, interactive English courses for Spanish speakers — beginner to upper-intermediate. No sign-up, no paywall. Built by a real NYC English teacher."
+  description="Free, interactive English courses for Spanish speakers — A1 beginner through C2 executive. No sign-up, no paywall. Built by a real NYC English teacher."
 >
   <!-- Hero -->
   <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-16 pb-20 md:pt-20 md:pb-24">
@@ -46,9 +46,9 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
           English Courses That Actually Work for Spanish Speakers
         </h1>
         <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
-          Two free, interactive courses built specifically for Spanish speakers.
-          No sign-up. No paywall. No textbook drudgery. Just real progress
-          from the first lesson.
+          Four free, interactive courses built for Spanish speakers — beginner
+          through executive. No sign-up. No paywall. No textbook drudgery.
+          Just real progress from the first lesson.
         </p>
       </div>
     </div>
@@ -78,7 +78,9 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
           </div>
           <div class="p-6">
             <p class="text-slate-600 text-sm leading-relaxed mb-4">
-              {courseInfo.description}
+              Most courses make Spanish speakers start from zero. We don't.
+              You already know 1,500+ English words — they're hiding in your
+              Spanish. By Unit 10, you're holding a real conversation.
             </p>
             <ul class="space-y-2 mb-6">
               <li class="flex items-start gap-2 text-sm text-slate-700">
@@ -125,7 +127,10 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
           </div>
           <div class="p-6">
             <p class="text-slate-600 text-sm leading-relaxed mb-4">
-              {intermediateInfo.description}
+              You can hold a conversation — but every sentence still goes
+              through Spanish first. This course rewires that. Phrasal verbs,
+              conditionals, and the natural patterns natives actually use,
+              drilled until English comes out without translating.
             </p>
             <ul class="space-y-2 mb-6">
               <li class="flex items-start gap-2 text-sm text-slate-700">
@@ -172,7 +177,10 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
           </div>
           <div class="p-6">
             <p class="text-slate-600 text-sm leading-relaxed mb-4">
-              Fix the granular errors that mark a non-native speaker even at C1. Skill-based drills — no themes, no vocabulary memorization.
+              Your English is fluent. It's not polished. Even at C1, the wrong
+              article, the missed "fewer", and the soft TH give you away in
+              the first thirty seconds. Drills that fix the exact errors
+              haunting advanced Spanish speakers — no themes, no memorization.
             </p>
             <ul class="space-y-2 mb-6">
               <li class="flex items-start gap-2 text-sm text-slate-700">
@@ -190,7 +198,7 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
             </ul>
             <div class="flex items-center justify-between">
               <span class="text-xs font-semibold text-violet-600 uppercase tracking-wider">
-                {advancedAvailable} unit available · more coming
+                {advancedAvailable} units available
               </span>
               <span class="inline-flex items-center gap-1 text-violet-600 font-semibold text-sm group-hover:gap-2 transition-all">
                 Start course
@@ -219,7 +227,10 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
           </div>
           <div class="p-6">
             <p class="text-slate-600 text-sm leading-relaxed mb-4">
-              The productized version of Robert's 1-on-1 executive coaching. Drill-based, speaking-first training for senior leaders who need to lead in English.
+              When the room expects a leader, fluent isn't enough. The
+              productized version of Robert's 1-on-1 executive coaching —
+              speaking-first drills, named frameworks, and the precision
+              language that signals command under pressure.
             </p>
             <ul class="space-y-2 mb-6">
               <li class="flex items-start gap-2 text-sm text-slate-700">
@@ -237,9 +248,7 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
             </ul>
             <div class="flex items-center justify-between">
               <span class="text-xs font-semibold text-amber-600 uppercase tracking-wider">
-                {executiveAvailable > 0
-                  ? `${executiveAvailable} unit${executiveAvailable === 1 ? "" : "s"} available · more coming`
-                  : "Early access · building now"}
+                {executiveAvailable} units available
               </span>
               <span class="inline-flex items-center gap-1 text-amber-600 font-semibold text-sm group-hover:gap-2 transition-all">
                 Start course

--- a/src/pages/es/cursos/index.astro
+++ b/src/pages/es/cursos/index.astro
@@ -21,7 +21,7 @@ const tkey = "courses" as const;
 
 const beginnerAvailable = units.length;
 const intermediateAvailable = intermediateUnits.length;
-const advancedAvailable = advancedUnits.filter((u) => u.id === 1).length;
+const advancedAvailable = advancedUnits.length;
 const executiveAvailable = executiveUnits.filter((u) => u.published).length;
 ---
 
@@ -29,7 +29,7 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
   lang={lang}
   tkey={tkey}
   title="Cursos Gratis de Inglés para Hispanohablantes | NY English"
-  description="Cursos de inglés gratuitos para hispanohablantes. De principiante a intermedio alto. Sin registro ni barreras. Hechos por un maestro de inglés de Nueva York."
+  description="Cursos de inglés gratuitos para hispanohablantes — de A1 principiante a C2 ejecutivo. Sin registro ni barreras. Hechos por un maestro de inglés de NY."
 >
   <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-16 pb-20 md:pt-20 md:pb-24">
     <div class="site-container mx-auto px-4 text-white">
@@ -45,9 +45,9 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
           Cursos de Inglés que Realmente Funcionan para Hispanohablantes
         </h1>
         <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
-          Dos cursos gratuitos e interactivos hechos específicamente para hispanohablantes.
-          Sin registro. Sin barreras. Sin la pesadez de los libros de texto.
-          Solo progreso real desde la primera lección.
+          Cuatro cursos gratuitos e interactivos hechos para hispanohablantes —
+          de principiante a ejecutivo. Sin registro. Sin barreras. Sin la pesadez
+          de los libros de texto. Solo progreso real desde la primera lección.
         </p>
       </div>
     </div>
@@ -76,7 +76,10 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
           </div>
           <div class="p-6">
             <p class="text-slate-600 text-sm leading-relaxed mb-4">
-              {courseInfo.descriptionEs}
+              La mayoría de los cursos hacen que los hispanohablantes empiecen
+              desde cero. Nosotros no. Ya conoces más de 1,500 palabras en
+              inglés — están escondidas en tu español. Para la Unidad 10,
+              sostienes una conversación real.
             </p>
             <ul class="space-y-2 mb-6">
               <li class="flex items-start gap-2 text-sm text-slate-700">
@@ -123,7 +126,10 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
           </div>
           <div class="p-6">
             <p class="text-slate-600 text-sm leading-relaxed mb-4">
-              {intermediateInfo.descriptionEs}
+              Sostienes una conversación — pero cada oración pasa primero por
+              el español. Este curso lo recablea. Phrasal verbs, condicionales
+              y los patrones naturales que usan los nativos, practicados hasta
+              que el inglés sale sin traducir.
             </p>
             <ul class="space-y-2 mb-6">
               <li class="flex items-start gap-2 text-sm text-slate-700">
@@ -170,7 +176,11 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
           </div>
           <div class="p-6">
             <p class="text-slate-600 text-sm leading-relaxed mb-4">
-              Corrige los errores granulares que delatan al hablante no nativo incluso a nivel C1. Ejercicios basados en habilidades — sin temas, sin memorización de vocabulario.
+              Tu inglés es fluido. No está pulido. Incluso a nivel C1, el
+              artículo equivocado, el "fewer" perdido y la TH suave te delatan
+              en los primeros treinta segundos. Drills que corrigen los errores
+              exactos que persiguen a los hispanohablantes avanzados — sin
+              temas, sin memorización.
             </p>
             <ul class="space-y-2 mb-6">
               <li class="flex items-start gap-2 text-sm text-slate-700">
@@ -188,7 +198,7 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
             </ul>
             <div class="flex items-center justify-between">
               <span class="text-xs font-semibold text-violet-600 uppercase tracking-wider">
-                {advancedAvailable} unidad disponible · más en camino
+                {advancedAvailable} unidades disponibles
               </span>
               <span class="inline-flex items-center gap-1 text-violet-600 font-semibold text-sm group-hover:gap-2 transition-all">
                 Empezar curso
@@ -217,7 +227,10 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
           </div>
           <div class="p-6">
             <p class="text-slate-600 text-sm leading-relaxed mb-4">
-              La versión productizada del coaching ejecutivo 1-a-1 de Robert. Entrenamiento basado en drills, hablado primero, para líderes senior que necesitan liderar en inglés.
+              Cuando la sala espera a un líder, ser fluido no basta. La versión
+              productizada del coaching ejecutivo 1-a-1 de Robert — drills
+              hablados, marcos con nombre, y el lenguaje preciso que señala
+              mando bajo presión.
             </p>
             <ul class="space-y-2 mb-6">
               <li class="flex items-start gap-2 text-sm text-slate-700">
@@ -235,9 +248,7 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
             </ul>
             <div class="flex items-center justify-between">
               <span class="text-xs font-semibold text-amber-600 uppercase tracking-wider">
-                {executiveAvailable > 0
-                  ? `${executiveAvailable} unidad${executiveAvailable === 1 ? "" : "es"} disponible${executiveAvailable === 1 ? "" : "s"} · más en camino`
-                  : "Acceso anticipado · construyendo ahora"}
+                {executiveAvailable} unidades disponibles
               </span>
               <span class="inline-flex items-center gap-1 text-amber-600 font-semibold text-sm group-hover:gap-2 transition-all">
                 Empezar curso


### PR DESCRIPTION
## Summary
- Removes the artificial "1 unit available · more coming" gate on the Advanced course (it shipped 2026-04-13 with all 10 units)
- Removes "more coming" from Executive (shipped 2026-04-16 with all 10 units)
- Updates hero "Two free courses" → "Four free courses" to match reality
- Updates meta description to cover the full A1-C2 ladder (was capped at "upper-intermediate")
- Rewrites all four course pitches inline for stronger hooks and clearer pain points

## Why this matters
A visitor evaluating credibility would see "1 unit available" on Advanced and assume the course is half-built — when it actually has the full 10 units plus a final exam. Same misleading signal on Executive. The artificial gate is a release-flagging miss, not a missing feature.

## Pitch changes
| Course | Before | After (lead) |
|---|---|---|
| Beginner | "Free 10-unit course… 1,500+ words English and Spanish share" | "Most courses make Spanish speakers start from zero. We don't." |
| Intermediate | "Master phrasal verbs, complex tenses, and natural speech patterns through real-world dialogues" | "You can hold a conversation — but every sentence still goes through Spanish first." |
| Advanced | "Fix the granular errors that mark a non-native speaker even at C1" | "Your English is fluent. It's not polished." |
| Executive | "The productized version of Robert's 1-on-1 executive coaching" | "When the room expects a leader, fluent isn't enough." |

## Test plan
- [x] `npm run build` passes; meta-description-gate confirms 0 too-long, 17 too-short (all non-sitemap, unchanged)
- [ ] Vercel preview deploy: confirm /en/courses/ and /es/cursos/ show "10 units available" on all 4 cards (no "more coming")
- [ ] Confirm new pitches render correctly in both languages