### PR TITLE
chore(lint): clean up unused imports and dead variables

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -13,7 +13,6 @@ import Button from "@components/ui/Button.astro";
 
 const isSpanishPath = Astro.url.pathname.startsWith("/es");
 const lang = isSpanishPath ? "es" : "en";
-const translationSlug = isSpanishPath ? "/en/404" : "/es/404";
 
 // Define all text content for both languages
 const content = {

--- a/src/pages/en/blog/[slug].astro
+++ b/src/pages/en/blog/[slug].astro
@@ -117,7 +117,6 @@ const relatedPosts = allPosts
 
 // Get site URL for structured data
 const siteUrl = siteConfig.siteUrl || 'https://www.nyenglishteacher.com';
-const cleanSiteUrl = siteUrl.replace(/https?:\/\/www\.www\./i, 'https://www.').replace(/\/$/, '');
 
 // Generate proper hreflang for individual blog posts
 const lang = 'en';

--- a/src/pages/en/course/advanced/index.astro
+++ b/src/pages/en/course/advanced/index.astro
@@ -3,7 +3,7 @@ export const prerender = true;
 
 import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
-import { advancedInfo, advancedUnits } from "@data/advanced/units";
+import { advancedUnits } from "@data/advanced/units";
 import {
   Sparkles,
   AlertTriangle,

--- a/src/pages/en/course/beginners/index.astro
+++ b/src/pages/en/course/beginners/index.astro
@@ -3,7 +3,7 @@ export const prerender = true;
 
 import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
-import { courseInfo, units } from "@data/course/units";
+import { units } from "@data/course/units";
 import {
   Lightbulb,
   Heart,

--- a/src/pages/en/course/beginners/unit-1.astro
+++ b/src/pages/en/course/beginners/unit-1.astro
@@ -2,15 +2,13 @@
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
-import Button from "@components/ui/Button.astro";
 import CourseProgress from "@components/course/CourseProgress";
 import CognateDiscovery from "@components/course/CognateDiscovery";
 import SentenceBuilder from "@components/course/SentenceBuilder";
 import PronunciationDrill from "@components/course/PronunciationDrill";
 import ConnectorChallenge from "@components/course/ConnectorChallenge";
 import SelfTest from "@components/course/SelfTest";
-import AudioButton from "@components/course/AudioButton";
-import { units, courseInfo } from "@data/course/units";
+import { units } from "@data/course/units";
 import {
   cognateWaves,
   sentenceBlocks,

--- a/src/pages/en/course/beginners/unit-2.astro
+++ b/src/pages/en/course/beginners/unit-2.astro
@@ -2,7 +2,6 @@
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
-import Button from "@components/ui/Button.astro";
 import CourseProgress from "@components/course/CourseProgress";
 import CognateDiscovery from "@components/course/CognateDiscovery";
 import SentenceBuilder from "@components/course/SentenceBuilder";

--- a/src/pages/en/course/elementary/index.astro
+++ b/src/pages/en/course/elementary/index.astro
@@ -3,7 +3,7 @@ export const prerender = true;
 
 import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
-import { elementaryInfo, elementaryUnits } from "@data/elementary/units";
+import { elementaryUnits } from "@data/elementary/units";
 import {
   BookOpen,
   Clock,

--- a/src/pages/en/course/executive/index.astro
+++ b/src/pages/en/course/executive/index.astro
@@ -3,7 +3,7 @@ export const prerender = true;
 
 import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
-import { executiveInfo, executiveUnits } from "@data/executive/units";
+import { executiveUnits } from "@data/executive/units";
 import {
   Target,
   Zap,

--- a/src/pages/en/course/intermediate/index.astro
+++ b/src/pages/en/course/intermediate/index.astro
@@ -3,7 +3,7 @@ export const prerender = true;
 
 import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
-import { intermediateInfo, intermediateUnits } from "@data/intermediate/units";
+import { intermediateUnits } from "@data/intermediate/units";
 import {
   Puzzle,
   Briefcase,

--- a/src/pages/en/course/intermediate/unit-1.astro
+++ b/src/pages/en/course/intermediate/unit-1.astro
@@ -10,8 +10,7 @@ import SentenceBuilder from "@components/course/SentenceBuilder";
 import ErrorCorrection from "@components/course/ErrorCorrection";
 import PronunciationDrill from "@components/course/PronunciationDrill";
 import SelfTest from "@components/course/SelfTest";
-import AudioButton from "@components/course/AudioButton";
-import { intermediateUnits, intermediateInfo } from "@data/intermediate/units";
+import { intermediateUnits } from "@data/intermediate/units";
 import {
   phrasalVerbGroups,
   dialogues,

--- a/src/pages/en/quiz/[quizType]/results.astro
+++ b/src/pages/en/quiz/[quizType]/results.astro
@@ -14,7 +14,6 @@ import {
   getAvailableQuizTypes,
 } from "@/data/quiz/configs";
 import type { QuizType } from "@/data/quiz/types";
-import { Mail } from "lucide-astro";
 
 export const prerender = true;
 

--- a/src/pages/en/resources.astro
+++ b/src/pages/en/resources.astro
@@ -8,7 +8,6 @@
 import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
 import FreeResourcesHub from "@components/free/FreeResourcesHub";
-import { Sparkles, FileText, Headphones, MessageCircle } from "lucide-astro";
 import type { FreeAsset } from "@/types/free-asset";
 
 const title = "Executive English Resource Library | New York English";

--- a/src/pages/en/resources/[slug].astro
+++ b/src/pages/en/resources/[slug].astro
@@ -11,7 +11,6 @@
 
 import Base from "@layouts/Base.astro";
 import GenericFreeAsset from "@components/free/GenericFreeAsset";
-import { getCollection } from "astro:content";
 import type { TKey } from "../../../lib/i18n";
 
 // Generate static paths for all free assets

--- a/src/pages/en/services/executive-english.astro
+++ b/src/pages/en/services/executive-english.astro
@@ -9,7 +9,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // Import services data for centralized image management
@@ -76,8 +75,6 @@ const ctaContent = {
   ],
 };
 
-// Translation slug for Spanish version
-const translationSlug = "ingles-para-ejecutivos";
 
 const faqs = serviceFaqs["executive-english"]?.en || [];
 ---

--- a/src/pages/en/services/high-stakes-english.astro
+++ b/src/pages/en/services/high-stakes-english.astro
@@ -9,7 +9,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // prevent autosave tools from removing imports (used in template)
@@ -81,8 +80,6 @@ const ctaContent = {
   ],
 };
 
-// Translation slug for Spanish version
-const translationSlug = "ingles-para-presentaciones";
 
 const faqs = serviceFaqs["high-stakes-english"]?.en || [];
 ---

--- a/src/pages/en/services/interview-prep.astro
+++ b/src/pages/en/services/interview-prep.astro
@@ -10,7 +10,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // prevent autosave tools from removing imports (used in template)
@@ -70,8 +69,6 @@ const ctaContent = {
   ]
 };
 
-// Translation slug for Spanish version
-const translationSlug = "preparacion-para-entrevistas";
 
 const faqs = serviceFaqs["interview-prep"]?.en || [];
 ---

--- a/src/pages/en/services/logistics-english.astro
+++ b/src/pages/en/services/logistics-english.astro
@@ -9,7 +9,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // prevent autosave tools from removing imports (used in template)
@@ -83,8 +82,6 @@ const ctaContent = {
   ],
 };
 
-// Translation slug for Spanish version
-const translationSlug = "ingles-para-logistica";
 
 const faqs = serviceFaqs["logistics-english"]?.en || [];
 ---

--- a/src/pages/en/services/medical-english.astro
+++ b/src/pages/en/services/medical-english.astro
@@ -9,7 +9,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // prevent autosave tools from removing imports (used in template)
@@ -73,8 +72,6 @@ const ctaContent = {
   ]
 };
 
-// Translation slug for Spanish version
-const translationSlug = "ingles-para-medicos";
 
 const faqs = serviceFaqs["medical-english"]?.en || [];
 ---

--- a/src/pages/en/services/professional-english.astro
+++ b/src/pages/en/services/professional-english.astro
@@ -9,7 +9,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // Import services data
@@ -77,8 +76,6 @@ const ctaContent = {
   ],
 };
 
-// Translation slug for Spanish version
-const translationSlug = "ingles-para-profesionales";
 
 const faqs = serviceFaqs["professional-english"]?.en || [];
 ---

--- a/src/pages/en/services/public-speaking-english.astro
+++ b/src/pages/en/services/public-speaking-english.astro
@@ -10,7 +10,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // Import services data

--- a/src/pages/en/services/startup-founders.astro
+++ b/src/pages/en/services/startup-founders.astro
@@ -10,7 +10,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // Import data
@@ -65,8 +64,6 @@ const ctaContent = {
   ]
 };
 
-// Translation slug for Spanish version
-const translationSlug = "ingles-para-fundadores-de-startups";
 
 const faqs = serviceFaqs["startup-founders"]?.en || [];
 ---

--- a/src/pages/en/services/tech-english.astro
+++ b/src/pages/en/services/tech-english.astro
@@ -10,7 +10,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // Import data
@@ -67,8 +66,6 @@ const ctaContent = {
   ],
 };
 
