### PR TITLE
feat(blog): Tier 1 TTS retrofit (EN) + BACKLOG.md + ES architecture finding

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,122 @@
+# Backlog — Open Loops & Parking Lot
+
+This file captures **unfinished work, technical debt, content debt, and ideas in flight** that don't fit cleanly into a current PR or sprint. Append-only; resolved items move to the bottom under "Recently resolved" or get deleted.
+
+This file is **complementary** to:
+- `SEO-MARKETING-PLAN.md` — the active content roadmap (what's planned & shipped)
+- `~/.claude/projects/.../memory/` — Claude's auto-memory (durable facts about Robert/the project)
+
+`BACKLOG.md` is for *project-specific open loops* — things any future session (Claude or Robert) should be able to pick up without context.
+
+---
+
+## Content & Copy Debt
+
+### 🚨 ES Bilingual Architecture Decision (HIGH PRIORITY — UNRESOLVED)
+
+**Status:** Discovered 2026-05-02 during the Tier 1 TTS retrofit work. Needs Robert's strategic decision before remediation.
+
+**The finding:** Most "teaching English" blog posts have ES siblings where the example English phrases were *translated to Spanish*, defeating the pedagogical purpose. Concrete examples discovered:
+
+| EN slug | ES slug | Issue |
+|---|---|---|
+| `executive-video-call` | `presencia-ejecutiva-en-videollamadas` | All 7 example templates ("Thanks for joining…", "We met last week's target…", interruption phrases, PREP example, closing template) translated to Spanish in ES version |
+| `mexico-us-workplace-communication-guide` | `guia-comunicacion-laboral-mexico-estados-unidos` | Comparison tables (American vs. Mexican phrasings) fully in Spanish — defeats the purpose of showing American phrasings to Spanish-speakers |
+| `why-executive-english-accelerates-careers` | `por-que-ingles-ejecutivo-acelera-tu-carrera` | Four signals examples ("this is a disaster" → "this is impacting performance…") translated to Spanish |
+| (Likely many others — full audit not yet done) | | |
+
+**The pattern that works (where English IS preserved in ES):**
+- `english-register-for-spanish-speakers` ↔ `registro-en-ingles-para-hispanohablantes` — English phrases preserved in ES because the article literally teaches English register mechanics
+- `executive-reframing-drills` ↔ `ejercicios-reformulacion-ejecutiva` — English phrases preserved (14 TTS spans both langs)
+- `daily-standup-english` ↔ `ingles-para-daily-standup-frases` — English phrases preserved (74 TTS spans both langs)
+
+**Why this matters:** Robert's instinct on 2026-05-02: *"a lot of our readers could default to the Spanish version, and so obviously this is where hearing the English and listening to the English is going to be more important than the English version itself."* Without English phrases in ES, the audio layer can't work — and the ES reader can't actually learn the English they came for.
+
+**Decision required:**
+- **Option A — Bilingual rewrite for teaching-English posts:** Update affected ES posts so example phrases stay in English with Spanish prose around them (matches the register article pattern). Adds full TTS coverage in both languages. Larger lift but matches the brand's stated value.
+- **Option B — Leave as-is, document scope:** Accept that some ES posts will never have audio, only mark posts that already have English-preserved content as TTS-eligible.
+- **Option C — Hybrid per-article decision:** Each ES post gets evaluated individually; some keep Spanish translations, some get rewritten with English-preserved phrases.
+
+**Affected posts (audit needed):** Run the parity audit (script in `BACKLOG.md` history or recreate with `node -e ...`) to enumerate the full list. Initial findings showed 5 EN posts with significant ES parity gaps (192+ missing TTS spans total): `business-english-mistakes-mexican-professionals` (65 gap), `us-interview-prep` (43), `english-nearshore-developers-skills` (35), `lead-meeting-english-phrases` (25), `how-to-negotiate-in-english-framework` (24).
+
+---
+
+### Tier 2 TTS retrofit candidates (lower-priority sweep)
+
+Posts with English example phrases but no `speak-en` spans, where benefit is real but smaller than Tier 1:
+
+- `5-practical-ways-to-boost-business-english` (priority ~11 in audit)
+- `7-questions-corporate-english-vendor` (~10)
+- `4-secrets-executives-use` (~9)
+- `women-leaders-command-rooms-english` (~9)
+- `corporate-english-transformation-case-study` (~8)
+
+**When to do:** bundle into a future cleanup PR or pick up while editing one of these posts for another reason. Not standalone-PR-worthy.
+
+---
+
+### Hreflang map gaps in `astro.config.mjs`
+
+The `blogTranslations` map in `astro.config.mjs` is the source of truth for cross-language hreflang generation. Posts with EN ↔ ES siblings on disk but missing from this map don't get linked translations in the sitemap.
+
+**Known fix shipping this PR:** `mexico-us-workplace-communication-guide` ↔ `guia-comunicacion-laboral-mexico-estados-unidos` was missing — added.
+
+**Action:** Periodically audit by running:
+```bash
+node -e "const fs=require('fs');const cfg=fs.readFileSync('astro.config.mjs','utf8');const en=fs.readdirSync('src/content/blog/en').filter(f=>f.match(/\\.mdx?\$/)).map(f=>f.replace(/\\.mdx?\$/,'')); for(const s of en){if(!cfg.includes('\"'+s+'\":'))console.log('Missing:',s);}"
+```
+
+---
+
+## Technical Debt
+
+### Astro glob-loader duplicate-id warning
+
+Build emits `[WARN] [glob-loader] Duplicate id "en/<slug>" found in [path]` for some posts. Cosmetic only — pages build correctly. Likely an Astro 5.x quirk with the content collection glob pattern. Investigate when convenient or after Astro upgrade.
+
+### MDX support for `speak-en` spans
+
+`executive-communication-playbook.mdx` is the first MDX file we've added TTS spans to. MDX should handle inline HTML the same as Markdown, but the file uses a `FlipCardGrid` React component — verify that surrounding span markup doesn't get caught up in MDX/JSX parsing. If it works, document the pattern; if not, add to debt.
+
+---
+
+## Process Patterns to Apply Elsewhere
+
+### Cross-language internal linking on related-post clusters
+
+When publishing a sequel/related post, add forward-links from the prior posts in BOTH languages. Pattern established with `english-register-for-spanish-speakers` ← `why-executive-english-accelerates-careers` cross-link. Apply to future content clusters.
+
+### "Bring your own image" naming convention
+
+Hero images named to match the post slug (`<slug>.webp` in the language-specific images dir) so Astro asset pipeline can deduplicate identical EN/ES files into one served asset. Pattern proven on the register article (1962KB → 92KB, deduped). Future hero images should follow this.
+
+---
+
+## Marketing Ideas In Flight
+
+### Schedule GSC performance check on the executive-comm content cluster
+
+Robert greenlit (in principle) a `/schedule` agent in ~3 weeks (~2026-05-22) to pull GSC data on:
+- `why-executive-english-accelerates-careers`
+- `english-register-for-spanish-speakers`
+
+Cluster ranks vs. either piece alone. **Action:** create the schedule when Robert is ready.
+
+### Social content drafted but not posted
+
+Drafts exist in `content-marketing/`:
+- `why-executive-english-accelerates-careers-social.md`
+- `english-register-for-spanish-speakers-social.md`
+
+LinkedIn long-form, Twitter/X threads, Facebook posts, Spanish versions. Robert needs to copy/paste into platforms or we add platform integrations.
+
+---
+
+## Recently Resolved
+
+*(items here are resolved/shipped — keep for ~30 days for reference, then prune)*
+
+- **2026-05-02** — Tier 1 TTS retrofit (EN side): added `speak-en` spans to 5 high-value posts (`why-executive-english-accelerates-careers`, `executive-video-call`, `mexico-us-workplace-communication-guide`, `real-cost-weak-english-mexican-companies`, `executive-communication-playbook`). ES side blocked pending architecture decision (see above).
+- **2026-05-01** — Register article TTS sweep (EN+ES) — all 10 phrases wrapped, audio working in production.
+- **2026-05-01** — Register article published with custom split-image hero (EN+ES). Cross-linked to exec post.
+- **2026-04-30** — Executive English Accelerates Careers article published (EN+ES).

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -53,6 +53,7 @@ const blogTranslations = {
   "corporate-english-training-roi": "/es/blog/roi-capacitacion-ingles-corporativo/",
   "why-executive-english-accelerates-careers": "/es/blog/por-que-ingles-ejecutivo-acelera-tu-carrera/",
   "english-register-for-spanish-speakers": "/es/blog/registro-en-ingles-para-hispanohablantes/",
+  "mexico-us-workplace-communication-guide": "/es/blog/guia-comunicacion-laboral-mexico-estados-unidos/",
 };
 
 // Reverse map (ES slug -> EN path)

--- a/src/content/blog/en/executive-communication-playbook.mdx
+++ b/src/content/blog/en/executive-communication-playbook.mdx
@@ -49,13 +49,15 @@ When something goes wrong, most non-native speakers default to reactive language
 
 Here's what reactive vs. leadership language sounds like in practice:
 
+*Click the speaker icon next to any example below to hear it with proper executive pacing and tone.*
+
 **Reactive (how most people report):**
 
-> "There's a problem with the shipment. The carrier didn't pick up on time and the client is upset."
+> <span class="speak-en">"There's a problem with the shipment. The carrier didn't pick up on time and the client is upset."</span>
 
 **Leadership (what executives actually say):**
 
-> "We've identified a delay in the carrier pickup. We've already escalated with the logistics partner, the client has been notified with an updated timeline, and I'll have a confirmed resolution by 3 PM."
+> <span class="speak-en">"We've identified a delay in the carrier pickup. We've already escalated with the logistics partner, the client has been notified with an updated timeline, and I'll have a confirmed resolution by 3 PM."</span>
 
 The difference isn't about using fancier words. It's about answering three questions in every statement:
 
@@ -138,11 +140,11 @@ This distinction matters enormously in cross-cultural business. Latin American e
 
 **Key persuasion phrases to master:**
 
-- "What I'm proposing is..."
-- "The strategic case for this is..."
-- "If we invest in X, we unlock Y..."
-- "This positions us to..."
-- "The opportunity cost of not acting is..."
+- <span class="speak-en">"What I'm proposing is..."</span>
+- <span class="speak-en">"The strategic case for this is..."</span>
+- <span class="speak-en">"If we invest in X, we unlock Y..."</span>
+- <span class="speak-en">"This positions us to..."</span>
+- <span class="speak-en">"The opportunity cost of not acting is..."</span>
 
 ### Test Your Knowledge: Pillars 1 & 2
 
@@ -211,17 +213,17 @@ Here's a costly mistake I see constantly: using weak language in negotiation cre
 
 When you say things like:
 
-> "I guess we could probably do that..."
-> "Maybe we could make it work..."
-> "I suppose that's okay..."
+> <span class="speak-en">"I guess we could probably do that..."</span>
+> <span class="speak-en">"Maybe we could make it work..."</span>
+> <span class="speak-en">"I suppose that's okay..."</span>
 
 You're signaling that your position isn't firm—and the other side will push harder next time. Every "I guess" costs you money, timeline, or scope in future negotiations.
 
 **Strong alternatives:**
 
-- "That's something I can commit to." (clear yes)
-- "That's outside what I can accommodate in this scope." (clear no)
-- "Here's what I can do..." (redirecting)
+- <span class="speak-en">"That's something I can commit to."</span> (clear yes)
+- <span class="speak-en">"That's outside what I can accommodate in this scope."</span> (clear no)
+- <span class="speak-en">"Here's what I can do..."</span> (redirecting)
 
 **Ready to assess your negotiation communication?** [Take the Communication Confidence Quiz](/en/quiz/executives/) to see where you stand.
 
@@ -379,11 +381,11 @@ Junior professionals describe. Senior professionals direct. Compare:
 
 | Junior                                | Senior                                    |
 | ------------------------------------- | ----------------------------------------- |
-| "I think we should maybe consider..." | "My recommendation is..."                 |
-| "We had some problems with..."        | "We navigated a challenge around..."      |
-| "It's kind of complicated because..." | "The complexity here is..."               |
-| "I was wondering if we could..."      | "What I'd propose is..."                  |
-| "Sorry, but I disagree..."            | "I see it differently, and here's why..." |
+| <span class="speak-en">"I think we should maybe consider..."</span> | <span class="speak-en">"My recommendation is..."</span> |
+| <span class="speak-en">"We had some problems with..."</span> | <span class="speak-en">"We navigated a challenge around..."</span> |
+| <span class="speak-en">"It's kind of complicated because..."</span> | <span class="speak-en">"The complexity here is..."</span> |
+| <span class="speak-en">"I was wondering if we could..."</span> | <span class="speak-en">"What I'd propose is..."</span> |
+| <span class="speak-en">"Sorry, but I disagree..."</span> | <span class="speak-en">"I see it differently, and here's why..."</span> |
 
 Every word choice is a signal. When you consistently choose language that projects clarity and direction, people unconsciously assign you more authority—regardless of your accent, your title, or your first language.
 

--- a/src/content/blog/en/executive-video-call.md
+++ b/src/content/blog/en/executive-video-call.md
@@ -24,6 +24,8 @@ Video calls are where deals move forward, teams align, and leaders are judged—
 
 At New York English, I coach executives and senior managers in tech, finance, logistics, and professional services to communicate with clarity and authority. If you're looking to build foundational confidence first, check out my guide on [5 Simple Strategies to Gain Confidence](/en/blog/boost-eng-confidence/). Here are seven field-tested habits you can apply today.
 
+*Click the speaker icon next to any example phrase below to hear it with proper executive pacing and tone.*
+
 ---
 
 ### What You’ll Learn
@@ -42,7 +44,7 @@ Open the room and set expectations immediately.
 
 **Template:**
 
-> “Thanks for joining. We’ll use 25 minutes. Agenda: status in 5, decision on X in 10, next steps in 10. If questions pop up, drop them in chat and I’ll park them for the Q\&A.”
+> <span class="speak-en">“Thanks for joining. We’ll use 25 minutes. Agenda: status in 5, decision on X in 10, next steps in 10. If questions pop up, drop them in chat and I’ll park them for the Q\&A.”</span>
 
 This signals control, respect for time, and a clear path to outcomes.
 
@@ -54,7 +56,7 @@ Aim for **three sentences** of **\~30 words total** before you pause. Short bloc
 
 **Example:**
 
-> “We met last week’s target. Two risks remain: timeline and budget. I’ll propose a trade-off that protects launch.”
+> <span class="speak-en">“We met last week’s target. Two risks remain: timeline and budget. I’ll propose a trade-off that protects launch.”</span>
 
 ---
 
@@ -90,9 +92,9 @@ Maintain flow without sounding rigid.
 
 **Phrases that work:**
 
-- “Great point—let me finish this thought and I’ll come back to you.”
-- “I’ll park that in chat so we can decide on X first.”
-- “Can we hold questions for two minutes while I show the impact?”
+- <span class="speak-en">“Great point—let me finish this thought and I’ll come back to you.”</span>
+- <span class="speak-en">“I’ll park that in chat so we can decide on X first.”</span>
+- <span class="speak-en">“Can we hold questions for two minutes while I show the impact?”</span>
 
 ---
 
@@ -102,7 +104,7 @@ Use **PREP** (Point → Reason → Example → Point) to respond clearly under p
 
 **Example:**
 
-> “We should delay launch (Point). Quality risks could damage trust (Reason). Our last rushed release cost two clients (Example). So a two-week delay protects the relationship (Point).”
+> <span class="speak-en">“We should delay launch. Quality risks could damage trust. Our last rushed release cost two clients. So a two-week delay protects the relationship.”</span> (Point — Reason — Example — Point)
 
 ---
 
@@ -112,7 +114,7 @@ Replace weak endings with actions, owners, and timing. For 25 field-tested phras
 
 **Template:**
 
-> “Recap: Decision A approved. Next steps—**Maria** drafts the client note by **Thursday**, **Jorge** updates the timeline by **EOD Friday**. I’ll send a summary in 30 minutes. Anything blocking those?”
+> <span class="speak-en">“Recap: Decision A approved. Next steps — Maria drafts the client note by Thursday, Jorge updates the timeline by end of day Friday. I’ll send a summary in 30 minutes. Anything blocking those?”</span>
 
 This prevents drift and boosts accountability.
 

--- a/src/content/blog/en/mexico-us-workplace-communication-guide.md
+++ b/src/content/blog/en/mexico-us-workplace-communication-guide.md
@@ -41,13 +41,13 @@ American professionals favor getting straight to the point. Bluntness signals ef
 
 Mexican professionals view open disagreement or blunt criticism as disrespectful. Preserving personal dignity — **saving face** — takes priority over transactional clarity.
 
-**The same feedback, two cultures:**
+**The same feedback, two cultures.** *Click the speaker icon next to any phrase to hear it spoken with proper executive pacing and tone.*
 
 | Situation | American Manager | Mexican Manager |
 |-----------|-----------------|-----------------|
-| Report has missing data | "This report is missing data." | "The report is very comprehensive; perhaps we could add more data." |
-| Deadline will be missed | "We're going to miss the deadline." | "We're making progress. There are some factors we're managing." |
-| Disagreeing with a proposal | "I don't think that approach will work." | "That's interesting. Have we also considered...?" |
+| Report has missing data | <span class="speak-en">"This report is missing data."</span> | <span class="speak-en">"The report is very comprehensive; perhaps we could add more data."</span> |
+| Deadline will be missed | <span class="speak-en">"We're going to miss the deadline."</span> | <span class="speak-en">"We're making progress. There are some factors we're managing."</span> |
+| Disagreeing with a proposal | <span class="speak-en">"I don't think that approach will work."</span> | <span class="speak-en">"That's interesting. Have we also considered...?"</span> |
 
 Neither approach is wrong. But when an American reads a Mexican's diplomatic framing as evasion, or a Mexican reads an American's directness as aggression, the relationship breaks down.
 
@@ -165,9 +165,9 @@ Mexico relies on **highly indirect negative feedback.** Because personal dignity
 
 | American Feedback | Mexican Equivalent |
 |------------------|-------------------|
-| "This report is missing data." | "The report is very comprehensive; perhaps we could look at adding more data to make it even stronger." |
-| "This approach won't work." | "This is an interesting direction. Have we also considered some alternatives?" |
-| "You missed the deadline." | "I know you've been working very hard on this. When do you think we might see the final version?" |
+| <span class="speak-en">"This report is missing data."</span> | <span class="speak-en">"The report is very comprehensive; perhaps we could look at adding more data to make it even stronger."</span> |
+| <span class="speak-en">"This approach won't work."</span> | <span class="speak-en">"This is an interesting direction. Have we also considered some alternatives?"</span> |
+| <span class="speak-en">"You missed the deadline."</span> | <span class="speak-en">"I know you've been working very hard on this. When do you think we might see the final version?"</span> |
 
 ### Disagreeing: Confrontational (US) vs. Avoids Confrontation (Mexico)
 
@@ -284,17 +284,17 @@ This means the cultural dynamics described above are **compounded by language ba
 
 4. **Adapt your deadline culture.** Use high-frequency check-ins and daily progress markers instead of distant deadlines with hard boundaries.
 
-5. **Soften your Slack.** Add context, pleasantries, and greetings to digital messages. "Hey María, hope your morning is going well — quick question on the API endpoint" lands differently than "What's the status on the API endpoint?"
+5. **Soften your Slack.** Add context, pleasantries, and greetings to digital messages. <span class="speak-en">"Hey María, hope your morning is going well — quick question on the API endpoint"</span> lands differently than <span class="speak-en">"What's the status on the API endpoint?"</span>
 
 ### For Mexican Professionals Working with Americans
 
 1. **Understand that directness isn't aggression.** When your US colleague says "this doesn't work," they're providing efficient feedback, not attacking you personally.
 
-2. **Flag blockers early and explicitly.** In American work culture, admitting a problem early is respected — hiding it until it becomes a crisis is not. "I'm blocked on X and need Y to proceed" is the highest-trust sentence you can say.
+2. **Flag blockers early and explicitly.** In American work culture, admitting a problem early is respected — hiding it until it becomes a crisis is not. <span class="speak-en">"I'm blocked on X and need Y to proceed"</span> is the highest-trust sentence you can say.
 
 3. **Say "no" when you mean no.** The American "yes" is a binding commitment. If you're uncertain, say "I need to check on that" or "Let me confirm the timeline." This is more respected than agreeing and underdelivering.
 
-4. **Lead with the recommendation.** Americans prefer applications-first communication. Instead of building to your conclusion, start with it: "I recommend X because Y" — then provide the supporting detail.
+4. **Lead with the recommendation.** Americans prefer applications-first communication. Instead of building to your conclusion, start with it: <span class="speak-en">"I recommend X because Y"</span> — then provide the supporting detail.
 
 5. **Own individual accountability.** In US teams, taking responsibility for a specific outcome — even failure — builds credibility faster than collective ambiguity.
 

--- a/src/content/blog/en/real-cost-weak-english-mexican-companies.md
+++ b/src/content/blog/en/real-cost-weak-english-mexican-companies.md
@@ -96,7 +96,7 @@ Here's where the money disappears:
 
 A 50-person Guadalajara software house reached the final round for a U.S. fintech company's year-long engagement. The technical evaluation went well. Then came the executive presentation.
 
-The CTO spoke for 40 minutes. He knew the material cold—architecture decisions, security compliance, delivery model. But his delivery was halting. He translated in his head. He said "How I can say..." twice. He missed the CEO's question about risk mitigation strategy entirely and had to ask him to repeat it.
+The CTO spoke for 40 minutes. He knew the material cold—architecture decisions, security compliance, delivery model. But his delivery was halting. He translated in his head. He said <span class="speak-en">"How I can say..."</span> twice. He missed the CEO's question about risk mitigation strategy entirely and had to ask him to repeat it.
 
 **The Consequence:**
 
@@ -453,19 +453,19 @@ The stuck developers see this. They know they're passed over because of language
 
 It's not about grammar. It's about:
 
-**Running effective meetings in English:**
+**Running effective meetings in English.** *Click the speaker icon to hear each phrase with proper executive pacing.*
 
-- "Let's start with the biggest blocker."
-- "I hear two different perspectives—let me make sure I understand both."
-- "We need to make a decision today. Here are the tradeoffs."
+- <span class="speak-en">"Let's start with the biggest blocker."</span>
+- <span class="speak-en">"I hear two different perspectives—let me make sure I understand both."</span>
+- <span class="speak-en">"We need to make a decision today. Here are the tradeoffs."</span>
 
 **Explaining technical concepts to non-technical people:**
 
-- "Think of it like a restaurant kitchen. We can serve more customers if we hire more cooks, but only if the kitchen space can handle them. That's our scalability constraint."
+- <span class="speak-en">"Think of it like a restaurant kitchen. We can serve more customers if we hire more cooks, but only if the kitchen space can handle them. That's our scalability constraint."</span>
 
 **Handling conflict diplomatically:**
 
-- "I understand the urgency, but this approach creates technical debt. Let me show you the long-term cost."
+- <span class="speak-en">"I understand the urgency, but this approach creates technical debt. Let me show you the long-term cost."</span>
 
 **Projecting executive presence:**
 
@@ -689,15 +689,15 @@ Don't memorize individual words. Learn high-frequency phrases.
 
 **Framework phrases:**
 
-- "Let me walk you through three options."
-- "The tradeoff here is X versus Y."
-- "To clarify, are you asking about A or B?"
+- <span class="speak-en">"Let me walk you through three options."</span>
+- <span class="speak-en">"The tradeoff here is X versus Y."</span>
+- <span class="speak-en">"To clarify, are you asking about A or B?"</span>
 
 **Scenario-specific phrases:**
 
-- **Starting a story:** "Let me give you some context." / "Here's what happened."
-- **Status updates:** "We're on track for X. The blocker is Y. We'll resolve it by Z."
-- **Handling objections:** "I understand your concern. Let me address that directly."
+- **Starting a story:** <span class="speak-en">"Let me give you some context."</span> / <span class="speak-en">"Here's what happened."</span>
+- **Status updates:** <span class="speak-en">"We're on track for X. The blocker is Y. We'll resolve it by Z."</span>
+- **Handling objections:** <span class="speak-en">"I understand your concern. Let me address that directly."</span>
 
 Build a personal phrase bank for the situations you face repeatedly. Practice these until they're automatic.
 
@@ -728,8 +728,8 @@ Your language choices signal your identity. Train to match the persona you want 
 
 **Example:**
 
-- **Weak:** "Um, yeah, I think we could maybe try to do it that way, if that works for everyone."
-- **Strong:** "Yes, that approach is feasible. Here's what we'll need to make it work."
+- **Weak:** <span class="speak-en">"Um, yeah, I think we could maybe try to do it that way, if that works for everyone."</span>
+- **Strong:** <span class="speak-en">"Yes, that approach is feasible. Here's what we'll need to make it work."</span>
 
 The content is similar. The perception is completely different.
 

--- a/src/content/blog/en/why-executive-english-accelerates-careers.md
+++ b/src/content/blog/en/why-executive-english-accelerates-careers.md
@@ -58,13 +58,15 @@ These are small linguistic habits. The career cost compounds for years.
 
 Senior leaders who command rooms are not the loudest, the most charismatic, or the most polished. They are the ones who have learned to suppress four specific signals that mark someone as not-quite-ready:
 
-**Emotion.** Visible reactivity reads as loss of control. Peer-reviewed research links cognitive reappraisal — the ability to reframe rather than react — to higher leadership performance ratings from both supervisors and peers (Lopes et al., *Frontiers in Psychology*). The senior leader does not say "this is a disaster." They say "this is impacting performance and requires adjustment." Same reality. Different signal.
+*Click the speaker icon next to each example below to hear the weak version and the executive reframing — the difference lives in the delivery, not just the words.*
 
-**Weakness.** "I'm struggling with this" is a true statement. It is also a signal that downgrades you in the listener's mental model. The executive equivalent — "this is currently a challenge that needs to be addressed" — communicates the same fact while preserving authority. The skill is not denial. It is *framing*.
+**Emotion.** Visible reactivity reads as loss of control. Peer-reviewed research links cognitive reappraisal — the ability to reframe rather than react — to higher leadership performance ratings from both supervisors and peers (Lopes et al., *Frontiers in Psychology*). The senior leader does not say <span class="speak-en">"this is a disaster."</span> They say <span class="speak-en">"this is impacting performance and requires adjustment."</span> Same reality. Different signal.
 
-**Unpreparedness.** "I'm not sure yet" sounds honest, but in a senior meeting it reads as unprepared. "The analysis is still being finalized" communicates the same uncertainty without the credibility cost. Executives are allowed to not know. They are not allowed to *sound* unprepared.
+**Weakness.** <span class="speak-en">"I'm struggling with this"</span> is a true statement. It is also a signal that downgrades you in the listener's mental model. The executive equivalent — <span class="speak-en">"this is currently a challenge that needs to be addressed"</span> — communicates the same fact while preserving authority. The skill is not denial. It is *framing*.
 
-**Deference where authority is required.** "Can you take a look when you have time?" gives away control. "This requires your review" preserves it. The most consistent pattern across senior leaders is that they do not soften where the situation calls for direction. Softening is not politeness — it is a quiet transfer of authority the moment did not ask you to make.
+**Unpreparedness.** <span class="speak-en">"I'm not sure yet"</span> sounds honest, but in a senior meeting it reads as unprepared. <span class="speak-en">"The analysis is still being finalized"</span> communicates the same uncertainty without the credibility cost. Executives are allowed to not know. They are not allowed to *sound* unprepared.
+
+**Deference where authority is required.** <span class="speak-en">"Can you take a look when you have time?"</span> gives away control. <span class="speak-en">"This requires your review"</span> preserves it. The most consistent pattern across senior leaders is that they do not soften where the situation calls for direction. Softening is not politeness — it is a quiet transfer of authority the moment did not ask you to make.
 
 These four shifts are not personality. They are habits — and habits are trainable.
 


### PR DESCRIPTION
## Summary

Tier 1 TTS retrofit on 5 high-value EN posts (69 speaker buttons added across the cluster). Plus a new `BACKLOG.md` at repo root, plus a missing hreflang map entry fix.

**Critical finding documented in BACKLOG.md:** Most ES sibling posts translate the example English phrases to Spanish, defeating the pedagogical value of the audio layer. This is a content architecture question that needs your strategic call before any ES TTS remediation. The PR description explains, the BACKLOG.md captures it as the headline open loop.

## What shipped

### TTS spans (69 total across 5 posts)

| Post | Spans | What's wrapped |
|---|---|---|
| `why-executive-english-accelerates-careers` | 8 | The 4 weak/executive pairs in the four signals section |
| `executive-video-call` | 7 | Opening template, 3×30 example, 3 interruption phrases, PREP example, closing template |
| `mexico-us-workplace-communication-guide` | 16 | American + Mexican phrases in both comparison tables, Slack examples, "I'm blocked" template, "I recommend X" template |
| `real-cost-weak-english-mexican-companies` | 15 | The "How I can say" bad-example, 3 meeting facilitator phrases, 2 weak/strong examples, 3 framework phrases, 5 scenario phrases |
| `executive-communication-playbook.mdx` | 23 | Reactive vs leadership, 5 persuasion phrases, 3 weak + 3 strong alternatives, 5 junior/senior pairs |

Plus instructional sentences ("Click the speaker icon next to each example…") matching the convention from `executive-reframing-drills.md`.

### Hreflang fix

`mexico-us-workplace-communication-guide` ↔ `guia-comunicacion-laboral-mexico-estados-unidos` was missing from the `blogTranslations` map in `astro.config.mjs`. Added — search engines will now see them as proper translation alternates.

### BACKLOG.md (new)

Repo-root markdown file capturing **unfinished work, technical debt, content/copy debt, and ideas in flight**. Three sections: Content & Copy Debt, Technical Debt, Process Patterns to Apply Elsewhere, Marketing Ideas In Flight. Recently Resolved log at the bottom for ~30-day reference.

The headline entry is the **ES Bilingual Architecture Decision** — see "ES architecture finding" section below.

## ES architecture finding (NOT addressed in this PR)

While reading the ES siblings of these 5 posts to mirror the TTS edits, I discovered most ES versions have the example English phrases **translated to Spanish**, not preserved in English. Concrete examples:

- `presencia-ejecutiva-en-videollamadas` line 46: `"Gracias por unirse. Usaremos 25 minutos…"` (Spanish, not the English template)
- `por-que-ingles-ejecutivo-acelera-tu-carrera` line 61: `"esto es un desastre" / "esto está impactando el desempeño…"` (Spanish translations)
- `guia-comunicacion-laboral-mexico-estados-unidos` tables: Spanish translations of the American + Mexican phrases

This means I **can't** add `speak-en` spans to those ES posts — TTS would try to read Spanish text in an English voice. The "ES parity gap" the audit revealed earlier (192+ missing TTS spans across 5 *other* posts: `business-english-mistakes-mexican-professionals` has 65 EN spans / 0 ES, `us-interview-prep` has 43/0, etc.) has the same root cause.

**The pattern that works** (where English IS preserved in ES): `english-register-for-spanish-speakers ↔ registro-en-ingles-para-hispanohablantes`, `executive-reframing-drills ↔ ejercicios-reformulacion-ejecutiva`, `daily-standup-english ↔ ingles-para-daily-standup-frases`. These keep English example phrases inline because the article is teaching English mechanics.

**Decision required from Robert** (full options in BACKLOG.md):
- A: Bilingual rewrite for teaching-English ES posts so example phrases stay in English with Spanish prose around them. Larger lift, matches stated brand value.
- B: Accept ES TTS gaps; only mark posts that already have English-preserved content as TTS-eligible.
- C: Per-article hybrid decision.

## Validation

- ✅ `npm run build` — clean, no errors
- ✅ Sitemap valid, 0 errors
- ✅ Meta description gate passes
- ✅ All 5 posts confirmed to have correct number of `speak-en` spans in built HTML
- ✅ MDX file (`executive-communication-playbook.mdx`) renders inline `<span>` correctly alongside the `FlipCardGrid` React component

## Test plan

- [ ] Verify speaker buttons appear next to wrapped phrases on Vercel preview
- [ ] Click a sample on each post and confirm Azure TTS plays (not browser fallback)
- [ ] Verify the MDX post (`executive-communication-playbook`) renders cleanly with both the `FlipCardGrid` component AND the new `speak-en` spans
- [ ] Verify the comparison-table cells in `mexico-us-workplace-communication-guide` render the speaker buttons inside the table layout

## Post-merge

No SEO resubmission needed (URLs unchanged, content enhanced). The hreflang fix benefits the next sitemap crawl naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)