### PR TITLE
feat(blog): Tier 1 ES bilingual rewrite — restore English phrases + TTS

### DIFF
--- a/src/content/blog/es/costo-real-ingles-debil-empresas-mexicanas.md
+++ b/src/content/blog/es/costo-real-ingles-debil-empresas-mexicanas.md
@@ -96,7 +96,7 @@ Aquí es donde desaparece el dinero:
 
 Una casa de software de 50 personas en Guadalajara llegó a la ronda final para un compromiso de un año con una empresa fintech estadounidense. La evaluación técnica salió bien. Luego vino la presentación ejecutiva.
 
-El CTO habló durante 40 minutos. Conocía el material perfectamente—decisiones de arquitectura, cumplimiento de seguridad, modelo de entrega. Pero su entrega era vacilante. Traducía en su cabeza. Dijo "How I can say..." dos veces. Se perdió completamente la pregunta del CEO sobre estrategia de mitigación de riesgos y tuvo que pedirle que la repitiera.
+El CTO habló durante 40 minutos. Conocía el material perfectamente—decisiones de arquitectura, cumplimiento de seguridad, modelo de entrega. Pero su entrega era vacilante. Traducía en su cabeza. Dijo <span class="speak-en">"How I can say..."</span> dos veces. Se perdió completamente la pregunta del CEO sobre estrategia de mitigación de riesgos y tuvo que pedirle que la repitiera.
 
 **La Consecuencia:**
 
@@ -453,19 +453,19 @@ Los desarrolladores estancados ven esto. Saben que los pasan por alto por el idi
 
 No se trata de gramática. Se trata de:
 
-**Dirigir reuniones efectivas en inglés:**
+**Dirigir reuniones efectivas en inglés.** *Haz clic en el ícono del altavoz junto a cada frase para escucharla con la cadencia ejecutiva correcta.*
 
-- "Empecemos con el mayor obstáculo."
-- "Escucho dos perspectivas diferentes—déjenme asegurarme de que entiendo ambas."
-- "Necesitamos tomar una decisión hoy. Aquí están las compensaciones."
+- <span class="speak-en">"Let's start with the biggest blocker."</span>
+- <span class="speak-en">"I hear two different perspectives—let me make sure I understand both."</span>
+- <span class="speak-en">"We need to make a decision today. Here are the tradeoffs."</span>
 
 **Explicar conceptos técnicos a personas no técnicas:**
 
-- "Piénsenlo como una cocina de restaurante. Podemos servir a más clientes si contratamos más cocineros, pero solo si el espacio de la cocina puede manejarlos. Esa es nuestra restricción de escalabilidad."
+- <span class="speak-en">"Think of it like a restaurant kitchen. We can serve more customers if we hire more cooks, but only if the kitchen space can handle them. That's our scalability constraint."</span>
 
 **Manejar conflictos diplomáticamente:**
 
-- "Entiendo la urgencia, pero este enfoque crea deuda técnica. Déjenme mostrarles el costo a largo plazo."
+- <span class="speak-en">"I understand the urgency, but this approach creates technical debt. Let me show you the long-term cost."</span>
 
 **Proyectar presencia ejecutiva:**
 
@@ -689,15 +689,15 @@ No memorices palabras individuales. Aprende frases de alta frecuencia.
 
 **Frases marco:**
 
-- "Let me walk you through three options."
-- "The tradeoff here is X versus Y."
-- "To clarify, are you asking about A or B?"
+- <span class="speak-en">"Let me walk you through three options."</span>
+- <span class="speak-en">"The tradeoff here is X versus Y."</span>
+- <span class="speak-en">"To clarify, are you asking about A or B?"</span>
 
 **Frases específicas de escenario:**
 
