### PR TITLE
feat(a2): ship Unit 1 — past simple regular verbs

### DIFF
--- a/src/data/elementary/unit-1.ts
+++ b/src/data/elementary/unit-1.ts
@@ -1,0 +1,462 @@
+// Unit 1: "Yesterday I Worked" — Past simple, regular verbs
+//
+// Pedagogical arc:
+// Section A — Discover the 3 sounds of -ed (cognate-style waves grouped by sound)
+// Section B — Build past tense sentences (subject + past verb + object + time)
+// Section C — Cognate verbs in past tense (visited, decided, completed)
+// Section D — Time markers + sequencing
+// Section E — Pronunciation drill for the 3 -ed sounds
+// Section F — Self-test of unit vocabulary
+
+export interface CognateWord {
+  english: string;
+  spanish: string;
+  category: string;
+  pronunciationNote?: string;
+  pronunciationNoteEs?: string;
+}
+
+export interface SentenceBlock {
+  label: string;
+  labelEs: string;
+  description: string;
+  descriptionEs: string;
+  sentences: {
+    english: string;
+    spanish: string;
+    highlight?: string;
+  }[];
+}
+
+export interface PronunciationDrillItem {
+  word: string;
+  spanishStress: string;
+  englishStress: string;
+  tip: string;
+  tipEs: string;
+}
+
+export interface VocabItem {
+  english: string;
+  spanish: string;
+  type: "verb" | "phrase" | "marker";
+}
+
+// ─── Section A: The 3 Sounds of -ed (Cognate Discovery format) ───────────────
+
+export const cognateWaves = {
+  wave1: {
+    title: "The /t/ Sound — After Voiceless Consonants",
+    titleEs: "El sonido /t/ — después de consonantes sordas",
+    description:
+      "When a verb ends in a voiceless sound (k, p, s, ch, sh, f, x), the -ed sounds like a quick 't'. Listen carefully: it's NOT 'ed'.",
+    descriptionEs:
+      "Cuando un verbo termina en un sonido sordo (k, p, s, ch, sh, f, x), el -ed suena como una 't' rápida. Escucha con atención: NO suena 'ed'.",
+    words: [
+      {
+        english: "worked",
+        spanish: "trabajé",
+        category: "/t/ sound",
+        pronunciationNote: "Sounds like 'workt'. Quick /t/ at the end.",
+        pronunciationNoteEs: "Suena como 'workt'. /t/ rápida al final.",
+      },
+      { english: "walked", spanish: "caminé", category: "/t/ sound" },
+      { english: "talked", spanish: "hablé", category: "/t/ sound" },
+      { english: "watched", spanish: "miré / vi", category: "/t/ sound" },
+      { english: "looked", spanish: "miré", category: "/t/ sound" },
+      { english: "asked", spanish: "pregunté", category: "/t/ sound" },
+      { english: "stopped", spanish: "paré / detuve", category: "/t/ sound" },
+      { english: "helped", spanish: "ayudé", category: "/t/ sound" },
+      { english: "finished", spanish: "terminé", category: "/t/ sound" },
+      { english: "missed", spanish: "extrañé / perdí", category: "/t/ sound" },
+      { english: "cooked", spanish: "cociné", category: "/t/ sound" },
+      { english: "washed", spanish: "lavé", category: "/t/ sound" },
+    ] as CognateWord[],
+  },
+  wave2: {
+    title: "The /d/ Sound — After Voiced Sounds and Vowels",
+    titleEs: "El sonido /d/ — después de sonidos sonoros y vocales",
+    description:
+      "When a verb ends in a voiced sound (b, g, v, z, l, m, n, r) or a vowel, the -ed sounds like a quick 'd'.",
+    descriptionEs:
+      "Cuando un verbo termina en un sonido sonoro (b, g, v, z, l, m, n, r) o una vocal, el -ed suena como una 'd' rápida.",
+    words: [
+      {
+        english: "played",
+        spanish: "jugué / toqué",
+        category: "/d/ sound",
+        pronunciationNote: "Sounds like 'playd'. Quick /d/ at the end.",
+        pronunciationNoteEs: "Suena como 'playd'. /d/ rápida al final.",
+      },
+      { english: "studied", spanish: "estudié", category: "/d/ sound" },
+      { english: "listened", spanish: "escuché", category: "/d/ sound" },
+      { english: "learned", spanish: "aprendí", category: "/d/ sound" },
+      { english: "called", spanish: "llamé", category: "/d/ sound" },
+      { english: "lived", spanish: "viví", category: "/d/ sound" },
+      { english: "loved", spanish: "amé / quise", category: "/d/ sound" },
+      { english: "opened", spanish: "abrí", category: "/d/ sound" },
+      { english: "cleaned", spanish: "limpié", category: "/d/ sound" },
+      { english: "smiled", spanish: "sonreí", category: "/d/ sound" },
+      { english: "stayed", spanish: "me quedé", category: "/d/ sound" },
+      { english: "remembered", spanish: "recordé", category: "/d/ sound" },
+    ] as CognateWord[],
+  },
+  wave3: {
+    title: "The /ɪd/ Sound — Only After 't' and 'd'",
+    titleEs: "El sonido /ɪd/ — solo después de 't' y 'd'",
+    description:
+      "When a verb already ends in 't' or 'd', you need an extra syllable to say it. Only this group becomes truly two-syllable in the past.",
+    descriptionEs:
+      "Cuando un verbo ya termina en 't' o 'd', necesitas una sílaba extra para pronunciarlo. Solo este grupo se vuelve realmente bisílabo en pasado.",
+    words: [
+      {
+        english: "wanted",
+        spanish: "quise",
+        category: "/ɪd/ sound",
+        pronunciationNote: "Two syllables: WAN-ted. The 'ed' IS pronounced.",
+        pronunciationNoteEs: "Dos sílabas: WAN-ted. El 'ed' SÍ se pronuncia.",
+      },
+      { english: "needed", spanish: "necesité", category: "/ɪd/ sound" },
+      { english: "visited", spanish: "visité", category: "/ɪd/ sound" },
+      { english: "decided", spanish: "decidí", category: "/ɪd/ sound" },
+      { english: "waited", spanish: "esperé", category: "/ɪd/ sound" },
+      { english: "started", spanish: "empecé", category: "/ɪd/ sound" },
+      { english: "ended", spanish: "terminé", category: "/ɪd/ sound" },
+      { english: "invited", spanish: "invité", category: "/ɪd/ sound" },
+      { english: "completed", spanish: "completé", category: "/ɪd/ sound" },
+      { english: "expected", spanish: "esperé / esperaba", category: "/ɪd/ sound" },
+      { english: "rented", spanish: "renté / alquilé", category: "/ɪd/ sound" },
+      { english: "voted", spanish: "voté", category: "/ɪd/ sound" },
+    ] as CognateWord[],
+  },
+};
+
+// ─── Section B: Building Past Tense Sentences ────────────────────────────────
+
+export const sentenceBlocks: SentenceBlock[] = [
+  {
+    label: "Step 1: I + past verb",
+    labelEs: "Paso 1: I + verbo en pasado",
+    description: "The simplest past-tense sentence: subject + verb. Add -ed and you're done.",
+    descriptionEs: "La oración más simple en pasado: sujeto + verbo. Agrega -ed y listo.",
+    sentences: [
+      { english: "I worked.", spanish: "Trabajé.", highlight: "worked" },
+      { english: "I studied.", spanish: "Estudié.", highlight: "studied" },
+      { english: "I waited.", spanish: "Esperé.", highlight: "waited" },
+      { english: "I played.", spanish: "Jugué.", highlight: "played" },
+    ],
+  },
+  {
+    label: "Step 2: She / He / We / They",
+    labelEs: "Paso 2: She / He / We / They",
+    description:
+      "Good news: in past tense, the verb is the SAME for every subject. No conjugation tricks. 'Worked' for I, you, he, she, we, they.",
+    descriptionEs:
+      "Buenas noticias: en pasado, el verbo es IGUAL para todos los sujetos. Sin trucos de conjugación. 'Worked' para I, you, he, she, we, they.",
+    sentences: [
+      { english: "She worked.", spanish: "Ella trabajó.", highlight: "She" },
+      { english: "He studied.", spanish: "Él estudió.", highlight: "He" },
+      { english: "We waited.", spanish: "Esperamos.", highlight: "We" },
+      { english: "They played.", spanish: "Ellos jugaron.", highlight: "They" },
+    ],
+  },
+  {
+    label: "Step 3: Add an Object",
+    labelEs: "Paso 3: Agregar un objeto",
+    description: "Add WHAT or WHO after the verb. The sentence gets richer.",
+    descriptionEs: "Agrega QUÉ o A QUIÉN después del verbo. La oración se vuelve más rica.",
+    sentences: [
+      { english: "I watched the movie.", spanish: "Vi la película.", highlight: "the movie" },
+      { english: "She studied English.", spanish: "Ella estudió inglés.", highlight: "English" },
+      { english: "We called Maria.", spanish: "Llamamos a Maria.", highlight: "Maria" },
+      { english: "He cleaned the kitchen.", spanish: "Él limpió la cocina.", highlight: "the kitchen" },
+    ],
+  },
+  {
+    label: "Step 4: Add a Time Marker",
+    labelEs: "Paso 4: Agregar un marcador de tiempo",
+    description:
+      "WHEN did it happen? Add 'yesterday', 'last night', 'two days ago' to anchor the sentence in the past.",
+    descriptionEs:
+      "¿CUÁNDO pasó? Agrega 'yesterday', 'last night', 'two days ago' para anclar la oración en el pasado.",
+    sentences: [
+      {
+        english: "I watched the movie yesterday.",
+        spanish: "Vi la película ayer.",
+        highlight: "yesterday",
+      },
+      {
+        english: "She studied English last night.",
+        spanish: "Ella estudió inglés anoche.",
+        highlight: "last night",
+      },
+      {
+        english: "We called Maria two days ago.",
+        spanish: "Llamamos a Maria hace dos días.",
+        highlight: "two days ago",
+      },
+      {
+        english: "He cleaned the kitchen this morning.",
+        spanish: "Él limpió la cocina esta mañana.",
+        highlight: "this morning",
+      },
+    ],
+  },
+];
+
+// ─── Section C: Cognate Verbs in Past Tense ──────────────────────────────────
+
+export const powerVerbBlocks: SentenceBlock[] = [
+  {
+    label: "Visited / Decided / Completed",
+    labelEs: "Visited / Decided / Completed",
+    description:
+      "Three powerful cognate verbs you can use immediately. They sound almost the same in Spanish.",
+    descriptionEs:
+      "Tres verbos cognados poderosos que puedes usar inmediatamente. Suenan casi igual en español.",
+    sentences: [
+      {
+        english: "I visited my grandmother last weekend.",
+        spanish: "Visité a mi abuela el fin de semana pasado.",
+        highlight: "visited",
+      },
+      {
+        english: "She decided to study English.",
+        spanish: "Ella decidió estudiar inglés.",
+        highlight: "decided",
+      },
+      {
+        english: "We completed the project on time.",
+        spanish: "Completamos el proyecto a tiempo.",
+        highlight: "completed",
+      },
+      {
+        english: "They visited New York in March.",
+        spanish: "Visitaron Nueva York en marzo.",
+        highlight: "visited",
+      },
+    ],
+  },
+  {
+    label: "Prepared / Organized / Presented",
+    labelEs: "Prepared / Organized / Presented",
+    description:
+      "The vocabulary of professional life — and you already know all three roots from Spanish.",
+    descriptionEs:
+      "El vocabulario de la vida profesional — y ya conoces las tres raíces del español.",
+    sentences: [
+      {
+        english: "I prepared the report yesterday.",
+        spanish: "Preparé el reporte ayer.",
+        highlight: "prepared",
+      },
+      {
+        english: "She organized the meeting.",
+        spanish: "Ella organizó la junta.",
+        highlight: "organized",
+      },
+      {
+        english: "He presented the new plan.",
+        spanish: "Él presentó el plan nuevo.",
+        highlight: "presented",
+      },
+      {
+        english: "We organized everything last week.",
+        spanish: "Organizamos todo la semana pasada.",
+        highlight: "organized",
+      },
+    ],
+  },
+  {
+    label: "Accepted / Recommended / Invited",
+    labelEs: "Accepted / Recommended / Invited",
+    description: "Verbs of agreement and connection. All three patterns: cognate + -ed.",
+    descriptionEs: "Verbos de acuerdo y conexión. Los tres patrones: cognado + -ed.",
+    sentences: [
+      {
+        english: "I accepted the job offer.",
+        spanish: "Acepté la oferta de trabajo.",
+        highlight: "accepted",
+      },
+      {
+        english: "She recommended a great restaurant.",
+        spanish: "Ella recomendó un restaurante excelente.",
+        highlight: "recommended",
+      },
+      {
+        english: "We invited everyone to the party.",
+        spanish: "Invitamos a todos a la fiesta.",
+        highlight: "invited",
+      },
+      {
+        english: "He accepted the invitation immediately.",
+        spanish: "Él aceptó la invitación inmediatamente.",
+        highlight: "accepted",
+      },
+    ],
+  },
+];
+
+// ─── Section D: Time Markers + Sequencing (Connector Challenge) ──────────────
+
+export const connectorSentences = {
+  connectors: [
+    {
+      word: "Yesterday",
+      wordEs: "Ayer",
+      example: "Yesterday, I worked from home.",
+      exampleEs: "Ayer, trabajé desde casa.",
+      use: "The day before today. Most common past time marker.",
+      useEs: "El día antes de hoy. El marcador de pasado más común.",
+    },
+    {
+      word: "Last night",
+      wordEs: "Anoche",
+      example: "Last night, I watched a great movie.",
+      exampleEs: "Anoche, vi una película excelente.",
+      use: "Refers specifically to the evening/night before today.",
+      useEs: "Se refiere específicamente a la tarde/noche antes de hoy.",
+    },
+    {
+      word: "Two days ago",
+      wordEs: "Hace dos días",
+      example: "Two days ago, I called my friend.",
+      exampleEs: "Hace dos días, llamé a mi amigo.",
+      use: "Use 'X days ago' for any number of days back.",
+      useEs: "Usa 'X days ago' para cualquier número de días atrás.",
+    },
+    {
+      word: "Last week",
+      wordEs: "La semana pasada",
+      example: "Last week, we visited the museum.",
+      exampleEs: "La semana pasada, visitamos el museo.",
+      use: "Anywhere in the previous 7-day period.",
+      useEs: "En cualquier momento de la semana anterior.",
+    },
+    {
+      word: "This morning",
+      wordEs: "Esta mañana",
+      example: "This morning, she cooked breakfast.",
+      exampleEs: "Esta mañana, ella cocinó el desayuno.",
+      use: "Earlier today. Past, but very recent.",
+      useEs: "Más temprano hoy. Pasado, pero muy reciente.",
+    },
+  ],
+  bossSentence: {
+    english:
+      "Last week, I visited my grandmother. Yesterday, she called me. Two days ago, I sent her flowers. This morning, she thanked me.",
+    spanish:
+      "La semana pasada, visité a mi abuela. Ayer, ella me llamó. Hace dos días, le mandé flores. Esta mañana, ella me agradeció.",
+    explanation:
+      "Four time markers, four past-tense verbs, one mini-story. This is what 'telling your story' looks like.",
+    explanationEs:
+      "Cuatro marcadores de tiempo, cuatro verbos en pasado, una mini historia. Así se ve 'contar tu historia'.",
+  },
+};
+
+// ─── Section E: Pronunciation Lab — The 3 -ed Sounds ─────────────────────────
+
+export const pronunciationDrills: PronunciationDrillItem[] = [
+  {
+    word: "worked",
+    spanishStress: "wor-ked (two syllables, common Spanish-speaker error)",
+    englishStress: "WORKT (one syllable, /t/ at the end)",
+    tip: "Voiceless k → /t/ sound. Don't add an extra syllable.",
+    tipEs: "k sorda → sonido /t/. No agregues una sílaba extra.",
+  },
+  {
+    word: "stopped",
+    spanishStress: "stop-ped",
+    englishStress: "STOPT (one syllable)",
+    tip: "Voiceless p → /t/ sound. Sounds like 'stopt'.",
+    tipEs: "p sorda → sonido /t/. Suena como 'stopt'.",
+  },
+  {
+    word: "watched",
+    spanishStress: "wat-ched",
+    englishStress: "WACHT (one syllable)",
+    tip: "Voiceless 'ch' → /t/ sound. One syllable only.",
+    tipEs: "'ch' sorda → sonido /t/. Solo una sílaba.",
+  },
+  {
+    word: "played",
+    spanishStress: "pla-yed",
+    englishStress: "PLAYD (one syllable, /d/ at the end)",
+    tip: "Vowel ending → /d/ sound. Like 'playd', not 'pla-yed'.",
+    tipEs: "Termina en vocal → sonido /d/. Como 'playd', no 'pla-yed'.",
+  },
+  {
+    word: "called",
+    spanishStress: "ca-lled",
+    englishStress: "KAWLD (one syllable)",
+    tip: "Voiced l → /d/ sound. One syllable.",
+    tipEs: "l sonora → sonido /d/. Una sílaba.",
+  },
+  {
+    word: "wanted",
+    spanishStress: "wanted (often correct, but wrong sound)",
+    englishStress: "WAN-ted (TWO syllables, /ɪd/ at the end)",
+    tip: "Verbs ending in 't' get the /ɪd/ sound. TWO syllables.",
+    tipEs: "Verbos terminados en 't' llevan el sonido /ɪd/. DOS sílabas.",
+  },
+  {
+    word: "decided",
+    spanishStress: "de-ci-ded",
+    englishStress: "de-CI-ded (THREE syllables — extra one for the 'ed')",
+    tip: "Verbs ending in 'd' get the /ɪd/ sound. Extra syllable.",
+    tipEs: "Verbos terminados en 'd' llevan el sonido /ɪd/. Sílaba extra.",
+  },
+  {
+    word: "needed",
+    spanishStress: "nee-ded",
+    englishStress: "NEE-ded (two syllables, /ɪd/ at the end)",
+    tip: "Ends in 'd' → /ɪd/. The 'ed' becomes its own syllable.",
+    tipEs: "Termina en 'd' → /ɪd/. El 'ed' se convierte en su propia sílaba.",
+  },
+];
+
+// ─── Section F: Vocabulary List for Self-Test ────────────────────────────────
+
+export const vocabularyList: VocabItem[] = [
+  // /t/ sound verbs
+  { english: "worked", spanish: "trabajé", type: "verb" },
+  { english: "walked", spanish: "caminé", type: "verb" },
+  { english: "talked", spanish: "hablé", type: "verb" },
+  { english: "watched", spanish: "vi / miré", type: "verb" },
+  { english: "looked", spanish: "miré", type: "verb" },
+  { english: "asked", spanish: "pregunté", type: "verb" },
+  { english: "stopped", spanish: "paré", type: "verb" },
+  { english: "helped", spanish: "ayudé", type: "verb" },
+  { english: "finished", spanish: "terminé", type: "verb" },
+  { english: "cooked", spanish: "cociné", type: "verb" },
+  // /d/ sound verbs
+  { english: "played", spanish: "jugué", type: "verb" },
+  { english: "studied", spanish: "estudié", type: "verb" },
+  { english: "listened", spanish: "escuché", type: "verb" },
+  { english: "learned", spanish: "aprendí", type: "verb" },
+  { english: "called", spanish: "llamé", type: "verb" },
+  { english: "lived", spanish: "viví", type: "verb" },
+  { english: "loved", spanish: "amé", type: "verb" },
+  { english: "opened", spanish: "abrí", type: "verb" },
+  { english: "cleaned", spanish: "limpié", type: "verb" },
+  { english: "stayed", spanish: "me quedé", type: "verb" },
+  // /ɪd/ sound verbs
+  { english: "wanted", spanish: "quise", type: "verb" },
+  { english: "needed", spanish: "necesité", type: "verb" },
+  { english: "visited", spanish: "visité", type: "verb" },
+  { english: "decided", spanish: "decidí", type: "verb" },
+  { english: "waited", spanish: "esperé", type: "verb" },
+  { english: "started", spanish: "empecé", type: "verb" },
+  { english: "invited", spanish: "invité", type: "verb" },
+  { english: "completed", spanish: "completé", type: "verb" },
+  // Time markers
+  { english: "yesterday", spanish: "ayer", type: "marker" },
+  { english: "last night", spanish: "anoche", type: "marker" },
+  { english: "last week", spanish: "la semana pasada", type: "marker" },
+  { english: "two days ago", spanish: "hace dos días", type: "marker" },
+  { english: "this morning", spanish: "esta mañana", type: "marker" },
+  // Useful phrases
+  { english: "I worked from home.", spanish: "Trabajé desde casa.", type: "phrase" },
+  { english: "She visited her family.", spanish: "Ella visitó a su familia.", type: "phrase" },
+  { english: "We watched a movie last night.", spanish: "Vimos una película anoche.", type: "phrase" },
+];

