### PR TITLE
feat(a2): ship Unit 2 — past simple irregular verbs

### DIFF
--- a/src/data/elementary/unit-2.ts
+++ b/src/data/elementary/unit-2.ts
@@ -1,0 +1,444 @@
+// Unit 2: "Yesterday I Went" — Past simple, irregular verbs
+//
+// Pedagogical arc:
+// Section A — 30 most common irregular verbs, grouped into 3 memorable waves
+// Section B — Was/were (the irregular past of "to be")
+// Section C — Did/didn't questions and negatives
+// Section D — Time markers + sequencing with irregulars in the Boss Sentence
+// Section E — Pronunciation drill: ought/aught, was/were, no extra syllables
+// Section F — Self-test of unit vocabulary
+
+export interface CognateWord {
+  english: string;
+  spanish: string;
+  category: string;
+  pronunciationNote?: string;
+  pronunciationNoteEs?: string;
+}
+
+export interface SentenceBlock {
+  label: string;
+  labelEs: string;
+  description: string;
+  descriptionEs: string;
+  sentences: {
+    english: string;
+    spanish: string;
+    highlight?: string;
+  }[];
+}
+
+export interface PronunciationDrillItem {
+  word: string;
+  spanishStress: string;
+  englishStress: string;
+  tip: string;
+  tipEs: string;
+}
+
+export interface VocabItem {
+  english: string;
+  spanish: string;
+  type: "verb" | "phrase" | "marker";
+}
+
+// ─── Section A: Three Waves of Irregular Verbs (Cognate Discovery format) ────
+
+export const cognateWaves = {
+  wave1: {
+    title: "The Daily 10 — Verbs You Use Every Day",
+    titleEs: "Los 10 Diarios — Verbos que usas todos los días",
+    description:
+      "These ten irregular verbs cover most of what you say in past tense. Don't try to memorize them all at once — the sentences in Section B will drill them in.",
+    descriptionEs:
+      "Estos diez verbos irregulares cubren la mayoría de lo que dices en pasado. No intentes memorizarlos todos de una vez — las oraciones en la Sección B los van a fijar.",
+    words: [
+      {
+        english: "went (go)",
+        spanish: "fui (ir)",
+        category: "Daily 10",
+        pronunciationNote: "One syllable: 'WENT'. Don't say 'goed'.",
+        pronunciationNoteEs: "Una sílaba: 'WENT'. No digas 'goed'.",
+      },
+      {
+        english: "did (do)",
+        spanish: "hice (hacer)",
+        category: "Daily 10",
+        pronunciationNote: "One syllable: 'DID'. Don't say 'doed'.",
+        pronunciationNoteEs: "Una sílaba: 'DID'. No digas 'doed'.",
+      },
+      { english: "had (have)", spanish: "tuve (tener)", category: "Daily 10" },
+      { english: "got (get)", spanish: "obtuve / conseguí (get)", category: "Daily 10" },
+      { english: "made (make)", spanish: "hice (hacer/crear)", category: "Daily 10" },
+      {
+        english: "said (say)",
+        spanish: "dije (decir)",
+        category: "Daily 10",
+        pronunciationNote: "Pronounced 'SED', not 'SAYD'. Common error.",
+        pronunciationNoteEs: "Se pronuncia 'SED', no 'SAYD'. Error común.",
+      },
+      { english: "saw (see)", spanish: "vi (ver)", category: "Daily 10" },
+      { english: "came (come)", spanish: "vine (venir)", category: "Daily 10" },
+      { english: "took (take)", spanish: "tomé (tomar)", category: "Daily 10" },
+      { english: "gave (give)", spanish: "di (dar)", category: "Daily 10" },
+    ] as CognateWord[],
+  },
+  wave2: {
+    title: "The Story Verbs — For Telling Stories",
+    titleEs: "Los Verbos de Historia — Para contar historias",
+    description:
+      "These ten unlock the language of storytelling: what someone said, what you thought, what you found. Story verbs are how memories become sentences.",
+    descriptionEs:
+      "Estos diez desbloquean el lenguaje de la narración: qué dijo alguien, qué pensaste, qué encontraste. Los verbos de historia son cómo los recuerdos se vuelven oraciones.",
+    words: [
+      { english: "told (tell)", spanish: "dije / conté (contar)", category: "Story Verbs" },
+      {
+        english: "thought (think)",
+        spanish: "pensé (pensar)",
+        category: "Story Verbs",
+        pronunciationNote: "Sounds like 'THOT'. Silent 'gh'.",
+        pronunciationNoteEs: "Suena como 'THOT'. La 'gh' es muda.",
+      },
+      { english: "knew (know)", spanish: "supe / conocí", category: "Story Verbs" },
+      { english: "found (find)", spanish: "encontré", category: "Story Verbs" },
+      { english: "left (leave)", spanish: "dejé / me fui", category: "Story Verbs" },
+      { english: "felt (feel)", spanish: "sentí (sentir)", category: "Story Verbs" },
+      { english: "became (become)", spanish: "me volví / llegué a ser", category: "Story Verbs" },
+      {
+        english: "brought (bring)",
+        spanish: "traje (traer)",
+        category: "Story Verbs",
+        pronunciationNote: "Sounds like 'BRAWT'. Same vowel as 'thought'.",
+        pronunciationNoteEs: "Suena como 'BRAWT'. Misma vocal que 'thought'.",
+      },
+      { english: "wrote (write)", spanish: "escribí", category: "Story Verbs" },
+      {
+        english: "read (read)",
+        spanish: "leí",
+        category: "Story Verbs",
+        pronunciationNote:
+          "Spelling unchanged but PRONOUNCED differently: present 'REED', past 'RED'.",
+        pronunciationNoteEs:
+          "Misma escritura pero PRONUNCIACIÓN diferente: presente 'REED', pasado 'RED'.",
+      },
+    ] as CognateWord[],
+  },
+  wave3: {
+    title: "The Same-Form 10 — Look Unchanged",
+    titleEs: "Los 10 Inalterados — Se ven iguales",
+    description:
+      "These verbs don't change spelling at all in past tense. The good news: you already know the past tense form — it's the same word.",
+    descriptionEs:
+      "Estos verbos no cambian de ortografía en pasado. La buena noticia: ya conoces la forma del pasado — es la misma palabra.",
+    words: [
+      {
+        english: "put",
+        spanish: "puse / puso",
+        category: "Same-Form 10",
+        pronunciationNote: "Same word, same sound. Context tells you it's past.",
+        pronunciationNoteEs: "Misma palabra, mismo sonido. El contexto te dice que es pasado.",
+      },
+      { english: "cut", spanish: "corté", category: "Same-Form 10" },
+      { english: "hit", spanish: "golpeé / pegué", category: "Same-Form 10" },
+      { english: "let", spanish: "dejé / permití", category: "Same-Form 10" },
+      { english: "set", spanish: "puse / fijé", category: "Same-Form 10" },
+      { english: "shut", spanish: "cerré", category: "Same-Form 10" },
+      { english: "cost", spanish: "costó", category: "Same-Form 10" },
+      { english: "hurt", spanish: "dolió / lastimé", category: "Same-Form 10" },
+      { english: "fit", spanish: "quedó / me quedó (talla)", category: "Same-Form 10" },
+      { english: "spread", spanish: "esparcí / extendí", category: "Same-Form 10" },
+    ] as CognateWord[],
+  },
+};
+
+// ─── Section B: Was / Were (the irregular past of "to be") ───────────────────
+
+export const sentenceBlocks: SentenceBlock[] = [
+  {
+    label: "Step 1: I / He / She / It was",
+    labelEs: "Paso 1: I / He / She / It was",
+    description:
+      "'Was' is the past form for ONE person or thing. I, he, she, it — all use 'was'.",
+    descriptionEs:
+      "'Was' es la forma del pasado para UNA persona o cosa. I, he, she, it — todos usan 'was'.",
+    sentences: [
+      { english: "I was tired yesterday.", spanish: "Estaba cansado ayer.", highlight: "was" },
+      { english: "She was at the office.", spanish: "Ella estaba en la oficina.", highlight: "was" },
+      { english: "He was happy with the result.", spanish: "Él estaba contento con el resultado.", highlight: "was" },
+      { english: "It was a long meeting.", spanish: "Fue una junta larga.", highlight: "was" },
+    ],
+  },
+  {
+    label: "Step 2: We / You / They were",
+    labelEs: "Paso 2: We / You / They were",
+    description:
+      "'Were' is the past form for plural subjects — and for 'you' (singular OR plural). Two simple rules cover all cases.",
+    descriptionEs:
+      "'Were' es la forma del pasado para sujetos plurales — y para 'you' (singular O plural). Dos reglas simples cubren todos los casos.",
+    sentences: [
+      { english: "We were busy last week.", spanish: "Estuvimos ocupados la semana pasada.", highlight: "were" },
+      { english: "You were right about that.", spanish: "Tenías razón sobre eso.", highlight: "were" },
+      { english: "They were at the conference.", spanish: "Ellos estaban en la conferencia.", highlight: "were" },
+      { english: "We were tired but happy.", spanish: "Estábamos cansados pero contentos.", highlight: "were" },
+    ],
+  },
+  {
+    label: "Step 3: Negatives — wasn't / weren't",
+    labelEs: "Paso 3: Negativos — wasn't / weren't",
+    description:
+      "Add 'not' to make a negative. The contractions are very common: wasn't = was not, weren't = were not.",
+    descriptionEs:
+      "Agrega 'not' para hacer un negativo. Las contracciones son muy comunes: wasn't = was not, weren't = were not.",
+    sentences: [
+      { english: "I wasn't ready.", spanish: "No estaba listo.", highlight: "wasn't" },
+      { english: "She wasn't at home.", spanish: "Ella no estaba en casa.", highlight: "wasn't" },
+      { english: "They weren't invited.", spanish: "No fueron invitados.", highlight: "weren't" },
+      { english: "We weren't sure about the plan.", spanish: "No estábamos seguros del plan.", highlight: "weren't" },
+    ],
+  },
+  {
+    label: "Step 4: Questions — Was / Were + subject?",
+    labelEs: "Paso 4: Preguntas — Was / Were + sujeto?",
+    description:
+      "To ask a question, just flip the order: 'Was/Were' comes BEFORE the subject. No extra word needed.",
+    descriptionEs:
+      "Para hacer una pregunta, solo invierte el orden: 'Was/Were' va ANTES del sujeto. No se necesita palabra extra.",
+    sentences: [
+      { english: "Was she at the meeting?", spanish: "¿Estuvo ella en la junta?", highlight: "Was she" },
+      { english: "Were you tired?", spanish: "¿Estabas cansado?", highlight: "Were you" },
+      { english: "Was it expensive?", spanish: "¿Fue caro?", highlight: "Was it" },
+      { english: "Were they happy with the result?", spanish: "¿Estuvieron contentos con el resultado?", highlight: "Were they" },
+    ],
+  },
+];
+
+// ─── Section C: Did / Didn't (questions and negatives for ALL other verbs) ───
+
+export const powerVerbBlocks: SentenceBlock[] = [
+  {
+    label: "Question: Did + subject + BASE verb?",
+    labelEs: "Pregunta: Did + sujeto + verbo BASE?",
+    description:
+      "Critical rule: after 'Did', use the BASE form (go, see, do) — NOT the past form. 'Did' already carries the past meaning.",
+    descriptionEs:
+      "Regla crítica: después de 'Did', usa la forma BASE (go, see, do) — NO la forma pasada. 'Did' ya carga el significado del pasado.",
+    sentences: [
+      { english: "Did you go to the meeting?", spanish: "¿Fuiste a la junta?", highlight: "go" },
+      { english: "Did she see the report?", spanish: "¿Vio ella el reporte?", highlight: "see" },
+      { english: "Did they have lunch together?", spanish: "¿Almorzaron juntos?", highlight: "have" },
+      { english: "Did he come to the office?", spanish: "¿Vino él a la oficina?", highlight: "come" },
+    ],
+  },
+  {
+    label: "Negative: subject + didn't + BASE verb",
+    labelEs: "Negativo: sujeto + didn't + verbo BASE",
+    description:
+      "Same rule: after 'didn't', use the BASE form. 'I didn't go' — NEVER 'I didn't went.' This is the #1 error to avoid.",
+    descriptionEs:
+      "Misma regla: después de 'didn't', usa la forma BASE. 'I didn't go' — NUNCA 'I didn't went.' Este es el error #1 a evitar.",
+    sentences: [
+      { english: "I didn't go yesterday.", spanish: "No fui ayer.", highlight: "go" },
+      { english: "She didn't see the email.", spanish: "Ella no vio el correo.", highlight: "see" },
+      { english: "We didn't have time.", spanish: "No tuvimos tiempo.", highlight: "have" },
+      { english: "They didn't come to the party.", spanish: "No vinieron a la fiesta.", highlight: "come" },
+    ],
+  },
+  {
+    label: "Wh-Questions: What/Where/When + did + subject + BASE?",
+    labelEs: "Preguntas Wh-: What/Where/When + did + sujeto + BASE?",
+    description:
+      "Add a question word in front. The rest of the structure stays the same — 'did + subject + BASE verb'.",
+    descriptionEs:
+      "Agrega una palabra de pregunta al inicio. El resto de la estructura es igual — 'did + sujeto + verbo BASE'.",
+    sentences: [
+      { english: "What did you do yesterday?", spanish: "¿Qué hiciste ayer?", highlight: "What did" },
+      { english: "Where did she go?", spanish: "¿A dónde fue ella?", highlight: "Where did" },
+      { english: "When did they arrive?", spanish: "¿Cuándo llegaron?", highlight: "When did" },
+      { english: "Why did he leave early?", spanish: "¿Por qué se fue temprano?", highlight: "Why did" },
+    ],
+  },
+  {
+    label: "Short answers: Yes, I did. / No, I didn't.",
+    labelEs: "Respuestas cortas: Yes, I did. / No, I didn't.",
+    description:
+      "Native speakers rarely answer with the full verb. Just 'did' or 'didn't' is enough. This sounds natural; full answers can sound rehearsed.",
+    descriptionEs:
+      "Los nativos rara vez responden con el verbo completo. Solo 'did' o 'didn't' es suficiente. Esto suena natural; las respuestas completas pueden sonar ensayadas.",
+    sentences: [
+      { english: "Did you go? — Yes, I did.", spanish: "¿Fuiste? — Sí, fui.", highlight: "Yes, I did" },
+      { english: "Did she call? — No, she didn't.", spanish: "¿Llamó ella? — No, no llamó.", highlight: "No, she didn't" },
+      { english: "Did they finish? — Yes, they did.", spanish: "¿Terminaron? — Sí, terminaron.", highlight: "Yes, they did" },
+      { english: "Did he see it? — No, he didn't.", spanish: "¿Lo vio? — No, no lo vio.", highlight: "No, he didn't" },
+    ],
+  },
+];
+
+// ─── Section D: Time Markers + Sequencing (Connector Challenge) ──────────────
+
+export const connectorSentences = {
+  connectors: [
+    {
+      word: "Yesterday morning",
+      wordEs: "Ayer en la mañana",
+      example: "Yesterday morning, I went to a meeting.",
+      exampleEs: "Ayer en la mañana, fui a una junta.",
+      use: "More precise than just 'yesterday' — narrows the time of day.",
+      useEs: "Más preciso que solo 'yesterday' — acota la hora del día.",
+    },
+    {
+      word: "After that",
+      wordEs: "Después de eso",
+      example: "After that, I had lunch with a colleague.",
+      exampleEs: "Después de eso, almorcé con un colega.",
+      use: "Connects one past event to the next. The story-telling connector.",
+      useEs: "Conecta un evento pasado con el siguiente. El conector narrativo.",
+    },
+    {
+      word: "Later",
+      wordEs: "Más tarde",
+      example: "Later, she sent me an email.",
+      exampleEs: "Más tarde, ella me mandó un correo.",
+      use: "An unspecified time after another past event. Looser than 'after that'.",
+      useEs: "Un tiempo no especificado después de otro evento pasado. Más amplio que 'after that'.",
+    },
+    {
+      word: "Then",
+      wordEs: "Entonces / Luego",
+      example: "Then I went home.",
+      exampleEs: "Luego me fui a casa.",
+      use: "The most common sequencing word. Use it freely.",
+      useEs: "La palabra de secuencia más común. Úsala libremente.",
+    },
+    {
+      word: "Finally",
+      wordEs: "Finalmente",
+      example: "Finally, I got the answer I needed.",
+      exampleEs: "Finalmente, obtuve la respuesta que necesitaba.",
+      use: "Marks the LAST event in a sequence. Strong story closer.",
+      useEs: "Marca el ÚLTIMO evento en una secuencia. Fuerte cerrador de historia.",
+    },
+  ],
+  bossSentence: {
+    english:
+      "Yesterday morning, I went to Boston. There, I saw an old friend. After that, we had lunch together. Then I took the train home. Finally, I wrote about the trip in my journal.",
+    spanish:
+      "Ayer en la mañana, fui a Boston. Allí, vi a un viejo amigo. Después de eso, almorzamos juntos. Luego tomé el tren a casa. Finalmente, escribí sobre el viaje en mi diario.",
+    explanation:
+      "Five sentences. Five irregular verbs (went, saw, had, took, wrote). Five connectors. This is what telling a real story sounds like.",
+    explanationEs:
+      "Cinco oraciones. Cinco verbos irregulares (went, saw, had, took, wrote). Cinco conectores. Así suena contar una historia real.",
+  },
+};
+
+// ─── Section E: Pronunciation Lab — Trickiest Irregular Verb Sounds ──────────
+
+export const pronunciationDrills: PronunciationDrillItem[] = [
+  {
+    word: "went",
+    spanishStress: "wen-ted (common Spanish-speaker error)",
+    englishStress: "WENT (one syllable)",
+    tip: "'Went' is ONE syllable. Don't add -ed. The verb already IS the past.",
+    tipEs: "'Went' es UNA sílaba. No agregues -ed. El verbo YA ES el pasado.",
+  },
+  {
+    word: "said",
+    spanishStress: "SAYD (sounds like 'paid' — wrong)",
+    englishStress: "SED (rhymes with 'red')",
+    tip: "'Said' is pronounced 'SED', not 'SAYD'. The most common pronunciation trap in English.",
+    tipEs: "'Said' se pronuncia 'SED', no 'SAYD'. La trampa de pronunciación más común del inglés.",
+  },
+  {
+    word: "thought",
+    spanishStress: "thoht / thoog (silent letters confuse Spanish speakers)",
+    englishStress: "THOT (silent 'gh', short vowel)",
+    tip: "Silent 'gh'. Sounds exactly like 'THOT'. Same pattern in 'bought', 'brought', 'caught', 'taught'.",
+    tipEs: "'gh' muda. Suena exactamente como 'THOT'. Mismo patrón en 'bought', 'brought', 'caught', 'taught'.",
+  },
+  {
+    word: "brought",
+    spanishStress: "broh-gat",
+    englishStress: "BRAWT (one syllable, silent 'gh')",
+    tip: "Same vowel as 'thought'. The 'aw' sound — like a doctor saying 'open up'.",
+    tipEs: "Misma vocal que 'thought'. El sonido 'aw' — como un doctor diciendo 'open up'.",
+  },
+  {
+    word: "was",
+    spanishStress: "WAS (full pronunciation, stressed)",
+    englishStress: "wuz (reduced in fast speech, sounds like 'wuz')",
+    tip: "In fast speech, 'was' is reduced to 'wuz'. 'I was there' sounds like 'I wuz there'.",
+    tipEs: "En habla rápida, 'was' se reduce a 'wuz'. 'I was there' suena como 'I wuz there'.",
+  },
+  {
+    word: "were",
+    spanishStress: "WERE (with the Spanish 'r')",
+    englishStress: "wur (reduced, with the English R)",
+    tip: "In fast speech, 'were' is reduced to 'wur'. The English R curls back; doesn't roll.",
+    tipEs: "En habla rápida, 'were' se reduce a 'wur'. La R del inglés se curva; no vibra.",
+  },
+  {
+    word: "read (past)",
+    spanishStress: "REED (same as the present tense)",
+    englishStress: "RED (rhymes with 'bed')",
+    tip: "Spelled the same. Past tense is pronounced 'RED', not 'REED'. Context tells listeners which one you mean.",
+    tipEs: "Se escribe igual. El pasado se pronuncia 'RED', no 'REED'. El contexto le dice al oyente cuál.",
+  },
+  {
+    word: "didn't",
+    spanishStress: "did-uhnt (over-pronounced)",
+    englishStress: "DIDN'T (one syllable, contracted hard)",
+    tip: "The 't' at the end is sharp. The whole contraction is fast — like one beat: 'DIDN'T'.",
+    tipEs: "La 't' al final es aguda. Toda la contracción es rápida — como un solo golpe: 'DIDN'T'.",
+  },
+];
+
+// ─── Section F: Vocabulary List for Self-Test ────────────────────────────────
+
+export const vocabularyList: VocabItem[] = [
+  // Daily 10
+  { english: "went", spanish: "fui (ir)", type: "verb" },
+  { english: "did", spanish: "hice (hacer)", type: "verb" },
+  { english: "had", spanish: "tuve (tener)", type: "verb" },
+  { english: "got", spanish: "obtuve (get)", type: "verb" },
+  { english: "made", spanish: "hice/creé (make)", type: "verb" },
+  { english: "said", spanish: "dije (decir)", type: "verb" },
+  { english: "saw", spanish: "vi (ver)", type: "verb" },
+  { english: "came", spanish: "vine (venir)", type: "verb" },
+  { english: "took", spanish: "tomé (tomar)", type: "verb" },
+  { english: "gave", spanish: "di (dar)", type: "verb" },
+  // Story Verbs
+  { english: "told", spanish: "dije/conté (tell)", type: "verb" },
+  { english: "thought", spanish: "pensé", type: "verb" },
+  { english: "knew", spanish: "supe/conocí", type: "verb" },
+  { english: "found", spanish: "encontré", type: "verb" },
+  { english: "left", spanish: "dejé/me fui", type: "verb" },
+  { english: "felt", spanish: "sentí", type: "verb" },
+  { english: "became", spanish: "me volví", type: "verb" },
+  { english: "brought", spanish: "traje", type: "verb" },
+  { english: "wrote", spanish: "escribí", type: "verb" },
+  { english: "read (past)", spanish: "leí", type: "verb" },
+  // Same-Form 10
+  { english: "put", spanish: "puse", type: "verb" },
+  { english: "cut", spanish: "corté", type: "verb" },
+  { english: "hit", spanish: "golpeé", type: "verb" },
+  { english: "let", spanish: "dejé/permití", type: "verb" },
+  { english: "shut", spanish: "cerré", type: "verb" },
+  { english: "cost", spanish: "costó", type: "verb" },
+  { english: "hurt", spanish: "dolió/lastimé", type: "verb" },
+  // Was/were forms
+  { english: "I was", spanish: "yo era/estaba/fui", type: "phrase" },
+  { english: "she was", spanish: "ella era/estaba/fue", type: "phrase" },
+  { english: "we were", spanish: "estábamos/éramos", type: "phrase" },
+  { english: "they were", spanish: "ellos estaban/eran", type: "phrase" },
+  { english: "wasn't", spanish: "no era/estaba", type: "phrase" },
+  { english: "weren't", spanish: "no éramos/eran", type: "phrase" },
+  // Did/didn't structures
+  { english: "Did you go?", spanish: "¿Fuiste?", type: "phrase" },
+  { english: "I didn't go.", spanish: "No fui.", type: "phrase" },
+  { english: "Yes, I did.", spanish: "Sí, fui.", type: "phrase" },
+  { english: "No, I didn't.", spanish: "No, no fui.", type: "phrase" },
+  // Time markers + sequencing
+  { english: "yesterday morning", spanish: "ayer en la mañana", type: "marker" },
+  { english: "after that", spanish: "después de eso", type: "marker" },
+  { english: "then", spanish: "luego/entonces", type: "marker" },
+  { english: "finally", spanish: "finalmente", type: "marker" },
+];

