### PR TITLE
chore(sentry): filter onReady browser-extension noise

### DIFF
--- a/sentry.client.config.mjs
+++ b/sentry.client.config.mjs
@@ -15,6 +15,7 @@ Sentry.init({
     /removeHighlight is not defined/,
     /tapAt is not defined/,
     /onLoad is not defined/,
+    /onReady is not defined/,
     /className\.indexOf is not a function/,
     /Identifier '.+' has already been declared/,
 


### PR DESCRIPTION
## Summary

Adds `/onReady is not defined/` to the `ignoreErrors` list in `sentry.client.config.mjs` — the last gap in the browser-extension noise filter we shipped 2026-04-27.

Of the 6 historical Sentry errors visible (all 5d ago, all stale and not recurring), 5 already matched existing patterns. This 1-line addition catches the 6th.

## Verification this is browser-extension noise

`grep -rn "onReady" src/ public/` returns no matches — the function name doesn't exist anywhere in our source. Like the other filtered patterns, it's a classic browser-extension script-injection error (likely a YouTube IFrame API callback or similar pattern, injected by a user's extension).

## Files changed

- `sentry.client.config.mjs` — 1 line added

## Test plan

- [ ] Vercel deploys successfully (no build issues from the regex)
- [ ] Robert resolves the 6 historical errors in Sentry
- [ ] Going forward, `onReady is not defined` events do not show in the Sentry feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)