### PR TITLE
feat(a2): ship Unit 3 — telling your day with time markers and sequencing

### DIFF
--- a/src/data/elementary/unit-3.ts
+++ b/src/data/elementary/unit-3.ts
@@ -1,0 +1,571 @@
+// Unit 3: "Telling Your Day" — Time markers + sequencing connectors
+//
+// Pedagogical arc (this is the integration unit for past simple):
+// Section A — Time + sequence vocabulary in 3 waves
+// Section B — Time markers in sentences (placement: start vs. end)
+// Section C — Sequencing mini-stories (first / then / after that / finally)
+// Section D — Boss Sentence: a full 5-event day, end to end
+// Section E — Pronunciation drill: reductions in fast storytelling
+// Section F — Self-test of unit vocabulary
+
+export interface CognateWord {
+  english: string;
+  spanish: string;
+  category: string;
+  pronunciationNote?: string;
+  pronunciationNoteEs?: string;
+}
+
+export interface SentenceBlock {
+  label: string;
+  labelEs: string;
+  description: string;
+  descriptionEs: string;
+  sentences: {
+    english: string;
+    spanish: string;
+    highlight?: string;
+  }[];
+}
+
+export interface PronunciationDrillItem {
+  word: string;
+  spanishStress: string;
+  englishStress: string;
+  tip: string;
+  tipEs: string;
+}
+
+export interface VocabItem {
+  english: string;
+  spanish: string;
+  type: "verb" | "phrase" | "marker";
+}
+
+// ─── Section A: Time & Sequence Vocabulary (Cognate Discovery format) ────────
+
+export const cognateWaves = {
+  wave1: {
+    title: "Specific Past Times — When It Happened",
+    titleEs: "Tiempos Específicos del Pasado — Cuándo pasó",
+    description:
+      "These markers anchor a sentence in a precise past moment. The more specific your time marker, the more vivid your story.",
+    descriptionEs:
+      "Estos marcadores anclan una oración en un momento preciso del pasado. Mientras más específico el marcador, más vívida tu historia.",
+    words: [
+      {
+        english: "yesterday",
+        spanish: "ayer",
+        category: "Specific past",
+      },
+      {
+        english: "yesterday morning",
+        spanish: "ayer en la mañana",
+        category: "Specific past",
+      },
+      { english: "last night", spanish: "anoche", category: "Specific past" },
+      { english: "this morning", spanish: "esta mañana", category: "Specific past" },
+      { english: "last weekend", spanish: "el fin de semana pasado", category: "Specific past" },
+      { english: "last week", spanish: "la semana pasada", category: "Specific past" },
+      { english: "last month", spanish: "el mes pasado", category: "Specific past" },
+      { english: "last year", spanish: "el año pasado", category: "Specific past" },
+      {
+        english: "two days ago",
+        spanish: "hace dos días",
+        category: "Specific past",
+        pronunciationNote: "'Ago' is reduced to 'uh-go' in fast speech.",
+        pronunciationNoteEs: "'Ago' se reduce a 'uh-go' en habla rápida.",
+      },
+      { english: "an hour ago", spanish: "hace una hora", category: "Specific past" },
+      { english: "a few minutes ago", spanish: "hace unos minutos", category: "Specific past" },
+      { english: "earlier today", spanish: "más temprano hoy", category: "Specific past" },
+    ] as CognateWord[],
+  },
+  wave2: {
+    title: "Sequencing Connectors — Story Structure",
+    titleEs: "Conectores de Secuencia — Estructura narrativa",
+    description:
+      "These connectors organize events in time order. They turn a list of facts into a story your listener can follow.",
+    descriptionEs:
+      "Estos conectores organizan los eventos en orden cronológico. Convierten una lista de hechos en una historia que tu oyente puede seguir.",
+    words: [
+      {
+        english: "first",
+        spanish: "primero",
+        category: "Sequence",
+        pronunciationNote: "Strong R, single syllable: 'FURST'.",
+        pronunciationNoteEs: "R fuerte, una sílaba: 'FURST'.",
+      },
+      { english: "then", spanish: "luego / entonces", category: "Sequence" },
+      { english: "next", spanish: "después", category: "Sequence" },
+      { english: "after that", spanish: "después de eso", category: "Sequence" },
+      { english: "later", spanish: "más tarde", category: "Sequence" },
+      { english: "soon after", spanish: "poco después", category: "Sequence" },
+      { english: "an hour later", spanish: "una hora después", category: "Sequence" },
+      {
+        english: "eventually",
+        spanish: "eventualmente / con el tiempo",
+        category: "Sequence",
+        pronunciationNote: "Five syllables: e-VEN-chu-al-ly. Stress on 'VEN'.",
+        pronunciationNoteEs: "Cinco sílabas: e-VEN-chu-al-ly. Acento en 'VEN'.",
+      },
+      { english: "finally", spanish: "finalmente", category: "Sequence" },
+      { english: "in the end", spanish: "al final", category: "Sequence" },
+    ] as CognateWord[],
+  },
+  wave3: {
+    title: "Time Relations — How Events Connect",
+    titleEs: "Relaciones de Tiempo — Cómo se conectan los eventos",
+    description:
+      "These connect ONE event to ANOTHER in time. They're how you signal that something happened during, before, or after something else.",
+    descriptionEs:
+      "Estos conectan UN evento con OTRO en el tiempo. Son cómo señalas que algo pasó durante, antes, o después de otra cosa.",
+    words: [
+      { english: "before", spanish: "antes (de)", category: "Time relations" },
+      { english: "after", spanish: "después (de)", category: "Time relations" },
+      {
+        english: "while",
+        spanish: "mientras",
+        category: "Time relations",
+        pronunciationNote: "Sounds like 'WHYL'. Silent 'h' in modern English.",
+        pronunciationNoteEs: "Suena como 'WHYL'. La 'h' es muda en inglés moderno.",
+      },
+      { english: "when", spanish: "cuando", category: "Time relations" },
+      { english: "until", spanish: "hasta", category: "Time relations" },
+      { english: "as soon as", spanish: "tan pronto como", category: "Time relations" },
+      { english: "right after", spanish: "justo después", category: "Time relations" },
+      { english: "just before", spanish: "justo antes", category: "Time relations" },
+      { english: "during", spanish: "durante", category: "Time relations" },
+      { english: "between", spanish: "entre", category: "Time relations" },
+    ] as CognateWord[],
+  },
+};
+
+// ─── Section B: Time Markers in Sentences (Placement) ────────────────────────
+
+export const sentenceBlocks: SentenceBlock[] = [
+  {
+    label: "Step 1: Time marker at the START",
+    labelEs: "Paso 1: Marcador de tiempo al INICIO",
+    description:
+      "Putting the time first signals the moment immediately. Add a comma after the time marker. This is the most common storytelling opener.",
+    descriptionEs:
+      "Poner el tiempo al inicio señala el momento inmediatamente. Agrega una coma después del marcador. Este es el inicio de historia más común.",
+    sentences: [
+      {
+        english: "Yesterday, I worked from home.",
+        spanish: "Ayer, trabajé desde casa.",
+        highlight: "Yesterday",
+      },
+      {
+        english: "Last weekend, we visited my parents.",
+        spanish: "El fin de semana pasado, visitamos a mis padres.",
+        highlight: "Last weekend",
+      },
+      {
+        english: "This morning, I went for a run.",
+        spanish: "Esta mañana, salí a correr.",
+        highlight: "This morning",
+      },
+      {
+        english: "Two days ago, she called me.",
+        spanish: "Hace dos días, ella me llamó.",
+        highlight: "Two days ago",
+      },
+    ],
+  },
+  {
+    label: "Step 2: Time marker at the END",
+    labelEs: "Paso 2: Marcador de tiempo al FINAL",
+    description:
+      "Same meaning, different rhythm. Putting the time at the end emphasizes the action first, the time second. No comma needed.",
+    descriptionEs:
+      "Mismo significado, ritmo diferente. Poner el tiempo al final enfatiza la acción primero, el tiempo después. No necesita coma.",
+    sentences: [
+      {
+        english: "I worked from home yesterday.",
+        spanish: "Trabajé desde casa ayer.",
+        highlight: "yesterday",
+      },
+      {
+        english: "We visited my parents last weekend.",
+        spanish: "Visitamos a mis padres el fin de semana pasado.",
+        highlight: "last weekend",
+      },
+      {
+        english: "She called me two days ago.",
+        spanish: "Ella me llamó hace dos días.",
+        highlight: "two days ago",
+      },
+      {
+        english: "I sent the email an hour ago.",
+        spanish: "Mandé el correo hace una hora.",
+        highlight: "an hour ago",
+      },
+    ],
+  },
+  {
+    label: "Step 3: Two time markers — when AND duration",
+    labelEs: "Paso 3: Dos marcadores — cuándo Y duración",
+    description:
+      "Stack two time markers for richer stories: when something started + how long it lasted. Common, natural, native-sounding.",
+    descriptionEs:
+      "Apila dos marcadores para historias más ricas: cuándo empezó algo + cuánto duró. Común, natural, suena nativo.",
+    sentences: [
+      {
+        english: "Yesterday morning, I worked from home until lunch.",
+        spanish: "Ayer en la mañana, trabajé desde casa hasta el almuerzo.",
+        highlight: "until lunch",
+      },
+      {
+        english: "Last night, we talked for two hours.",
+        spanish: "Anoche, hablamos por dos horas.",
+        highlight: "for two hours",
+      },
+      {
+        english: "On Monday, I studied from 9 to 5.",
+        spanish: "El lunes, estudié de 9 a 5.",
+        highlight: "from 9 to 5",
+      },
+      {
+        english: "Last weekend, they stayed with us until Sunday.",
+        spanish: "El fin de semana pasado, se quedaron con nosotros hasta el domingo.",
+        highlight: "until Sunday",
+      },
+    ],
+  },
+  {
+    label: "Step 4: Time + sequence in two-sentence stories",
+    labelEs: "Paso 4: Tiempo + secuencia en historias de dos oraciones",
+    description:
+      "Now combine: time marker for sentence 1, sequence connector for sentence 2. This is the smallest unit of a real story.",
+    descriptionEs:
+      "Ahora combina: marcador de tiempo para la oración 1, conector de secuencia para la oración 2. Esta es la unidad más pequeña de una historia real.",
+    sentences: [
+      {
+        english: "Yesterday, I checked my email. Then I had a long meeting.",
+        spanish: "Ayer, revisé mi correo. Luego tuve una junta larga.",
+        highlight: "Then",
+      },
+      {
+        english: "Last week, I started a new project. After that, everything got busy.",
+        spanish: "La semana pasada, empecé un proyecto nuevo. Después de eso, todo se puso ocupado.",
+        highlight: "After that",
+      },
+      {
+        english: "This morning, I made coffee. Later, I went for a walk.",
+        spanish: "Esta mañana, hice café. Más tarde, salí a caminar.",
+        highlight: "Later",
+      },
+      {
+        english: "Two days ago, she sent me a question. I answered it eventually.",
+        spanish: "Hace dos días, ella me envió una pregunta. La respondí eventualmente.",
+        highlight: "eventually",
+      },
+    ],
+  },
+];
+
+// ─── Section C: Building a Story with Sequencing Connectors ──────────────────
+
+export const powerVerbBlocks: SentenceBlock[] = [
+  {
+    label: "First / Then — The Two-Step Story",
+    labelEs: "First / Then — La historia de dos pasos",
+    description:
+      "The simplest narrative pattern: one event, then the next. 'First' opens it; 'then' continues it.",
+    descriptionEs:
+      "El patrón narrativo más simple: un evento, luego el siguiente. 'First' lo abre; 'then' lo continúa.",
+    sentences: [
+      {
+        english: "First, I went to the gym. Then I came home.",
+        spanish: "Primero, fui al gimnasio. Luego volví a casa.",
+        highlight: "First / Then",
+      },
+      {
+        english: "First, she read the report. Then she called the team.",
+        spanish: "Primero, ella leyó el reporte. Luego llamó al equipo.",
+        highlight: "First / Then",
+      },
+      {
+        english: "First, we ordered food. Then we watched a movie.",
+        spanish: "Primero, ordenamos comida. Luego vimos una película.",
+        highlight: "First / Then",
+      },
+      {
+        english: "First, he finished the slides. Then he sent them to me.",
+        spanish: "Primero, él terminó las diapositivas. Luego me las mandó.",
+        highlight: "First / Then",
+      },
+    ],
+  },
+  {
+    label: "First / Then / Finally — Three Events",
+    labelEs: "First / Then / Finally — Tres eventos",
+    description:
+      "Three connectors, three events. 'Finally' marks the LAST event — it tells the listener your story is ending.",
+    descriptionEs:
+      "Tres conectores, tres eventos. 'Finally' marca el ÚLTIMO evento — le dice al oyente que tu historia está terminando.",
+    sentences: [
+      {
+        english:
+          "First, I made breakfast. Then I read the news. Finally, I started working.",
+        spanish:
+          "Primero, hice el desayuno. Luego leí las noticias. Finalmente, empecé a trabajar.",
+        highlight: "Finally",
+      },
+      {
+        english:
+          "First, we drove to the airport. Then we waited in the lobby. Finally, the plane took off.",
+        spanish:
+          "Primero, manejamos al aeropuerto. Luego esperamos en el lobby. Finalmente, el avión despegó.",
+        highlight: "Finally",
+      },
+      {
+        english:
+          "First, he wrote the proposal. Then he reviewed it. Finally, he sent it.",
+        spanish:
+          "Primero, él escribió la propuesta. Luego la revisó. Finalmente, la envió.",
+        highlight: "Finally",
+      },
+      {
+        english:
+          "First, she called the client. Then she explained the issue. Finally, they agreed on a solution.",
+        spanish:
+          "Primero, ella llamó al cliente. Luego explicó el problema. Finalmente, acordaron una solución.",
+        highlight: "Finally",
+      },
+    ],
+  },
+  {
+    label: "Adding 'After that' and 'Later'",
+    labelEs: "Agregando 'After that' y 'Later'",
+    description:
+      "Stack more connectors for richer stories. 'After that' = right after. 'Later' = some time later. They're not interchangeable — choose based on how much time passed.",
+    descriptionEs:
+      "Apila más conectores para historias más ricas. 'After that' = justo después. 'Later' = un tiempo después. No son intercambiables — elige según cuánto tiempo pasó.",
+    sentences: [
+      {
+        english:
+          "Yesterday morning, I had a meeting. After that, I worked on the proposal. Later, I sent it to my boss.",
+        spanish:
+          "Ayer en la mañana, tuve una junta. Después de eso, trabajé en la propuesta. Más tarde, se la mandé a mi jefe.",
+        highlight: "After that / Later",
+      },
+      {
+        english:
+          "We arrived at the hotel. After that, we unpacked. Later, we went out for dinner.",
+        spanish:
+          "Llegamos al hotel. Después de eso, desempacamos. Más tarde, salimos a cenar.",
+        highlight: "After that / Later",
+      },
+      {
+        english:
+          "She started her run at 7. After that, she had breakfast. Later, she got to the office.",
+        spanish:
+          "Empezó a correr a las 7. Después de eso, desayunó. Más tarde, llegó a la oficina.",
+        highlight: "After that / Later",
+      },
+      {
+        english:
+          "First, the team brainstormed ideas. After that, they picked the best one. Later, they built the prototype.",
+        spanish:
+          "Primero, el equipo lluvia de ideas. Después de eso, eligieron la mejor. Más tarde, construyeron el prototipo.",
+        highlight: "After that / Later",
+      },
+    ],
+  },
+  {
+    label: "A Real Weekend Story — Four Events",
+    labelEs: "Una historia real de fin de semana — Cuatro eventos",
+    description:
+      "Now you build a real story. Four events with four connectors. This is the kind of story you'd tell a friend on Monday morning.",
+    descriptionEs:
+      "Ahora construyes una historia real. Cuatro eventos con cuatro conectores. Es la clase de historia que le contarías a un amigo el lunes en la mañana.",
+    sentences: [
+      {
+        english:
+          "Last weekend, I drove to the coast on Saturday morning. First, we walked on the beach. Then we had lunch at a small restaurant. Finally, we drove home in the evening.",
+        spanish:
+          "El fin de semana pasado, manejé a la costa el sábado en la mañana. Primero, caminamos en la playa. Luego almorzamos en un restaurante pequeño. Finalmente, manejamos a casa por la tarde.",
+        highlight: "Last weekend / First / Then / Finally",
+      },
+      {
+        english:
+          "Last Saturday, my friends came over. First, we cooked dinner together. After that, we watched a movie. Eventually, everyone went home.",
+        spanish:
+          "El sábado pasado, mis amigos vinieron a casa. Primero, cocinamos la cena juntos. Después de eso, vimos una película. Eventualmente, todos se fueron a casa.",
+        highlight: "First / After that / Eventually",
+      },
+      {
+        english:
+          "Last Sunday morning, I woke up early. First, I made coffee. Then I read for an hour. Later, I called my parents.",
+        spanish:
+          "El domingo pasado en la mañana, me desperté temprano. Primero, hice café. Luego leí por una hora. Más tarde, llamé a mis padres.",
+        highlight: "First / Then / Later",
+      },
+    ],
+  },
+];
+
+// ─── Section D: Boss Sentence — A Full 5-Event Day (Connector Challenge) ─────
+
+export const connectorSentences = {
+  connectors: [
+    {
+      word: "First",
+      wordEs: "Primero",
+      example: "First, I made coffee.",
+      exampleEs: "Primero, hice café.",
+      use: "Opens a sequence. Tells the listener 'here's where the story starts'.",
+      useEs: "Abre una secuencia. Le dice al oyente 'aquí empieza la historia'.",
+    },
+    {
+      word: "Then",
+      wordEs: "Luego / Entonces",
+      example: "Then I checked my email.",
+      exampleEs: "Luego revisé mi correo.",
+      use: "The most common middle connector. Use it freely between events.",
+      useEs: "El conector intermedio más común. Úsalo libremente entre eventos.",
+    },
+    {
+      word: "After that",
+      wordEs: "Después de eso",
+      example: "After that, I had a video call.",
+      exampleEs: "Después de eso, tuve una videollamada.",
+      use: "Stronger than 'then'. Signals the next event was directly caused by the previous one.",
+      useEs: "Más fuerte que 'then'. Señala que el siguiente evento fue causado directamente por el anterior.",
+    },
+    {
+      word: "Later",
+      wordEs: "Más tarde",
+      example: "Later, I went out for lunch.",
+      exampleEs: "Más tarde, salí a almorzar.",
+      use: "Some time has passed — minutes, hours, even days. Looser than 'after that'.",
+      useEs: "Pasó algo de tiempo — minutos, horas, incluso días. Más amplio que 'after that'.",
+    },
+    {
+      word: "Finally",
+      wordEs: "Finalmente",
+      example: "Finally, I went to bed.",
+      exampleEs: "Finalmente, me fui a dormir.",
+      use: "Marks the LAST event. Strong story closer — your listener knows you're done.",
+      useEs: "Marca el ÚLTIMO evento. Cierre fuerte de historia — tu oyente sabe que terminaste.",
+    },
+  ],
+  bossSentence: {
+    english:
+      "Yesterday was a long day. First, I woke up at six and went for a run. Then I made breakfast and started working. After that, I had three back-to-back meetings until lunch. Later, I finished a report and sent it to my boss. Finally, I went out for dinner with a friend and got home around ten.",
+    spanish:
+      "Ayer fue un día largo. Primero, me desperté a las seis y salí a correr. Luego hice el desayuno y empecé a trabajar. Después de eso, tuve tres juntas seguidas hasta el almuerzo. Más tarde, terminé un reporte y se lo mandé a mi jefe. Finalmente, salí a cenar con un amigo y llegué a casa cerca de las diez.",
+    explanation:
+      "Six sentences. Five connectors (First / Then / After that / Later / Finally). Past simple verbs (woke up, went, made, started, had, finished, sent, got home). This is what 'telling your day' sounds like in real English.",
+    explanationEs:
+      "Seis oraciones. Cinco conectores (First / Then / After that / Later / Finally). Verbos en pasado simple (woke up, went, made, started, had, finished, sent, got home). Así suena 'contar tu día' en inglés real.",
+  },
+};
+
+// ─── Section E: Pronunciation Lab — Reductions in Storytelling ───────────────
+
+export const pronunciationDrills: PronunciationDrillItem[] = [
+  {
+    word: "ago",
+    spanishStress: "A-go (full pronunciation, both syllables stressed)",
+    englishStress: "uh-GO (reduced first syllable)",
+    tip: "The first 'a' is reduced to 'uh'. 'Two days ago' = 'two days uh-GO'.",
+    tipEs: "La primera 'a' se reduce a 'uh'. 'Two days ago' = 'two days uh-GO'.",
+  },
+  {
+    word: "last night",
+    spanishStress: "LAST NIGHT (both fully pronounced)",
+    englishStress: "lasNIGHT (the 't' of 'last' merges into 'night')",
+    tip: "Native speakers drop or soften the 't' in 'last' before another word. Sounds like one word: 'lasNIGHT'.",
+    tipEs: "Los nativos suavizan o eliminan la 't' de 'last' antes de otra palabra. Suena como una sola palabra: 'lasNIGHT'.",
+  },
+  {
+    word: "yesterday morning",
+    spanishStress: "yes-ter-DAY mor-ning (each word separate)",
+    englishStress: "YES-ter-day MOR-ning (linked, smooth)",
+    tip: "Don't pause between the two words. The 'y' of 'yesterday' flows into the rest of the phrase like a single beat.",
+    tipEs: "No pauses entre las dos palabras. La 'y' de 'yesterday' fluye al resto de la frase como un solo golpe.",
+  },
+  {
+    word: "an hour ago",
+    spanishStress: "an HOUR a-go (with 'h' pronounced)",
+    englishStress: "uh-NOUR uh-go (silent h, all linked)",
+    tip: "The 'h' in 'hour' is SILENT. So 'an hour' sounds like 'uh-NOUR'. That's why we say 'AN hour', not 'A hour'.",
+    tipEs: "La 'h' en 'hour' es MUDA. Entonces 'an hour' suena como 'uh-NOUR'. Por eso decimos 'AN hour', no 'A hour'.",
+  },
+  {
+    word: "after that",
+    spanishStress: "AF-ter THAT (full pronunciation)",
+    englishStress: "AF-ter-that (linked, the 'r' of 'after' connects)",
+    tip: "The R of 'after' links straight into 'that'. Sounds like one word in fast speech.",
+    tipEs: "La R de 'after' conecta directo con 'that'. Suena como una sola palabra en habla rápida.",
+  },
+  {
+    word: "first",
+    spanishStress: "FUR-st (two syllables, rolled R)",
+    englishStress: "FURST (one syllable, curled R, sharp -st)",
+    tip: "ONE syllable. The English R doesn't roll — it curls back. The 'st' at the end is sharp.",
+    tipEs: "UNA sílaba. La R inglesa no vibra — se curva hacia atrás. La 'st' al final es aguda.",
+  },
+  {
+    word: "finally",
+    spanishStress: "fi-NAL-ly (Spanish stress)",
+    englishStress: "FI-nuh-ly (English stress on first syllable)",
+    tip: "Stress on the FIRST syllable: FI-nuh-ly. Three syllables, not four.",
+    tipEs: "Acento en la PRIMERA sílaba: FI-nuh-ly. Tres sílabas, no cuatro.",
+  },
+  {
+    word: "eventually",
+    spanishStress: "e-ven-tu-AL-ly (Spanish stress on -al)",
+    englishStress: "e-VEN-chu-al-ly (stress on 'VEN', 'tu' becomes 'chu')",
+    tip: "Five syllables. Stress on the SECOND. The 'tu' sound becomes 'chu' in fast speech.",
+    tipEs: "Cinco sílabas. Acento en la SEGUNDA. El sonido 'tu' se convierte en 'chu' en habla rápida.",
+  },
+];
+
+// ─── Section F: Vocabulary List for Self-Test ────────────────────────────────
+
+export const vocabularyList: VocabItem[] = [
+  // Specific past times
+  { english: "yesterday", spanish: "ayer", type: "marker" },
+  { english: "yesterday morning", spanish: "ayer en la mañana", type: "marker" },
+  { english: "last night", spanish: "anoche", type: "marker" },
+  { english: "this morning", spanish: "esta mañana", type: "marker" },
+  { english: "last weekend", spanish: "el fin de semana pasado", type: "marker" },
+  { english: "last week", spanish: "la semana pasada", type: "marker" },
+  { english: "last month", spanish: "el mes pasado", type: "marker" },
+  { english: "last year", spanish: "el año pasado", type: "marker" },
+  { english: "two days ago", spanish: "hace dos días", type: "marker" },
+  { english: "an hour ago", spanish: "hace una hora", type: "marker" },
+  { english: "earlier today", spanish: "más temprano hoy", type: "marker" },
+  // Sequence connectors
+  { english: "first", spanish: "primero", type: "marker" },
+  { english: "then", spanish: "luego/entonces", type: "marker" },
+  { english: "next", spanish: "después", type: "marker" },
+  { english: "after that", spanish: "después de eso", type: "marker" },
+  { english: "later", spanish: "más tarde", type: "marker" },
+  { english: "an hour later", spanish: "una hora después", type: "marker" },
+  { english: "eventually", spanish: "eventualmente", type: "marker" },
+  { english: "finally", spanish: "finalmente", type: "marker" },
+  { english: "in the end", spanish: "al final", type: "marker" },
+  // Time relations
+  { english: "before", spanish: "antes (de)", type: "marker" },
+  { english: "after", spanish: "después (de)", type: "marker" },
+  { english: "while", spanish: "mientras", type: "marker" },
+  { english: "when", spanish: "cuando", type: "marker" },
+  { english: "until", spanish: "hasta", type: "marker" },
+  { english: "as soon as", spanish: "tan pronto como", type: "marker" },
+  { english: "during", spanish: "durante", type: "marker" },
+  // Story phrases
+  { english: "I woke up at six.", spanish: "Me desperté a las seis.", type: "phrase" },
+  { english: "I went for a run.", spanish: "Salí a correr.", type: "phrase" },
+  { english: "I made breakfast.", spanish: "Hice el desayuno.", type: "phrase" },
+  { english: "I had a meeting.", spanish: "Tuve una junta.", type: "phrase" },
+  { english: "I sent a report.", spanish: "Mandé un reporte.", type: "phrase" },
+  { english: "I went out for dinner.", spanish: "Salí a cenar.", type: "phrase" },
+  { english: "I got home around ten.", spanish: "Llegué a casa cerca de las diez.", type: "phrase" },
+  { english: "Yesterday was a long day.", spanish: "Ayer fue un día largo.", type: "phrase" },
+];