-- **Comenzar una historia:** "Let me give you some context." / "Here's what happened."
-- **Actualizaciones de estado:** "We're on track for X. The blocker is Y. We'll resolve it by Z."
-- **Manejo de objeciones:** "I understand your concern. Let me address that directly."
+- **Comenzar una historia:** <span class="speak-en">"Let me give you some context."</span> / <span class="speak-en">"Here's what happened."</span>
+- **Actualizaciones de estado:** <span class="speak-en">"We're on track for X. The blocker is Y. We'll resolve it by Z."</span>
+- **Manejo de objeciones:** <span class="speak-en">"I understand your concern. Let me address that directly."</span>
 
 Construye un banco de frases personal para las situaciones que enfrentas repetidamente. Practica estas hasta que sean automáticas.
 
@@ -728,8 +728,8 @@ Tus elecciones de lenguaje señalan tu identidad. Entrena para coincidir con la 
 
 **Ejemplo:**
 
-- **Débil:** "Um, sí, creo que podríamos tal vez intentar hacerlo de esa manera, si funciona para todos."
-- **Fuerte:** "Sí, ese enfoque es factible. Esto es lo que necesitaremos para que funcione."
+- **Débil:** <span class="speak-en">"Um, yeah, I think we could maybe try to do it that way, if that works for everyone."</span>
+- **Fuerte:** <span class="speak-en">"Yes, that approach is feasible. Here's what we'll need to make it work."</span>
 
 El contenido es similar. La percepción es completamente diferente.
 

--- a/src/content/blog/es/guia-comunicacion-laboral-mexico-estados-unidos.md
+++ b/src/content/blog/es/guia-comunicacion-laboral-mexico-estados-unidos.md
@@ -41,13 +41,13 @@ Los profesionales estadounidenses prefieren ir directo al grano. La contundencia
 
 Los profesionales mexicanos consideran que el desacuerdo abierto o la crítica directa son irrespetuosos. Preservar la dignidad personal — **cuidar las apariencias** — tiene prioridad sobre la claridad transaccional.
 
-**La misma retroalimentación, dos culturas:**
+**La misma retroalimentación, dos culturas.** *Las frases ejemplo se mantienen en inglés porque son las que vas a escuchar y necesitas reconocer en el trabajo. Haz clic en el ícono del altavoz junto a cada una para escucharla.*
 
 | Situación | Gerente Estadounidense | Gerente Mexicano |
 |-----------|----------------------|-----------------|
-| El reporte tiene datos faltantes | "A este reporte le faltan datos." | "El reporte es muy completo; quizás podríamos agregar más datos." |
-| Se va a incumplir el plazo | "No vamos a cumplir con la fecha límite." | "Estamos avanzando. Hay algunos factores que estamos gestionando." |
-| Desacuerdo con una propuesta | "No creo que ese enfoque vaya a funcionar." | "Es interesante. ¿También hemos considerado...?" |
+| El reporte tiene datos faltantes | <span class="speak-en">"This report is missing data."</span> | <span class="speak-en">"The report is very comprehensive; perhaps we could add more data."</span> |
+| Se va a incumplir el plazo | <span class="speak-en">"We're going to miss the deadline."</span> | <span class="speak-en">"We're making progress. There are some factors we're managing."</span> |
+| Desacuerdo con una propuesta | <span class="speak-en">"I don't think that approach will work."</span> | <span class="speak-en">"That's interesting. Have we also considered...?"</span> |
 
 Ninguno de los dos enfoques es incorrecto. Pero cuando un estadounidense interpreta el encuadre diplomático de un mexicano como evasión, o un mexicano interpreta la franqueza de un estadounidense como agresión, la relación se deteriora.
 
@@ -165,9 +165,9 @@ México emplea una **retroalimentación negativa altamente indirecta.** Dado que
 
 | Retroalimentación Estadounidense | Equivalente Mexicano |
 |--------------------------------|---------------------|