-// Translation slug for Spanish version
-const translationSlug = "ingles-para-tecnologia";
 
 const faqs = serviceFaqs["tech-english"]?.en || [];
 ---

--- a/src/pages/en/services/technical-sales-english.astro
+++ b/src/pages/en/services/technical-sales-english.astro
@@ -9,7 +9,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // Import services data
@@ -72,8 +71,6 @@ const ctaContent = {
   ],
 };
 
-// Translation slug for Spanish version
-const translationSlug = "ingles-para-ventas-tecnicas";
 
 const faqs = serviceFaqs["technical-sales-english"]?.en || [];
 ---

--- a/src/pages/en/testimonials/[industry].astro
+++ b/src/pages/en/testimonials/[industry].astro
@@ -48,12 +48,6 @@ const description =
     ? "Read success stories from executives, founders, and professionals who transformed their English communication with personalized coaching."
     : `Success stories from ${industryLabel.toLowerCase()} who transformed their English communication with personalized coaching. See real results.`;
 
-// Spanish counterpart for language switcher
-const translationSlugEs =
-  currentIndustry === "all"
-    ? "/es/testimonios/"
-    : `/es/testimonios/${currentIndustry}/`;
-
 // Create custom hreflangs for each industry page
 const currentUrl =
   currentIndustry === "all"