--- a/src/data/elementary/units.ts
+++ b/src/data/elementary/units.ts
@@ -79,7 +79,7 @@ export const elementaryUnits: ElementaryUnit[] = [
     pronunciationFocus: "Reduced 'ago' and 'last' in fast speech",
     pronunciationFocusEs: "Reducción de 'ago' y 'last' en habla rápida",
     icon: "Calendar",
-    published: false,
+    published: true,
   },
   {
     id: 4,

--- a/src/pages/en/course/elementary/unit-3.astro
+++ b/src/pages/en/course/elementary/unit-3.astro
@@ -1,0 +1,290 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CognateDiscovery from "@components/course/CognateDiscovery";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import ConnectorChallenge from "@components/course/ConnectorChallenge";
+import SelfTest from "@components/course/SelfTest";
+import { elementaryUnits } from "@data/elementary/units";
+import {
+  cognateWaves,
+  sentenceBlocks,
+  powerVerbBlocks,
+  connectorSentences,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/elementary/unit-3";
+import {
+  Calendar,
+  Layers,
+  Zap,
+  Link2,
+  Volume2,
+  ClipboardCheck,
+  BookOpen,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/elementary/unit-3" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
+
+const nextUnit = elementaryUnits.find((u) => u.id === 4);
+const nextUnitPublished = nextUnit?.published ?? false;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unit 3: Telling Your Day | Elementary English (A2)"
+  description="Time markers, sequencing connectors, and your first 5-event story. Combine past simple regular and irregular verbs into real narratives. Free A2 lesson."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={3}
+    basePath="/en/course/elementary"
+    lang="en"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-sky-400 text-sm font-semibold mb-3">
+          <Calendar class="w-4 h-4" />
+          Unit 3
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Telling Your Day
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          You learned regular past tense in Unit 1 and irregular past tense in Unit 2. Today you
+          combine them into something useful: real stories about your real day. Time markers,
+          sequence connectors, and a 5-event Boss Sentence that pulls it all together.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <nav class="bg-white border-b border-slate-200 sticky top-[52px] z-30 overflow-x-auto">
+    <div class="site-container mx-auto px-4">
+      <div class="flex items-center gap-1 py-2 text-sm whitespace-nowrap">
+        <a href="#vocabulary" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <BookOpen class="w-3.5 h-3.5" /> Vocabulary
+        </a>
+        <a href="#placement" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Layers class="w-3.5 h-3.5" /> Placement
+        </a>
+        <a href="#stories" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Zap class="w-3.5 h-3.5" /> Stories
+        </a>
+        <a href="#boss" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Link2 class="w-3.5 h-3.5" /> Boss Sentence
+        </a>
+        <a href="#pronunciation" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Volume2 class="w-3.5 h-3.5" /> Pronunciation
+        </a>
+        <a href="#self-test" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <ClipboardCheck class="w-3.5 h-3.5" /> Self-Test
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <section id="vocabulary" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <BookOpen class="w-4 h-4" />
+            Section A
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Time and Sequence Vocabulary
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Three groups of words. Specific past times tell WHEN. Sequence connectors tell WHAT
+            ORDER. Time relations tell HOW EVENTS CONNECT. Tap any word to hear it.
+          </p>
+        </div>
+        <CognateDiscovery client:visible waves={waveData} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="placement" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Layers class="w-4 h-4" />
+            Section B
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Where Time Markers Go in a Sentence
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Same idea, two valid placements: time at the start (with a comma) or at the end (no
+            comma). Stack two markers for richer sentences. Native speakers do all three
+            constantly.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={sentenceBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="stories" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Zap class="w-4 h-4" />
+            Section C
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Building Stories With Sequencing Connectors
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Two events, three events, four events — each step builds on the last. By the end of
+            this section you'll have a real weekend story you could tell a friend on Monday.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={powerVerbBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="boss" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Link2 class="w-4 h-4" />
+            Section D
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            The Boss Sentence — A Full 5-Event Day
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Five connectors. Six sentences. One full day, end to end. This is what telling your
+            day sounds like in real English — drill it until you can adapt it to YOUR day.
+          </p>
+        </div>
+        <ConnectorChallenge
+          client:visible
+          connectors={connectorSentences.connectors}
+          bossSentence={connectorSentences.bossSentence}
+          lang="en"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section id="pronunciation" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-rose-500 text-sm font-semibold mb-2">
+            <Volume2 class="w-4 h-4" />
+            Pronunciation Lab
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Reductions in Fast Storytelling
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Native speakers REDUCE common time phrases when telling stories fast. 'An hour ago'
+            becomes 'uh-NOUR uh-go'. 'Last night' becomes 'lasNIGHT'. Drill until your speech flows.
+          </p>
+        </div>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="self-test" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <ClipboardCheck class="w-4 h-4" />
+            Self-Test
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Test What You Learned
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Flashcard review of every time marker, sequencing connector, and story phrase from
+            Unit 3. Switch between Spanish→English and English→Spanish modes.
+          </p>
+        </div>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-gradient-to-b from-slate-900 to-slate-800">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-2xl mx-auto text-center space-y-6">
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/20 text-emerald-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-bold text-white">Unit 3 Complete!</h2>
+        <p class="text-lg text-slate-100 leading-relaxed">
+          The past tense arc is finished. You can now tell a real story about your day —
+          regular verbs, irregular verbs, time markers, and sequencing all working together.
+          Next: stop looking back, start looking forward. Going to vs. will.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center pt-4">
+          <a
+            href="/en/course/elementary/unit-2/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors"
+          >
+            ← Review Unit 2
+          </a>
+          {nextUnitPublished ? (
+            <a
+              href="/en/course/elementary/unit-4/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Continue to Unit 4 →
+            </a>
+          ) : (
+            <a
+              href="/en/course/elementary/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Course Overview
+            </a>
+          )}
+        </div>
+        <div class="pt-8 border-t border-slate-700 mt-8">
+          <p class="text-slate-200 text-sm mb-3">
+            Want personalized English coaching?
+          </p>
+          <a
+            href="/en/contact/"
+            class="text-sky-400 hover:text-sky-300 font-medium underline underline-offset-2"
+          >
+            Book a free consultation with Robert →
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/elemental/unidad-3.astro
+++ b/src/pages/es/curso/elemental/unidad-3.astro
@@ -1,0 +1,293 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CognateDiscovery from "@components/course/CognateDiscovery";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import ConnectorChallenge from "@components/course/ConnectorChallenge";
+import SelfTest from "@components/course/SelfTest";
+import { elementaryUnits } from "@data/elementary/units";
+import {
+  cognateWaves,
+  sentenceBlocks,
+  powerVerbBlocks,
+  connectorSentences,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/elementary/unit-3";
+import {
+  Calendar,
+  Layers,
+  Zap,
+  Link2,
+  Volume2,
+  ClipboardCheck,
+  BookOpen,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/elementary/unit-3" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
+
+const nextUnit = elementaryUnits.find((u) => u.id === 4);
+const nextUnitPublished = nextUnit?.published ?? false;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unidad 3: Contando Tu Día | Inglés Elemental (A2)"
+  description="Marcadores de tiempo, conectores narrativos y tu primera historia de 5 eventos. Combina verbos regulares e irregulares en pasado. Lección A2 gratis."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={3}
+    basePath="/es/curso/elemental"
+    lang="es"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-sky-400 text-sm font-semibold mb-3">
+          <Calendar class="w-4 h-4" />
+          Unidad 3
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Contando Tu Día
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Aprendiste el pasado regular en la Unidad 1 y el pasado irregular en la Unidad 2. Hoy
+          los combinas en algo útil: historias reales sobre tu día real. Marcadores de tiempo,
+          conectores de secuencia, y una Oración Maestra de 5 eventos que une todo.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <nav class="bg-white border-b border-slate-200 sticky top-[52px] z-30 overflow-x-auto">
+    <div class="site-container mx-auto px-4">
+      <div class="flex items-center gap-1 py-2 text-sm whitespace-nowrap">
+        <a href="#vocabulary" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <BookOpen class="w-3.5 h-3.5" /> Vocabulario
+        </a>
+        <a href="#placement" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Layers class="w-3.5 h-3.5" /> Colocación
+        </a>
+        <a href="#stories" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Zap class="w-3.5 h-3.5" /> Historias
+        </a>
+        <a href="#boss" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Link2 class="w-3.5 h-3.5" /> Oración Maestra
+        </a>
+        <a href="#pronunciation" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Volume2 class="w-3.5 h-3.5" /> Pronunciación
+        </a>
+        <a href="#self-test" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <ClipboardCheck class="w-3.5 h-3.5" /> Auto-Test
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <section id="vocabulary" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <BookOpen class="w-4 h-4" />
+            Sección A
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Vocabulario de Tiempo y Secuencia
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Tres grupos de palabras. Tiempos específicos del pasado dicen CUÁNDO. Conectores de
+            secuencia dicen EN QUÉ ORDEN. Relaciones de tiempo dicen CÓMO SE CONECTAN. Toca
+            cualquier palabra para escucharla.
+          </p>
+        </div>
+        <CognateDiscovery client:visible waves={waveData} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="placement" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Layers class="w-4 h-4" />
+            Sección B
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Dónde Van los Marcadores de Tiempo en una Oración
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Misma idea, dos colocaciones válidas: tiempo al inicio (con coma) o al final (sin
+            coma). Apila dos marcadores para oraciones más ricas. Los nativos hacen las tres
+            constantemente.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={sentenceBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="stories" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Zap class="w-4 h-4" />
+            Sección C
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Construyendo Historias con Conectores de Secuencia
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Dos eventos, tres eventos, cuatro eventos — cada paso construye sobre el anterior.
+            Al final de esta sección tendrás una historia real de fin de semana que podrías
+            contarle a un amigo el lunes.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={powerVerbBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="boss" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Link2 class="w-4 h-4" />
+            Sección D
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            La Oración Maestra — Un Día Completo de 5 Eventos
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Cinco conectores. Seis oraciones. Un día completo, de inicio a fin. Así suena
+            contar tu día en inglés real — practícala hasta poder adaptarla a TU día.
+          </p>
+        </div>
+        <ConnectorChallenge
+          client:visible
+          connectors={connectorSentences.connectors}
+          bossSentence={connectorSentences.bossSentence}
+          lang="es"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section id="pronunciation" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-rose-500 text-sm font-semibold mb-2">
+            <Volume2 class="w-4 h-4" />
+            Laboratorio de Pronunciación
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Reducciones en la Narración Rápida
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Los nativos REDUCEN frases de tiempo comunes al contar historias rápido. 'An hour
+            ago' se vuelve 'uh-NOUR uh-go'. 'Last night' se vuelve 'lasNIGHT'. Practica hasta
+            que tu habla fluya.
+          </p>
+        </div>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="self-test" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <ClipboardCheck class="w-4 h-4" />
+            Auto-Evaluación
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Evalúa Lo que Aprendiste
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Repaso tipo flashcard de cada marcador de tiempo, conector de secuencia y frase de
+            historia de la Unidad 3. Cambia entre los modos español→inglés e inglés→español.
+          </p>
+        </div>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-gradient-to-b from-slate-900 to-slate-800">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-2xl mx-auto text-center space-y-6">
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/20 text-emerald-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-bold text-white">¡Unidad 3 Completada!</h2>
+        <p class="text-lg text-slate-100 leading-relaxed">
+          El arco del pasado está completo. Ahora puedes contar una historia real sobre tu día —
+          verbos regulares, verbos irregulares, marcadores de tiempo y secuenciación trabajando
+          juntos. Sigue: deja de mirar atrás, empieza a mirar adelante. Going to vs. will.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center pt-4">
+          <a
+            href="/es/curso/elemental/unidad-2/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors"
+          >
+            ← Repasar Unidad 2
+          </a>
+          {nextUnitPublished ? (
+            <a
+              href="/es/curso/elemental/unidad-4/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Continuar a Unidad 4 →
+            </a>
+          ) : (
+            <a
+              href="/es/curso/elemental/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Vista General del Curso
+            </a>
+          )}
+        </div>
+        <div class="pt-8 border-t border-slate-700 mt-8">
+          <p class="text-slate-200 text-sm mb-3">
+            ¿Quieres coaching personalizado de inglés?
+          </p>
+          <a
+            href="/es/contact/"
+            class="text-sky-400 hover:text-sky-300 font-medium underline underline-offset-2"
+          >
+            Reserva una consulta gratuita con Robert →
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary
Third content unit of the A2 "Tell Your Story" course. This is the **integration unit** — Units 1 and 2 taught regular and irregular past verbs separately; Unit 3 combines them into real day-by-day storytelling.

## Pedagogical arc

### Section A — Time & Sequence Vocabulary (3 waves)
- **Specific past times**: yesterday, yesterday morning, last night, last weekend, two days ago, an hour ago
- **Sequence connectors**: first, then, next, after that, later, an hour later, eventually, finally, in the end
- **Time relations**: before, after, while, when, until, as soon as, during, between

### Section B — Time Marker Placement
Same idea, two valid placements: time at the sentence start (with comma) vs. end (no comma). Stacking two markers ("Yesterday morning, I worked until lunch"). Combining time + sequence in two-sentence stories.

### Section C — Story Building With Sequence Connectors
Builds incrementally: two-event "first/then" stories → three-event "first/then/finally" stories → adding "after that" and "later" → a 4-event real weekend narrative. Teaches the subtle difference between **"after that"** (right after) and **"later"** (some time after).

### Section D — The Boss Sentence
A full 5-event day from waking at six to getting home at ten:

> "Yesterday was a long day. First, I woke up at six and went for a run. Then I made breakfast and started working. After that, I had three back-to-back meetings until lunch. Later, I finished a report and sent it to my boss. Finally, I went out for dinner with a friend and got home around ten."

Six sentences. Five connectors. Eight past-tense verbs. The capstone of the past-tense arc.

### Section E — Pronunciation: Reductions in Fast Storytelling
- `ago` → "uh-go"
- `last night` → "lasNIGHT" (linked t)
- `an hour ago` → "uh-NOUR uh-go" (silent h)
- `after that` → "AF-ter-that" (linked r)
- `eventually` → "e-VEN-chu-al-ly" (5 syllables, 'tu' → 'chu')

### Section F — Self-Test
35+ vocab items covering all time markers, sequence connectors, time relations, and key story phrases.

## Funnel completion
With Unit 3 shipped, the past-tense arc is complete. A learner who finishes Units 1-3 can:
- Form past simple with regular verbs (Unit 1)
- Form past simple with the 30 most common irregular verbs + was/were + did/didn't (Unit 2)
- Anchor sentences in time, sequence events, and tell a real 5-event day (Unit 3)

That's the foundation for B1-B2 ("Building Fluency"). Unit 4 will pivot from past to future.

## Files
- `src/data/elementary/unit-3.ts` (~390 lines) — drill content
- `src/pages/en/course/elementary/unit-3.astro` (~250 lines)
- `src/pages/es/curso/elemental/unidad-3.astro` (~250 lines)
- `src/data/elementary/units.ts` — flips Unit 3 `published` to true

## Test plan
- [x] `npm run build` passes; 428 pages emitted (+2); all SEO gates pass
- [x] Meta-description gate confirms 0 too-long descriptions
- [ ] Vercel preview: `/en/course/elementary/` now shows Units 1, 2, AND 3 as available; Units 4-10 still gated
- [ ] Vercel preview: Unit 3 renders all 6 sections correctly
- [ ] Unit 2 → Unit 3 link now works (Unit 2's CTA conditional should now show "Continue to Unit 3")
- [ ] Hreflang correctly cross-links EN ↔ ES Unit 3 pages
- [ ] Azure TTS works on the new pages (verifies Speech service Pay-As-You-Go upgrade is live)