-| "A este reporte le faltan datos." | "El reporte es muy completo; quizás podríamos considerar agregar más datos para hacerlo aún más sólido." |
-| "Este enfoque no va a funcionar." | "Es una dirección interesante. ¿También hemos considerado algunas alternativas?" |
-| "No cumpliste con la fecha límite." | "Sé que has estado trabajando muy duro en esto. ¿Cuándo crees que podríamos ver la versión final?" |
+| <span class="speak-en">"This report is missing data."</span> | <span class="speak-en">"The report is very comprehensive; perhaps we could look at adding more data to make it even stronger."</span> |
+| <span class="speak-en">"This approach won't work."</span> | <span class="speak-en">"This is an interesting direction. Have we also considered some alternatives?"</span> |
+| <span class="speak-en">"You missed the deadline."</span> | <span class="speak-en">"I know you've been working very hard on this. When do you think we might see the final version?"</span> |
 
 ### Desacuerdo: Confrontación (EE.UU.) vs. Evitación de la Confrontación (México)
 
@@ -284,17 +284,17 @@ Esto significa que las dinámicas culturales descritas anteriormente se **agrava
 
 4. **Adapta tu cultura de fechas límite.** Usa check-ins de alta frecuencia y marcadores de progreso diarios en lugar de fechas lejanas con límites rígidos.
 
-5. **Suaviza tu Slack.** Agrega contexto, amabilidades y saludos a los mensajes digitales. "Hola María, espero que tu mañana vaya bien — una pregunta rápida sobre el API endpoint" aterriza muy diferente que "¿Cuál es el estatus del API endpoint?"
+5. **Suaviza tu Slack.** Agrega contexto, amabilidades y saludos a los mensajes digitales. <span class="speak-en">"Hey María, hope your morning is going well — quick question on the API endpoint"</span> aterriza muy diferente que <span class="speak-en">"What's the status on the API endpoint?"</span>
 
 ### Para Profesionales Mexicanos que Trabajan con Estadounidenses
 
 1. **Entiende que la franqueza no es agresión.** Cuando tu colega estadounidense dice "esto no funciona", está dando retroalimentación eficiente, no atacándote personalmente.
 
-2. **Señala los bloqueos temprano y de forma explícita.** En la cultura laboral estadounidense, admitir un problema temprano es respetado — ocultarlo hasta que se convierta en crisis no lo es. "Estoy bloqueado en X y necesito Y para avanzar" es la frase que más confianza genera.
+2. **Señala los bloqueos temprano y de forma explícita.** En la cultura laboral estadounidense, admitir un problema temprano es respetado — ocultarlo hasta que se convierta en crisis no lo es. <span class="speak-en">"I'm blocked on X and need Y to proceed"</span> es la frase que más confianza genera.
 
 3. **Di "no" cuando quieras decir no.** El "sí" estadounidense es un compromiso vinculante. Si no estás seguro, di "necesito verificar eso" o "déjame confirmar el cronograma." Esto es más respetado que aceptar y entregar menos de lo prometido.
 
-4. **Empieza con la recomendación.** Los estadounidenses prefieren la comunicación centrada en la aplicación. En lugar de construir hacia tu conclusión, comienza con ella: "Recomiendo X porque Y" — y luego proporciona el detalle de respaldo.
+4. **Empieza con la recomendación.** Los estadounidenses prefieren la comunicación centrada en la aplicación. En lugar de construir hacia tu conclusión, comienza con ella: <span class="speak-en">"I recommend X because Y"</span> — y luego proporciona el detalle de respaldo.
 
 5. **Asume la responsabilidad individual.** En equipos estadounidenses, hacerse responsable de un resultado específico — incluso de un fracaso — genera credibilidad más rápido que la ambigüedad colectiva.
 

--- a/src/content/blog/es/manual-comunicacion-ejecutiva.md
+++ b/src/content/blog/es/manual-comunicacion-ejecutiva.md
@@ -46,11 +46,13 @@ Cuando algo sale mal, la mayoría de los hablantes no nativos recurren al lengua
 
 Así suena el lenguaje reactivo vs. el lenguaje de liderazgo en la práctica:
 
+*Haz clic en el ícono del altavoz junto a cada frase en inglés para escucharla con la cadencia y el tono ejecutivo correctos.*
+
 **Reactivo (cómo reporta la mayoría):**
-> "There's a problem with the shipment. The carrier didn't pick up on time and the client is upset."
+> <span class="speak-en">"There's a problem with the shipment. The carrier didn't pick up on time and the client is upset."</span>
 
 **Liderazgo (lo que realmente dicen los ejecutivos):**