--- a/src/data/elementary/units.ts
+++ b/src/data/elementary/units.ts
@@ -60,7 +60,7 @@ export const elementaryUnits: ElementaryUnit[] = [
     pronunciationFocus: "Was vs. were stress patterns",
     pronunciationFocusEs: "Patrones de acento en was vs. were",
     icon: "BookOpen",
-    published: false,
+    published: true,
   },
   {
     id: 3,

--- a/src/pages/en/course/elementary/unit-2.astro
+++ b/src/pages/en/course/elementary/unit-2.astro
@@ -1,0 +1,290 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CognateDiscovery from "@components/course/CognateDiscovery";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import ConnectorChallenge from "@components/course/ConnectorChallenge";
+import SelfTest from "@components/course/SelfTest";
+import { elementaryUnits } from "@data/elementary/units";
+import {
+  cognateWaves,
+  sentenceBlocks,
+  powerVerbBlocks,
+  connectorSentences,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/elementary/unit-2";
+import {
+  BookOpen,
+  Layers,
+  Zap,
+  Link2,
+  Volume2,
+  ClipboardCheck,
+  HelpCircle,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/elementary/unit-2" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
+
+const nextUnit = elementaryUnits.find((u) => u.id === 3);
+const nextUnitPublished = nextUnit?.published ?? false;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unit 2: Yesterday I Went | Elementary English (A2)"
+  description="Past simple irregular verbs: 30 most common, plus was/were and did/didn't questions. Speak fluently about yesterday. Free A2 lesson for Spanish speakers."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={2}
+    basePath="/en/course/elementary"
+    lang="en"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-sky-400 text-sm font-semibold mb-3">
+          <BookOpen class="w-4 h-4" />
+          Unit 2
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Yesterday I Went
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Irregular verbs look scary but they're FINITE. About 200 exist; 30 cover most of what
+          you'll ever say in past tense. Today we drill those 30 — grouped by pattern so they
+          stick — plus 'was/were' and the question form 'Did you...?'
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <nav class="bg-white border-b border-slate-200 sticky top-[52px] z-30 overflow-x-auto">
+    <div class="site-container mx-auto px-4">
+      <div class="flex items-center gap-1 py-2 text-sm whitespace-nowrap">
+        <a href="#irregulars" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <BookOpen class="w-3.5 h-3.5" /> 30 Irregulars
+        </a>
+        <a href="#was-were" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Layers class="w-3.5 h-3.5" /> Was / Were
+        </a>
+        <a href="#did" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <HelpCircle class="w-3.5 h-3.5" /> Did / Didn't
+        </a>
+        <a href="#sequencing" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Link2 class="w-3.5 h-3.5" /> Story Connectors
+        </a>
+        <a href="#pronunciation" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Volume2 class="w-3.5 h-3.5" /> Pronunciation
+        </a>
+        <a href="#self-test" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <ClipboardCheck class="w-3.5 h-3.5" /> Self-Test
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <section id="irregulars" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <BookOpen class="w-4 h-4" />
+            Section A
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            The 30 Irregular Verbs You Actually Need
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Three groups of ten. The Daily 10 (used every day), the Story Verbs (for telling
+            stories), and the Same-Form 10 (look unchanged). Tap any verb to hear the past form.
+          </p>
+        </div>
+        <CognateDiscovery client:visible waves={waveData} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="was-were" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Layers class="w-4 h-4" />
+            Section B
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Was and Were — The Two Forms of "To Be" in Past
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Was' for I/he/she/it. 'Were' for we/you/they. That's it. Add 'not' for negatives,
+            flip the order for questions. Five minutes of drilling to make this automatic.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={sentenceBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="did" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <HelpCircle class="w-4 h-4" />
+            Section C
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Did / Didn't — Questions and Negatives for Every Verb
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            One critical rule: after 'Did' or 'didn't', the verb goes back to its BASE form.
+            'Did you go' (NOT 'Did you went'). 'I didn't see' (NOT 'I didn't saw'). The #1
+            past-tense error in English — and the easiest one to fix.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={powerVerbBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="sequencing" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Link2 class="w-4 h-4" />
+            Section D
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Story Connectors — Sequencing Past Events
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Five connectors that turn isolated past sentences into a flowing story. Then a Boss
+            Sentence: a five-step trip to Boston using five irregular verbs and five connectors.
+          </p>
+        </div>
+        <ConnectorChallenge
+          client:visible
+          connectors={connectorSentences.connectors}
+          bossSentence={connectorSentences.bossSentence}
+          lang="en"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section id="pronunciation" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-rose-500 text-sm font-semibold mb-2">
+            <Volume2 class="w-4 h-4" />
+            Pronunciation Lab
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            The Three Big Pronunciation Traps
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Said' sounds like 'SED' (not 'SAYD'). 'Thought' sounds like 'THOT' (silent gh).
+            'Read' in past tense rhymes with 'bed' (not 'reed'). Drill until they sound natural.
+          </p>
+        </div>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="self-test" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <ClipboardCheck class="w-4 h-4" />
+            Self-Test
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Test What You Learned
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Flashcard review of all 30 irregular verbs, the was/were forms, and the did/didn't
+            structures. Switch between Spanish→English and English→Spanish modes.
+          </p>
+        </div>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-gradient-to-b from-slate-900 to-slate-800">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-2xl mx-auto text-center space-y-6">
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/20 text-emerald-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-bold text-white">Unit 2 Complete!</h2>
+        <p class="text-lg text-slate-100 leading-relaxed">
+          You can now talk about yesterday with both regular AND irregular verbs, ask past-tense
+          questions with 'Did', and use 'was/were' for any subject. That's the foundation. Next:
+          using all of it to tell your day as a real story.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center pt-4">
+          <a
+            href="/en/course/elementary/unit-1/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors"
+          >
+            ← Review Unit 1
+          </a>
+          {nextUnitPublished ? (
+            <a
+              href="/en/course/elementary/unit-3/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Continue to Unit 3 →
+            </a>
+          ) : (
+            <a
+              href="/en/course/elementary/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Course Overview
+            </a>
+          )}
+        </div>
+        <div class="pt-8 border-t border-slate-700 mt-8">
+          <p class="text-slate-200 text-sm mb-3">
+            Want personalized English coaching?
+          </p>
+          <a
+            href="/en/contact/"
+            class="text-sky-400 hover:text-sky-300 font-medium underline underline-offset-2"
+          >
+            Book a free consultation with Robert →
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/elemental/unidad-2.astro
+++ b/src/pages/es/curso/elemental/unidad-2.astro
@@ -1,0 +1,293 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CognateDiscovery from "@components/course/CognateDiscovery";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import ConnectorChallenge from "@components/course/ConnectorChallenge";
+import SelfTest from "@components/course/SelfTest";
+import { elementaryUnits } from "@data/elementary/units";
+import {
+  cognateWaves,
+  sentenceBlocks,
+  powerVerbBlocks,
+  connectorSentences,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/elementary/unit-2";
+import {
+  BookOpen,
+  Layers,
+  Zap,
+  Link2,
+  Volume2,
+  ClipboardCheck,
+  HelpCircle,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/elementary/unit-2" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
+
+const nextUnit = elementaryUnits.find((u) => u.id === 3);
+const nextUnitPublished = nextUnit?.published ?? false;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unidad 2: Ayer Fui | Inglés Elemental (A2)"
+  description="Verbos irregulares en pasado simple: los 30 más comunes, más was/were y preguntas con did/didn't. Habla con fluidez de ayer. Lección A2 gratis."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={2}
+    basePath="/es/curso/elemental"
+    lang="es"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-sky-400 text-sm font-semibold mb-3">
+          <BookOpen class="w-4 h-4" />
+          Unidad 2
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Ayer Fui
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Los verbos irregulares parecen aterradores pero son FINITOS. Existen unos 200; 30
+          cubren la mayoría de lo que dirás en pasado. Hoy practicamos esos 30 — agrupados por
+          patrón para que se queden — más 'was/were' y la forma de pregunta 'Did you...?'
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <nav class="bg-white border-b border-slate-200 sticky top-[52px] z-30 overflow-x-auto">
+    <div class="site-container mx-auto px-4">
+      <div class="flex items-center gap-1 py-2 text-sm whitespace-nowrap">
+        <a href="#irregulars" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <BookOpen class="w-3.5 h-3.5" /> 30 Irregulares
+        </a>
+        <a href="#was-were" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Layers class="w-3.5 h-3.5" /> Was / Were
+        </a>
+        <a href="#did" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <HelpCircle class="w-3.5 h-3.5" /> Did / Didn't
+        </a>
+        <a href="#sequencing" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Link2 class="w-3.5 h-3.5" /> Conectores
+        </a>
+        <a href="#pronunciation" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Volume2 class="w-3.5 h-3.5" /> Pronunciación
+        </a>
+        <a href="#self-test" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <ClipboardCheck class="w-3.5 h-3.5" /> Auto-Test
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <section id="irregulars" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <BookOpen class="w-4 h-4" />
+            Sección A
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Los 30 Verbos Irregulares Que Realmente Necesitas
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Tres grupos de diez. Los 10 Diarios (que usas todos los días), los Verbos de Historia
+            (para contar historias), y los 10 Inalterados (se ven iguales). Toca cualquier verbo
+            para escuchar su forma del pasado.
+          </p>
+        </div>
+        <CognateDiscovery client:visible waves={waveData} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="was-were" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Layers class="w-4 h-4" />
+            Sección B
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Was y Were — Las Dos Formas de "To Be" en Pasado
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Was' para I/he/she/it. 'Were' para we/you/they. Eso es todo. Agrega 'not' para
+            negativos, invierte el orden para preguntas. Cinco minutos de práctica para que sea
+            automático.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={sentenceBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="did" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <HelpCircle class="w-4 h-4" />
+            Sección C
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Did / Didn't — Preguntas y Negativos para Cualquier Verbo
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Una regla crítica: después de 'Did' o 'didn't', el verbo regresa a su forma BASE.
+            'Did you go' (NO 'Did you went'). 'I didn't see' (NO 'I didn't saw'). El error #1 del
+            pasado en inglés — y el más fácil de corregir.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={powerVerbBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="sequencing" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Link2 class="w-4 h-4" />
+            Sección D
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Conectores Narrativos — Secuenciando Eventos Pasados
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Cinco conectores que convierten oraciones aisladas en pasado en una historia que
+            fluye. Después una Oración Maestra: un viaje de cinco pasos a Boston usando cinco
+            verbos irregulares y cinco conectores.
+          </p>
+        </div>
+        <ConnectorChallenge
+          client:visible
+          connectors={connectorSentences.connectors}
+          bossSentence={connectorSentences.bossSentence}
+          lang="es"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section id="pronunciation" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-rose-500 text-sm font-semibold mb-2">
+            <Volume2 class="w-4 h-4" />
+            Laboratorio de Pronunciación
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Las Tres Trampas Grandes de Pronunciación
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Said' suena como 'SED' (no 'SAYD'). 'Thought' suena como 'THOT' (gh muda). 'Read' en
+            pasado rima con 'bed' (no 'reed'). Practica hasta que suenen naturales.
+          </p>
+        </div>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="self-test" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <ClipboardCheck class="w-4 h-4" />
+            Auto-Evaluación
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Evalúa Lo que Aprendiste
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Repaso tipo flashcard de los 30 verbos irregulares, las formas was/were, y las
+            estructuras did/didn't. Cambia entre los modos español→inglés e inglés→español.
+          </p>
+        </div>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-gradient-to-b from-slate-900 to-slate-800">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-2xl mx-auto text-center space-y-6">
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/20 text-emerald-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-bold text-white">¡Unidad 2 Completada!</h2>
+        <p class="text-lg text-slate-100 leading-relaxed">
+          Ahora puedes hablar de ayer con verbos regulares E irregulares, hacer preguntas en
+          pasado con 'Did', y usar 'was/were' para cualquier sujeto. Esa es la base. Sigue: usar
+          todo eso para contar tu día como una historia real.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center pt-4">
+          <a
+            href="/es/curso/elemental/unidad-1/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors"
+          >
+            ← Repasar Unidad 1
+          </a>
+          {nextUnitPublished ? (
+            <a
+              href="/es/curso/elemental/unidad-3/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Continuar a Unidad 3 →
+            </a>
+          ) : (
+            <a
+              href="/es/curso/elemental/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Vista General del Curso
+            </a>
+          )}
+        </div>
+        <div class="pt-8 border-t border-slate-700 mt-8">
+          <p class="text-slate-200 text-sm mb-3">
+            ¿Quieres coaching personalizado de inglés?
+          </p>
+          <a
+            href="/es/contact/"
+            class="text-sky-400 hover:text-sky-300 font-medium underline underline-offset-2"
+          >
+            Reserva una consulta gratuita con Robert →
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary
Second content unit of the A2 "Tell Your Story" course. Picks up where Unit 1 left off — regular -ed verbs gave learners the rule; Unit 2 gives them the irregulars that "don't follow the rules but follow patterns."

## Pedagogical arc

### Section A — 30 Irregulars in 3 Memorable Waves
The Daily 10 (went, did, had, got, made, said, saw, came, took, gave), the Story Verbs (told, thought, knew, found, left, felt, became, brought, wrote, read), and the Same-Form 10 (put, cut, hit, let, set, shut, cost, hurt, fit, spread). Grouping by usage frequency and pattern type makes them stick better than alphabetical lists.

### Section B — Was / Were
Drills affirmative ("I was tired"), negative ("They weren't invited"), and questions ("Were you tired?") across all 6 subject pronouns. Two forms, two simple rules.

### Section C — Did / Didn't
The #1 past-tense error in English: using the past form after `did` ("Did you went" — wrong; "Did you go" — right). This section drills that critical rule across questions, negatives, Wh-questions, and short answers.

### Section D — Story Connectors
Five narrative connectors (yesterday morning, after that, later, then, finally) plus a Boss Sentence: a 5-step Boston trip using 5 irregular verbs and 5 connectors. This is what telling a real story sounds like.

### Section E — Pronunciation Traps
Three big ones drilled: `said` → SED (not SAYD), `thought` → THOT (silent gh), `read` past tense → RED (rhymes with bed). Plus `was`/`were` reductions in fast speech.

### Section F — Self-Test
40+ vocab items: all 30 irregulars + was/were forms + did/didn't structures + sequencing markers.

## Conditional next-unit CTA
"Continue to Unit 3" only renders if `unit 3.published === true`. Otherwise falls back to "Course Overview" — avoids 404s during the gradual rollout.

## Files
- `src/data/elementary/unit-2.ts` (~340 lines) — drill content
- `src/pages/en/course/elementary/unit-2.astro` (~250 lines)
- `src/pages/es/curso/elemental/unidad-2.astro` (~250 lines)
- `src/data/elementary/units.ts` — flips Unit 2's `published` to `true`

## Test plan
- [x] `npm run build` passes; 426 pages emitted (+2 from main); all SEO gates pass
- [x] Meta-description gate confirms 0 too-long descriptions on new pages
- [ ] Vercel preview: `/en/course/elementary/` now shows Units 1 AND 2 as available; Units 3-10 still gated
- [ ] Vercel preview: `/en/course/elementary/unit-2/` and `/es/curso/elemental/unidad-2/` render all 6 sections
- [ ] Unit 1 → Unit 2 link now works (Unit 1's CTA is conditional and should now show "Continue to Unit 2")
- [ ] Hreflang correctly cross-links EN ↔ ES Unit 2 pages