### PR TITLE
feat(a2): ship Unit 6 — quantifiers (much/many, some/any, a few)

### DIFF
--- a/src/data/elementary/unit-6.ts
+++ b/src/data/elementary/unit-6.ts
@@ -1,0 +1,441 @@
+// Unit 6: "How Much, How Many" — Quantifiers
+//
+// Pedagogical arc:
+// Section A — 3 waves: countable nouns, uncountable nouns, the quantifiers themselves
+// Section B — Much vs. many + a lot of + a few/a little
+// Section C — Some / any / no — the affirmative/negative/question pattern
+// Section D — Boss Sentence: a real meeting recap using all the quantifiers
+// Section E — Pronunciation: 'a lot of' linking, 'any' vowel, 'some' reduction
+// Section F — Self-test of unit vocabulary
+
+export interface CognateWord {
+  english: string;
+  spanish: string;
+  category: string;
+  pronunciationNote?: string;
+  pronunciationNoteEs?: string;
+}
+
+export interface SentenceBlock {
+  label: string;
+  labelEs: string;
+  description: string;
+  descriptionEs: string;
+  sentences: {
+    english: string;
+    spanish: string;
+    highlight?: string;
+  }[];
+}
+
+export interface PronunciationDrillItem {
+  word: string;
+  spanishStress: string;
+  englishStress: string;
+  tip: string;
+  tipEs: string;
+}
+
+export interface VocabItem {
+  english: string;
+  spanish: string;
+  type: "verb" | "phrase" | "marker";
+}
+
+// ─── Section A: Countable, Uncountable, and Quantifiers ──────────────────────
+
+export const cognateWaves = {
+  wave1: {
+    title: "Countable Nouns — Things You Can Count",
+    titleEs: "Sustantivos Contables — Cosas que puedes contar",
+    description:
+      "If you can put a NUMBER in front (one chair, two chairs), the noun is countable. Plural form ends in -s. These take 'many' and 'a few'.",
+    descriptionEs:
+      "Si puedes poner un NÚMERO adelante (one chair, two chairs), el sustantivo es contable. La forma plural termina en -s. Llevan 'many' y 'a few'.",
+    words: [
+      { english: "chairs", spanish: "sillas", category: "Countable" },
+      { english: "people", spanish: "personas", category: "Countable" },
+      {
+        english: "books",
+        spanish: "libros",
+        category: "Countable",
+        pronunciationNote: "Plural -s sounds like /s/ after voiceless k.",
+        pronunciationNoteEs: "El -s plural suena /s/ después de k sorda.",
+      },
+      { english: "meetings", spanish: "juntas", category: "Countable" },
+      { english: "emails", spanish: "correos", category: "Countable" },
+      { english: "ideas", spanish: "ideas", category: "Countable" },
+      { english: "friends", spanish: "amigos", category: "Countable" },
+      { english: "hours", spanish: "horas", category: "Countable" },
+      { english: "questions", spanish: "preguntas", category: "Countable" },
+      { english: "problems", spanish: "problemas", category: "Countable" },
+      { english: "minutes", spanish: "minutos", category: "Countable" },
+      { english: "days", spanish: "días", category: "Countable" },
+    ] as CognateWord[],
+  },
+  wave2: {
+    title: "Uncountable Nouns — Mass / Abstract Things",
+    titleEs: "Sustantivos Incontables — Cosas masa / abstractas",
+    description:
+      "If you CAN'T put a number directly in front (NOT 'two waters', NOT 'three advices'), it's uncountable. No plural -s. These take 'much' and 'a little'.",
+    descriptionEs:
+      "Si NO puedes poner un número directamente adelante (NO 'two waters', NO 'three advices'), es incontable. Sin -s plural. Llevan 'much' y 'a little'.",
+    words: [
+      {
+        english: "water",
+        spanish: "agua",
+        category: "Uncountable",
+        pronunciationNote: "Never plural in English (unlike Spanish 'aguas'). Always 'water'.",
+        pronunciationNoteEs: "Nunca plural en inglés (distinto a 'aguas' en español). Siempre 'water'.",
+      },
+      { english: "time", spanish: "tiempo", category: "Uncountable" },
+      { english: "money", spanish: "dinero", category: "Uncountable" },
+      {
+        english: "advice",
+        spanish: "consejo",
+        category: "Uncountable",
+        pronunciationNote: "ALWAYS uncountable. NEVER 'advices'. The #1 Spanish-speaker error.",
+        pronunciationNoteEs: "SIEMPRE incontable. NUNCA 'advices'. El error #1 de los hispanohablantes.",
+      },
+      { english: "work", spanish: "trabajo", category: "Uncountable" },
+      {
+        english: "information",
+        spanish: "información",
+        category: "Uncountable",
+        pronunciationNote: "Always uncountable. NEVER 'informations'.",
+        pronunciationNoteEs: "Siempre incontable. NUNCA 'informations'.",
+      },
+      { english: "traffic", spanish: "tráfico", category: "Uncountable" },
+      {
+        english: "news",
+        spanish: "noticias",
+        category: "Uncountable",
+        pronunciationNote: "Looks plural, but is uncountable. 'The news IS good' (NOT 'are').",
+        pronunciationNoteEs: "Parece plural, pero es incontable. 'The news IS good' (NO 'are').",
+      },
+      { english: "music", spanish: "música", category: "Uncountable" },
+      { english: "homework", spanish: "tarea", category: "Uncountable" },
+      {
+        english: "furniture",
+        spanish: "muebles",
+        category: "Uncountable",
+        pronunciationNote: "NEVER 'furnitures'. Use 'pieces of furniture' if you need to count.",
+        pronunciationNoteEs: "NUNCA 'furnitures'. Usa 'pieces of furniture' si necesitas contar.",
+      },
+      { english: "feedback", spanish: "retroalimentación", category: "Uncountable" },
+    ] as CognateWord[],
+  },
+  wave3: {
+    title: "The Quantifiers — Words That Tell You How Much",
+    titleEs: "Los Cuantificadores — Palabras que dicen cuánto",
+    description:
+      "Each quantifier pairs with a SPECIFIC type of noun. 'Many' takes countable. 'Much' takes uncountable. 'A lot of' is the safe choice — it works with both.",
+    descriptionEs:
+      "Cada cuantificador va con un tipo ESPECÍFICO de sustantivo. 'Many' va con contables. 'Much' con incontables. 'A lot of' es la opción segura — funciona con ambos.",
+    words: [
+      { english: "many (+ countable)", spanish: "muchos/as (con contables)", category: "Quantifier" },
+      { english: "much (+ uncountable)", spanish: "mucho/a (con incontables)", category: "Quantifier" },
+      { english: "a lot of (+ both)", spanish: "muchos/as (con ambos)", category: "Quantifier" },
+      { english: "lots of (+ both)", spanish: "muchos/as (informal, ambos)", category: "Quantifier" },
+      { english: "a few (+ countable)", spanish: "algunos pocos (contables)", category: "Quantifier" },
+      { english: "a little (+ uncountable)", spanish: "un poco de (incontables)", category: "Quantifier" },
+      { english: "some (+ both)", spanish: "algunos / un poco (ambos)", category: "Quantifier" },
+      { english: "any (+ both, neg/quest)", spanish: "ninguno / algún (negativos/preguntas)", category: "Quantifier" },
+      { english: "no (+ both)", spanish: "ningún / nada de", category: "Quantifier" },
+      { english: "plenty of (+ both)", spanish: "bastante/s", category: "Quantifier" },
+    ] as CognateWord[],
+  },
+};
+
+// ─── Section B: Much vs. Many + a lot of + a few / a little ──────────────────
+
+export const sentenceBlocks: SentenceBlock[] = [
+  {
+    label: "Step 1: Many + countable plural",
+    labelEs: "Paso 1: Many + plural contable",
+    description:
+      "Use 'many' when the noun is COUNTABLE and PLURAL. Common in questions and negatives. In affirmatives, 'a lot of' often sounds more natural than 'many'.",
+    descriptionEs:
+      "Usa 'many' cuando el sustantivo es CONTABLE y PLURAL. Común en preguntas y negativos. En afirmativos, 'a lot of' suele sonar más natural que 'many'.",
+    sentences: [
+      { english: "How many people came to the meeting?", spanish: "¿Cuántas personas vinieron a la junta?", highlight: "many" },
+      { english: "I don't have many friends in this city.", spanish: "No tengo muchos amigos en esta ciudad.", highlight: "many" },
+      { english: "She sent many emails today.", spanish: "Ella mandó muchos correos hoy.", highlight: "many" },
+      { english: "There aren't many chairs in the room.", spanish: "No hay muchas sillas en el cuarto.", highlight: "many" },
+    ],
+  },
+  {
+    label: "Step 2: Much + uncountable",
+    labelEs: "Paso 2: Much + incontable",
+    description:
+      "Use 'much' when the noun is UNCOUNTABLE. Almost always in questions and negatives. In affirmatives, switch to 'a lot of' — 'much' sounds formal/old-fashioned.",
+    descriptionEs:
+      "Usa 'much' cuando el sustantivo es INCONTABLE. Casi siempre en preguntas y negativos. En afirmativos, cambia a 'a lot of' — 'much' suena formal/anticuado.",
+    sentences: [
+      { english: "How much time do we have?", spanish: "¿Cuánto tiempo tenemos?", highlight: "much" },
+      { english: "I don't have much money this month.", spanish: "No tengo mucho dinero este mes.", highlight: "much" },
+      { english: "There isn't much traffic today.", spanish: "No hay mucho tráfico hoy.", highlight: "much" },
+      { english: "She doesn't drink much coffee.", spanish: "Ella no toma mucho café.", highlight: "much" },
+    ],
+  },
+  {
+    label: "Step 3: A lot of + both — the safe choice",
+    labelEs: "Paso 3: A lot of + ambos — la opción segura",
+    description:
+      "'A lot of' works with countable AND uncountable. When in doubt, use it. 'Lots of' is the same — slightly more informal.",
+    descriptionEs:
+      "'A lot of' funciona con contables E incontables. Cuando dudes, úsalo. 'Lots of' es lo mismo — ligeramente más informal.",
+    sentences: [
+      { english: "I have a lot of work this week.", spanish: "Tengo mucho trabajo esta semana.", highlight: "a lot of" },
+      { english: "She drinks a lot of coffee.", spanish: "Ella toma mucho café.", highlight: "a lot of" },
+      { english: "There are a lot of people here.", spanish: "Hay mucha gente aquí.", highlight: "a lot of" },
+      { english: "We had lots of fun at the party.", spanish: "Nos divertimos mucho en la fiesta.", highlight: "lots of" },
+    ],
+  },
+  {
+    label: "Step 4: A few (countable) vs. a little (uncountable)",
+    labelEs: "Paso 4: A few (contable) vs. a little (incontable)",
+    description:
+      "'A few' = a small POSITIVE amount of countable things ('a few friends'). 'A little' = a small POSITIVE amount of uncountable ('a little time'). Both mean 'some, but not many/much'.",
+    descriptionEs:
+      "'A few' = una pequeña cantidad POSITIVA de cosas contables ('a few friends'). 'A little' = una pequeña cantidad POSITIVA de incontable ('a little time'). Ambos significan 'algunos, pero no muchos'.",
+    sentences: [
+      { english: "I have a few questions about the report.", spanish: "Tengo algunas preguntas sobre el reporte.", highlight: "a few" },
+      { english: "She has a little time before the meeting.", spanish: "Ella tiene un poco de tiempo antes de la junta.", highlight: "a little" },
+      { english: "We met a few interesting people.", spanish: "Conocimos a algunas personas interesantes.", highlight: "a few" },
+      { english: "I need a little help with this.", spanish: "Necesito un poco de ayuda con esto.", highlight: "a little" },
+    ],
+  },
+];
+
+// ─── Section C: Some / Any / No ──────────────────────────────────────────────
+
+export const powerVerbBlocks: SentenceBlock[] = [
+  {
+    label: "Some — Affirmative Sentences",
+    labelEs: "Some — Oraciones afirmativas",
+    description:
+      "Use 'some' in AFFIRMATIVE sentences. Works with both countable plurals and uncountable nouns. Translates roughly to 'algunos' or 'un poco de'.",
+    descriptionEs:
+      "Usa 'some' en oraciones AFIRMATIVAS. Funciona con plurales contables e incontables. Se traduce como 'algunos' o 'un poco de'.",
+    sentences: [
+      { english: "I have some questions for you.", spanish: "Tengo algunas preguntas para ti.", highlight: "some" },
+      { english: "She bought some new books.", spanish: "Ella compró algunos libros nuevos.", highlight: "some" },
+      { english: "There's some milk in the fridge.", spanish: "Hay un poco de leche en el refri.", highlight: "some" },
+      { english: "We need some advice on this project.", spanish: "Necesitamos un poco de consejo en este proyecto.", highlight: "some" },
+    ],
+  },
+  {
+    label: "Any — Negatives and Questions",
+    labelEs: "Any — Negativos y preguntas",
+    description:
+      "Use 'any' in NEGATIVES and QUESTIONS. Same rule as 'some' (works with both types of nouns), but switches WHERE you use it.",
+    descriptionEs:
+      "Usa 'any' en NEGATIVOS y PREGUNTAS. Misma regla que 'some' (funciona con ambos tipos), pero cambia DÓNDE lo usas.",
+    sentences: [
+      { english: "Do you have any questions?", spanish: "¿Tienes alguna pregunta?", highlight: "any" },
+      { english: "I don't have any time today.", spanish: "No tengo tiempo hoy.", highlight: "any" },
+      { english: "Are there any chairs in that room?", spanish: "¿Hay sillas en ese cuarto?", highlight: "any" },
+      { english: "She doesn't speak any French.", spanish: "Ella no habla francés (nada).", highlight: "any" },
+    ],
+  },
+  {
+    label: "No — Strong Negation",
+    labelEs: "No — Negación fuerte",
+    description:
+      "'No + noun' is stronger and shorter than 'not any + noun'. Both mean the same. Use 'no' for emphasis: 'I have NO time' is stronger than 'I don't have any time'.",
+    descriptionEs:
+      "'No + sustantivo' es más fuerte y corto que 'not any + sustantivo'. Ambos significan lo mismo. Usa 'no' para énfasis: 'I have NO time' es más fuerte que 'I don't have any time'.",
+    sentences: [
+      { english: "I have no time for that.", spanish: "No tengo tiempo para eso.", highlight: "no" },
+      { english: "There are no chairs in this room.", spanish: "No hay sillas en este cuarto.", highlight: "no" },
+      { english: "She has no patience for excuses.", spanish: "Ella no tiene paciencia para excusas.", highlight: "no" },
+      { english: "There's no problem at all.", spanish: "No hay ningún problema.", highlight: "no" },
+    ],
+  },
+  {
+    label: "The Some/Any Exception — Offers and Requests",
+    labelEs: "La excepción de Some/Any — Ofrecimientos y peticiones",
+    description:
+      "When you OFFER or REQUEST something — even in question form — use 'some'. Why? Because you're not really asking; you're EXPECTING yes.",
+    descriptionEs:
+      "Cuando OFRECES o PIDES algo — incluso en forma de pregunta — usa 'some'. ¿Por qué? Porque no estás realmente preguntando; ESPERAS un sí.",
+    sentences: [
+      { english: "Would you like some coffee?", spanish: "¿Te gustaría un poco de café?", highlight: "some (offer)" },
+      { english: "Can I have some water, please?", spanish: "¿Me das un poco de agua, por favor?", highlight: "some (request)" },
+      { english: "Could I borrow some money?", spanish: "¿Me prestas un poco de dinero?", highlight: "some (request)" },
+      { english: "Do you want some help with that?", spanish: "¿Quieres ayuda con eso?", highlight: "some (offer)" },
+    ],
+  },
+];
+
+// ─── Section D: Boss Sentence — A Real Meeting Recap (Connector Challenge) ───
+
+export const connectorSentences = {
+  connectors: [
+    {
+      word: "many",
+      wordEs: "muchos",
+      example: "There were many people at the meeting.",
+      exampleEs: "Había muchas personas en la junta.",
+      use: "Use with COUNTABLE nouns. In affirmatives, 'a lot of' is more natural than 'many'.",
+      useEs: "Usa con sustantivos CONTABLES. En afirmativas, 'a lot of' es más natural que 'many'.",
+    },
+    {
+      word: "much",
+      wordEs: "mucho",
+      example: "We didn't have much time.",
+      exampleEs: "No tuvimos mucho tiempo.",
+      use: "Use with UNCOUNTABLE nouns. Almost always in negatives and questions.",
+      useEs: "Usa con sustantivos INCONTABLES. Casi siempre en negativos y preguntas.",
+    },
+    {
+      word: "a few",
+      wordEs: "algunos pocos",
+      example: "We had a few good ideas.",
+      exampleEs: "Tuvimos algunas buenas ideas.",
+      use: "A small POSITIVE amount of countable things — 'some, but not many'.",
+      useEs: "Una pequeña cantidad POSITIVA de cosas contables — 'algunos, pero no muchos'.",
+    },
+    {
+      word: "some",
+      wordEs: "algunos / un poco",
+      example: "There were some questions about the budget.",
+      exampleEs: "Hubo algunas preguntas sobre el presupuesto.",
+      use: "Use in affirmative sentences. Works with both countable and uncountable.",
+      useEs: "Usa en oraciones afirmativas. Funciona con contables e incontables.",
+    },
+    {
+      word: "no",
+      wordEs: "ningún / nada de",
+      example: "There were no major concerns.",
+      exampleEs: "No hubo preocupaciones mayores.",
+      use: "Strong negation. Shorter and more emphatic than 'not any'.",
+      useEs: "Negación fuerte. Más corta y enfática que 'not any'.",
+    },
+    {
+      word: "a lot of",
+      wordEs: "mucho / muchos",
+      example: "Honestly, we have a lot of work to do.",
+      exampleEs: "Honestamente, tenemos mucho trabajo por hacer.",
+      use: "Works with EVERYTHING — countable or uncountable. The safe choice.",
+      useEs: "Funciona con TODO — contable o incontable. La opción segura.",
+    },
+  ],
+  bossSentence: {
+    english:
+      "There were many people at the meeting today. We had a few good ideas, but we didn't have much time. There were some questions about the budget, but no major concerns. The team has plenty of energy, but I think we have a lot of work to do before next month.",
+    spanish:
+      "Hubo muchas personas en la junta hoy. Tuvimos algunas buenas ideas, pero no tuvimos mucho tiempo. Hubo algunas preguntas sobre el presupuesto, pero no hubo preocupaciones mayores. El equipo tiene mucha energía, pero creo que tenemos mucho trabajo por hacer antes del próximo mes.",
+    explanation:
+      "Five sentences. Six different quantifiers (many, a few, much, some, no, plenty of, a lot of). Mixing countable (people, ideas, questions, concerns) and uncountable (time, energy, work). This is what natural quantification sounds like in real meetings.",
+    explanationEs:
+      "Cinco oraciones. Seis cuantificadores diferentes (many, a few, much, some, no, plenty of, a lot of). Mezclando contables (people, ideas, questions, concerns) e incontables (time, energy, work). Así suena la cuantificación natural en juntas reales.",
+  },
+};
+
+// ─── Section E: Pronunciation Lab — Quantifier Sounds ────────────────────────
+
+export const pronunciationDrills: PronunciationDrillItem[] = [
+  {
+    word: "many",
+    spanishStress: "MA-NY (Spanish 'a' sound)",
+    englishStress: "MEN-ee (short 'e' sound)",
+    tip: "Sounds like 'MEN-ee', NOT 'MA-nee'. Same vowel as 'pen' or 'ten'.",
+    tipEs: "Suena como 'MEN-ee', NO 'MA-nee'. Misma vocal que 'pen' o 'ten'.",
+  },
+  {
+    word: "much",
+    spanishStress: "MUCH (Spanish 'u' sound)",
+    englishStress: "MUHCH (short 'uh' sound, like 'cup')",
+    tip: "The 'u' is short — like the 'u' in 'cup' or 'duck', not Spanish 'u'.",
+    tipEs: "La 'u' es corta — como la 'u' en 'cup' o 'duck', no como la 'u' en español.",
+  },
+  {
+    word: "any",
+    spanishStress: "A-NEE (Spanish-style 'a')",
+    englishStress: "EN-ee (short 'e' sound, same as 'many')",
+    tip: "Sounds like 'EN-ee'. Same vowel as 'many'. NOT 'AY-nee'.",
+    tipEs: "Suena como 'EN-ee'. Misma vocal que 'many'. NO 'AY-nee'.",
+  },
+  {
+    word: "a lot of",
+    spanishStress: "A LOT OF (three separate words)",
+    englishStress: "uh-LOT-uh (linked, sounds like one word)",
+    tip: "In fast speech, 'a lot of' merges into 'uh-LOT-uh'. The 'f' almost disappears before the next noun.",
+    tipEs: "En habla rápida, 'a lot of' se junta en 'uh-LOT-uh'. La 'f' casi desaparece antes del siguiente sustantivo.",
+  },
+  {
+    word: "some",
+    spanishStress: "SOME (full pronunciation)",
+    englishStress: "SUM (rhymes with 'come' or 'thumb')",
+    tip: "Sounds exactly like the math word 'sum'. NOT 'soh-mey'. ONE syllable.",
+    tipEs: "Suena exactamente como la palabra matemática 'sum'. NO 'soh-mey'. UNA sílaba.",
+  },
+  {
+    word: "no (negation)",
+    spanishStress: "NO (Spanish 'o')",
+    englishStress: "NOH (long English 'oh' sound)",
+    tip: "The 'o' is long, like in 'go' or 'toe'. Slightly more drawn out than the Spanish 'no'.",
+    tipEs: "La 'o' es larga, como en 'go' o 'toe'. Un poco más estirada que el 'no' español.",
+  },
+  {
+    word: "plenty of",
+    spanishStress: "PLEN-TI OF (Spanish 'i')",
+    englishStress: "PLEN-tee-uh (linked, soft T)",
+    tip: "Three syllables linked: PLEN-tee-uh. The 't' is soft (American T). The 'of' becomes 'uh'.",
+    tipEs: "Tres sílabas ligadas: PLEN-tee-uh. La 't' es suave (T americana). El 'of' se vuelve 'uh'.",
+  },
+  {
+    word: "a few",
+    spanishStress: "A FEW (full pronunciation)",
+    englishStress: "uh-FYOO (the 'a' is reduced, FEW is stressed)",
+    tip: "The 'a' is reduced to 'uh'. 'FEW' has a 'y' sound at the start: FYOO. Like 'view' or 'cue'.",
+    tipEs: "La 'a' se reduce a 'uh'. 'FEW' tiene un sonido 'y' al inicio: FYOO. Como 'view' o 'cue'.",
+  },
+];
+
+// ─── Section F: Vocabulary List for Self-Test ────────────────────────────────
+
+export const vocabularyList: VocabItem[] = [
+  // Countable nouns
+  { english: "people", spanish: "personas", type: "phrase" },
+  { english: "books", spanish: "libros", type: "phrase" },
+  { english: "meetings", spanish: "juntas", type: "phrase" },
+  { english: "questions", spanish: "preguntas", type: "phrase" },
+  { english: "ideas", spanish: "ideas", type: "phrase" },
+  { english: "friends", spanish: "amigos", type: "phrase" },
+  // Uncountable nouns
+  { english: "water", spanish: "agua", type: "phrase" },
+  { english: "time", spanish: "tiempo", type: "phrase" },
+  { english: "money", spanish: "dinero", type: "phrase" },
+  { english: "advice (uncountable!)", spanish: "consejo (¡incontable!)", type: "phrase" },
+  { english: "work", spanish: "trabajo", type: "phrase" },
+  { english: "information (uncountable!)", spanish: "información (¡incontable!)", type: "phrase" },
+  { english: "traffic", spanish: "tráfico", type: "phrase" },
+  { english: "news (uncountable!)", spanish: "noticias (¡incontable!)", type: "phrase" },
+  { english: "homework", spanish: "tarea", type: "phrase" },
+  { english: "feedback", spanish: "retroalimentación", type: "phrase" },
+  // Quantifiers
+  { english: "many", spanish: "muchos (contable)", type: "marker" },
+  { english: "much", spanish: "mucho (incontable)", type: "marker" },
+  { english: "a lot of", spanish: "muchos / mucho (ambos)", type: "marker" },
+  { english: "lots of", spanish: "muchos (informal)", type: "marker" },
+  { english: "a few", spanish: "algunos pocos (contable)", type: "marker" },
+  { english: "a little", spanish: "un poco (incontable)", type: "marker" },
+  { english: "some", spanish: "algunos / un poco (afirmativos)", type: "marker" },
+  { english: "any", spanish: "algunos (negativos/preguntas)", type: "marker" },
+  { english: "no", spanish: "ningún / nada de", type: "marker" },
+  { english: "plenty of", spanish: "bastante/s", type: "marker" },
+  // Useful phrases
+  { english: "How many people?", spanish: "¿Cuántas personas?", type: "phrase" },
+  { english: "How much time?", spanish: "¿Cuánto tiempo?", type: "phrase" },
+  { english: "I don't have much money.", spanish: "No tengo mucho dinero.", type: "phrase" },
+  { english: "There aren't many chairs.", spanish: "No hay muchas sillas.", type: "phrase" },
+  { english: "I have a few questions.", spanish: "Tengo algunas preguntas.", type: "phrase" },
+  { english: "We need a little help.", spanish: "Necesitamos un poco de ayuda.", type: "phrase" },
+  { english: "Do you have any questions?", spanish: "¿Tienes alguna pregunta?", type: "phrase" },
+  { english: "There's no time.", spanish: "No hay tiempo.", type: "phrase" },
+  { english: "Would you like some coffee?", spanish: "¿Te gustaría un poco de café?", type: "phrase" },
+  { english: "We have a lot of work.", spanish: "Tenemos mucho trabajo.", type: "phrase" },
+];