-> "We've identified a delay in the carrier pickup. We've already escalated with the logistics partner, the client has been notified with an updated timeline, and I'll have a confirmed resolution by 3 PM."
+> <span class="speak-en">"We've identified a delay in the carrier pickup. We've already escalated with the logistics partner, the client has been notified with an updated timeline, and I'll have a confirmed resolution by 3 PM."</span>
 
 La diferencia no está en usar palabras más elegantes. Está en responder tres preguntas en cada declaración:
 
@@ -119,11 +121,11 @@ La primera versión crea enemigos. La segunda crea alineación. Ambas describen 
 Esta distinción importa enormemente en los negocios interculturales. Los ejecutivos latinoamericanos frecuentemente se preocupan por sonar demasiado directos o agresivos en inglés. La solución no es suavizar todo — es redirigir la franqueza hacia sistemas y procesos en lugar de personas.
 
 **Frases clave de persuasión que debes dominar:**
-- "What I'm proposing is..."
-- "The strategic case for this is..."
-- "If we invest in X, we unlock Y..."
-- "This positions us to..."
-- "The opportunity cost of not acting is..."
+- <span class="speak-en">"What I'm proposing is..."</span>
+- <span class="speak-en">"The strategic case for this is..."</span>
+- <span class="speak-en">"If we invest in X, we unlock Y..."</span>
+- <span class="speak-en">"This positions us to..."</span>
+- <span class="speak-en">"The opportunity cost of not acting is..."</span>
 
 ---
 
@@ -154,16 +156,16 @@ Observa lo que logra esto: no dice "no." No pelea. Reposiciona la conversación 
 Este es un error costoso que veo constantemente: usar lenguaje débil en negociaciones crea precedentes caros.
 
 Cuando dices cosas como:
-> "I guess we could probably do that..."
-> "Maybe we could make it work..."
-> "I suppose that's okay..."
+> <span class="speak-en">"I guess we could probably do that..."</span>
+> <span class="speak-en">"Maybe we could make it work..."</span>
+> <span class="speak-en">"I suppose that's okay..."</span>
 
 Estás señalando que tu posición no es firme — y la otra parte va a presionar más fuerte la próxima vez. Cada "I guess" te cuesta dinero, tiempo o alcance en futuras negociaciones.
 
 **Alternativas fuertes:**
-- "That's something I can commit to." (un sí claro)
-- "That's outside what I can accommodate in this scope." (un no claro)
-- "Here's what I can do..." (redirigiendo)
+- <span class="speak-en">"That's something I can commit to."</span> (un sí claro)
+- <span class="speak-en">"That's outside what I can accommodate in this scope."</span> (un no claro)
+- <span class="speak-en">"Here's what I can do..."</span> (redirigiendo)
 
 **¿Listo para evaluar tu comunicación en negociaciones?** [Toma el Quiz de Confianza en Comunicación](/es/quiz/executives/) para ver dónde estás parado.
 
@@ -312,11 +314,11 @@ Los profesionales junior describen. Los profesionales senior dirigen. Compara:
 
 | Junior | Senior |
 |--------|--------|
-| "I think we should maybe consider..." | "My recommendation is..." |
-| "We had some problems with..." | "We navigated a challenge around..." |
-| "It's kind of complicated because..." | "The complexity here is..." |
-| "I was wondering if we could..." | "What I'd propose is..." |
-| "Sorry, but I disagree..." | "I see it differently, and here's why..." |
+| <span class="speak-en">"I think we should maybe consider..."</span> | <span class="speak-en">"My recommendation is..."</span> |
+| <span class="speak-en">"We had some problems with..."</span> | <span class="speak-en">"We navigated a challenge around..."</span> |
+| <span class="speak-en">"It's kind of complicated because..."</span> | <span class="speak-en">"The complexity here is..."</span> |
+| <span class="speak-en">"I was wondering if we could..."</span> | <span class="speak-en">"What I'd propose is..."</span> |
+| <span class="speak-en">"Sorry, but I disagree..."</span> | <span class="speak-en">"I see it differently, and here's why..."</span> |
 
 Cada elección de palabra es una señal. Cuando consistentemente eliges lenguaje que proyecta claridad y dirección, las personas inconscientemente te asignan más autoridad — independientemente de tu acento, tu título o tu primer idioma.
 

