### PR TITLE
feat(blog): add TTS speaker buttons to register article (EN+ES)

### DIFF
--- a/src/content/blog/en/english-register-for-spanish-speakers.md
+++ b/src/content/blog/en/english-register-for-spanish-speakers.md
@@ -55,13 +55,15 @@ Without the knob, the speaker often defaults to one of two failure modes — too
 
 These are the four levers a Spanish-native senior professional needs to learn to operate consciously, because there is no grammatical autopilot in English doing it for them.
 
+*Click the speaker icon next to each example below to hear it with proper executive pacing and tone.*
+
 ### 1. Modal verbs
 
 English does its register-shifting in the modal layer — *can / could / would / might / should / may*. This is where most of the work happens.
 
-- "Send the report by Friday." (direct, unhedged — appropriate downward to a direct report on a clear task)
-- "Could you send the report by Friday?" (consultative — peer or upward request)
-- "Would it be possible to have the report by Friday?" (formal, deferential — external client or senior stakeholder you are not close to)
+- <span class="speak-en">"Send the report by Friday."</span> (direct, unhedged — appropriate downward to a direct report on a clear task)
+- <span class="speak-en">"Could you send the report by Friday?"</span> (consultative — peer or upward request)
+- <span class="speak-en">"Would it be possible to have the report by Friday?"</span> (formal, deferential — external client or senior stakeholder you are not close to)
 
 Same content. Three different positions on the formality gradient. The grammar did not change — only the modal verb stack did. For a Spanish speaker, *podría* is a verb form. In English, *could / would / might* are tools you stack and combine.
 
@@ -69,9 +71,9 @@ Same content. Three different positions on the formality gradient. The grammar d
 
 English speakers signal register partly through how often they hedge. Senior English communicators rarely strip hedges entirely (that reads as aggressive); they vary the *density* by context. A board update has lower hedging density than a peer brainstorm. A vendor escalation has lower hedging density than a request to a senior leader for a decision they may resist.
 
-- Low hedging: "We're behind plan and need to recalibrate the forecast."
-- Medium hedging: "We're tracking somewhat behind plan, and I think it would be worth recalibrating the forecast this week."
-- High hedging: "I wonder if it might be worth us taking another look at the forecast — there are a few signals suggesting we may need to recalibrate."
+- Low hedging: <span class="speak-en">"We're behind plan and need to recalibrate the forecast."</span>
+- Medium hedging: <span class="speak-en">"We're tracking somewhat behind plan, and I think it would be worth recalibrating the forecast this week."</span>
+- High hedging: <span class="speak-en">"I wonder if it might be worth us taking another look at the forecast — there are a few signals suggesting we may need to recalibrate."</span>
 
 Spanish has hedges too (*creo que, me parece que, sería bueno que*). The mistake is one-to-one mapping — a Spanish speaker drops their *me parece* into English as "I think" and assumes English needs the same density everywhere. It usually needs *less* in senior decision contexts and *more* in deferential ones than the Spanish instinct suggests.
 
@@ -79,9 +81,9 @@ Spanish has hedges too (*creo que, me parece que, sería bueno que*). The mistak
 
 English encodes deference and softening by converting statements into questions. Senior leaders making a request rarely give direct commands to peers or upward — they almost always frame the decision as a question that contains the answer.
 
-- Direct statement: "Move the meeting to Tuesday."
-- Indirect via question: "Would it work to move the meeting to Tuesday?"
-- More indirect: "I wonder if Tuesday might work better for everyone."
+- Direct statement: <span class="speak-en">"Move the meeting to Tuesday."</span>
+- Indirect via question: <span class="speak-en">"Would it work to move the meeting to Tuesday?"</span>
+- More indirect: <span class="speak-en">"I wonder if Tuesday might work better for everyone."</span>
 
 Spanish does this too, but less. English upper-register communication leans heavily on the interrogative-as-request. The Spanish speaker who keeps issuing direct statements upward in English — even technically correct ones — reads as blunt in a way that has nothing to do with their intention.
 
@@ -99,7 +101,7 @@ For Spanish speakers, this is paradoxically *easier* than for English natives �
 
 When the grammatical control disappears and the instinct does not get redirected to the four mechanics, two failure patterns emerge.
 