--- a/src/data/elementary/units.ts
+++ b/src/data/elementary/units.ts
@@ -136,7 +136,7 @@ export const elementaryUnits: ElementaryUnit[] = [
     pronunciationFocus: "Stress on quantifiers in negation ('NOT many', 'NOT much')",
     pronunciationFocusEs: "Acento en cuantificadores en negación ('NOT many', 'NOT much')",
     icon: "Hash",
-    published: false,
+    published: true,
   },
   {
     id: 7,

--- a/src/pages/en/course/elementary/unit-6.astro
+++ b/src/pages/en/course/elementary/unit-6.astro
@@ -1,0 +1,296 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CognateDiscovery from "@components/course/CognateDiscovery";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import ConnectorChallenge from "@components/course/ConnectorChallenge";
+import SelfTest from "@components/course/SelfTest";
+import { elementaryUnits } from "@data/elementary/units";
+import {
+  cognateWaves,
+  sentenceBlocks,
+  powerVerbBlocks,
+  connectorSentences,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/elementary/unit-6";
+import {
+  Hash,
+  Layers,
+  Zap,
+  Link2,
+  Volume2,
+  ClipboardCheck,
+  BookOpen,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/elementary/unit-6" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
+
+const nextUnit = elementaryUnits.find((u) => u.id === 7);
+const nextUnitPublished = nextUnit?.published ?? false;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unit 6: How Much, How Many | Elementary English (A2)"
+  description="Quantifiers — much/many, some/any, a few, a little. The countable/uncountable rule that exposes Spanish speakers in seconds. Free A2 lesson."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={6}
+    basePath="/en/course/elementary"
+    lang="en"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-sky-400 text-sm font-semibold mb-3">
+          <Hash class="w-4 h-4" />
+          Unit 6
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          How Much, How Many
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          The quiet grammar that exposes Spanish speakers in seconds. Much vs. many. Some vs.
+          any. Why 'advice' has no plural. Why 'informations' is wrong every time. The rule:
+          some nouns can be counted, others can't — and the quantifier you choose has to match.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <nav class="bg-white border-b border-slate-200 sticky top-[52px] z-30 overflow-x-auto">
+    <div class="site-container mx-auto px-4">
+      <div class="flex items-center gap-1 py-2 text-sm whitespace-nowrap">
+        <a href="#vocabulary" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <BookOpen class="w-3.5 h-3.5" /> Countables
+        </a>
+        <a href="#much-many" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Layers class="w-3.5 h-3.5" /> Much / Many
+        </a>
+        <a href="#some-any" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Zap class="w-3.5 h-3.5" /> Some / Any
+        </a>
+        <a href="#boss" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Link2 class="w-3.5 h-3.5" /> Boss Sentence
+        </a>
+        <a href="#pronunciation" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Volume2 class="w-3.5 h-3.5" /> Pronunciation
+        </a>
+        <a href="#self-test" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <ClipboardCheck class="w-3.5 h-3.5" /> Self-Test
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <section id="vocabulary" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <BookOpen class="w-4 h-4" />
+            Section A
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Countables, Uncountables, and Quantifiers
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Three waves. Wave 1: nouns you can count (chairs, people, hours). Wave 2: nouns you
+            CAN'T count (water, time, advice — yes, advice). Wave 3: the ten quantifiers and
+            which type each pairs with. Tap any entry to hear it.
+          </p>
+        </div>
+        <CognateDiscovery client:visible waves={waveData} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="much-many" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Layers class="w-4 h-4" />
+            Section B
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Much vs. Many — Plus 'A Lot Of', 'A Few', 'A Little'
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Many' takes countable. 'Much' takes uncountable. 'A lot of' is the safe choice — it
+            works with both, and it sounds more natural in affirmatives than 'much' or 'many'
+            alone. 'A few' (countable) and 'a little' (uncountable) are the small-amount pair.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={sentenceBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="some-any" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Zap class="w-4 h-4" />
+            Section C
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Some / Any / No — The Affirmative-Negative-Question Pattern
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Some' in affirmatives. 'Any' in negatives and questions. 'No' for stronger
+            negation. Plus the exception: when you OFFER or REQUEST something, switch back to
+            'some' — even in question form ('Would you like some coffee?').
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={powerVerbBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="boss" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Link2 class="w-4 h-4" />
+            Section D
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            The Boss Sentence — A Real Meeting Recap
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Five sentences. Six different quantifiers (many, a few, much, some, no, plenty of,
+            a lot of). Mixing countable nouns (people, ideas, questions, concerns) and
+            uncountable nouns (time, energy, work). This is what natural quantification sounds
+            like in real meetings.
+          </p>
+        </div>
+        <ConnectorChallenge
+          client:visible
+          connectors={connectorSentences.connectors}
+          bossSentence={connectorSentences.bossSentence}
+          lang="en"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section id="pronunciation" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-rose-500 text-sm font-semibold mb-2">
+            <Volume2 class="w-4 h-4" />
+            Pronunciation Lab
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Quantifier Sounds — Vowels and Linking
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Many' and 'any' both have the short 'e' sound (like 'pen'). 'Much' has the 'uh'
+            sound (like 'cup'). 'A lot of' merges into 'uh-LOT-uh'. 'Some' rhymes with 'sum'.
+            Drill these — the pronunciation is what makes quantifiers sound natural, not just
+            grammatically correct.
+          </p>
+        </div>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="self-test" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <ClipboardCheck class="w-4 h-4" />
+            Self-Test
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Test What You Learned
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Flashcard review of every countable/uncountable noun, quantifier, and useful phrase
+            from Unit 6. Switch between Spanish→English and English→Spanish modes.
+          </p>
+        </div>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-gradient-to-b from-slate-900 to-slate-800">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-2xl mx-auto text-center space-y-6">
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/20 text-emerald-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-bold text-white">Unit 6 Complete!</h2>
+        <p class="text-lg text-slate-100 leading-relaxed">
+          You can now talk about quantities the way native speakers do — without saying
+          'advices', 'informations', or 'much chairs'. Six units down, four to go. Next: real
+          questions that go beyond yes and no.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center pt-4">
+          <a
+            href="/en/course/elementary/unit-5/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors"
+          >
+            ← Review Unit 5
+          </a>
+          {nextUnitPublished ? (
+            <a
+              href="/en/course/elementary/unit-7/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Continue to Unit 7 →
+            </a>
+          ) : (
+            <a
+              href="/en/course/elementary/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Course Overview
+            </a>
+          )}
+        </div>
+        <div class="pt-8 border-t border-slate-700 mt-8">
+          <p class="text-slate-200 text-sm mb-3">
+            Want personalized English coaching?
+          </p>
+          <a
+            href="/en/contact/"
+            class="text-sky-400 hover:text-sky-300 font-medium underline underline-offset-2"
+          >
+            Book a free consultation with Robert →
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/elemental/unidad-6.astro
+++ b/src/pages/es/curso/elemental/unidad-6.astro
@@ -1,0 +1,298 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CognateDiscovery from "@components/course/CognateDiscovery";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import ConnectorChallenge from "@components/course/ConnectorChallenge";
+import SelfTest from "@components/course/SelfTest";
+import { elementaryUnits } from "@data/elementary/units";
+import {
+  cognateWaves,
+  sentenceBlocks,
+  powerVerbBlocks,
+  connectorSentences,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/elementary/unit-6";
+import {
+  Hash,
+  Layers,
+  Zap,
+  Link2,
+  Volume2,
+  ClipboardCheck,
+  BookOpen,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/elementary/unit-6" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
+
+const nextUnit = elementaryUnits.find((u) => u.id === 7);
+const nextUnitPublished = nextUnit?.published ?? false;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unidad 6: Cuánto, Cuántos | Inglés Elemental (A2)"
+  description="Cuantificadores — much/many, some/any, a few, a little. La regla contable/incontable que delata a hispanohablantes en segundos. Lección A2 gratis."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={6}
+    basePath="/es/curso/elemental"
+    lang="es"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-sky-400 text-sm font-semibold mb-3">
+          <Hash class="w-4 h-4" />
+          Unidad 6
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Cuánto, Cuántos
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          La gramática silenciosa que delata a los hispanohablantes en segundos. Much vs. many.
+          Some vs. any. Por qué 'advice' no tiene plural. Por qué 'informations' siempre está
+          mal. La regla: algunos sustantivos se pueden contar, otros no — y el cuantificador
+          que elijas debe coincidir.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <nav class="bg-white border-b border-slate-200 sticky top-[52px] z-30 overflow-x-auto">
+    <div class="site-container mx-auto px-4">
+      <div class="flex items-center gap-1 py-2 text-sm whitespace-nowrap">
+        <a href="#vocabulary" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <BookOpen class="w-3.5 h-3.5" /> Contables
+        </a>
+        <a href="#much-many" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Layers class="w-3.5 h-3.5" /> Much / Many
+        </a>
+        <a href="#some-any" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Zap class="w-3.5 h-3.5" /> Some / Any
+        </a>
+        <a href="#boss" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Link2 class="w-3.5 h-3.5" /> Oración Maestra
+        </a>
+        <a href="#pronunciation" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Volume2 class="w-3.5 h-3.5" /> Pronunciación
+        </a>
+        <a href="#self-test" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <ClipboardCheck class="w-3.5 h-3.5" /> Auto-Test
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <section id="vocabulary" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <BookOpen class="w-4 h-4" />
+            Sección A
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Contables, Incontables y Cuantificadores
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Tres olas. Ola 1: sustantivos que puedes contar (chairs, people, hours). Ola 2:
+            sustantivos que NO puedes contar (water, time, advice — sí, advice). Ola 3: los
+            diez cuantificadores y con qué tipo va cada uno. Toca cualquier entrada para
+            escucharla.
+          </p>
+        </div>
+        <CognateDiscovery client:visible waves={waveData} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="much-many" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Layers class="w-4 h-4" />
+            Sección B
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Much vs. Many — Más 'A Lot Of', 'A Few', 'A Little'
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Many' va con contables. 'Much' va con incontables. 'A lot of' es la opción segura
+            — funciona con ambos, y suena más natural en afirmativas que 'much' o 'many' solos.
+            'A few' (contable) y 'a little' (incontable) son el par de cantidad pequeña.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={sentenceBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="some-any" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Zap class="w-4 h-4" />
+            Sección C
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Some / Any / No — El Patrón Afirmativo-Negativo-Pregunta
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Some' en afirmativas. 'Any' en negativos y preguntas. 'No' para negación más
+            fuerte. Más la excepción: cuando OFRECES o PIDES algo, regresa a 'some' — incluso
+            en pregunta ('Would you like some coffee?').
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={powerVerbBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="boss" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Link2 class="w-4 h-4" />
+            Sección D
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            La Oración Maestra — Resumen Real de Una Junta
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Cinco oraciones. Seis cuantificadores diferentes (many, a few, much, some, no,
+            plenty of, a lot of). Mezclando contables (people, ideas, questions, concerns) e
+            incontables (time, energy, work). Así suena la cuantificación natural en juntas
+            reales.
+          </p>
+        </div>
+        <ConnectorChallenge
+          client:visible
+          connectors={connectorSentences.connectors}
+          bossSentence={connectorSentences.bossSentence}
+          lang="es"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section id="pronunciation" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-rose-500 text-sm font-semibold mb-2">
+            <Volume2 class="w-4 h-4" />
+            Laboratorio de Pronunciación
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Sonidos de Cuantificadores — Vocales y Enlace
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Many' y 'any' tienen la 'e' corta (como 'pen'). 'Much' tiene el sonido 'uh' (como
+            'cup'). 'A lot of' se junta en 'uh-LOT-uh'. 'Some' rima con 'sum'. Practica estos —
+            la pronunciación es lo que hace que los cuantificadores suenen naturales, no solo
+            gramaticalmente correctos.
+          </p>
+        </div>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="self-test" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <ClipboardCheck class="w-4 h-4" />
+            Auto-Evaluación
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Evalúa Lo que Aprendiste
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Repaso tipo flashcard de cada sustantivo contable/incontable, cuantificador y frase
+            útil de la Unidad 6. Cambia entre los modos español→inglés e inglés→español.
+          </p>
+        </div>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-gradient-to-b from-slate-900 to-slate-800">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-2xl mx-auto text-center space-y-6">
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/20 text-emerald-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-bold text-white">¡Unidad 6 Completada!</h2>
+        <p class="text-lg text-slate-100 leading-relaxed">
+          Ahora puedes hablar de cantidades como los nativos — sin decir 'advices',
+          'informations' ni 'much chairs'. Seis unidades terminadas, cuatro por venir. Sigue:
+          preguntas reales que van más allá del sí y no.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center pt-4">
+          <a
+            href="/es/curso/elemental/unidad-5/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors"
+          >
+            ← Repasar Unidad 5
+          </a>
+          {nextUnitPublished ? (
+            <a
+              href="/es/curso/elemental/unidad-7/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Continuar a Unidad 7 →
+            </a>
+          ) : (
+            <a
+              href="/es/curso/elemental/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Vista General del Curso
+            </a>
+          )}
+        </div>
+        <div class="pt-8 border-t border-slate-700 mt-8">
+          <p class="text-slate-200 text-sm mb-3">
+            ¿Quieres coaching personalizado de inglés?
+          </p>
+          <a
+            href="/es/contact/"
+            class="text-sky-400 hover:text-sky-300 font-medium underline underline-offset-2"
+          >
+            Reserva una consulta gratuita con Robert →
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary
Sixth content unit of the A2 "Tell Your Story" course. Drills the **countable/uncountable distinction** and the quantifiers that pair with each — the quiet grammar that exposes Spanish speakers in seconds when they say "advices", "informations", or "much chairs".

## Pedagogical arc

### Section A — Countables, Uncountables, Quantifiers (3 waves)
- **Countable nouns** (12): chairs, people, books, meetings, emails, ideas, friends, hours, questions, problems, minutes, days
- **Uncountable nouns** (12): water, time, money, **advice**, work, **information**, traffic, **news**, music, homework, **furniture**, feedback — flagged warnings on the ones Spanish speakers most commonly pluralize wrongly
- **The 10 quantifiers**: many, much, a lot of, lots of, a few, a little, some, any, no, plenty of — each labeled with which noun type it takes

### Section B — Much / Many / A Lot Of / A Few / A Little (4 blocks)
- Many + countable plural ("How many people?")
- Much + uncountable ("How much time?")
- A lot of + both — **the safe choice**
- A few (countable) vs. a little (uncountable)

### Section C — Some / Any / No (4 blocks)
- Some in affirmatives
- Any in negatives and questions
- No for stronger negation
- **The exception**: 'some' in offers and requests ("Would you like some coffee?")

### Section D — Boss Sentence
A real meeting recap:

> "There were many people at the meeting today. We had a few good ideas, but we didn't have much time. There were some questions about the budget, but no major concerns. The team has plenty of energy, but I think we have a lot of work to do before next month."

Five sentences, six different quantifiers, mixing countable and uncountable nouns.

### Section E — Pronunciation
- `many` → **MEN-ee** (short e, like 'pen')
- `much` → **MUHCH** (short uh, like 'cup')
- `any` → **EN-ee** (short e, NOT 'AY-nee')
- `a lot of` → **uh-LOT-uh** (linked)
- `some` → rhymes with **'sum'**
- `plenty of` → **PLEN-tee-uh** (soft American T)
- `a few` → **uh-FYOO** (Y sound at start)

### Section F — Self-Test
35+ vocab items, with explicit "uncountable!" flags on `advice`, `information`, `news`, `furniture` — the four nouns Spanish speakers most commonly pluralize wrongly.

## The errors this unit kills
1. **'advices' / 'informations' / 'furnitures'** — already-uncountable nouns that Spanish speakers wrongly pluralize
2. **'much chairs' / 'many time'** — mismatched quantifier + noun type
3. **Using 'some' in negatives** or **'any' in affirmatives**

## Course status
6 of 10 units shipped (60% complete). 4 remaining: questions, routines, past continuous, capstone.

## Files
- `src/data/elementary/unit-6.ts` (~370 lines) — drill content
- `src/pages/en/course/elementary/unit-6.astro` (~250 lines)
- `src/pages/es/curso/elemental/unidad-6.astro` (~250 lines)
- `src/data/elementary/units.ts` — flips Unit 6 `published` to true

## Test plan
- [x] `npm run build` passes; 434 pages emitted (+2); all SEO gates pass
- [x] Meta-description gate confirms 0 too-long descriptions on new pages
- [ ] Vercel preview: `/en/course/elementary/` shows Units 1-6 available; Units 7-10 still gated
- [ ] Vercel preview: Unit 6 renders all 6 sections, Azure TTS works on speakers
- [ ] Unit 5 → Unit 6 link now works (Unit 5's CTA conditional should now show "Continue to Unit 6")
- [ ] Hreflang correctly cross-links EN ↔ ES Unit 6 pages