--- a/src/content/blog/es/por-que-ingles-ejecutivo-acelera-tu-carrera.md
+++ b/src/content/blog/es/por-que-ingles-ejecutivo-acelera-tu-carrera.md
@@ -58,13 +58,15 @@ Estos son pequeños hábitos lingüísticos. El costo a la carrera se acumula du
 
 Los líderes senior que dominan las salas no son los más ruidosos, los más carismáticos, ni los más pulidos. Son los que han aprendido a suprimir cuatro señales específicas que marcan a alguien como aún-no-listo:
 
-**Emoción.** La reactividad visible se lee como pérdida de control. Investigación revisada por pares conecta la reevaluación cognitiva — la capacidad de reformular en lugar de reaccionar — con calificaciones de desempeño de liderazgo más altas, tanto de supervisores como de pares (Lopes et al., *Frontiers in Psychology*). El líder senior no dice "esto es un desastre". Dice "esto está impactando el desempeño y requiere ajuste". Misma realidad. Diferente señal.
+*Haz clic en el ícono del altavoz junto a cada ejemplo en inglés para escuchar la versión débil y la reformulación ejecutiva — la diferencia vive en la entrega, no solo en las palabras.*
 
-**Debilidad.** "Estoy batallando con esto" es una afirmación verdadera. También es una señal que te degrada en el modelo mental del oyente. El equivalente ejecutivo — "este es actualmente un reto que necesita ser atendido" — comunica el mismo hecho mientras preserva la autoridad. La habilidad no es negación. Es *encuadre*.
+**Emoción.** La reactividad visible se lee como pérdida de control. Investigación revisada por pares conecta la reevaluación cognitiva — la capacidad de reformular en lugar de reaccionar — con calificaciones de desempeño de liderazgo más altas, tanto de supervisores como de pares (Lopes et al., *Frontiers in Psychology*). El líder senior no dice <span class="speak-en">"this is a disaster."</span> Dice <span class="speak-en">"this is impacting performance and requires adjustment."</span> Misma realidad. Diferente señal.
 
-**Falta de preparación.** "Aún no estoy seguro" suena honesto, pero en una junta senior se lee como no preparado. "El análisis aún se está finalizando" comunica la misma incertidumbre sin el costo de credibilidad. A los ejecutivos se les permite no saber. No se les permite *sonar* no preparados.
+**Debilidad.** Decir <span class="speak-en">"I'm struggling with this"</span> es una afirmación verdadera. También es una señal que te degrada en el modelo mental del oyente. El equivalente ejecutivo — <span class="speak-en">"this is currently a challenge that needs to be addressed"</span> — comunica el mismo hecho mientras preserva la autoridad. La habilidad no es negación. Es *encuadre*.
 
-**Deferencia donde se requiere autoridad.** "¿Puedes revisarlo cuando tengas tiempo?" cede el control. "Esto requiere tu revisión" lo preserva. El patrón más consistente entre los líderes senior es que no suavizan donde la situación pide dirección. Suavizar no es cortesía — es una transferencia silenciosa de autoridad que el momento no te pidió hacer.
+**Falta de preparación.** <span class="speak-en">"I'm not sure yet"</span> suena honesto, pero en una junta senior se lee como no preparado. <span class="speak-en">"The analysis is still being finalized"</span> comunica la misma incertidumbre sin el costo de credibilidad. A los ejecutivos se les permite no saber. No se les permite *sonar* no preparados.
+
+**Deferencia donde se requiere autoridad.** <span class="speak-en">"Can you take a look when you have time?"</span> cede el control. <span class="speak-en">"This requires your review"</span> lo preserva. El patrón más consistente entre los líderes senior es que no suavizan donde la situación pide dirección. Suavizar no es cortesía — es una transferencia silenciosa de autoridad que el momento no te pidió hacer.
 
 Estos cuatro cambios no son personalidad. Son hábitos — y los hábitos son entrenables.
 