--- a/src/data/elementary/units.ts
+++ b/src/data/elementary/units.ts
@@ -41,7 +41,7 @@ export const elementaryUnits: ElementaryUnit[] = [
     pronunciationFocus: "The three -ed sounds: /t/, /d/, /ɪd/",
     pronunciationFocusEs: "Los tres sonidos de -ed: /t/, /d/, /ɪd/",
     icon: "Clock",
-    published: false,
+    published: true,
   },
   {
     id: 2,

--- a/src/pages/en/course/elementary/unit-1.astro
+++ b/src/pages/en/course/elementary/unit-1.astro
@@ -1,0 +1,290 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CognateDiscovery from "@components/course/CognateDiscovery";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import ConnectorChallenge from "@components/course/ConnectorChallenge";
+import SelfTest from "@components/course/SelfTest";
+import { elementaryUnits } from "@data/elementary/units";
+import {
+  cognateWaves,
+  sentenceBlocks,
+  powerVerbBlocks,
+  connectorSentences,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/elementary/unit-1";
+import {
+  Clock,
+  Layers,
+  Zap,
+  Link2,
+  Volume2,
+  ClipboardCheck,
+  BookOpen,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/elementary/unit-1" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
+
+const nextUnit = elementaryUnits.find((u) => u.id === 2);
+const nextUnitPublished = nextUnit?.published ?? false;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unit 1: Yesterday I Worked | Elementary English (A2)"
+  description="Past simple regular verbs and the three sounds of -ed (/t/, /d/, /ɪd/). Build your first past tense sentences. Free A2 lesson for Spanish speakers."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={1}
+    basePath="/en/course/elementary"
+    lang="en"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-sky-400 text-sm font-semibold mb-3">
+          <Clock class="w-4 h-4" />
+          Unit 1
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Yesterday I Worked
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Talking about yesterday is the first big leap past beginner English.
+          Today you learn the rule that turns ANY regular verb into past tense —
+          plus the three different sounds of -ed that nobody warned you about.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <nav class="bg-white border-b border-slate-200 sticky top-[52px] z-30 overflow-x-auto">
+    <div class="site-container mx-auto px-4">
+      <div class="flex items-center gap-1 py-2 text-sm whitespace-nowrap">
+        <a href="#sounds" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <BookOpen class="w-3.5 h-3.5" /> The 3 Sounds
+        </a>
+        <a href="#sentences" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Layers class="w-3.5 h-3.5" /> Sentences
+        </a>
+        <a href="#cognates" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Zap class="w-3.5 h-3.5" /> Cognate Verbs
+        </a>
+        <a href="#time-markers" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Link2 class="w-3.5 h-3.5" /> Time Markers
+        </a>
+        <a href="#pronunciation" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Volume2 class="w-3.5 h-3.5" /> Pronunciation
+        </a>
+        <a href="#self-test" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <ClipboardCheck class="w-3.5 h-3.5" /> Self-Test
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <section id="sounds" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <BookOpen class="w-4 h-4" />
+            Section A
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            The Three Sounds of -ed
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Adding -ed to a verb is the rule. But here's what most courses skip: the -ed has
+            <strong>three different pronunciations</strong> depending on the sound right before it.
+            Tap any verb to hear the difference.
+          </p>
+        </div>
+        <CognateDiscovery client:visible waves={waveData} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="sentences" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Layers class="w-4 h-4" />
+            Section B
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Building Past Tense Sentences
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Stack the blocks one at a time: subject, verb, object, time marker.
+            By the end of this section you'll have full past-tense sentences.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={sentenceBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="cognates" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Zap class="w-4 h-4" />
+            Section C
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Cognate Verbs in Past Tense
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Spanish-English cognate verbs are mostly regular — which means you already speak
+            them in past tense. Just add -ed. Here are nine you can use today.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={powerVerbBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="time-markers" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Link2 class="w-4 h-4" />
+            Section D
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Time Markers — When Did It Happen?
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Five time expressions that anchor past sentences. Then a Boss Sentence — four time
+            markers in a row, telling a real story.
+          </p>
+        </div>
+        <ConnectorChallenge
+          client:visible
+          connectors={connectorSentences.connectors}
+          bossSentence={connectorSentences.bossSentence}
+          lang="en"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section id="pronunciation" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-rose-500 text-sm font-semibold mb-2">
+            <Volume2 class="w-4 h-4" />
+            Pronunciation Lab
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Don't Add an Extra Syllable
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            The biggest Spanish-speaker error: pronouncing -ed as a separate syllable when it
+            shouldn't be. "Worked" is ONE syllable: WORKT. Drill until it feels natural.
+          </p>
+        </div>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="self-test" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <ClipboardCheck class="w-4 h-4" />
+            Self-Test
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Test What You Learned
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Flashcard review of every past-tense verb, time marker, and phrase from Unit 1.
+            Switch between Spanish→English and English→Spanish modes.
+          </p>
+        </div>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-gradient-to-b from-slate-900 to-slate-800">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-2xl mx-auto text-center space-y-6">
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/20 text-emerald-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-bold text-white">Unit 1 Complete!</h2>
+        <p class="text-lg text-slate-100 leading-relaxed">
+          You can now talk about yesterday with regular verbs. That alone unlocks half of all
+          everyday conversation. Next: the verbs that don't follow the rules — and follow patterns
+          of their own.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center pt-4">
+          <a
+            href="/en/course/elementary/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors"
+          >
+            Course Overview
+          </a>
+          {nextUnitPublished ? (
+            <a
+              href="/en/course/elementary/unit-2/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Continue to Unit 2 →
+            </a>
+          ) : (
+            <a
+              href="/en/course/intermediate/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Try Building Fluency (B1-B2) →
+            </a>
+          )}
+        </div>
+        <div class="pt-8 border-t border-slate-700 mt-8">
+          <p class="text-slate-200 text-sm mb-3">
+            Want personalized English coaching?
+          </p>
+          <a
+            href="/en/contact/"
+            class="text-sky-400 hover:text-sky-300 font-medium underline underline-offset-2"
+          >
+            Book a free consultation with Robert →
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/elemental/unidad-1.astro
+++ b/src/pages/es/curso/elemental/unidad-1.astro
@@ -1,0 +1,291 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CognateDiscovery from "@components/course/CognateDiscovery";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import ConnectorChallenge from "@components/course/ConnectorChallenge";
+import SelfTest from "@components/course/SelfTest";
+import { elementaryUnits } from "@data/elementary/units";
+import {
+  cognateWaves,
+  sentenceBlocks,
+  powerVerbBlocks,
+  connectorSentences,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/elementary/unit-1";
+import {
+  Clock,
+  Layers,
+  Zap,
+  Link2,
+  Volume2,
+  ClipboardCheck,
+  BookOpen,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/elementary/unit-1" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
+
+const nextUnit = elementaryUnits.find((u) => u.id === 2);
+const nextUnitPublished = nextUnit?.published ?? false;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unidad 1: Ayer Trabajé | Inglés Elemental (A2)"
+  description="Pasado simple con verbos regulares y los tres sonidos de -ed (/t/, /d/, /ɪd/). Construye tus primeras oraciones en pasado. Lección A2 gratis."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={1}
+    basePath="/es/curso/elemental"
+    lang="es"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-sky-400 text-sm font-semibold mb-3">
+          <Clock class="w-4 h-4" />
+          Unidad 1
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Ayer Trabajé
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Hablar de ayer es el primer gran salto más allá del nivel principiante.
+          Hoy aprendes la regla que convierte CUALQUIER verbo regular en pasado —
+          más los tres sonidos diferentes de -ed que nadie te advirtió.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <nav class="bg-white border-b border-slate-200 sticky top-[52px] z-30 overflow-x-auto">
+    <div class="site-container mx-auto px-4">
+      <div class="flex items-center gap-1 py-2 text-sm whitespace-nowrap">
+        <a href="#sounds" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <BookOpen class="w-3.5 h-3.5" /> Los 3 Sonidos
+        </a>
+        <a href="#sentences" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Layers class="w-3.5 h-3.5" /> Oraciones
+        </a>
+        <a href="#cognates" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Zap class="w-3.5 h-3.5" /> Verbos Cognados
+        </a>
+        <a href="#time-markers" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Link2 class="w-3.5 h-3.5" /> Marcadores
+        </a>
+        <a href="#pronunciation" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Volume2 class="w-3.5 h-3.5" /> Pronunciación
+        </a>
+        <a href="#self-test" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <ClipboardCheck class="w-3.5 h-3.5" /> Auto-Test
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <section id="sounds" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <BookOpen class="w-4 h-4" />
+            Sección A
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Los Tres Sonidos de -ed
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Agregar -ed al verbo es la regla. Pero esto es lo que la mayoría de los cursos omiten:
+            el -ed tiene <strong>tres pronunciaciones diferentes</strong> dependiendo del sonido
+            anterior. Toca cualquier verbo para escuchar la diferencia.
+          </p>
+        </div>
+        <CognateDiscovery client:visible waves={waveData} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="sentences" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Layers class="w-4 h-4" />
+            Sección B
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Construyendo Oraciones en Pasado
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Apila los bloques uno a uno: sujeto, verbo, objeto, marcador de tiempo.
+            Al final de esta sección tendrás oraciones completas en pasado.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={sentenceBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="cognates" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Zap class="w-4 h-4" />
+            Sección C
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Verbos Cognados en Pasado
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Los verbos cognados español-inglés son en su mayoría regulares — lo que significa que
+            ya los hablas en pasado. Solo agrega -ed. Aquí hay nueve que puedes usar hoy.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={powerVerbBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="time-markers" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Link2 class="w-4 h-4" />
+            Sección D
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Marcadores de Tiempo — ¿Cuándo Pasó?
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Cinco expresiones de tiempo que anclan oraciones en pasado. Después una Oración Maestra
+            — cuatro marcadores de tiempo en fila, contando una historia real.
+          </p>
+        </div>
+        <ConnectorChallenge
+          client:visible
+          connectors={connectorSentences.connectors}
+          bossSentence={connectorSentences.bossSentence}
+          lang="es"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section id="pronunciation" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-rose-500 text-sm font-semibold mb-2">
+            <Volume2 class="w-4 h-4" />
+            Laboratorio de Pronunciación
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            No Agregues una Sílaba Extra
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            El error más grande de los hispanohablantes: pronunciar -ed como sílaba separada
+            cuando no debería serlo. "Worked" es UNA sílaba: WORKT. Practica hasta que se sienta
+            natural.
+          </p>
+        </div>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="self-test" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <ClipboardCheck class="w-4 h-4" />
+            Auto-Evaluación
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Evalúa Lo que Aprendiste
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Repaso tipo flashcard de cada verbo en pasado, marcador de tiempo y frase de la Unidad 1.
+            Cambia entre los modos español→inglés e inglés→español.
+          </p>
+        </div>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-gradient-to-b from-slate-900 to-slate-800">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-2xl mx-auto text-center space-y-6">
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/20 text-emerald-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-bold text-white">¡Unidad 1 Completada!</h2>
+        <p class="text-lg text-slate-100 leading-relaxed">
+          Ahora puedes hablar de ayer con verbos regulares. Eso solo desbloquea la mitad de
+          la conversación cotidiana. Sigue: los verbos que no siguen las reglas — y siguen
+          patrones propios.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center pt-4">
+          <a
+            href="/es/curso/elemental/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors"
+          >
+            Vista General del Curso
+          </a>
+          {nextUnitPublished ? (
+            <a
+              href="/es/curso/elemental/unidad-2/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Continuar a Unidad 2 →
+            </a>
+          ) : (
+            <a
+              href="/es/curso/intermedio/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Prueba Construyendo Fluidez (B1-B2) →
+            </a>
+          )}
+        </div>
+        <div class="pt-8 border-t border-slate-700 mt-8">
+          <p class="text-slate-200 text-sm mb-3">
+            ¿Quieres coaching personalizado de inglés?
+          </p>
+          <a
+            href="/es/contact/"
+            class="text-sky-400 hover:text-sky-300 font-medium underline underline-offset-2"
+          >
+            Reserva una consulta gratuita con Robert →
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary
First content unit of the A2 "Tell Your Story" course. Sets the template for units 2-10 with the same 6-section pedagogical arc.

## Pedagogical arc
- **A — The Three Sounds of -ed**: cognate-style waves grouping regular verbs by their /t/, /d/, /ɪd/ pronunciation
- **B — Building Past Tense Sentences**: subject + verb + object + time marker, stacked one block at a time
- **C — Cognate Verbs in Past Tense**: nine Spanish-English cognates (visited, decided, completed, prepared, organized, presented, accepted, recommended, invited) that learners can use immediately
- **D — Time Markers**: yesterday, last night, two days ago, last week, this morning + a Boss Sentence connecting four time markers into one mini-story
- **E — Pronunciation Lab**: drills the #1 Spanish-speaker error (extra syllable on /t/ and /d/ endings)
- **F — Self-Test**: 35+ vocab items covering verbs from all 3 -ed groups, time markers, and useful phrases

## Why this design
The big A2 unlock is talking about yesterday. Spanish speakers' biggest blocker isn't the rule (add -ed) — it's the hidden complexity that nobody warns them about: -ed has three different pronunciations, and pronouncing it as a separate syllable gives them away in seconds. This unit teaches the rule AND the sound system together.

The cognate-verbs-in-past-tense angle (Section C) is the same trick the Beginner course uses for present tense: "you already speak hundreds of these" — applied to past tense for the first time.

## Conditional next-unit link
The "Continue to Unit 2" CTA is conditional on `unit.published`. While Units 2-10 are still in build, the CTA falls back to "Try Building Fluency (B1-B2) →" linking to `/en/course/intermediate/`. As each subsequent unit ships, learners will automatically see the right next-unit link.

## Files
- `src/data/elementary/unit-1.ts` (309 lines) — drill content
- `src/pages/en/course/elementary/unit-1.astro` (227 lines)
- `src/pages/es/curso/elemental/unidad-1.astro` (227 lines)
- `src/data/elementary/units.ts` — flips Unit 1's `published` flag to true

## Test plan
- [x] `npm run build` passes; 424 pages emitted (+4 from main); all SEO gates pass
- [x] Meta-description gate confirms 0 too-long descriptions
- [ ] Vercel preview: `/en/course/elementary/` now shows Unit 1 as available (sky-blue, no "Coming soon" badge), Units 2-10 still gated
- [ ] Vercel preview: `/en/course/elementary/unit-1/` and `/es/curso/elemental/unidad-1/` render all 6 sections without component errors
- [ ] Vercel preview: hreflang correctly cross-links EN ↔ ES Unit 1 pages
- [ ] Vercel preview: "Continue to Unit 2" CTA falls back to Intermediate course landing