### PR TITLE
feat(a2): ship Unit 5 — comparing things (comparatives + superlatives)

### DIFF
--- a/src/data/elementary/unit-5.ts
+++ b/src/data/elementary/unit-5.ts
@@ -1,0 +1,436 @@
+// Unit 5: "Comparing Things" — Comparatives + superlatives + irregulars
+//
+// Pedagogical arc:
+// Section A — 3 vocabulary waves: short -er adjectives, long 'more' adjectives, irregulars
+// Section B — Building comparatives (X is -er/more X than Y)
+// Section C — Building superlatives (X is the -est/the most X)
+// Section D — Boss Sentence: comparing real things across multiple dimensions
+// Section E — Pronunciation: 'than' reduction, schwa-r endings, stress on "the most"
+// Section F — Self-test of unit vocabulary
+
+export interface CognateWord {
+  english: string;
+  spanish: string;
+  category: string;
+  pronunciationNote?: string;
+  pronunciationNoteEs?: string;
+}
+
+export interface SentenceBlock {
+  label: string;
+  labelEs: string;
+  description: string;
+  descriptionEs: string;
+  sentences: {
+    english: string;
+    spanish: string;
+    highlight?: string;
+  }[];
+}
+
+export interface PronunciationDrillItem {
+  word: string;
+  spanishStress: string;
+  englishStress: string;
+  tip: string;
+  tipEs: string;
+}
+
+export interface VocabItem {
+  english: string;
+  spanish: string;
+  type: "verb" | "phrase" | "marker";
+}
+
+// ─── Section A: Comparison Vocabulary (Cognate Discovery format) ─────────────
+
+export const cognateWaves = {
+  wave1: {
+    title: "Short Adjectives + -er — The Easy Pattern",
+    titleEs: "Adjetivos Cortos + -er — El patrón fácil",
+    description:
+      "For short adjectives (one or two syllables), just add -er for the comparative and -est for the superlative. Cleanest rule in English.",
+    descriptionEs:
+      "Para adjetivos cortos (una o dos sílabas), solo agrega -er para el comparativo y -est para el superlativo. La regla más limpia del inglés.",
+    words: [
+      {
+        english: "big / bigger / the biggest",
+        spanish: "grande / más grande / el más grande",
+        category: "Short -er",
+        pronunciationNote: "Double the consonant: big → bigGer. Same for hot/hotter.",
+        pronunciationNoteEs: "Dobla la consonante: big → bigGer. Igual hot/hotter.",
+      },
+      { english: "small / smaller / the smallest", spanish: "pequeño / más pequeño / el más pequeño", category: "Short -er" },
+      { english: "fast / faster / the fastest", spanish: "rápido / más rápido / el más rápido", category: "Short -er" },
+      { english: "slow / slower / the slowest", spanish: "lento / más lento / el más lento", category: "Short -er" },
+      { english: "tall / taller / the tallest", spanish: "alto / más alto / el más alto", category: "Short -er" },
+      { english: "short / shorter / the shortest", spanish: "bajo / más bajo / el más bajo", category: "Short -er" },
+      { english: "old / older / the oldest", spanish: "viejo / más viejo / el más viejo", category: "Short -er" },
+      { english: "young / younger / the youngest", spanish: "joven / más joven / el más joven", category: "Short -er" },
+      { english: "cheap / cheaper / the cheapest", spanish: "barato / más barato / el más barato", category: "Short -er" },
+      {
+        english: "easy / easier / the easiest",
+        spanish: "fácil / más fácil / el más fácil",
+        category: "Short -er",
+        pronunciationNote: "Adjectives ending in -y change to -ier: easy → easier, happy → happier.",
+        pronunciationNoteEs: "Adjetivos en -y cambian a -ier: easy → easier, happy → happier.",
+      },
+    ] as CognateWord[],
+  },
+  wave2: {
+    title: "Long Adjectives + 'more' — The Other Pattern",
+    titleEs: "Adjetivos Largos + 'more' — El otro patrón",
+    description:
+      "For longer adjectives (3+ syllables), don't add -er. Use 'more X' for comparatives and 'the most X' for superlatives. NEVER 'more better' — only one or the other.",
+    descriptionEs:
+      "Para adjetivos más largos (3+ sílabas), no agregues -er. Usa 'more X' para comparativos y 'the most X' para superlativos. NUNCA 'more better' — solo uno u otro.",
+    words: [
+      { english: "interesting / more interesting / the most interesting", spanish: "interesante / más interesante / el más interesante", category: "Long 'more'" },
+      { english: "expensive / more expensive / the most expensive", spanish: "caro / más caro / el más caro", category: "Long 'more'" },
+      { english: "important / more important / the most important", spanish: "importante / más importante / el más importante", category: "Long 'more'" },
+      { english: "difficult / more difficult / the most difficult", spanish: "difícil / más difícil / el más difícil", category: "Long 'more'" },
+      { english: "popular / more popular / the most popular", spanish: "popular / más popular / el más popular", category: "Long 'more'" },
+      { english: "intelligent / more intelligent / the most intelligent", spanish: "inteligente / más inteligente / el más inteligente", category: "Long 'more'" },
+      { english: "beautiful / more beautiful / the most beautiful", spanish: "hermoso / más hermoso / el más hermoso", category: "Long 'more'" },
+      { english: "comfortable / more comfortable / the most comfortable", spanish: "cómodo / más cómodo / el más cómodo", category: "Long 'more'" },
+      { english: "dangerous / more dangerous / the most dangerous", spanish: "peligroso / más peligroso / el más peligroso", category: "Long 'more'" },
+      { english: "successful / more successful / the most successful", spanish: "exitoso / más exitoso / el más exitoso", category: "Long 'more'" },
+    ] as CognateWord[],
+  },
+  wave3: {
+    title: "Irregulars — No Pattern, Just Memorize",
+    titleEs: "Irregulares — Sin patrón, solo memoriza",
+    description:
+      "Five irregular comparisons. There's no pattern — they don't follow either rule. The good news: they're the FIVE most common, so memorizing them solves most of the irregular problem.",
+    descriptionEs:
+      "Cinco comparaciones irregulares. No tienen patrón — no siguen ninguna regla. La buena noticia: son los CINCO más comunes, así que memorizarlos resuelve la mayor parte del problema irregular.",
+    words: [
+      {
+        english: "good / better / the best",
+        spanish: "bueno / mejor / el mejor",
+        category: "Irregular",
+        pronunciationNote:
+          "Most common irregular. NEVER say 'more better' — that's the #1 error among Spanish speakers.",
+        pronunciationNoteEs:
+          "El irregular más común. NUNCA digas 'more better' — ese es el error #1 entre hispanohablantes.",
+      },
+      { english: "bad / worse / the worst", spanish: "malo / peor / el peor", category: "Irregular" },
+      {
+        english: "far / farther / the farthest",
+        spanish: "lejos / más lejos / el más lejos",
+        category: "Irregular",
+        pronunciationNote: "'Further' is also accepted — same meaning. Both are correct.",
+        pronunciationNoteEs: "'Further' también se acepta — mismo significado. Ambas son correctas.",
+      },
+      { english: "little / less / the least", spanish: "poco / menos / el menos", category: "Irregular" },
+      { english: "much / more / the most", spanish: "mucho / más / el más", category: "Irregular" },
+    ] as CognateWord[],
+  },
+};
+
+// ─── Section B: Building Comparatives (X is -er/more X than Y) ───────────────
+
+export const sentenceBlocks: SentenceBlock[] = [
+  {
+    label: "Step 1: Short adjective + -er + than",
+    labelEs: "Paso 1: Adjetivo corto + -er + than",
+    description:
+      "The basic pattern for short adjectives: 'X is [adjective+er] than Y'. The word 'than' connects the two things being compared.",
+    descriptionEs:
+      "El patrón básico para adjetivos cortos: 'X is [adjetivo+er] than Y'. La palabra 'than' conecta las dos cosas comparadas.",
+    sentences: [
+      { english: "My phone is faster than my old one.", spanish: "Mi teléfono es más rápido que mi viejo.", highlight: "faster than" },
+      { english: "Mexico City is bigger than Boston.", spanish: "Ciudad de México es más grande que Boston.", highlight: "bigger than" },
+      { english: "She's taller than her brother.", spanish: "Ella es más alta que su hermano.", highlight: "taller than" },
+      { english: "This restaurant is cheaper than the other one.", spanish: "Este restaurante es más barato que el otro.", highlight: "cheaper than" },
+    ],
+  },
+  {
+    label: "Step 2: Long adjective + more + than",
+    labelEs: "Paso 2: Adjetivo largo + more + than",
+    description:
+      "For longer adjectives, 'more X than'. Same comparison structure — different signal word. NEVER combine: not 'more bigger', not 'more interesting-er'.",
+    descriptionEs:
+      "Para adjetivos más largos, 'more X than'. Misma estructura — palabra de señalización diferente. NUNCA combines: no 'more bigger', no 'more interesting-er'.",
+    sentences: [
+      { english: "This book is more interesting than the last one.", spanish: "Este libro es más interesante que el anterior.", highlight: "more interesting than" },
+      { english: "New York is more expensive than Mexico City.", spanish: "Nueva York es más cara que Ciudad de México.", highlight: "more expensive than" },
+      { english: "Her job is more difficult than mine.", spanish: "Su trabajo es más difícil que el mío.", highlight: "more difficult than" },
+      { english: "This route is more dangerous than the highway.", spanish: "Esta ruta es más peligrosa que la autopista.", highlight: "more dangerous than" },
+    ],
+  },
+  {
+    label: "Step 3: Irregulars — better, worse, more, less",
+    labelEs: "Paso 3: Irregulares — better, worse, more, less",
+    description:
+      "The irregulars need their own block because they're so common. NEVER 'more better' — just 'better'. NEVER 'more worse' — just 'worse'.",
+    descriptionEs:
+      "Los irregulares necesitan su propio bloque porque son muy comunes. NUNCA 'more better' — solo 'better'. NUNCA 'more worse' — solo 'worse'.",
+    sentences: [
+      { english: "This coffee is better than the one at home.", spanish: "Este café es mejor que el de casa.", highlight: "better than" },
+      { english: "The weather today is worse than yesterday.", spanish: "El clima hoy está peor que ayer.", highlight: "worse than" },
+      { english: "I have more time on weekends.", spanish: "Tengo más tiempo los fines de semana.", highlight: "more" },
+      { english: "She has less work this week than last week.", spanish: "Ella tiene menos trabajo esta semana que la pasada.", highlight: "less" },
+    ],
+  },
+  {
+    label: "Step 4: 'as ... as' — When Two Things Are Equal",
+    labelEs: "Paso 4: 'as ... as' — Cuando dos cosas son iguales",
+    description:
+      "When two things are EQUAL, use 'as X as'. For NEGATIVE comparison (not equal), use 'not as X as' — softer than 'less X than'.",
+    descriptionEs:
+      "Cuando dos cosas son IGUALES, usa 'as X as'. Para comparación NEGATIVA (no iguales), usa 'not as X as' — más suave que 'less X than'.",
+    sentences: [
+      { english: "My phone is as fast as yours.", spanish: "Mi teléfono es tan rápido como el tuyo.", highlight: "as fast as" },
+      { english: "She's as tall as her sister.", spanish: "Ella es tan alta como su hermana.", highlight: "as tall as" },
+      { english: "This restaurant isn't as expensive as I thought.", spanish: "Este restaurante no es tan caro como pensé.", highlight: "isn't as expensive as" },
+      { english: "The movie wasn't as good as the book.", spanish: "La película no fue tan buena como el libro.", highlight: "wasn't as good as" },
+    ],
+  },
+];
+
+// ─── Section C: Building Superlatives (the -est / the most X) ────────────────
+
+export const powerVerbBlocks: SentenceBlock[] = [
+  {
+    label: "The -est — Short Adjectives",
+    labelEs: "The -est — Adjetivos cortos",
+    description:
+      "For short adjectives, add -est and put 'the' in front: 'the biggest', 'the fastest', 'the cheapest'. The 'the' is REQUIRED — it makes it superlative.",
+    descriptionEs:
+      "Para adjetivos cortos, agrega -est y pon 'the' adelante: 'the biggest', 'the fastest', 'the cheapest'. El 'the' es OBLIGATORIO — eso lo hace superlativo.",
+    sentences: [
+      { english: "Mexico City is the biggest city in Mexico.", spanish: "Ciudad de México es la ciudad más grande de México.", highlight: "the biggest" },
+      { english: "She's the tallest person in our team.", spanish: "Ella es la persona más alta de nuestro equipo.", highlight: "the tallest" },
+      { english: "This is the cheapest hotel in the area.", spanish: "Este es el hotel más barato de la zona.", highlight: "the cheapest" },
+      { english: "He's the youngest manager at the company.", spanish: "Él es el gerente más joven de la empresa.", highlight: "the youngest" },
+    ],
+  },
+  {
+    label: "The most — Long Adjectives",
+    labelEs: "The most — Adjetivos largos",
+    description:
+      "For long adjectives: 'the most X'. Just like 'more' for comparatives, but with 'the most' for superlatives.",
+    descriptionEs:
+      "Para adjetivos largos: 'the most X'. Igual que 'more' para comparativos, pero con 'the most' para superlativos.",
+    sentences: [
+      { english: "It's the most interesting book I've read this year.", spanish: "Es el libro más interesante que he leído este año.", highlight: "the most interesting" },
+      { english: "She's the most successful person in her family.", spanish: "Ella es la persona más exitosa de su familia.", highlight: "the most successful" },
+      { english: "This is the most expensive restaurant in town.", spanish: "Este es el restaurante más caro de la ciudad.", highlight: "the most expensive" },
+      { english: "That was the most difficult exam of the year.", spanish: "Ese fue el examen más difícil del año.", highlight: "the most difficult" },
+    ],
+  },
+  {
+    label: "The Best, The Worst, The Most — Irregulars",
+    labelEs: "The Best, The Worst, The Most — Irregulares",
+    description:
+      "The irregular superlatives. 'The best' (NOT 'the most good'), 'the worst' (NOT 'the most bad'), 'the most' (NOT 'the muchest'). Memorize, then use freely.",
+    descriptionEs:
+      "Los superlativos irregulares. 'The best' (NO 'the most good'), 'the worst' (NO 'the most bad'), 'the most' (NO 'the muchest'). Memoriza, después úsalos libremente.",
+    sentences: [
+      { english: "This is the best coffee in the city.", spanish: "Este es el mejor café de la ciudad.", highlight: "the best" },
+      { english: "That was the worst meeting of the year.", spanish: "Esa fue la peor junta del año.", highlight: "the worst" },
+      { english: "She has the most experience on the team.", spanish: "Ella tiene la más experiencia del equipo.", highlight: "the most" },
+      { english: "I drink the least coffee of anyone here.", spanish: "Yo tomo el menos café de todos aquí.", highlight: "the least" },
+    ],
+  },
+  {
+    label: "Real Comparisons — Mixing All Forms",
+    labelEs: "Comparaciones reales — Mezclando todas las formas",
+    description:
+      "In real conversation you mix comparatives and superlatives. This block shows how natives weave both forms into a single thought.",
+    descriptionEs:
+      "En conversación real mezclas comparativos y superlativos. Este bloque muestra cómo los nativos tejen ambas formas en un solo pensamiento.",
+    sentences: [
+      {
+        english: "This restaurant is more expensive than the other one, but it's the best in the area.",
+        spanish: "Este restaurante es más caro que el otro, pero es el mejor de la zona.",
+        highlight: "more expensive / the best",
+      },
+      {
+        english: "Her job is harder than mine, but it pays better and the team is the most supportive.",
+        spanish: "Su trabajo es más difícil que el mío, pero paga mejor y el equipo es el más solidario.",
+        highlight: "harder / better / the most supportive",
+      },
+      {
+        english: "Mexico City is bigger than Monterrey, but Monterrey is the cleanest city in the country.",
+        spanish: "Ciudad de México es más grande que Monterrey, pero Monterrey es la ciudad más limpia del país.",
+        highlight: "bigger / the cleanest",
+      },
+      {
+        english: "This summer is hotter than last summer, but it's not the hottest one I remember.",
+        spanish: "Este verano está más caliente que el verano pasado, pero no es el más caliente que recuerdo.",
+        highlight: "hotter / the hottest",
+      },
+    ],
+  },
+];
+
+// ─── Section D: Boss Sentence — Comparing Real Things (Connector Challenge) ──
+
+export const connectorSentences = {
+  connectors: [
+    {
+      word: "than",
+      wordEs: "que",
+      example: "My new phone is faster than my old one.",
+      exampleEs: "Mi teléfono nuevo es más rápido que el viejo.",
+      use: "The comparison connector. Always pairs with -er or 'more'. Reduced to 'thun' in fast speech.",
+      useEs: "El conector de comparación. Siempre va con -er o 'more'. Se reduce a 'thun' en habla rápida.",
+    },
+    {
+      word: "the most",
+      wordEs: "el/la más",
+      example: "It's the most interesting book in my library.",
+      exampleEs: "Es el libro más interesante de mi biblioteca.",
+      use: "Superlative for long adjectives. The 'the' is REQUIRED — never just 'most interesting'.",
+      useEs: "Superlativo para adjetivos largos. El 'the' es OBLIGATORIO — nunca solo 'most interesting'.",
+    },
+    {
+      word: "as ... as",
+      wordEs: "tan ... como",
+      example: "My phone is as fast as yours.",
+      exampleEs: "Mi teléfono es tan rápido como el tuyo.",
+      use: "Equal comparison. Same idea on both sides. Add 'not' in front to negate: 'not as fast as'.",
+      useEs: "Comparación de igualdad. Misma idea en ambos lados. Agrega 'not' adelante para negar: 'not as fast as'.",
+    },
+    {
+      word: "much / way more",
+      wordEs: "mucho más",
+      example: "This route is way more dangerous than the highway.",
+      exampleEs: "Esta ruta es mucho más peligrosa que la autopista.",
+      use: "Intensifies comparisons. 'Way more' is informal but very common in spoken English.",
+      useEs: "Intensifica las comparaciones. 'Way more' es informal pero muy común en inglés hablado.",
+    },
+    {
+      word: "by far",
+      wordEs: "por mucho",
+      example: "She's by far the best player on the team.",
+      exampleEs: "Ella es por mucho la mejor jugadora del equipo.",
+      use: "Strengthens superlatives. Signals there's no close second.",
+      useEs: "Refuerza superlativos. Señala que no hay un segundo cercano.",
+    },
+  ],
+  bossSentence: {
+    english:
+      "I just moved into a new apartment, and let me compare. The new one is bigger than my old place and way more comfortable. The kitchen is the most modern I've ever had. It's a little more expensive than my old apartment, but the location is much better — by far the best neighborhood in the city. Honestly, this is the best decision I've made all year.",
+    spanish:
+      "Acabo de mudarme a un nuevo departamento, y déjame comparar. El nuevo es más grande que mi lugar anterior y mucho más cómodo. La cocina es la más moderna que he tenido. Es un poco más caro que mi viejo departamento, pero la ubicación es mucho mejor — por mucho el mejor vecindario de la ciudad. Honestamente, esta es la mejor decisión que he tomado en todo el año.",
+    explanation:
+      "Six sentences. Comparatives (bigger, more comfortable, more expensive, better) AND superlatives (the most modern, by far the best, the best). Plus intensifiers (way more, much better, by far). This is what a real comparison sounds like in fast English.",
+    explanationEs:
+      "Seis oraciones. Comparativos (bigger, more comfortable, more expensive, better) Y superlativos (the most modern, by far the best, the best). Más intensificadores (way more, much better, by far). Así suena una comparación real en inglés rápido.",
+  },
+};
+
+// ─── Section E: Pronunciation Lab — Comparison Sounds ────────────────────────
+
+export const pronunciationDrills: PronunciationDrillItem[] = [
+  {
+    word: "than",
+    spanishStress: "THAN (full pronunciation, both letters strong)",
+    englishStress: "thun (reduced, almost like 'th' + schwa + 'n')",
+    tip: "In fast speech, 'than' is reduced. 'Faster than' sounds like 'fasterthun' — almost one word.",
+    tipEs: "En habla rápida, 'than' se reduce. 'Faster than' suena como 'fasterthun' — casi una sola palabra.",
+  },
+  {
+    word: "bigger",
+    spanishStress: "BI-GER (Spanish G hard)",
+    englishStress: "BIG-er (the -er is a schwa-r sound)",
+    tip: "The -er at the end is the 'schwa-r' sound: relaxed, not stressed. Like the end of 'teacher' or 'better'.",
+    tipEs: "El -er al final es el sonido 'schwa-r': relajado, sin acento. Como el final de 'teacher' o 'better'.",
+  },
+  {
+    word: "the most",
+    spanishStress: "the MOST (both words equal)",
+    englishStress: "thuh MOST (the 'the' is reduced, MOST is heavily stressed)",
+    tip: "Stress on MOST. The 'the' before it is reduced to 'thuh'. 'The most expensive' = 'thuh MOST expensive'.",
+    tipEs: "Acento en MOST. El 'the' previo se reduce a 'thuh'. 'The most expensive' = 'thuh MOST expensive'.",
+  },
+  {
+    word: "better",
+    spanishStress: "BE-TER (Spanish stress, hard T)",
+    englishStress: "BET-er (American T is soft, almost like a quick D)",
+    tip: "American 'better' sounds like 'BED-er'. The middle T is soft — almost a quick D sound.",
+    tipEs: "El 'better' americano suena como 'BED-er'. La T del medio es suave — casi una D rápida.",
+  },
+  {
+    word: "worse",
+    spanishStress: "WOR-SE (two syllables)",
+    englishStress: "WURS (one syllable, ends in sharp S)",
+    tip: "ONE syllable. Rhymes with 'curse' or 'nurse'. Don't add an extra syllable at the end.",
+    tipEs: "UNA sílaba. Rima con 'curse' o 'nurse'. No agregues sílaba extra al final.",
+  },
+  {
+    word: "most",
+    spanishStress: "MOST (regular pronunciation)",
+    englishStress: "MOHST (long 'oh' sound, sharp 'st')",
+    tip: "Long 'oh' sound. Rhymes with 'toast' or 'host'. Sharp 'st' at the end.",
+    tipEs: "Sonido 'oh' largo. Rima con 'toast' o 'host'. 'st' agudo al final.",
+  },
+  {
+    word: "easier",
+    spanishStress: "e-SI-er (Spanish-style stress)",
+    englishStress: "EE-zee-er (three syllables, stress on first, soft Z)",
+    tip: "Three syllables: EE-zee-er. The 's' becomes a 'z' sound, and the stress is on the first syllable.",
+    tipEs: "Tres sílabas: EE-zee-er. La 's' se vuelve sonido 'z', y el acento está en la primera sílaba.",
+  },
+  {
+    word: "way more",
+    spanishStress: "WAY MORE (both words equal)",
+    englishStress: "way-MORE (linked, MORE is stressed)",
+    tip: "Two words but linked tightly. The stress is on MORE — 'WAY more expensive' becomes 'way-MORE expensive'.",
+    tipEs: "Dos palabras pero ligadas. El acento está en MORE — 'WAY more expensive' se vuelve 'way-MORE expensive'.",
+  },
+];
+
+// ─── Section F: Vocabulary List for Self-Test ────────────────────────────────
+
+export const vocabularyList: VocabItem[] = [
+  // Short -er adjectives
+  { english: "bigger", spanish: "más grande", type: "phrase" },
+  { english: "smaller", spanish: "más pequeño", type: "phrase" },
+  { english: "faster", spanish: "más rápido", type: "phrase" },
+  { english: "slower", spanish: "más lento", type: "phrase" },
+  { english: "taller", spanish: "más alto", type: "phrase" },
+  { english: "shorter", spanish: "más bajo", type: "phrase" },
+  { english: "older", spanish: "más viejo", type: "phrase" },
+  { english: "younger", spanish: "más joven", type: "phrase" },
+  { english: "cheaper", spanish: "más barato", type: "phrase" },
+  { english: "easier", spanish: "más fácil", type: "phrase" },
+  // Long 'more' adjectives
+  { english: "more interesting", spanish: "más interesante", type: "phrase" },
+  { english: "more expensive", spanish: "más caro", type: "phrase" },
+  { english: "more important", spanish: "más importante", type: "phrase" },
+  { english: "more difficult", spanish: "más difícil", type: "phrase" },
+  { english: "more popular", spanish: "más popular", type: "phrase" },
+  { english: "more comfortable", spanish: "más cómodo", type: "phrase" },
+  // Irregulars (comparative)
+  { english: "better", spanish: "mejor", type: "phrase" },
+  { english: "worse", spanish: "peor", type: "phrase" },
+  { english: "more", spanish: "más", type: "phrase" },
+  { english: "less", spanish: "menos", type: "phrase" },
+  { english: "farther / further", spanish: "más lejos", type: "phrase" },
+  // Superlatives
+  { english: "the biggest", spanish: "el más grande", type: "phrase" },
+  { english: "the fastest", spanish: "el más rápido", type: "phrase" },
+  { english: "the cheapest", spanish: "el más barato", type: "phrase" },
+  { english: "the most interesting", spanish: "el más interesante", type: "phrase" },
+  { english: "the most expensive", spanish: "el más caro", type: "phrase" },
+  { english: "the most important", spanish: "el más importante", type: "phrase" },
+  { english: "the best", spanish: "el mejor", type: "phrase" },
+  { english: "the worst", spanish: "el peor", type: "phrase" },
+  { english: "the most", spanish: "el más", type: "phrase" },
+  { english: "the least", spanish: "el menos", type: "phrase" },
+  // Connectors
+  { english: "than", spanish: "que (en comparación)", type: "marker" },
+  { english: "as ... as", spanish: "tan ... como", type: "marker" },
+  { english: "not as ... as", spanish: "no tan ... como", type: "marker" },
+  { english: "way more", spanish: "mucho más", type: "marker" },
+  { english: "much better", spanish: "mucho mejor", type: "marker" },
+  { english: "by far", spanish: "por mucho", type: "marker" },
+  // Useful phrases
+  { english: "It's the best in the city.", spanish: "Es el mejor de la ciudad.", type: "phrase" },
+  { english: "Mexico City is bigger than Monterrey.", spanish: "Ciudad de México es más grande que Monterrey.", type: "phrase" },
+  { english: "This is way more comfortable.", spanish: "Esto es mucho más cómodo.", type: "phrase" },
+];