--- a/src/content/blog/es/presencia-ejecutiva-en-videollamadas.md
+++ b/src/content/blog/es/presencia-ejecutiva-en-videollamadas.md
@@ -25,6 +25,8 @@ Las videollamadas son donde avanzan los acuerdos, se alinean equipos y se evalú
 
 En New York English, entreno a ejecutivos y gerentes senior en tecnología, finanzas, logística y servicios profesionales para comunicar con claridad y autoridad. Si necesitas construir confianza básica primero, revisa mi guía sobre [5 estrategias simples para ganar confianza](/es/blog/aumentar-confianza/). Aquí tienes siete hábitos comprobados que puedes aplicar hoy.
 
+*Las plantillas y frases ejemplo a continuación se mantienen en inglés porque son las que vas a usar en una videollamada en inglés. Haz clic en el ícono del altavoz junto a cada una para escucharla con la cadencia ejecutiva correcta.*
+
 ---
 
 ### Lo que aprenderás
@@ -43,7 +45,7 @@ Abre la sala y fija expectativas de inmediato.
 
 **Plantilla:**
 
-> “Gracias por unirse. Usaremos 25 minutos. Agenda: estatus en 5, decisión sobre X en 10, siguientes pasos en 10. Si surgen preguntas, déjenlas en el chat y las trato en el Q&A.”
+> <span class="speak-en">“Thanks for joining. We’ll use 25 minutes. Agenda: status in 5, decision on X in 10, next steps in 10. If questions pop up, drop them in chat and I’ll park them for the Q&A.”</span>
 
 Esto comunica control, respeto por el tiempo y una ruta clara a resultados.
 
@@ -55,7 +57,7 @@ Apunta a **tres oraciones** de **~30 palabras en total** antes de pausar. En vid
 
 **Ejemplo:**
 
-> “Cumplimos la meta de la semana pasada. Quedan dos riesgos: tiempos y presupuesto. Propondré un trade-off que protege el lanzamiento.”
+> <span class="speak-en">“We met last week’s target. Two risks remain: timeline and budget. I’ll propose a trade-off that protects launch.”</span>
 
 ---
 
@@ -91,9 +93,9 @@ Mantén el flujo sin sonar rígido. Si necesitas más frases para dirigir reunio
 
 **Frases que funcionan:**
 
-- “Excelente punto—déjame cerrar esta idea y vuelvo contigo.”
-- “Lo dejo pendiente en el chat para decidir X primero.”
-- “¿Podemos guardar preguntas dos minutos mientras muestro el impacto?”
+- <span class="speak-en">“Great point—let me finish this thought and I’ll come back to you.”</span>
+- <span class="speak-en">“I’ll park that in chat so we can decide on X first.”</span>
+- <span class="speak-en">“Can we hold questions for two minutes while I show the impact?”</span>
 
 ---
 
@@ -103,7 +105,7 @@ Usa **PREP** (Punto → Razón → Ejemplo → Punto) para responder con clarida
 
 **Ejemplo:**
 
-> “Debemos retrasar el lanzamiento (Punto). Los riesgos de calidad pueden dañar la confianza (Razón). La última prisa nos costó dos clientes (Ejemplo). Por eso dos semanas protegen la relación (Punto).”
+> <span class="speak-en">“We should delay launch. Quality risks could damage trust. Our last rushed release cost two clients. So a two-week delay protects the relationship.”</span> (Punto — Razón — Ejemplo — Punto)
 
 ---
 
@@ -113,7 +115,7 @@ Sustituye cierres débiles por acciones, responsables y tiempos.
 
 **Plantilla:**
 
-> "Resumen: Decisión A aprobada. Próximos pasos—**María** redacta la nota al cliente para el **jueves**, **José** revisa presupuesto para el **viernes**. ¿Alguna pregunta sobre responsabilidades?"
+> <span class="speak-en">“Recap: Decision A approved. Next steps — Maria drafts the client note by Thursday, Jorge updates the timeline by end of day Friday. I’ll send a summary in 30 minutes. Anything blocking those?”</span>
 
 ---
 