-**Failure mode 1: too stiff.** The speaker translates *usted* into a formality blanket. Every email reads like a legal document. Modal verbs stack defensively ("I would like to kindly request that you would consider…"). The vocabulary is uniformly Latinate. The reader feels held at arm's length even in moments where warmth would build alignment. Spanish speakers most often fall into this when they associate formality-in-Spanish with respect-in-English and over-translate the formality.
+**Failure mode 1: too stiff.** The speaker translates *usted* into a formality blanket. Every email reads like a legal document. Modal verbs stack defensively (<span class="speak-en">"I would like to kindly request that you would consider…"</span>). The vocabulary is uniformly Latinate. The reader feels held at arm's length even in moments where warmth would build alignment. Spanish speakers most often fall into this when they associate formality-in-Spanish with respect-in-English and over-translate the formality.
 
 **Failure mode 2: too casual.** The speaker, sensing that English does not have *usted*, defaults to a flat neutral middle register everywhere — board, team, vendor, client. The grammar is correct. The text is fine. But the calibration has gone missing. To a senior English-speaking listener, this often reads as *not quite serious enough* — the absence of register-shifting reads as the absence of situational awareness.
 

--- a/src/content/blog/es/registro-en-ingles-para-hispanohablantes.md
+++ b/src/content/blog/es/registro-en-ingles-para-hispanohablantes.md
@@ -55,13 +55,15 @@ Sin la perilla, el hablante muchas veces cae en uno de dos modos de falla — de
 
 Estas son las cuatro palancas que un profesional senior hispanohablante necesita aprender a operar conscientemente, porque no hay ningún piloto automático gramatical en inglés haciéndolo por él.
 
+*Haz clic en el ícono del altavoz junto a cada ejemplo para escucharlo con la cadencia y el tono ejecutivo correctos.*
+
 ### 1. Verbos modales
 
 El inglés hace su cambio de registro en la capa modal — *can / could / would / might / should / may*. Aquí es donde sucede la mayor parte del trabajo.
 
-- "Send the report by Friday." (directo, sin atenuantes — apropiado hacia abajo, a un colaborador directo, en una tarea clara)
-- "Could you send the report by Friday?" (consultativo — petición a un par o hacia arriba)
-- "Would it be possible to have the report by Friday?" (formal, deferente — cliente externo o stakeholder senior con quien no tienes cercanía)
+- <span class="speak-en">"Send the report by Friday."</span> (directo, sin atenuantes — apropiado hacia abajo, a un colaborador directo, en una tarea clara)
+- <span class="speak-en">"Could you send the report by Friday?"</span> (consultativo — petición a un par o hacia arriba)
+- <span class="speak-en">"Would it be possible to have the report by Friday?"</span> (formal, deferente — cliente externo o stakeholder senior con quien no tienes cercanía)
 
 Mismo contenido. Tres posiciones distintas en el gradiente de formalidad. La gramática no cambió — solo cambió la pila de verbos modales. Para un hispanohablante, *podría* es una forma verbal. En inglés, *could / would / might* son herramientas que apilas y combinas.
 
@@ -69,9 +71,9 @@ Mismo contenido. Tres posiciones distintas en el gradiente de formalidad. La gra
 
 Los hablantes de inglés señalan el registro en parte por la frecuencia con la que atenúan. Los comunicadores senior en inglés rara vez quitan los atenuantes por completo (eso se lee como agresivo); varían la *densidad* según el contexto. Una actualización al consejo tiene menor densidad de atenuantes que una lluvia de ideas con pares. Una escalación a un proveedor tiene menor densidad que una petición a un líder senior por una decisión que probablemente resista.
 
-- Atenuación baja: "We're behind plan and need to recalibrate the forecast."
-- Atenuación media: "We're tracking somewhat behind plan, and I think it would be worth recalibrating the forecast this week."
-- Atenuación alta: "I wonder if it might be worth us taking another look at the forecast — there are a few signals suggesting we may need to recalibrate."
+- Atenuación baja: <span class="speak-en">"We're behind plan and need to recalibrate the forecast."</span>
+- Atenuación media: <span class="speak-en">"We're tracking somewhat behind plan, and I think it would be worth recalibrating the forecast this week."</span>
+- Atenuación alta: <span class="speak-en">"I wonder if it might be worth us taking another look at the forecast — there are a few signals suggesting we may need to recalibrate."</span>
 
 El español también tiene atenuantes (*creo que, me parece que, sería bueno que*). El error es el mapeo uno-a-uno — un hispanohablante traduce *me parece* a "I think" y asume que el inglés necesita la misma densidad en todas partes. Generalmente necesita *menos* en contextos de decisión senior y *más* en contextos deferentes de lo que el instinto en español sugiere.
 