--- a/src/data/elementary/units.ts
+++ b/src/data/elementary/units.ts
@@ -117,7 +117,7 @@ export const elementaryUnits: ElementaryUnit[] = [
     pronunciationFocus: "-er and -est endings + 'than' reduction",
     pronunciationFocusEs: "Terminaciones -er y -est + reducción de 'than'",
     icon: "Scale",
-    published: false,
+    published: true,
   },
   {
     id: 6,

--- a/src/pages/en/course/elementary/unit-5.astro
+++ b/src/pages/en/course/elementary/unit-5.astro
@@ -1,0 +1,294 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CognateDiscovery from "@components/course/CognateDiscovery";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import ConnectorChallenge from "@components/course/ConnectorChallenge";
+import SelfTest from "@components/course/SelfTest";
+import { elementaryUnits } from "@data/elementary/units";
+import {
+  cognateWaves,
+  sentenceBlocks,
+  powerVerbBlocks,
+  connectorSentences,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/elementary/unit-5";
+import {
+  Scale,
+  Layers,
+  Zap,
+  Link2,
+  Volume2,
+  ClipboardCheck,
+  BookOpen,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/elementary/unit-5" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
+
+const nextUnit = elementaryUnits.find((u) => u.id === 6);
+const nextUnitPublished = nextUnit?.published ?? false;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unit 5: Comparing Things | Elementary English (A2)"
+  description="Comparatives and superlatives: -er than, more X than, the best, the worst, the most. Master the irregulars Spanish speakers always get wrong. Free A2 lesson."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={5}
+    basePath="/en/course/elementary"
+    lang="en"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-sky-400 text-sm font-semibold mb-3">
+          <Scale class="w-4 h-4" />
+          Unit 5
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Comparing Things
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Past and future are locked in. Today: comparing things. Bigger than. The best. The
+          most expensive. The grammar is straightforward, but the irregulars (good/better/best,
+          bad/worse/worst) trip up nearly every Spanish speaker. After this unit, you won't.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <nav class="bg-white border-b border-slate-200 sticky top-[52px] z-30 overflow-x-auto">
+    <div class="site-container mx-auto px-4">
+      <div class="flex items-center gap-1 py-2 text-sm whitespace-nowrap">
+        <a href="#vocabulary" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <BookOpen class="w-3.5 h-3.5" /> Vocabulary
+        </a>
+        <a href="#comparatives" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Layers class="w-3.5 h-3.5" /> Comparatives
+        </a>
+        <a href="#superlatives" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Zap class="w-3.5 h-3.5" /> Superlatives
+        </a>
+        <a href="#boss" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Link2 class="w-3.5 h-3.5" /> Boss Sentence
+        </a>
+        <a href="#pronunciation" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Volume2 class="w-3.5 h-3.5" /> Pronunciation
+        </a>
+        <a href="#self-test" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <ClipboardCheck class="w-3.5 h-3.5" /> Self-Test
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <section id="vocabulary" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <BookOpen class="w-4 h-4" />
+            Section A
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Three Patterns of Comparison
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Short adjectives use -er and -est. Long adjectives use 'more' and 'the most'. Five
+            irregulars don't follow either rule — and they're the most common ones. Tap any
+            entry to hear all three forms.
+          </p>
+        </div>
+        <CognateDiscovery client:visible waves={waveData} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="comparatives" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Layers class="w-4 h-4" />
+            Section B
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Building Comparatives — X is -er/more X than Y
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Four blocks: short adjectives + -er, long adjectives + 'more', the irregulars
+            (better/worse/more/less), and equal comparison ('as X as'). NEVER combine —
+            'more better' is the most common Spanish-speaker error.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={sentenceBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="superlatives" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Zap class="w-4 h-4" />
+            Section C
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Building Superlatives — The -est / The Most X
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'The' is REQUIRED — it's what makes a superlative a superlative. Then -est for
+            short, 'most' for long, irregulars for the irregulars. The final block weaves
+            comparatives AND superlatives into single thoughts the way natives actually do.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={powerVerbBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="boss" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Link2 class="w-4 h-4" />
+            Section D
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            The Boss Sentence — Comparing a New Apartment
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Six sentences. Three comparatives (bigger, more comfortable, more expensive). Three
+            superlatives (the most modern, by far the best, the best). Plus intensifiers (way
+            more, much better). This is what comparing real things sounds like.
+          </p>
+        </div>
+        <ConnectorChallenge
+          client:visible
+          connectors={connectorSentences.connectors}
+          bossSentence={connectorSentences.bossSentence}
+          lang="en"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section id="pronunciation" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-rose-500 text-sm font-semibold mb-2">
+            <Volume2 class="w-4 h-4" />
+            Pronunciation Lab
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Comparison Sounds — 'than' Reduction, Schwa-R, Soft T
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Than' is reduced to 'thun' in fast speech. The -er ending is the schwa-r (relaxed,
+            unstressed). American 'better' sounds like 'BED-er' (soft middle T). Drill these
+            until comparisons flow naturally.
+          </p>
+        </div>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="self-test" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <ClipboardCheck class="w-4 h-4" />
+            Self-Test
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Test What You Learned
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Flashcard review of every comparative, superlative, irregular, intensifier, and
+            useful phrase from Unit 5. Switch between Spanish→English and English→Spanish modes.
+          </p>
+        </div>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-gradient-to-b from-slate-900 to-slate-800">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-2xl mx-auto text-center space-y-6">
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/20 text-emerald-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-bold text-white">Unit 5 Complete!</h2>
+        <p class="text-lg text-slate-100 leading-relaxed">
+          You've now covered the past, the future, and how to compare anything. That's HALF the
+          A2 course. Five units down, five to go. Next: how much, how many — quantifiers and
+          the countable/uncountable distinction.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center pt-4">
+          <a
+            href="/en/course/elementary/unit-4/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors"
+          >
+            ← Review Unit 4
+          </a>
+          {nextUnitPublished ? (
+            <a
+              href="/en/course/elementary/unit-6/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Continue to Unit 6 →
+            </a>
+          ) : (
+            <a
+              href="/en/course/elementary/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Course Overview
+            </a>
+          )}
+        </div>
+        <div class="pt-8 border-t border-slate-700 mt-8">
+          <p class="text-slate-200 text-sm mb-3">
+            Want personalized English coaching?
+          </p>
+          <a
+            href="/en/contact/"
+            class="text-sky-400 hover:text-sky-300 font-medium underline underline-offset-2"
+          >
+            Book a free consultation with Robert →
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/elemental/unidad-5.astro
+++ b/src/pages/es/curso/elemental/unidad-5.astro
@@ -1,0 +1,296 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CognateDiscovery from "@components/course/CognateDiscovery";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import ConnectorChallenge from "@components/course/ConnectorChallenge";
+import SelfTest from "@components/course/SelfTest";
+import { elementaryUnits } from "@data/elementary/units";
+import {
+  cognateWaves,
+  sentenceBlocks,
+  powerVerbBlocks,
+  connectorSentences,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/elementary/unit-5";
+import {
+  Scale,
+  Layers,
+  Zap,
+  Link2,
+  Volume2,
+  ClipboardCheck,
+  BookOpen,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/elementary/unit-5" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
+
+const nextUnit = elementaryUnits.find((u) => u.id === 6);
+const nextUnitPublished = nextUnit?.published ?? false;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unidad 5: Comparando Cosas | Inglés Elemental (A2)"
+  description="Comparativos y superlativos en inglés: -er than, more X than, the best, the worst. Domina los irregulares que confunden a los hispanohablantes. Gratis A2."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={5}
+    basePath="/es/curso/elemental"
+    lang="es"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-sky-400 text-sm font-semibold mb-3">
+          <Scale class="w-4 h-4" />
+          Unidad 5
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Comparando Cosas
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          El pasado y el futuro están listos. Hoy: comparar cosas. Bigger than. The best. The
+          most expensive. La gramática es directa, pero los irregulares (good/better/best,
+          bad/worse/worst) confunden a casi todos los hispanohablantes. Después de esta unidad,
+          tú no.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <nav class="bg-white border-b border-slate-200 sticky top-[52px] z-30 overflow-x-auto">
+    <div class="site-container mx-auto px-4">
+      <div class="flex items-center gap-1 py-2 text-sm whitespace-nowrap">
+        <a href="#vocabulary" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <BookOpen class="w-3.5 h-3.5" /> Vocabulario
+        </a>
+        <a href="#comparatives" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Layers class="w-3.5 h-3.5" /> Comparativos
+        </a>
+        <a href="#superlatives" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Zap class="w-3.5 h-3.5" /> Superlativos
+        </a>
+        <a href="#boss" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Link2 class="w-3.5 h-3.5" /> Oración Maestra
+        </a>
+        <a href="#pronunciation" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Volume2 class="w-3.5 h-3.5" /> Pronunciación
+        </a>
+        <a href="#self-test" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <ClipboardCheck class="w-3.5 h-3.5" /> Auto-Test
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <section id="vocabulary" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <BookOpen class="w-4 h-4" />
+            Sección A
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Tres Patrones de Comparación
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Adjetivos cortos usan -er y -est. Adjetivos largos usan 'more' y 'the most'. Cinco
+            irregulares no siguen ninguna regla — y son los más comunes. Toca cualquier entrada
+            para escuchar las tres formas.
+          </p>
+        </div>
+        <CognateDiscovery client:visible waves={waveData} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="comparatives" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Layers class="w-4 h-4" />
+            Sección B
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Construyendo Comparativos — X is -er/more X than Y
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Cuatro bloques: adjetivos cortos + -er, adjetivos largos + 'more', los irregulares
+            (better/worse/more/less), y comparación de igualdad ('as X as'). NUNCA combines —
+            'more better' es el error más común de los hispanohablantes.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={sentenceBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="superlatives" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Zap class="w-4 h-4" />
+            Sección C
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Construyendo Superlativos — The -est / The Most X
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'The' es OBLIGATORIO — eso es lo que hace que un superlativo sea superlativo.
+            Después -est para cortos, 'most' para largos, irregulares para los irregulares. El
+            último bloque teje comparativos Y superlativos en un solo pensamiento como lo hacen
+            los nativos.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={powerVerbBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="boss" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Link2 class="w-4 h-4" />
+            Sección D
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            La Oración Maestra — Comparando un Departamento Nuevo
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Seis oraciones. Tres comparativos (bigger, more comfortable, more expensive). Tres
+            superlativos (the most modern, by far the best, the best). Más intensificadores
+            (way more, much better). Así suena comparar cosas reales.
+          </p>
+        </div>
+        <ConnectorChallenge
+          client:visible
+          connectors={connectorSentences.connectors}
+          bossSentence={connectorSentences.bossSentence}
+          lang="es"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section id="pronunciation" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-rose-500 text-sm font-semibold mb-2">
+            <Volume2 class="w-4 h-4" />
+            Laboratorio de Pronunciación
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Sonidos de Comparación — Reducción de 'than', Schwa-R, T Suave
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Than' se reduce a 'thun' en habla rápida. La terminación -er es el schwa-r
+            (relajado, sin acento). El 'better' americano suena como 'BED-er' (T del medio
+            suave). Practica hasta que las comparaciones fluyan naturalmente.
+          </p>
+        </div>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="self-test" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <ClipboardCheck class="w-4 h-4" />
+            Auto-Evaluación
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Evalúa Lo que Aprendiste
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Repaso tipo flashcard de cada comparativo, superlativo, irregular, intensificador, y
+            frase útil de la Unidad 5. Cambia entre los modos español→inglés e inglés→español.
+          </p>
+        </div>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-gradient-to-b from-slate-900 to-slate-800">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-2xl mx-auto text-center space-y-6">
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/20 text-emerald-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-bold text-white">¡Unidad 5 Completada!</h2>
+        <p class="text-lg text-slate-100 leading-relaxed">
+          Ahora cubriste el pasado, el futuro, y cómo comparar cualquier cosa. Eso es la MITAD
+          del curso A2. Cinco unidades terminadas, cinco por venir. Sigue: cuánto, cuántos —
+          cuantificadores y la distinción contable/incontable.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center pt-4">
+          <a
+            href="/es/curso/elemental/unidad-4/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors"
+          >
+            ← Repasar Unidad 4
+          </a>
+          {nextUnitPublished ? (
+            <a
+              href="/es/curso/elemental/unidad-6/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Continuar a Unidad 6 →
+            </a>
+          ) : (
+            <a
+              href="/es/curso/elemental/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Vista General del Curso
+            </a>
+          )}
+        </div>
+        <div class="pt-8 border-t border-slate-700 mt-8">
+          <p class="text-slate-200 text-sm mb-3">
+            ¿Quieres coaching personalizado de inglés?
+          </p>
+          <a
+            href="/es/contact/"
+            class="text-sky-400 hover:text-sky-300 font-medium underline underline-offset-2"
+          >
+            Reserva una consulta gratuita con Robert →
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary
Fifth content unit of the A2 "Tell Your Story" course. **Course is now 50% complete** — past, future, and comparison foundations are all in.

## Pedagogical arc

### Section A — 3 Patterns of Comparison
Each entry shows all 3 forms (base → comparative → superlative):
- **Short -er adjectives**: big/bigger/the biggest, fast/faster/the fastest, easy/easier/the easiest
- **Long 'more' adjectives**: interesting/more interesting/the most interesting, expensive/more expensive/the most expensive
- **Irregulars (5)**: good/better/the best, bad/worse/the worst, far/farther/the farthest, little/less/the least, much/more/the most

### Section B — Comparatives (4 blocks)
- Short + -er + than ("Mexico City is bigger than Boston")
- Long + 'more' + than ("more interesting than the last one")
- Irregulars (better/worse/more/less + than)
- 'as X as' / 'not as X as' — equal comparison, softer than 'less than'

### Section C — Superlatives (4 blocks)
- The -est ("the biggest city in Mexico")
- The most ("the most interesting book")
- Irregulars (the best, the worst, the most, the least)
- Mixing comparatives AND superlatives in single thoughts — how natives actually compare in conversation

### Section D — Boss Sentence
Comparing a new apartment in 6 sentences:

> "I just moved into a new apartment, and let me compare. The new one is bigger than my old place and way more comfortable. The kitchen is the most modern I've ever had. It's a little more expensive than my old apartment, but the location is much better — by far the best neighborhood in the city. Honestly, this is the best decision I've made all year."

3 comparatives, 3 superlatives, plus intensifiers (way more, much better, by far) — exactly how comparison sounds in real spoken English.

### Section E — Pronunciation
- `than` → reduced to **'thun'** in fast speech
- `-er` ending = the **schwa-r** (relaxed, unstressed)
- American `better` → sounds like **'BED-er'** (soft middle T)
- `the most` → **'thuh MOST'** (the reduced, MOST heavily stressed)
- `worse` = **ONE syllable** (rhymes with 'curse')

### Section F — Self-Test
40+ vocab items: every short, long, and irregular form, plus connectors (than, as...as, way more, by far) and useful comparison phrases.

## The error this unit kills
The #1 Spanish-speaker comparison error is **"more better"** (mixing the two patterns). Irregulars get a dedicated block in BOTH Sections B and C to ensure the correct form locks in. Same for "more good" / "more bad" — the data drives "better" and "worse" home repeatedly.

## Course status
- **Unit 1**: ✅ Past simple regular
- **Unit 2**: ✅ Past simple irregular + was/were + did/didn't
- **Unit 3**: ✅ Telling your day (time markers + sequencing)
- **Unit 4**: ✅ Going to vs. will (future)
- **Unit 5**: ✅ Comparing things (this PR)
- Units 6-10: still in build (Coming soon badges)

**5 of 10 units = 50% complete.** This was the original "first 5 units" milestone you asked for. Next phase: Units 6-10 (quantifiers, questions, routines, past continuous, capstone).

## Files
- `src/data/elementary/unit-5.ts` (~430 lines) — drill content
- `src/pages/en/course/elementary/unit-5.astro` (~250 lines)
- `src/pages/es/curso/elemental/unidad-5.astro` (~250 lines)
- `src/data/elementary/units.ts` — flips Unit 5 `published` to true

## Test plan
- [x] `npm run build` passes; 432 pages emitted (+2); all SEO gates pass
- [x] Meta-description gate confirms 0 too-long descriptions on new pages (one was caught at 168 chars and trimmed to 154 before commit)
- [ ] Vercel preview: `/en/course/elementary/` shows Units 1-5 available; Units 6-10 still gated
- [ ] Vercel preview: Unit 5 renders all 6 sections, Azure TTS works on speakers
- [ ] Unit 4 → Unit 5 link now works (Unit 4's CTA conditional should now show "Continue to Unit 5")
- [ ] Hreflang correctly cross-links EN ↔ ES Unit 5 pages