### PR DESCRIPTION
## Summary

Implements **Option A** from `BACKLOG.md`'s ES Bilingual Architecture Decision. For the 5 ES siblings of PR #131's Tier 1 posts: example phrases now stay in English (with Spanish prose around them), and the TTS audio layer works in both languages.

This is the natural completion of PR #131 — the EN side shipped 69 speaker buttons; this PR mirrors them on the ES side, where (per Robert's emphasis) hearing the English actually matters most because Spanish-speaking readers default to the Spanish version.

## What changed per post

| ES post | Spans | Type of work |
|---|---|---|
| `manual-comunicacion-ejecutiva` | **23** | Pure wrap — all 23 example phrases were already preserved in English in the ES version (reactive/leadership, persuasion phrases, concession-trap weak/strong, junior/senior table). Just added `speak-en` spans. |
| `costo-real-ingles-debil-empresas-mexicanas` | **15** | Mix — "How I can say" already English (just wrapped); framework + scenario phrases already English (just wrapped); meeting-facilitator + technical-concepts + conflict-diplomacy + weak/strong examples were Spanish (restored to English originals from the EN sibling, then wrapped). |
| `guia-comunicacion-laboral-mexico-estados-unidos` | **16** | Full restoration — comparison-table cells (American + Mexican phrasings) were Spanish translations; restored to English originals from EN sibling. Plus Slack examples, "I'm blocked" template, "I recommend X" template restored. |
| `presencia-ejecutiva-en-videollamadas` | **7** | Full restoration — opening template, 3×30 example, 3 interruption phrases, PREP example, closing template all were Spanish translations; restored to English originals. |
| `por-que-ingles-ejecutivo-acelera-tu-carrera` | **8** | Full restoration — 4 weak/executive pairs in the four signals section all were Spanish translations; restored to English originals. |

**Total: 69 ES spans, full parity with the 69 EN spans from PR #131.**

## Pattern applied

For each restored phrase: kept the surrounding Spanish prose intact (which contextualizes the phrase for the Spanish-speaking reader), restored the example phrase to its original English wording (matching the EN sibling), and wrapped with `<span class="speak-en">…</span>` so the existing Azure Neural TTS pipeline injects a speaker button.

Each post got a Spanish-language instructional sentence near the wrapped content — examples:
- Generic: *"Haz clic en el ícono del altavoz junto a cada frase en inglés para escucharla con la cadencia y el tono ejecutivo correctos."*
- Video-call post: *"Las plantillas y frases ejemplo a continuación se mantienen en inglés porque son las que vas a usar en una videollamada en inglés."*
- Mexico-US guide: *"Las frases ejemplo se mantienen en inglés porque son las que vas a escuchar y necesitas reconocer en el trabajo."*
- Exec-careers post: *"Haz clic en el ícono del altavoz junto a cada ejemplo en inglés para escuchar la versión débil y la reformulación ejecutiva."*

## Validation

- ✅ `npm run build` — clean
- ✅ Sitemap valid, meta descriptions pass gate
- ✅ Span count parity verified in built HTML for all 5 EN/ES pairs (8/8, 7/7, 16/16, 15/15, 23/23)

## Test plan

- [ ] Spot-check each ES post on Vercel preview — confirm speaker buttons appear next to English phrases inside Spanish prose
- [ ] Click a sample phrase on each post and confirm Azure TTS plays in English (not the browser fallback, not Spanish voice)
- [ ] Confirm the Spanish instructional sentence reads naturally near the section it introduces

## What's next (per BACKLOG.md)

The 5 backlog parity-gap posts (`business-english-mistakes-mexican-professionals` 65/0, `us-interview-prep` 43/0, `english-nearshore-developers-skills` 35/0, `lead-meeting-english-phrases` 25/0, `how-to-negotiate-in-english-framework` 36/12) are the next sweep — same Option A pattern. Estimated ~190 phrase edits across 5 ES posts. Will land in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)