@@ -79,9 +81,9 @@ El español también tiene atenuantes (*creo que, me parece que, sería bueno qu
 
 El inglés codifica la deferencia y el suavizado convirtiendo afirmaciones en preguntas. Los líderes senior haciendo una petición rara vez dan órdenes directas a pares o hacia arriba — casi siempre enmarcan la decisión como una pregunta que contiene la respuesta.
 
-- Afirmación directa: "Move the meeting to Tuesday."
-- Indirecta vía pregunta: "Would it work to move the meeting to Tuesday?"
-- Más indirecta: "I wonder if Tuesday might work better for everyone."
+- Afirmación directa: <span class="speak-en">"Move the meeting to Tuesday."</span>
+- Indirecta vía pregunta: <span class="speak-en">"Would it work to move the meeting to Tuesday?"</span>
+- Más indirecta: <span class="speak-en">"I wonder if Tuesday might work better for everyone."</span>
 
 El español también lo hace, pero menos. La comunicación de registro alto en inglés se apoya fuertemente en el interrogativo-como-petición. El hispanohablante que sigue emitiendo afirmaciones directas hacia arriba en inglés — incluso técnicamente correctas — se lee como brusco de una manera que no tiene nada que ver con su intención.
 
@@ -99,7 +101,7 @@ Para los hispanohablantes esto es paradójicamente *más fácil* que para los na
 
 Cuando el control gramatical desaparece y el instinto no se redirige a las cuatro mecánicas, emergen dos patrones de falla.
 
-**Modo de falla 1: demasiado rígido.** El hablante traduce *usted* en una manta de formalidad. Cada correo se lee como un documento legal. Los modales se apilan defensivamente ("I would like to kindly request that you would consider…"). El vocabulario es uniformemente latino. El lector se siente mantenido a distancia incluso en momentos donde la calidez construiría alineación. Los hispanohablantes caen aquí más a menudo cuando asocian la formalidad-en-español con el respeto-en-inglés y sobre-traducen la formalidad.
+**Modo de falla 1: demasiado rígido.** El hablante traduce *usted* en una manta de formalidad. Cada correo se lee como un documento legal. Los modales se apilan defensivamente (<span class="speak-en">"I would like to kindly request that you would consider…"</span>). El vocabulario es uniformemente latino. El lector se siente mantenido a distancia incluso en momentos donde la calidez construiría alineación. Los hispanohablantes caen aquí más a menudo cuando asocian la formalidad-en-español con el respeto-en-inglés y sobre-traducen la formalidad.
 
 **Modo de falla 2: demasiado casual.** El hablante, intuyendo que el inglés no tiene *usted*, se establece en un registro medio neutro y plano para todo — consejo, equipo, proveedor, cliente. La gramática es correcta. El texto está bien. Pero la calibración desapareció. Para un oyente senior anglohablante, esto a menudo se lee como *no del todo en serio* — la ausencia del cambio de registro se lee como la ausencia de conciencia situacional.
 


### PR DESCRIPTION
## Summary

Adds Azure Neural TTS speaker buttons to the 10 English example phrases in the four-mechanics section of the register article — the differentiating "audio layer" Robert flagged as the kind of detail that separates this from generic register content online.

The `SpeakEnglish.astro` component is already wired into both EN and ES blog templates and uses Azure Neural TTS with browser-API fallback and client-side audio caching. **Zero new infrastructure** — just wrap phrases with `<span class="speak-en">…</span>` and the speaker buttons appear automatically.

## Why it matters here specifically

The Spanish version of the post embeds the English example sentences inline (because the article teaches English mechanics). For Spanish-speaking readers, hearing the formality-gradient differences (intonation, pacing, stress) is exactly what text alone can't transmit — and that gradient is the whole point of the article.

## Phrases wrapped (10 total)

| Section | Count | Purpose |
|---|---|---|
| Modal verbs | 3 | Formality gradient on "send the report by Friday" |
| Hedging density | 3 | Low / medium / high gradient on the recalibration message |
| Indirectness via question form | 3 | Statement → indirect → wonder-form on the meeting move |
| Failure mode 1 (too stiff) | 1 | Over-stacked "I would like to kindly request that you would consider…" — the audio of how *bad* it sounds is the lesson |

Plus an instructional sentence at the top of the four-mechanics section in both languages: *"Click the speaker icon next to each example below to hear it with proper executive pacing and tone."* (Matches the convention from `executive-reframing-drills.md`.)

## Files changed

- `src/content/blog/en/english-register-for-spanish-speakers.md` — wrapped 10 phrases + instructional sentence
- `src/content/blog/es/registro-en-ingles-para-hispanohablantes.md` — same wrapping (English phrases identical) + Spanish instructional sentence

## Validation

- ✅ `npm run build` — clean
- ✅ Verified 10 `class="speak-en"` spans rendered in EN page output
- ✅ Verified 10 `class="speak-en"` spans rendered in ES page output
- ✅ Pre-existing benign Astro glob-loader warning ignored (not related to this change)

## Test plan

- [ ] Confirm speaker buttons appear next to each wrapped phrase on Vercel preview
- [ ] Click each button and confirm Azure TTS plays the audio (not the browser fallback)
- [ ] Confirm the instructional sentence is visible at the top of section 4 in both languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)