--- a/src/pages/es/blog/[slug].astro
+++ b/src/pages/es/blog/[slug].astro
@@ -116,7 +116,6 @@ const relatedPosts = allPosts
 
 // Get site URL for structured data
 const siteUrl = siteConfig.siteUrl || 'https://www.nyenglishteacher.com';
-const cleanSiteUrl = siteUrl.replace(/https?:\/\/www\.www\./i, 'https://www.').replace(/\/$/, '');
 
 // Generate proper hreflang for individual blog posts
 const lang = 'es';

--- a/src/pages/es/categoria/[category].astro
+++ b/src/pages/es/categoria/[category].astro
@@ -40,18 +40,6 @@ const allSpanishPosts = allPosts
       new Date(a.data.publishDate).getTime()
   );
 
-// Filter posts for this specific category (for display)
-const categoryPosts = allSpanishPosts.filter(
-  (post: CollectionEntry<"blog">) => {
-    const categoryNames = post.data.categories || [];
-    // Check both Spanish and English category names for compatibility
-    return (
-      categoryNames.includes(categoryData.name_es || categoryData.name) ||
-      categoryNames.includes(categoryData.name)
-    );
-  }
-);
-
 // Generate proper TKey for i18n system
 const tkey = `category/${categoryData.slug}` as TKey;
 

--- a/src/pages/es/curso/avanzado/index.astro
+++ b/src/pages/es/curso/avanzado/index.astro
@@ -3,7 +3,7 @@ export const prerender = true;
 
 import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
-import { advancedInfo, advancedUnits } from "@data/advanced/units";
+import { advancedUnits } from "@data/advanced/units";
 import {
   Sparkles,
   AlertTriangle,

--- a/src/pages/es/curso/ejecutivo/index.astro
+++ b/src/pages/es/curso/ejecutivo/index.astro
@@ -3,7 +3,7 @@ export const prerender = true;
 
 import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
-import { executiveInfo, executiveUnits } from "@data/executive/units";
+import { executiveUnits } from "@data/executive/units";
 import {
   Target,
   Zap,

--- a/src/pages/es/curso/elemental/index.astro
+++ b/src/pages/es/curso/elemental/index.astro
@@ -3,7 +3,7 @@ export const prerender = true;
 
 import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
-import { elementaryInfo, elementaryUnits } from "@data/elementary/units";
+import { elementaryUnits } from "@data/elementary/units";
 import {
   BookOpen,
   Clock,

--- a/src/pages/es/curso/intermedio/index.astro
+++ b/src/pages/es/curso/intermedio/index.astro
@@ -3,7 +3,7 @@ export const prerender = true;
 
 import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
-import { intermediateInfo, intermediateUnits } from "@data/intermediate/units";
+import { intermediateUnits } from "@data/intermediate/units";
 import {
   Puzzle,
   Briefcase,

--- a/src/pages/es/curso/intermedio/unidad-1.astro
+++ b/src/pages/es/curso/intermedio/unidad-1.astro
@@ -10,8 +10,7 @@ import SentenceBuilder from "@components/course/SentenceBuilder";
 import ErrorCorrection from "@components/course/ErrorCorrection";
 import PronunciationDrill from "@components/course/PronunciationDrill";
 import SelfTest from "@components/course/SelfTest";
-import AudioButton from "@components/course/AudioButton";
-import { intermediateUnits, intermediateInfo } from "@data/intermediate/units";
+import { intermediateUnits } from "@data/intermediate/units";
 import {
   phrasalVerbGroups,
   dialogues,

--- a/src/pages/es/curso/principiantes/index.astro
+++ b/src/pages/es/curso/principiantes/index.astro
@@ -3,7 +3,7 @@ export const prerender = true;
 
 import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
-import { courseInfo, units } from "@data/course/units";
+import { units } from "@data/course/units";
 import {
   Lightbulb,
   Heart,

--- a/src/pages/es/curso/principiantes/unidad-1.astro
+++ b/src/pages/es/curso/principiantes/unidad-1.astro
@@ -2,15 +2,13 @@
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
-import Button from "@components/ui/Button.astro";
 import CourseProgress from "@components/course/CourseProgress";
 import CognateDiscovery from "@components/course/CognateDiscovery";
 import SentenceBuilder from "@components/course/SentenceBuilder";
 import PronunciationDrill from "@components/course/PronunciationDrill";
 import ConnectorChallenge from "@components/course/ConnectorChallenge";
 import SelfTest from "@components/course/SelfTest";
-import AudioButton from "@components/course/AudioButton";
-import { units, courseInfo } from "@data/course/units";
+import { units } from "@data/course/units";
 import {
   cognateWaves,
   sentenceBlocks,

--- a/src/pages/es/curso/principiantes/unidad-2.astro
+++ b/src/pages/es/curso/principiantes/unidad-2.astro
@@ -2,7 +2,6 @@
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
-import Button from "@components/ui/Button.astro";
 import CourseProgress from "@components/course/CourseProgress";
 import CognateDiscovery from "@components/course/CognateDiscovery";
 import SentenceBuilder from "@components/course/SentenceBuilder";

--- a/src/pages/es/quiz/[quizType]/results.astro
+++ b/src/pages/es/quiz/[quizType]/results.astro
@@ -14,7 +14,6 @@ import {
   getAvailableQuizTypes,
 } from "@/data/quiz/configs";
 import type { QuizType } from "@/data/quiz/types";
-import { Mail } from "lucide-astro";
 
 export const prerender = true;
 

--- a/src/pages/es/recursos.astro
+++ b/src/pages/es/recursos.astro
@@ -8,7 +8,6 @@
 import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
 import FreeResourcesHub from "@components/free/FreeResourcesHub";
-import { Sparkles, FileText, Headphones, MessageCircle } from "lucide-astro";
 import type { FreeAsset } from "@/types/free-asset";
 
 const title = "Biblioteca de Recursos Ejecutivos | New York English";

--- a/src/pages/es/servicios/hablar-en-publico.astro
+++ b/src/pages/es/servicios/hablar-en-publico.astro
@@ -9,7 +9,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // Import services data
@@ -110,8 +109,6 @@ const ctaContent = {
   ],
 };
 
-// Translation slug for English version
-const translationSlug = "public-speaking-english";
 
 const faqs = serviceFaqs["public-speaking-english"]?.es || [];
 ---

--- a/src/pages/es/servicios/ingles-para-ejecutivos.astro
+++ b/src/pages/es/servicios/ingles-para-ejecutivos.astro
@@ -9,7 +9,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // Import services data

--- a/src/pages/es/servicios/ingles-para-fundadores-de-startups.astro
+++ b/src/pages/es/servicios/ingles-para-fundadores-de-startups.astro
@@ -9,7 +9,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // Import services data

--- a/src/pages/es/servicios/ingles-para-logistica.astro
+++ b/src/pages/es/servicios/ingles-para-logistica.astro
@@ -9,7 +9,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // Import services data

--- a/src/pages/es/servicios/ingles-para-medicos.astro
+++ b/src/pages/es/servicios/ingles-para-medicos.astro
@@ -9,7 +9,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // Import services data
@@ -105,8 +104,6 @@ const ctaContent = {
   ],
 };
 
-// Translation slug for English version
-const translationSlug = "medical-english";
 
 const faqs = serviceFaqs["medical-english"]?.es || [];
 ---

--- a/src/pages/es/servicios/ingles-para-presentaciones.astro
+++ b/src/pages/es/servicios/ingles-para-presentaciones.astro
@@ -9,7 +9,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // Import services data

--- a/src/pages/es/servicios/ingles-para-profesionales.astro
+++ b/src/pages/es/servicios/ingles-para-profesionales.astro
@@ -9,7 +9,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // Import services data

--- a/src/pages/es/servicios/ingles-para-tecnologia.astro
+++ b/src/pages/es/servicios/ingles-para-tecnologia.astro
@@ -9,7 +9,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // Import services data

--- a/src/pages/es/servicios/ingles-para-ventas-tecnicas.astro
+++ b/src/pages/es/servicios/ingles-para-ventas-tecnicas.astro
@@ -9,7 +9,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // Import services data
@@ -110,8 +109,6 @@ const ctaContent = {
   ],
 };
 
-// Translation slug for English version
-const translationSlug = "technical-sales-english";
 
 const faqs = serviceFaqs["technical-sales-english"]?.es || [];
 ---

--- a/src/pages/es/servicios/preparacion-para-entrevistas.astro
+++ b/src/pages/es/servicios/preparacion-para-entrevistas.astro
@@ -9,7 +9,6 @@ import FeaturedTestimonial from "@components/sections/FeaturedTestimonial.astro"
 import CtaSection from "@components/sections/CtaSection.astro";
 import ServiceFAQ from "@components/sections/ServiceFAQ.astro";
 import BreadcrumbSchema from "@components/seo/BreadcrumbSchema.astro";
-import Breadcrumbs from "@components/ui/Breadcrumbs.astro";
 import { serviceFaqs } from "@data/service-faqs";
 
 // Import services data
@@ -108,8 +107,6 @@ const ctaContent = {
   ],
 };
 
-// Translation slug for English version
-const translationSlug = "interview-prep";
 
 const faqs = serviceFaqs["interview-prep"]?.es || [];
 ---

--- a/src/pages/es/testimonios/[industry].astro
+++ b/src/pages/es/testimonios/[industry].astro
@@ -48,12 +48,6 @@ const description =
     ? "Historias de éxito de ejecutivos y profesionales que transformaron su comunicación en inglés con coaching personalizado."
     : `Historias de ${industryLabel.toLowerCase()} que transformaron su comunicación en inglés con coaching personalizado. Resultados reales.`;
 
-// English counterpart for language switcher
-const translationSlugEn =
-  currentIndustry === "all"
-    ? "/en/testimonials/"
-    : `/en/testimonials/${currentIndustry}/`;
-
 // Create custom hreflangs for each industry page
 const currentUrl =
   currentIndustry === "all"


### PR DESCRIPTION
## Summary

- Removes unused `Breadcrumbs` imports from 20 service pages (10 `en/services/`, 10 `es/servicios/`)
- Removes unused `translationSlug`/`translationSlugEs`/`translationSlugEn` declarations from 15 pages — these were computed but the `customHreflangs` props are all hardcoded, so the variables were dead
- Removes unused named imports: `AudioButton`, `*Info` course-data vars, `Mail` icon, `getCollection`, icon imports in resources pages
- Removes dead `categoryPosts` filter in `es/categoria/[category].astro` (template uses `allSpanishPosts` directly)
- Removes dead `cleanSiteUrl` in both blog slug pages

**47 files, 100 deletions.** All removals were verified by checking that each symbol appeared exactly once in its file (only the declaration, never referenced in the template).

## What's NOT fixed

A handful of multi-line unused `const` objects remain (`FooterCta`, `mainCta`, `footerCta`, `logosSection`, `seoData`) — these are safely removable but are multi-line declarations that are harder to verify manually without running the build. They can be cleaned up in a follow-on pass once `npm install` works locally (currently blocked by 403 on `@parcel/watcher-wasm`).

## Test plan

- [ ] `npm run build` — confirm no component-reference errors (the key risk is accidentally removing an import that IS used; all removals were grep-verified)
- [ ] Spot-check a few service pages in preview to confirm they render normally

https://claude.ai/code/session_011nPQsP9YV1B8TTtNM1zkgq

---
_Generated by [Claude Code](https://claude.ai/code/session_011nPQsP9YV1B8TTtNM1zkgq)_