### PR TITLE
feat(a2): ship Units 7-10 + final exam — A2 course complete

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -83,6 +83,39 @@ const categoryTranslationsReverse = Object.fromEntries(
   Object.entries(categoryTranslations).map(([en, es]) => [es, en])
 );
 
+// Course slug translations (EN slug -> ES slug) for unit pages and exams
+const courseTranslations = {
+  beginners: "principiantes",
+  elementary: "elemental",
+  intermediate: "intermedio",
+  advanced: "avanzado",
+  executive: "ejecutivo",
+};
+const courseTranslationsReverse = Object.fromEntries(
+  Object.entries(courseTranslations).map(([en, es]) => [es, en]),
+);
+
+// Course leaf-page translations (EN leaf -> ES leaf)
+// Covers unit pages, exam pages, and the executive capstone.
+const courseLeafTranslations = {
+  "unit-1": "unidad-1",
+  "unit-2": "unidad-2",
+  "unit-3": "unidad-3",
+  "unit-4": "unidad-4",
+  "unit-5": "unidad-5",
+  "unit-6": "unidad-6",
+  "unit-7": "unidad-7",
+  "unit-8": "unidad-8",
+  "unit-9": "unidad-9",
+  "unit-10": "unidad-10",
+  exam: "examen",
+  pronunciation: "pronunciacion",
+  capstone: "reto-final",
+};
+const courseLeafTranslationsReverse = Object.fromEntries(
+  Object.entries(courseLeafTranslations).map(([en, es]) => [es, en]),
+);
+
 // Testimonial industry slugs (same slug used in both languages, different path prefix)
 const testimonialIndustries = [
   "startup-founders",
@@ -318,6 +351,37 @@ export default defineConfig({
               links = [
                 { rel: "alternate", hreflang: "en-US", url: `${SITE}/en/category/${enSlug}/` },
                 { rel: "alternate", hreflang: "es-MX", url: `${SITE}/es/categoria/${esSlug}/` },
+              ];
+            }
+          }
+        }
+
+        // Handle course unit / exam / capstone pages
+        // EN: /en/course/{course}/{leaf}/  ES: /es/curso/{course-es}/{leaf-es}/
+        if (links.length === 0) {
+          const enCourseMatch = u.pathname.match(/^\/en\/course\/([^\/]+)\/([^\/]+)\/$/);
+          const esCourseMatch = u.pathname.match(/^\/es\/curso\/([^\/]+)\/([^\/]+)\/$/);
+
+          if (enCourseMatch) {
+            const enCourse = enCourseMatch[1];
+            const enLeaf = enCourseMatch[2];
+            const esCourse = courseTranslations[enCourse];
+            const esLeaf = courseLeafTranslations[enLeaf];
+            if (esCourse && esLeaf) {
+              links = [
+                { rel: "alternate", hreflang: "en-US", url: `${SITE}/en/course/${enCourse}/${enLeaf}/` },
+                { rel: "alternate", hreflang: "es-MX", url: `${SITE}/es/curso/${esCourse}/${esLeaf}/` },
+              ];
+            }
+          } else if (esCourseMatch) {
+            const esCourse = esCourseMatch[1];
+            const esLeaf = esCourseMatch[2];
+            const enCourse = courseTranslationsReverse[esCourse];
+            const enLeaf = courseLeafTranslationsReverse[esLeaf];
+            if (enCourse && enLeaf) {
+              links = [
+                { rel: "alternate", hreflang: "en-US", url: `${SITE}/en/course/${enCourse}/${enLeaf}/` },
+                { rel: "alternate", hreflang: "es-MX", url: `${SITE}/es/curso/${esCourse}/${esLeaf}/` },
               ];
             }
           }

--- a/src/data/elementary/exam.ts
+++ b/src/data/elementary/exam.ts
@@ -1,0 +1,506 @@
+// Final Exam: "Tell Your Story" — Elementary (A2) Comprehensive Assessment
+// 20 multiple-choice questions covering all 10 elementary units
+// Reuses ExamQuestion / ExamOption / ExamResult types from the beginner exam module
+
+import type { ExamQuestion, ExamResult } from "../course/exam";
+import type { ScoreTier } from "../../components/course/CourseExam";
+
+export const examMeta = {
+  title: "Final Exam",
+  titleEs: "Examen Final",
+  subtitle: "Tell Your Story — Comprehensive Assessment",
+  subtitleEs: "Cuenta Tu Historia — Evaluación Integral",
+  description:
+    "20 questions covering past simple, future plans, comparatives, quantifiers, Wh-questions, frequency adverbs, and past continuous from all 10 elementary units.",
+  descriptionEs:
+    "20 preguntas sobre pasado simple, planes futuros, comparativos, cuantificadores, preguntas Wh-, adverbios de frecuencia y pasado continuo de las 10 unidades elementales.",
+  passingScore: 70,
+};
+
+export const examQuestions: ExamQuestion[] = [
+  // ─── Unit 1: Past Simple — Regular Verbs ───────────────────────────────
+  {
+    id: 1,
+    unit: 1,
+    category: "grammar",
+    prompt: "Choose the correct past simple form of 'to work':",
+    promptEs: "Elige la forma correcta del pasado simple de 'to work':",
+    options: [
+      { text: "I worked late yesterday.", correct: true },
+      { text: "I worken late yesterday.", correct: false },
+      { text: "I work late yesterday.", correct: false },
+      { text: "I was work late yesterday.", correct: false },
+    ],
+    explanation:
+      "Regular verbs add -ed to form the past simple: work → worked. The same form is used for ALL persons (I, you, he, she, we, they).",
+    explanationEs:
+      "Los verbos regulares agregan -ed para el pasado simple: work → worked. La misma forma se usa para TODAS las personas (I, you, he, she, we, they).",
+  },
+  {
+    id: 2,
+    unit: 1,
+    category: "vocabulary",
+    prompt: 'Which sentence pronounces the -ed ending as /ɪd/ (extra syllable)?',
+    promptEs: '¿Qué oración pronuncia la terminación -ed como /ɪd/ (sílaba extra)?',
+    options: [
+      { text: "I waited for the bus.", correct: true },
+      { text: "I worked all day.", correct: false },
+      { text: "I called my mother.", correct: false },
+      { text: "I lived there for a year.", correct: false },
+    ],
+    explanation:
+      "Verbs ending in -t or -d (wait, need, decide) pronounce -ed as a separate /ɪd/ syllable: 'wait-ed', 'need-ed'. The other three are pronounced /t/ or /d/ with NO extra syllable.",
+    explanationEs:
+      "Los verbos que terminan en -t o -d (wait, need, decide) pronuncian -ed como sílaba aparte /ɪd/: 'wait-ed', 'need-ed'. Los otros tres se pronuncian /t/ o /d/ SIN sílaba extra.",
+  },
+
+  // ─── Unit 2: Past Simple — Irregular Verbs ─────────────────────────────
+  {
+    id: 3,
+    unit: 2,
+    category: "grammar",
+    prompt: "Choose the correct past simple form:",
+    promptEs: "Elige la forma correcta del pasado simple:",
+    options: [
+      { text: "She went to the store yesterday.", correct: true },
+      { text: "She goed to the store yesterday.", correct: false },
+      { text: "She wented to the store yesterday.", correct: false },
+      { text: "She was go to the store yesterday.", correct: false },
+    ],
+    explanation:
+      "'Go' is irregular: go → went. There is no '-ed' form. Common irregulars to memorize: go/went, see/saw, do/did, have/had, eat/ate, take/took.",
+    explanationEs:
+      "'Go' es irregular: go → went. No hay forma '-ed'. Irregulares comunes a memorizar: go/went, see/saw, do/did, have/had, eat/ate, take/took.",
+  },
+  {
+    id: 4,
+    unit: 2,
+    category: "grammar",
+    prompt: "Which is the correct past simple QUESTION?",
+    promptEs: "¿Cuál es la PREGUNTA correcta en pasado simple?",
+    options: [
+      { text: "Where did you go last night?", correct: true },
+      { text: "Where did you went last night?", correct: false },
+      { text: "Where you went last night?", correct: false },
+      { text: "Where you go last night?", correct: false },
+    ],
+    explanation:
+      "Past simple questions use 'did' as the helper, and the main verb goes BACK to base form: 'did you GO' (NOT 'did you went').",
+    explanationEs:
+      "Las preguntas en pasado simple usan 'did' como ayudante, y el verbo principal REGRESA a forma base: 'did you GO' (NO 'did you went').",
+  },
+
+  // ─── Unit 3: Time Markers and Sequencing ───────────────────────────────
+  {
+    id: 5,
+    unit: 3,
+    category: "vocabulary",
+    prompt: "Which sequencing connector marks the FIRST event in a story?",
+    promptEs: "¿Qué conector de secuencia marca el PRIMER evento de una historia?",
+    options: [
+      { text: "First", correct: true },
+      { text: "Finally", correct: false },
+      { text: "After that", correct: false },
+      { text: "In the end", correct: false },
+    ],
+    explanation:
+      "'First' opens a sequence. The order is: First → Then / After that → Finally / In the end. 'Finally' and 'In the end' mark the LAST event.",
+    explanationEs:
+      "'First' abre una secuencia. El orden es: First → Then / After that → Finally / In the end. 'Finally' e 'In the end' marcan el ÚLTIMO evento.",
+  },
+  {
+    id: 6,
+    unit: 3,
+    category: "translation",
+    prompt: 'How do you say "hace dos días" in English?',
+    promptEs: 'Traduce: "hace dos días"',
+    options: [
+      { text: "two days ago", correct: true },
+      { text: "two days before", correct: false },
+      { text: "ago two days", correct: false },
+      { text: "since two days", correct: false },
+    ],
+    explanation:
+      "'Ago' goes AFTER the time period in English: 'two days ago', 'a week ago', 'an hour ago'. NEVER 'ago two days'.",
+    explanationEs:
+      "'Ago' va DESPUÉS del período de tiempo en inglés: 'two days ago', 'a week ago', 'an hour ago'. NUNCA 'ago two days'.",
+  },
+
+  // ─── Unit 4: Going to vs. Will ─────────────────────────────────────────
+  {
+    id: 7,
+    unit: 4,
+    category: "grammar",
+    prompt: "Choose the right future for an ALREADY-MADE plan:",
+    promptEs: "Elige el futuro correcto para un plan YA HECHO:",
+    options: [
+      { text: "I'm going to visit my parents next weekend. I already bought the ticket.", correct: true },
+      { text: "I will visit my parents next weekend. I already bought the ticket.", correct: false },
+      { text: "I visit my parents next weekend. I already bought the ticket.", correct: false },
+      { text: "I going to visit my parents next weekend.", correct: false },
+    ],
+    explanation:
+      "Use 'going to' for plans you've ALREADY decided. Use 'will' for decisions made AT THE MOMENT of speaking. The bought ticket = pre-existing plan.",
+    explanationEs:
+      "Usa 'going to' para planes que YA decidiste. Usa 'will' para decisiones del MOMENTO de hablar. El boleto comprado = plan preexistente.",
+  },
+  {
+    id: 8,
+    unit: 4,
+    category: "grammar",
+    prompt: "Choose the spontaneous decision (use 'will'):",
+    promptEs: "Elige la decisión espontánea (usa 'will'):",
+    options: [
+      { text: "Your bag looks heavy. I'll carry it for you.", correct: true },
+      { text: "Your bag looks heavy. I'm going to carry it for you.", correct: false },
+      { text: "Your bag looks heavy. I carry it for you.", correct: false },
+      { text: "Your bag looks heavy. I going to carry it.", correct: false },
+    ],
+    explanation:
+      "'I'll carry it' = decision made RIGHT NOW, in response to seeing the heavy bag. 'I'm going to' would imply you planned this earlier — but you just decided.",
+    explanationEs:
+      "'I'll carry it' = decisión tomada AHORA MISMO, en respuesta a ver la bolsa pesada. 'I'm going to' implicaría que lo planeaste antes — pero acabas de decidir.",
+  },
+
+  // ─── Unit 5: Comparatives and Superlatives ─────────────────────────────
+  {
+    id: 9,
+    unit: 5,
+    category: "grammar",
+    prompt: "Choose the correct comparative form:",
+    promptEs: "Elige el comparativo correcto:",
+    options: [
+      { text: "New York is bigger than Boston.", correct: true },
+      { text: "New York is more bigger than Boston.", correct: false },
+      { text: "New York is more big than Boston.", correct: false },
+      { text: "New York is biggest than Boston.", correct: false },
+    ],
+    explanation:
+      "Short adjectives (one syllable) take -er: big → bigger. NEVER use 'more' with -er. NEVER 'more bigger'. The Spanish-style 'más grande' tempts speakers to add 'more'.",
+    explanationEs:
+      "Adjetivos cortos (una sílaba) toman -er: big → bigger. NUNCA uses 'more' con -er. NUNCA 'more bigger'. El estilo español 'más grande' tienta a agregar 'more'.",
+  },
+  {
+    id: 10,
+    unit: 5,
+    category: "grammar",
+    prompt: "Choose the correct irregular comparative:",
+    promptEs: "Elige el comparativo irregular correcto:",
+    options: [
+      { text: "This restaurant is better than the one near my house.", correct: true },
+      { text: "This restaurant is more better than the one near my house.", correct: false },
+      { text: "This restaurant is more good than the one near my house.", correct: false },
+      { text: "This restaurant is gooder than the one near my house.", correct: false },
+    ],
+    explanation:
+      "'Good' is irregular: good → better → best. Same for 'bad': bad → worse → worst. NEVER 'more better' or 'gooder'.",
+    explanationEs:
+      "'Good' es irregular: good → better → best. Igual para 'bad': bad → worse → worst. NUNCA 'more better' o 'gooder'.",
+  },
+
+  // ─── Unit 6: Quantifiers ──────────────────────────────────────────────
+  {
+    id: 11,
+    unit: 6,
+    category: "grammar",
+    prompt: "Choose the correct quantifier:",
+    promptEs: "Elige el cuantificador correcto:",
+    options: [
+      { text: "I don't have much money this month.", correct: true },
+      { text: "I don't have many money this month.", correct: false },
+      { text: "I don't have a few money this month.", correct: false },
+      { text: "I don't have any much money this month.", correct: false },
+    ],
+    explanation:
+      "'Money' is UNCOUNTABLE — use 'much'. 'Many' is for countable plurals (chairs, people). 'A few' is also countable.",
+    explanationEs:
+      "'Money' es INCONTABLE — usa 'much'. 'Many' es para plurales contables (chairs, people). 'A few' también es contable.",
+  },
+  {
+    id: 12,
+    unit: 6,
+    category: "vocabulary",
+    prompt: "Which English word is ALWAYS uncountable?",
+    promptEs: "¿Qué palabra en inglés es SIEMPRE incontable?",
+    options: [
+      { text: "advice", correct: true },
+      { text: "idea", correct: false },
+      { text: "question", correct: false },
+      { text: "meeting", correct: false },
+    ],
+    explanation:
+      "'Advice' is always uncountable in English — NEVER 'advices'. To pluralize, say 'pieces of advice'. Same for 'information' (NEVER 'informations') and 'furniture'.",
+    explanationEs:
+      "'Advice' siempre es incontable en inglés — NUNCA 'advices'. Para pluralizar, di 'pieces of advice'. Igual para 'information' (NUNCA 'informations') y 'furniture'.",
+  },
+
+  // ─── Unit 7: Wh-Questions ─────────────────────────────────────────────
+  {
+    id: 13,
+    unit: 7,
+    category: "grammar",
+    prompt: "Choose the correct question word order:",
+    promptEs: "Elige el orden correcto de la pregunta:",
+    options: [
+      { text: "Where do you work?", correct: true },
+      { text: "Where you work?", correct: false },
+      { text: "Where do you working?", correct: false },
+      { text: "Where works you?", correct: false },
+    ],
+    explanation:
+      "Wh-question word order: Wh + auxiliary (do/does) + subject + base verb. 'Where DO YOU WORK?'. The verb stays in BASE form.",
+    explanationEs:
+      "Orden de pregunta Wh-: Wh + auxiliar (do/does) + sujeto + verbo base. 'Where DO YOU WORK?'. El verbo queda en forma BASE.",
+  },
+  {
+    id: 14,
+    unit: 7,
+    category: "grammar",
+    prompt: "Choose the correct SUBJECT question (no helper verb):",
+    promptEs: "Elige la pregunta de SUJETO correcta (sin verbo ayudante):",
+    options: [
+      { text: "Who called you yesterday?", correct: true },
+      { text: "Who did called you yesterday?", correct: false },
+      { text: "Who did you call yesterday?", correct: false },
+      { text: "Who you called yesterday?", correct: false },
+    ],
+    explanation:
+      "When the Wh-word IS the subject ('Who' = the person who called), DROP 'do/did'. The verb takes its normal past tense ('called'). 'Who did you call?' is different — there 'you' is the subject.",
+    explanationEs:
+      "Cuando la palabra Wh- ES el sujeto ('Who' = la persona que llamó), QUITA 'do/did'. El verbo toma su pasado normal ('called'). 'Who did you call?' es diferente — ahí 'you' es el sujeto.",
+  },
+
+  // ─── Unit 8: Frequency Adverbs ─────────────────────────────────────────
+  {
+    id: 15,
+    unit: 8,
+    category: "grammar",
+    prompt: "Choose the correct position for the frequency adverb:",
+    promptEs: "Elige la posición correcta del adverbio de frecuencia:",
+    options: [
+      { text: "I always drink coffee in the morning.", correct: true },
+      { text: "I drink always coffee in the morning.", correct: false },
+      { text: "I drink coffee always in the morning.", correct: false },
+      { text: "Always I drink coffee in the morning.", correct: false },
+    ],
+    explanation:
+      "Frequency adverbs (always, usually, often, never) go BEFORE the main verb. NOT at the end like in Spanish, NOT after the verb. 'I always drink' — never 'I drink always'.",
+    explanationEs:
+      "Los adverbios de frecuencia (always, usually, often, never) van ANTES del verbo principal. NO al final como en español, NO después del verbo. 'I always drink' — nunca 'I drink always'.",
+  },
+  {
+    id: 16,
+    unit: 8,
+    category: "grammar",
+    prompt: "Where does the frequency adverb 'always' go with the verb 'BE'?",
+    promptEs: "¿Dónde va el adverbio de frecuencia 'always' con el verbo 'BE'?",
+    options: [
+      { text: "She is always late for meetings.", correct: true },
+      { text: "She always is late for meetings.", correct: false },
+      { text: "Always she is late for meetings.", correct: false },
+      { text: "She is late always for meetings.", correct: false },
+    ],
+    explanation:
+      "With BE (am/is/are/was/were), the adverb goes AFTER the verb — opposite of the regular rule. 'She IS ALWAYS late', NOT 'She ALWAYS IS late'. 'Always' cannot start a sentence in standard English.",
+    explanationEs:
+      "Con BE (am/is/are/was/were), el adverbio va DESPUÉS del verbo — opuesto a la regla regular. 'She IS ALWAYS late', NO 'She ALWAYS IS late'. 'Always' no puede iniciar una oración en inglés estándar.",
+  },
+
+  // ─── Unit 9: Past Continuous ───────────────────────────────────────────
+  {
+    id: 17,
+    unit: 9,
+    category: "grammar",
+    prompt: "Choose the correct past continuous form:",
+    promptEs: "Elige la forma correcta del pasado continuo:",
+    options: [
+      { text: "I was reading when she called.", correct: true },
+      { text: "I was read when she called.", correct: false },
+      { text: "I were reading when she called.", correct: false },
+      { text: "I am reading when she called.", correct: false },
+    ],
+    explanation:
+      "Past continuous = subject + was/were + verb-ing. 'Was' goes with I/he/she/it. 'Were' goes with you/we/they. The main verb MUST end in -ing.",
+    explanationEs:
+      "Pasado continuo = sujeto + was/were + verbo-ing. 'Was' va con I/he/she/it. 'Were' va con you/we/they. El verbo principal DEBE terminar en -ing.",
+  },
+  {
+    id: 18,
+    unit: 9,
+    category: "grammar",
+    prompt: "Choose the correctly-formed past continuous + past simple interruption:",
+    promptEs: "Elige la combinación de pasado continuo + pasado simple bien formada:",
+    options: [
+      { text: "I was eating dinner when the phone rang.", correct: true },
+      { text: "I was ate dinner when the phone rang.", correct: false },
+      { text: "I were eating dinner when the phone rang.", correct: false },
+      { text: "I eating dinner when the phone rang.", correct: false },
+    ],
+    explanation:
+      "The longer/background action goes in past continuous: was/were + verb-ing ('was eating'). The shorter interrupting action goes in past simple ('rang'). Use 'when' before the past simple. 'Was ate' and 'I eating' are not valid forms; 'I were' is wrong because 'I' takes 'was'.",
+    explanationEs:
+      "La acción más larga / de fondo va en pasado continuo: was/were + verbo-ing ('was eating'). La acción corta que interrumpe va en pasado simple ('rang'). Usa 'when' antes del pasado simple. 'Was ate' e 'I eating' no son formas válidas; 'I were' está mal porque 'I' lleva 'was'.",
+  },
+
+  // ─── Unit 10: Capstone — Integrated Storytelling ───────────────────────
+  {
+    id: 19,
+    unit: 10,
+    category: "translation",
+    prompt: 'Choose the most natural English narrative for: "Ayer estaba caminando cuando vi a un viejo amigo. Vamos a tomar café el sábado."',
+    promptEs: 'Elige la narrativa en inglés más natural para: "Ayer estaba caminando cuando vi a un viejo amigo. Vamos a tomar café el sábado."',
+    options: [
+      {
+        text: "Yesterday I was walking when I saw an old friend. We're going to have coffee on Saturday.",
+        correct: true,
+      },
+      {
+        text: "Yesterday I walked when I saw an old friend. We will to have coffee on Saturday.",
+        correct: false,
+      },
+      {
+        text: "Yesterday I am walking when I see an old friend. We have coffee on Saturday.",
+        correct: false,
+      },
+      {
+        text: "Yesterday I walking when I saw old friend. We going have coffee Saturday.",
+        correct: false,
+      },
+    ],
+    explanation:
+      "The walk was IN PROGRESS (past continuous: 'was walking'). The seeing INTERRUPTED it (past simple: 'saw'). The coffee plan is ALREADY DECIDED (going to: 'we're going to have'). This is the integrated A2 narrative pattern.",
+    explanationEs:
+      "El paseo estaba EN PROGRESO (pasado continuo: 'was walking'). Ver al amigo lo INTERRUMPIÓ (pasado simple: 'saw'). El plan del café YA ESTÁ DECIDIDO (going to: 'we're going to have'). Este es el patrón narrativo integrado de A2.",
+  },
+  {
+    id: 20,
+    unit: 10,
+    category: "grammar",
+    prompt: "Which sentence correctly mixes A2 grammar across multiple units?",
+    promptEs: "¿Qué oración mezcla correctamente la gramática A2 de varias unidades?",
+    options: [
+      {
+        text: "I usually work from home, but yesterday I went to the office because I had a few important meetings.",
+        correct: true,
+      },
+      {
+        text: "I usually working from home, but yesterday I go to the office because I had a many important meetings.",
+        correct: false,
+      },
+      {
+        text: "I usually work from home, but yesterday I was go to the office because I had much important meetings.",
+        correct: false,
+      },
+      {
+        text: "I working usually from home, but yesterday I went to office because I had a few importants meetings.",
+        correct: false,
+      },
+    ],
+    explanation:
+      "Correct sentence integrates: frequency adverb position ('usually work'), past simple irregular ('went'), quantifier with countable ('a few important meetings'). Adjectives never take -s in English ('importants' is wrong).",
+    explanationEs:
+      "La oración correcta integra: posición de adverbio de frecuencia ('usually work'), pasado simple irregular ('went'), cuantificador con contable ('a few important meetings'). Los adjetivos nunca llevan -s en inglés ('importants' es incorrecto).",
+  },
+];
+
+export function calculateExamResult(
+  answers: Record<number, number>,
+): ExamResult {
+  const unitScores: Record<number, { correct: number; total: number }> = {};
+  const categoryScores: Record<string, { correct: number; total: number }> = {};
+  let totalCorrect = 0;
+
+  for (const q of examQuestions) {
+    if (!unitScores[q.unit]) unitScores[q.unit] = { correct: 0, total: 0 };
+    if (!categoryScores[q.category])
+      categoryScores[q.category] = { correct: 0, total: 0 };
+
+    unitScores[q.unit].total++;
+    categoryScores[q.category].total++;
+
+    const selectedIndex = answers[q.id];
+    if (selectedIndex !== undefined && q.options[selectedIndex]?.correct) {
+      totalCorrect++;
+      unitScores[q.unit].correct++;
+      categoryScores[q.category].correct++;
+    }
+  }
+
+  return {
+    totalCorrect,
+    totalQuestions: examQuestions.length,
+    percentage: Math.round((totalCorrect / examQuestions.length) * 100),
+    unitScores,
+    categoryScores,
+  };
+}
+
+/**
+ * Tier definitions for the elementary course exam.
+ */
+export const examTiers = [
+  {
+    minPercent: 90,
+    tier: "Outstanding",
+    tierEs: "Sobresaliente",
+    color: "emerald",
+    message:
+      "Exceptional work. You've truly built A2 storytelling fluency. You're ready to jump into the intermediate course (Building Fluency) and tackle B1-B2 grammar.",
+    messageEs:
+      "Trabajo excepcional. Realmente has construido fluidez narrativa A2. Estás listo para saltar al curso intermedio (Construyendo Fluidez) y enfrentar la gramática B1-B2.",
+  },
+  {
+    minPercent: 70,
+    tier: "Passed",
+    tierEs: "Aprobado",
+    color: "amber",
+    message:
+      "Solid performance. You've mastered the core of elementary English. Review the units where you missed questions, then continue with Unit 10 (your story recording) and the intermediate course.",
+    messageEs:
+      "Desempeño sólido. Has dominado el núcleo del inglés elemental. Repasa las unidades donde fallaste preguntas, luego sigue con la Unidad 10 (tu historia grabada) y el curso intermedio.",
+  },
+  {
+    minPercent: 0,
+    tier: "Keep Practicing",
+    tierEs: "Sigue Practicando",
+    color: "rose",
+    message:
+      "You're making progress, but key A2 structures need more review. Go back to the units where you struggled — especially past tense, quantifiers, and frequency adverb position — and try again.",
+    messageEs:
+      "Estás progresando, pero las estructuras clave de A2 necesitan más repaso. Vuelve a las unidades donde tuviste dificultades — especialmente el pasado, los cuantificadores y la posición de los adverbios de frecuencia — e intenta de nuevo.",
+  },
+] as const;
+
+export function getScoreTier(percentage: number): ScoreTier {
+  if (percentage >= 90) {
+    return {
+      tier: "Outstanding",
+      tierEs: "Sobresaliente",
+      color: "emerald",
+      message:
+        "Exceptional work. You've truly built A2 storytelling fluency. You're ready to jump into the intermediate course (Building Fluency) and tackle B1-B2 grammar.",
+      messageEs:
+        "Trabajo excepcional. Realmente has construido fluidez narrativa A2. Estás listo para saltar al curso intermedio (Construyendo Fluidez) y enfrentar la gramática B1-B2.",
+    };
+  }
+  if (percentage >= 70) {
+    return {
+      tier: "Passed",
+      tierEs: "Aprobado",
+      color: "amber",
+      message:
+        "Solid performance. You've mastered the core of elementary English. Review the units where you missed questions, then continue with Unit 10 (your story recording) and the intermediate course.",
+      messageEs:
+        "Desempeño sólido. Has dominado el núcleo del inglés elemental. Repasa las unidades donde fallaste preguntas, luego sigue con la Unidad 10 (tu historia grabada) y el curso intermedio.",
+    };
+  }
+  return {
+    tier: "Keep Practicing",
+    tierEs: "Sigue Practicando",
+    color: "rose",
+    message:
+      "You're making progress, but key A2 structures need more review. Go back to the units where you struggled — especially past tense, quantifiers, and frequency adverb position — and try again.",
+    messageEs:
+      "Estás progresando, pero las estructuras clave de A2 necesitan más repaso. Vuelve a las unidades donde tuviste dificultades — especialmente el pasado, los cuantificadores y la posición de los adverbios de frecuencia — e intenta de nuevo.",
+  };
+}

--- a/src/data/elementary/unit-7.ts
+++ b/src/data/elementary/unit-7.ts
@@ -1,0 +1,448 @@
+// Unit 7: "Asking Real Questions" — Wh-questions
+//
+// Pedagogical arc:
+// Section A — 3 waves: the 7 Wh-words, the How + X compounds, common topic nouns
+// Section B — Question word order (Wh + Be / Wh + aux + subject + verb / past)
+// Section C — Subject vs. object questions ("Who called you?" vs. "Who did you call?")
+// Section D — Boss Sentence: a real first-meeting conversation
+// Section E — Pronunciation: Wh-question falling intonation, "do you" reduction
+// Section F — Self-test of unit vocabulary
+
+export interface CognateWord {
+  english: string;
+  spanish: string;
+  category: string;
+  pronunciationNote?: string;
+  pronunciationNoteEs?: string;
+}
+
+export interface SentenceBlock {
+  label: string;
+  labelEs: string;
+  description: string;
+  descriptionEs: string;
+  sentences: {
+    english: string;
+    spanish: string;
+    highlight?: string;
+  }[];
+}
+
+export interface PronunciationDrillItem {
+  word: string;
+  spanishStress: string;
+  englishStress: string;
+  tip: string;
+  tipEs: string;
+}
+
+export interface VocabItem {
+  english: string;
+  spanish: string;
+  type: "verb" | "phrase" | "marker";
+}
+
+// ─── Section A: Question Words and Topic Vocabulary ──────────────────────────
+
+export const cognateWaves = {
+  wave1: {
+    title: "The 7 Wh-Words — Your Question Toolkit",
+    titleEs: "Las 7 Palabras Wh- — Tu Caja de Herramientas",
+    description:
+      "Every real question in English starts with one of these. Memorize the meaning, then drill the pronunciation — most start with a 'wh' sound that doesn't exist in Spanish.",
+    descriptionEs:
+      "Cada pregunta real en inglés empieza con una de estas. Memoriza el significado, luego practica la pronunciación — la mayoría empieza con un sonido 'wh' que no existe en español.",
+    words: [
+      {
+        english: "what",
+        spanish: "qué",
+        category: "Wh-word",
+        pronunciationNote: "Sounds like 'WUT'. The 'wh' is just a 'w' sound — no 'h' breath.",
+        pronunciationNoteEs: "Suena como 'WUT'. El 'wh' es solo sonido 'w' — sin aire del 'h'.",
+      },
+      {
+        english: "where",
+        spanish: "dónde",
+        category: "Wh-word",
+        pronunciationNote: "Sounds like 'WAIR'. Rhymes with 'air' or 'hair'.",
+        pronunciationNoteEs: "Suena como 'WAIR'. Rima con 'air' o 'hair'.",
+      },
+      {
+        english: "when",
+        spanish: "cuándo",
+        category: "Wh-word",
+        pronunciationNote: "Sounds like 'WEN'. Same vowel as 'pen' or 'ten'.",
+        pronunciationNoteEs: "Suena como 'WEN'. Misma vocal que 'pen' o 'ten'.",
+      },
+      {
+        english: "why",
+        spanish: "por qué",
+        category: "Wh-word",
+        pronunciationNote: "Sounds like 'WHY' (rhymes with 'eye'). One syllable.",
+        pronunciationNoteEs: "Suena como 'WAI' (rima con 'eye'). Una sílaba.",
+      },
+      {
+        english: "who",
+        spanish: "quién",
+        category: "Wh-word",
+        pronunciationNote: "Sounds like 'HOO'. The 'w' is silent here. Rhymes with 'shoe'.",
+        pronunciationNoteEs: "Suena como 'JU' (en inglés). La 'w' es muda. Rima con 'shoe'.",
+      },
+      {
+        english: "which",
+        spanish: "cuál",
+        category: "Wh-word",
+        pronunciationNote: "Sounds like 'WICH'. Use when choosing from a known group.",
+        pronunciationNoteEs: "Suena como 'WICH'. Úsalo al elegir entre un grupo conocido.",
+      },
+      {
+        english: "how",
+        spanish: "cómo",
+        category: "Wh-word",
+        pronunciationNote: "Sounds like 'HOW' (rhymes with 'now'). The 'w' is silent here too.",
+        pronunciationNoteEs: "Suena como 'HOW' (rima con 'now'). Aquí la 'w' también es muda.",
+      },
+    ] as CognateWord[],
+  },
+  wave2: {
+    title: "How + X — The Compound Question Words",
+    titleEs: "How + X — Las Preguntas Compuestas",
+    description:
+      "'How' combines with another word to ask about quantity, time length, frequency, or degree. Spanish often uses one word; English uses two — 'how long', 'how often', 'how much'.",
+    descriptionEs:
+      "'How' se combina con otra palabra para preguntar sobre cantidad, duración, frecuencia o grado. El español a menudo usa una palabra; el inglés usa dos — 'how long', 'how often', 'how much'.",
+    words: [
+      { english: "how long", spanish: "cuánto tiempo", category: "How+X" },
+      { english: "how often", spanish: "con qué frecuencia", category: "How+X" },
+      { english: "how much", spanish: "cuánto (incontable)", category: "How+X" },
+      { english: "how many", spanish: "cuántos (contable)", category: "How+X" },
+      { english: "how old", spanish: "qué edad", category: "How+X" },
+      { english: "how far", spanish: "qué tan lejos", category: "How+X" },
+      { english: "how big", spanish: "qué tan grande", category: "How+X" },
+      { english: "how fast", spanish: "qué tan rápido", category: "How+X" },
+      { english: "how come", spanish: "cómo es que (informal por qué)", category: "How+X" },
+      {
+        english: "how about",
+        spanish: "qué tal",
+        category: "How+X",
+        pronunciationNote: "Used to suggest or check in. 'How about Friday?' = '¿Qué tal el viernes?'",
+        pronunciationNoteEs: "Usado para sugerir o consultar. 'How about Friday?' = '¿Qué tal el viernes?'",
+      },
+    ] as CognateWord[],
+  },
+  wave3: {
+    title: "Topic Vocabulary — What People Actually Ask About",
+    titleEs: "Vocabulario Temático — De Qué Habla la Gente",
+    description:
+      "These are the real topics in first conversations: where you live, what you do, your family, your weekend. Master these nouns and your Wh-questions land naturally.",
+    descriptionEs:
+      "Estos son los temas reales en primeras conversaciones: dónde vives, qué haces, tu familia, tu fin de semana. Domina estos sustantivos y tus preguntas Wh- caen natural.",
+    words: [
+      { english: "city", spanish: "ciudad", category: "Topic" },
+      { english: "country", spanish: "país", category: "Topic" },
+      { english: "neighborhood", spanish: "vecindario", category: "Topic" },
+      { english: "job", spanish: "trabajo", category: "Topic" },
+      { english: "company", spanish: "empresa", category: "Topic" },
+      { english: "family", spanish: "familia", category: "Topic" },
+      { english: "weekend", spanish: "fin de semana", category: "Topic" },
+      { english: "vacation", spanish: "vacaciones", category: "Topic" },
+      { english: "hobby", spanish: "pasatiempo", category: "Topic" },
+      { english: "favorite", spanish: "favorito/a", category: "Topic" },
+      { english: "free time", spanish: "tiempo libre", category: "Topic" },
+      { english: "language", spanish: "idioma", category: "Topic" },
+    ] as CognateWord[],
+  },
+};
+
+// ─── Section B: Question Word Order ──────────────────────────────────────────
+
+export const sentenceBlocks: SentenceBlock[] = [
+  {
+    label: "Step 1: Wh + Be + subject (present)",
+    labelEs: "Paso 1: Wh + Be + sujeto (presente)",
+    description:
+      "When the verb is BE (am/is/are), it jumps to position 2 — right after the Wh-word. Subject comes third. NO 'do/does'. This is the simplest pattern.",
+    descriptionEs:
+      "Cuando el verbo es BE (am/is/are), salta a la posición 2 — justo después de la palabra Wh-. El sujeto va tercero. SIN 'do/does'. Este es el patrón más simple.",
+    sentences: [
+      { english: "Where are you from?", spanish: "¿De dónde eres?", highlight: "are" },
+      { english: "What is your name?", spanish: "¿Cuál es tu nombre?", highlight: "is" },
+      { english: "How old is your son?", spanish: "¿Qué edad tiene tu hijo?", highlight: "is" },
+      { english: "Why are you tired?", spanish: "¿Por qué estás cansado?", highlight: "are" },
+    ],
+  },
+  {
+    label: "Step 2: Wh + do/does + subject + verb (present)",
+    labelEs: "Paso 2: Wh + do/does + sujeto + verbo (presente)",
+    description:
+      "For ALL OTHER verbs in present tense, you need 'do' (I/you/we/they) or 'does' (he/she/it) as a helper. The main verb stays in base form. NEVER add -s after 'does'.",
+    descriptionEs:
+      "Para TODOS los OTROS verbos en presente, necesitas 'do' (I/you/we/they) o 'does' (he/she/it) como ayudante. El verbo principal queda en forma base. NUNCA agregues -s después de 'does'.",
+    sentences: [
+      { english: "Where do you work?", spanish: "¿Dónde trabajas?", highlight: "do" },
+      { english: "What does she do for a living?", spanish: "¿A qué se dedica ella?", highlight: "does" },
+      { english: "How often do you exercise?", spanish: "¿Con qué frecuencia haces ejercicio?", highlight: "do" },
+      { english: "Why does he speak so fast?", spanish: "¿Por qué habla él tan rápido?", highlight: "does" },
+    ],
+  },
+  {
+    label: "Step 3: Wh + did + subject + base verb (past)",
+    labelEs: "Paso 3: Wh + did + sujeto + verbo base (pasado)",
+    description:
+      "For ALL past-tense questions, use 'did' as the helper — and the main verb goes BACK to base form. NEVER 'Where did you went?' Always 'Where did you go?'.",
+    descriptionEs:
+      "Para TODAS las preguntas en pasado, usa 'did' como ayudante — y el verbo principal REGRESA a forma base. NUNCA 'Where did you went?' Siempre 'Where did you go?'.",
+    sentences: [
+      { english: "Where did you go last weekend?", spanish: "¿A dónde fuiste el fin de semana pasado?", highlight: "did" },
+      { english: "When did she arrive?", spanish: "¿Cuándo llegó ella?", highlight: "did" },
+      { english: "What did you eat for lunch?", spanish: "¿Qué comiste de almuerzo?", highlight: "did" },
+      { english: "Why did they leave so early?", spanish: "¿Por qué se fueron tan temprano?", highlight: "did" },
+    ],
+  },
+  {
+    label: "Step 4: Wh + can/will/should + subject + base verb",
+    labelEs: "Paso 4: Wh + can/will/should + sujeto + verbo base",
+    description:
+      "With modals (can, will, should, could, would), the modal goes in position 2 — like 'be' did. Main verb stays base form. No 'do' needed.",
+    descriptionEs:
+      "Con modales (can, will, should, could, would), el modal va en posición 2 — como hizo 'be'. El verbo principal queda en forma base. No se necesita 'do'.",
+    sentences: [
+      { english: "How can I help you?", spanish: "¿Cómo puedo ayudarte?", highlight: "can" },
+      { english: "When will you finish the report?", spanish: "¿Cuándo terminarás el reporte?", highlight: "will" },
+      { english: "What should I do next?", spanish: "¿Qué debería hacer después?", highlight: "should" },
+      { english: "Where would you like to eat?", spanish: "¿Dónde te gustaría comer?", highlight: "would" },
+    ],
+  },
+];
+
+// ─── Section C: Subject Questions vs. Object Questions ───────────────────────
+
+export const powerVerbBlocks: SentenceBlock[] = [
+  {
+    label: "Object Questions — The Normal Pattern",
+    labelEs: "Preguntas de Objeto — El Patrón Normal",
+    description:
+      "When the Wh-word is the OBJECT (what/who you act on), you USE the helper 'do/does/did'. This is the pattern you've been drilling. The subject is still the person doing the action.",
+    descriptionEs:
+      "Cuando la palabra Wh- es el OBJETO (qué/a quién afectas), USAS el ayudante 'do/does/did'. Este es el patrón que has estado practicando. El sujeto sigue siendo quien hace la acción.",
+    sentences: [
+      { english: "Who did you call?", spanish: "¿A quién llamaste?", highlight: "did you call" },
+      { english: "What do you want?", spanish: "¿Qué quieres?", highlight: "do you want" },
+      { english: "Who does she work with?", spanish: "¿Con quién trabaja ella?", highlight: "does she work" },
+      { english: "What did they buy?", spanish: "¿Qué compraron ellos?", highlight: "did they buy" },
+    ],
+  },
+  {
+    label: "Subject Questions — DROP the helper",
+    labelEs: "Preguntas de Sujeto — QUITA el ayudante",
+    description:
+      "When the Wh-word IS the subject (who/what does the action), DROP 'do/does/did' completely. The verb takes its normal form — present -s for he/she/it, past -ed for past. This trips up almost every Spanish speaker.",
+    descriptionEs:
+      "Cuando la palabra Wh- ES el sujeto (quién/qué hace la acción), QUITA 'do/does/did' completamente. El verbo toma su forma normal — -s en presente para he/she/it, -ed en pasado. Esto confunde a casi todos los hispanohablantes.",
+    sentences: [
+      { english: "Who called you?", spanish: "¿Quién te llamó?", highlight: "called (no did)" },
+      { english: "What happened?", spanish: "¿Qué pasó?", highlight: "happened (no did)" },
+      { english: "Who lives here?", spanish: "¿Quién vive aquí?", highlight: "lives (no does)" },
+      { english: "What makes you happy?", spanish: "¿Qué te hace feliz?", highlight: "makes (no does)" },
+    ],
+  },
+  {
+    label: "How Long / How Often — Asking About Duration and Frequency",
+    labelEs: "How Long / How Often — Preguntas de Duración y Frecuencia",
+    description:
+      "'How long' asks how much TIME something takes or has lasted. 'How often' asks how FREQUENTLY something happens. Both pair with the helper pattern from Section B.",
+    descriptionEs:
+      "'How long' pregunta cuánto TIEMPO toma o ha durado algo. 'How often' pregunta con qué FRECUENCIA pasa algo. Ambos van con el patrón de ayudantes de la Sección B.",
+    sentences: [
+      { english: "How long have you lived here?", spanish: "¿Cuánto tiempo has vivido aquí?", highlight: "How long" },
+      { english: "How long does it take to drive?", spanish: "¿Cuánto tiempo toma manejar?", highlight: "How long" },
+      { english: "How often do you travel for work?", spanish: "¿Con qué frecuencia viajas por trabajo?", highlight: "How often" },
+      { english: "How often does the bus come?", spanish: "¿Con qué frecuencia viene el autobús?", highlight: "How often" },
+    ],
+  },
+  {
+    label: "How Much / How Many — From Unit 6, Now in Questions",
+    labelEs: "How Much / How Many — De la Unidad 6, Ahora en Preguntas",
+    description:
+      "'How many' for countables, 'How much' for uncountables — same rule as Unit 6. Now drill them in real question structures with the right helper verb.",
+    descriptionEs:
+      "'How many' para contables, 'How much' para incontables — misma regla que la Unidad 6. Ahora practícalos en estructuras reales de pregunta con el verbo ayudante correcto.",
+    sentences: [
+      { english: "How many siblings do you have?", spanish: "¿Cuántos hermanos tienes?", highlight: "How many" },
+      { english: "How much does this cost?", spanish: "¿Cuánto cuesta esto?", highlight: "How much" },
+      { english: "How many languages does she speak?", spanish: "¿Cuántos idiomas habla ella?", highlight: "How many" },
+      { english: "How much time do we have?", spanish: "¿Cuánto tiempo tenemos?", highlight: "How much" },
+    ],
+  },
+];
+
+// ─── Section D: Boss Sentence — A First Conversation (Connector Challenge) ───
+
+export const connectorSentences = {
+  connectors: [
+    {
+      word: "Where are you from?",
+      wordEs: "¿De dónde eres?",
+      example: "Where are you from originally?",
+      exampleEs: "¿De dónde eres originalmente?",
+      use: "The classic conversation opener. Wh + Be pattern — no 'do' needed because the verb is 'are'.",
+      useEs: "El abre-conversaciones clásico. Patrón Wh + Be — sin 'do' porque el verbo es 'are'.",
+    },
+    {
+      word: "What do you do?",
+      wordEs: "¿A qué te dedicas?",
+      example: "What do you do for work?",
+      exampleEs: "¿A qué te dedicas en el trabajo?",
+      use: "Standard 'tell me about your job' question. Use 'do' as helper, second 'do' is the main verb.",
+      useEs: "Pregunta estándar de 'háblame de tu trabajo'. Usa 'do' como ayudante, el segundo 'do' es el verbo principal.",
+    },
+    {
+      word: "How long",
+      wordEs: "Cuánto tiempo",
+      example: "How long have you been there?",
+      exampleEs: "¿Cuánto tiempo llevas allí?",
+      use: "Asks about duration. Pairs with 'have you been' (present perfect) for ongoing situations.",
+      useEs: "Pregunta por duración. Va con 'have you been' (presente perfecto) para situaciones continuas.",
+    },
+    {
+      word: "Why did you",
+      wordEs: "Por qué",
+      example: "Why did you decide to move?",
+      exampleEs: "¿Por qué decidiste mudarte?",
+      use: "Past-tense Wh- question. Note: main verb is base form ('decide', not 'decided').",
+      useEs: "Pregunta Wh- en pasado. Nota: el verbo principal va en forma base ('decide', no 'decided').",
+    },
+    {
+      word: "How often",
+      wordEs: "Con qué frecuencia",
+      example: "How often do you visit?",
+      exampleEs: "¿Con qué frecuencia visitas?",
+      use: "Asks about frequency. Same helper pattern as 'what do you do' — 'do' + base verb.",
+      useEs: "Pregunta por frecuencia. Mismo patrón ayudante que 'what do you do' — 'do' + verbo base.",
+    },
+    {
+      word: "What's your favorite",
+      wordEs: "Cuál es tu favorito",
+      example: "What's your favorite thing about it?",
+      exampleEs: "¿Cuál es tu cosa favorita al respecto?",
+      use: "Wh + Be (contracted to 'What's'). Natural way to ask for opinions and preferences.",
+      useEs: "Wh + Be (contraído a 'What's'). Forma natural de preguntar opiniones y preferencias.",
+    },
+  ],
+  bossSentence: {
+    english:
+      "So, where are you from originally? And what do you do for work? How long have you been at your company? Why did you decide to move to New York? How often do you go back to visit family? And what's your favorite thing about living here?",
+    spanish:
+      "Entonces, ¿de dónde eres originalmente? ¿Y a qué te dedicas? ¿Cuánto tiempo llevas en tu empresa? ¿Por qué decidiste mudarte a Nueva York? ¿Con qué frecuencia regresas a visitar a tu familia? ¿Y cuál es tu cosa favorita de vivir aquí?",
+    explanation:
+      "Six real questions, six different patterns: Wh+Be, Wh+do+verb, How long+present perfect, Why+did+base verb, How often+do+verb, What+Be. This is exactly what a first conversation in English sounds like — and exactly the questions you should be ready to ASK back.",
+    explanationEs:
+      "Seis preguntas reales, seis patrones diferentes: Wh+Be, Wh+do+verbo, How long+presente perfecto, Why+did+verbo base, How often+do+verbo, What+Be. Así suena una primera conversación en inglés — y exactamente las preguntas que deberías estar listo para HACER tú también.",
+  },
+};
+
+// ─── Section E: Pronunciation Lab — Question Sounds and Intonation ───────────
+
+export const pronunciationDrills: PronunciationDrillItem[] = [
+  {
+    word: "what",
+    spanishStress: "QUE (Spanish 'que')",
+    englishStress: "WUT (one syllable, short 'uh' sound)",
+    tip: "The 'wh' is just 'w'. Same vowel as 'cup' or 'much'. NOT 'WAT' with Spanish 'a'.",
+    tipEs: "El 'wh' es solo 'w'. Misma vocal que 'cup' o 'much'. NO 'WAT' con 'a' española.",
+  },
+  {
+    word: "where",
+    spanishStress: "DON-DE",
+    englishStress: "WAIR (rhymes with 'air')",
+    tip: "Sounds like 'WAIR'. Same as the word 'where' in 'wear a hat'. One syllable.",
+    tipEs: "Suena como 'WAIR'. Igual que la palabra 'wear' en 'wear a hat'. Una sílaba.",
+  },
+  {
+    word: "who",
+    spanishStress: "QUIEN",
+    englishStress: "HOO (silent 'w', rhymes with 'shoe')",
+    tip: "The 'w' is SILENT. Just say 'HOO'. Spanish speakers often add a 'w' sound — don't.",
+    tipEs: "La 'w' es MUDA. Solo di 'JU' (en inglés HOO). Los hispanohablantes a menudo agregan sonido 'w' — no lo hagas.",
+  },
+  {
+    word: "how",
+    spanishStress: "CO-MO",
+    englishStress: "HOW (rhymes with 'now', silent 'w' here too)",
+    tip: "The 'w' is SILENT. Sounds like 'HOW' rhyming with 'now', 'cow', 'bow'.",
+    tipEs: "La 'w' es MUDA. Suena como 'HOW' rimando con 'now', 'cow', 'bow'.",
+  },
+  {
+    word: "do you",
+    spanishStress: "DO YOU (two clear words)",
+    englishStress: "duh-YA / d'YA (linked, fast)",
+    tip: "In fast speech, 'do you' becomes 'd'YA'. 'Where do you live?' → 'WHERE-d'YA-LIV?'",
+    tipEs: "En habla rápida, 'do you' se vuelve 'd'YA'. 'Where do you live?' → 'WHERE-d'YA-LIV?'",
+  },
+  {
+    word: "did you",
+    spanishStress: "DID YOU (two clear words)",
+    englishStress: "DID-juh / DIH-juh (linked with 'j' sound)",
+    tip: "'Did you' merges into 'DID-juh'. The 'd' + 'y' creates a 'j' sound. 'What did you do?' → 'WHAT-DIDJUH-DOO?'",
+    tipEs: "'Did you' se junta en 'DID-juh'. La 'd' + 'y' crea sonido 'j' (inglés). 'What did you do?' → 'WHAT-DIDJUH-DOO?'",
+  },
+  {
+    word: "Wh-question intonation",
+    spanishStress: "Rising at end (Spanish habit)",
+    englishStress: "FALLING at end (English Wh-questions)",
+    tip: "English Wh-questions END with FALLING pitch — opposite of Spanish. 'Where are you from?' goes DOWN on 'from'.",
+    tipEs: "Las preguntas Wh- en inglés TERMINAN con tono BAJANDO — opuesto al español. 'Where are you from?' BAJA en 'from'.",
+  },
+  {
+    word: "yes/no question intonation",
+    spanishStress: "Often flat in Spanish",
+    englishStress: "RISING at end (yes/no questions)",
+    tip: "Yes/no questions ('Are you ready?', 'Do you like it?') END with RISING pitch — UP on the last word.",
+    tipEs: "Las preguntas de sí/no ('Are you ready?', 'Do you like it?') TERMINAN con tono SUBIENDO — ARRIBA en la última palabra.",
+  },
+];
+
+// ─── Section F: Vocabulary List for Self-Test ────────────────────────────────
+
+export const vocabularyList: VocabItem[] = [
+  // Wh-words
+  { english: "what", spanish: "qué", type: "marker" },
+  { english: "where", spanish: "dónde", type: "marker" },
+  { english: "when", spanish: "cuándo", type: "marker" },
+  { english: "why", spanish: "por qué", type: "marker" },
+  { english: "who", spanish: "quién", type: "marker" },
+  { english: "which", spanish: "cuál", type: "marker" },
+  { english: "how", spanish: "cómo", type: "marker" },
+  // How+X compounds
+  { english: "how long", spanish: "cuánto tiempo", type: "marker" },
+  { english: "how often", spanish: "con qué frecuencia", type: "marker" },
+  { english: "how much", spanish: "cuánto (incontable)", type: "marker" },
+  { english: "how many", spanish: "cuántos (contable)", type: "marker" },
+  { english: "how old", spanish: "qué edad", type: "marker" },
+  { english: "how far", spanish: "qué tan lejos", type: "marker" },
+  { english: "how about", spanish: "qué tal", type: "marker" },
+  // Topic vocabulary
+  { english: "city", spanish: "ciudad", type: "phrase" },
+  { english: "country", spanish: "país", type: "phrase" },
+  { english: "job", spanish: "trabajo", type: "phrase" },
+  { english: "company", spanish: "empresa", type: "phrase" },
+  { english: "family", spanish: "familia", type: "phrase" },
+  { english: "weekend", spanish: "fin de semana", type: "phrase" },
+  { english: "vacation", spanish: "vacaciones", type: "phrase" },
+  { english: "hobby", spanish: "pasatiempo", type: "phrase" },
+  { english: "favorite", spanish: "favorito/a", type: "phrase" },
+  { english: "free time", spanish: "tiempo libre", type: "phrase" },
+  // Useful question phrases
+  { english: "Where are you from?", spanish: "¿De dónde eres?", type: "phrase" },
+  { english: "What do you do?", spanish: "¿A qué te dedicas?", type: "phrase" },
+  { english: "How long have you been here?", spanish: "¿Cuánto tiempo llevas aquí?", type: "phrase" },
+  { english: "Why did you move?", spanish: "¿Por qué te mudaste?", type: "phrase" },
+  { english: "How often do you travel?", spanish: "¿Con qué frecuencia viajas?", type: "phrase" },
+  { english: "What's your favorite…?", spanish: "¿Cuál es tu favorito…?", type: "phrase" },
+  { english: "Who called you?", spanish: "¿Quién te llamó?", type: "phrase" },
+  { english: "What happened?", spanish: "¿Qué pasó?", type: "phrase" },
+  { english: "How can I help?", spanish: "¿Cómo puedo ayudar?", type: "phrase" },
+  { english: "When does it start?", spanish: "¿Cuándo empieza?", type: "phrase" },
+  { english: "How much does it cost?", spanish: "¿Cuánto cuesta?", type: "phrase" },
+  { english: "How many people came?", spanish: "¿Cuántas personas vinieron?", type: "phrase" },
+];

--- a/src/data/elementary/unit-8.ts
+++ b/src/data/elementary/unit-8.ts
@@ -1,0 +1,422 @@
+// Unit 8: "Daily Life" — Frequency Adverbs and Routines
+//
+// Pedagogical arc:
+// Section A — 3 waves: frequency adverbs, daily routine verbs, time/period expressions
+// Section B — Position rules: before main verb, after BE, between aux and main
+// Section C — Frequency phrases (every day, once a week, on Mondays)
+// Section D — Boss Sentence: a real typical week
+// Section E — Pronunciation: 'usually' (3 syllables), silent t in 'often', 'always'
+// Section F — Self-test of unit vocabulary
+
+export interface CognateWord {
+  english: string;
+  spanish: string;
+  category: string;
+  pronunciationNote?: string;
+  pronunciationNoteEs?: string;
+}
+
+export interface SentenceBlock {
+  label: string;
+  labelEs: string;
+  description: string;
+  descriptionEs: string;
+  sentences: {
+    english: string;
+    spanish: string;
+    highlight?: string;
+  }[];
+}
+
+export interface PronunciationDrillItem {
+  word: string;
+  spanishStress: string;
+  englishStress: string;
+  tip: string;
+  tipEs: string;
+}
+
+export interface VocabItem {
+  english: string;
+  spanish: string;
+  type: "verb" | "phrase" | "marker";
+}
+
+// ─── Section A: Frequency Adverbs, Routine Verbs, Time Expressions ───────────
+
+export const cognateWaves = {
+  wave1: {
+    title: "The Frequency Adverbs — From Always to Never",
+    titleEs: "Los Adverbios de Frecuencia — De Always a Never",
+    description:
+      "These seven adverbs cover the full scale: 100% always → 0% never. Each one has a position rule that almost every Spanish speaker gets wrong. Memorize the meaning first, then drill the position in Section B.",
+    descriptionEs:
+      "Estos siete adverbios cubren toda la escala: 100% always → 0% never. Cada uno tiene una regla de posición que casi todos los hispanohablantes equivocan. Memoriza el significado primero, luego practica la posición en la Sección B.",
+    words: [
+      { english: "always (100%)", spanish: "siempre", category: "Frequency" },
+      { english: "usually (~90%)", spanish: "usualmente / por lo general", category: "Frequency" },
+      { english: "often (~70%)", spanish: "a menudo", category: "Frequency",
+        pronunciationNote: "The 't' is often SILENT — sounds like 'OFF-en'. Both 'OFF-en' and 'OFF-ten' are accepted.",
+        pronunciationNoteEs: "La 't' suele ser MUDA — suena como 'OFF-en'. Ambas 'OFF-en' y 'OFF-ten' son aceptadas.",
+      },
+      { english: "sometimes (~50%)", spanish: "a veces", category: "Frequency" },
+      { english: "rarely (~10%)", spanish: "raramente / casi nunca", category: "Frequency" },
+      { english: "hardly ever (~5%)", spanish: "casi nunca", category: "Frequency" },
+      {
+        english: "never (0%)",
+        spanish: "nunca",
+        category: "Frequency",
+        pronunciationNote: "Sounds like 'NEH-vur'. The first 'e' is short, like 'pen'.",
+        pronunciationNoteEs: "Suena como 'NEH-vur'. La primera 'e' es corta, como 'pen'.",
+      },
+    ] as CognateWord[],
+  },
+  wave2: {
+    title: "Daily Routine Verbs — What People Actually Do",
+    titleEs: "Verbos de Rutina Diaria — Lo Que la Gente Realmente Hace",
+    description:
+      "The verbs that describe a real day: from waking up to going to bed. Learn these as a sequence and you can describe any day of your life.",
+    descriptionEs:
+      "Los verbos que describen un día real: de despertar a acostarte. Apréndelos en secuencia y puedes describir cualquier día de tu vida.",
+    words: [
+      { english: "wake up", spanish: "despertarse", category: "Routine" },
+      {
+        english: "get up",
+        spanish: "levantarse",
+        category: "Routine",
+        pronunciationNote: "Different from 'wake up'. 'Wake up' = open eyes. 'Get up' = leave the bed.",
+        pronunciationNoteEs: "Diferente de 'wake up'. 'Wake up' = abrir los ojos. 'Get up' = salir de la cama.",
+      },
+      { english: "take a shower", spanish: "ducharse", category: "Routine" },
+      { english: "have breakfast", spanish: "desayunar", category: "Routine" },
+      {
+        english: "commute",
+        spanish: "trasladarse al trabajo",
+        category: "Routine",
+        pronunciationNote: "Both noun and verb. 'My commute is long' / 'I commute by train'.",
+        pronunciationNoteEs: "Sustantivo y verbo. 'My commute is long' / 'I commute by train'.",
+      },
+      { english: "start work", spanish: "empezar a trabajar", category: "Routine" },
+      { english: "have lunch", spanish: "almorzar", category: "Routine" },
+      { english: "finish work", spanish: "terminar de trabajar", category: "Routine" },
+      { english: "exercise", spanish: "hacer ejercicio", category: "Routine" },
+      { english: "have dinner", spanish: "cenar", category: "Routine" },
+      { english: "relax", spanish: "relajarse", category: "Routine" },
+      { english: "go to bed", spanish: "acostarse", category: "Routine" },
+    ] as CognateWord[],
+  },
+  wave3: {
+    title: "Time Period Expressions — When and How Often",
+    titleEs: "Expresiones de Período — Cuándo y Con Qué Frecuencia",
+    description:
+      "While frequency adverbs (always, usually) go BEFORE the verb, these phrases go at the END or BEGINNING of the sentence. They tell you the period: every day, on Mondays, twice a week.",
+    descriptionEs:
+      "Mientras los adverbios de frecuencia (always, usually) van ANTES del verbo, estas frases van al FINAL o INICIO de la oración. Te dicen el período: every day, on Mondays, twice a week.",
+    words: [
+      { english: "every day", spanish: "todos los días", category: "Period" },
+      { english: "every week", spanish: "cada semana", category: "Period" },
+      { english: "every weekend", spanish: "cada fin de semana", category: "Period" },
+      { english: "once a week", spanish: "una vez a la semana", category: "Period" },
+      { english: "twice a month", spanish: "dos veces al mes", category: "Period" },
+      { english: "three times a year", spanish: "tres veces al año", category: "Period" },
+      { english: "on Mondays", spanish: "los lunes", category: "Period" },
+      { english: "on weekends", spanish: "los fines de semana", category: "Period" },
+      { english: "in the morning", spanish: "en la mañana", category: "Period" },
+      { english: "at night", spanish: "en la noche", category: "Period" },
+      { english: "after work", spanish: "después del trabajo", category: "Period" },
+      { english: "before bed", spanish: "antes de dormir", category: "Period" },
+    ] as CognateWord[],
+  },
+};
+
+// ─── Section B: Position Rules for Frequency Adverbs ─────────────────────────
+
+export const sentenceBlocks: SentenceBlock[] = [
+  {
+    label: "Step 1: BEFORE the main verb (the most common rule)",
+    labelEs: "Paso 1: ANTES del verbo principal (la regla más común)",
+    description:
+      "With ALL regular verbs (work, eat, drink, go, etc.), the frequency adverb goes BETWEEN the subject and the verb. NOT at the end like in Spanish. 'I always work' — never 'I work always'.",
+    descriptionEs:
+      "Con TODOS los verbos regulares (work, eat, drink, go, etc.), el adverbio de frecuencia va ENTRE el sujeto y el verbo. NO al final como en español. 'I always work' — nunca 'I work always'.",
+    sentences: [
+      { english: "I always drink coffee in the morning.", spanish: "Siempre tomo café en la mañana.", highlight: "always" },
+      { english: "She usually takes the subway to work.", spanish: "Ella usualmente toma el metro al trabajo.", highlight: "usually" },
+      { english: "We often have dinner together.", spanish: "A menudo cenamos juntos.", highlight: "often" },
+      { english: "He never eats breakfast.", spanish: "Él nunca desayuna.", highlight: "never" },
+    ],
+  },
+  {
+    label: "Step 2: AFTER the verb 'BE' (am, is, are, was, were)",
+    labelEs: "Paso 2: DESPUÉS del verbo 'BE' (am, is, are, was, were)",
+    description:
+      "When the verb is BE, the rule FLIPS — adverb goes AFTER. 'She is always late' — NOT 'She always is late'. This is the #1 trap for Spanish speakers.",
+    descriptionEs:
+      "Cuando el verbo es BE, la regla SE INVIERTE — el adverbio va DESPUÉS. 'She is always late' — NO 'She always is late'. Este es el error #1 de los hispanohablantes.",
+    sentences: [
+      { english: "She is usually late for meetings.", spanish: "Ella usualmente llega tarde a las juntas.", highlight: "is usually" },
+      { english: "I am always tired on Mondays.", spanish: "Siempre estoy cansado los lunes.", highlight: "am always" },
+      { english: "They are never on time.", spanish: "Ellos nunca llegan a tiempo.", highlight: "are never" },
+      { english: "He was often confused.", spanish: "Él a menudo estaba confundido.", highlight: "was often" },
+    ],
+  },
+  {
+    label: "Step 3: BETWEEN auxiliary and main verb",
+    labelEs: "Paso 3: ENTRE el auxiliar y el verbo principal",
+    description:
+      "With auxiliary verbs (have, can, will, should, would, do/does/did), the adverb goes BETWEEN the auxiliary and the main verb. 'I have never been there' — NOT 'I never have been there'.",
+    descriptionEs:
+      "Con verbos auxiliares (have, can, will, should, would, do/does/did), el adverbio va ENTRE el auxiliar y el verbo principal. 'I have never been there' — NO 'I never have been there'.",
+    sentences: [
+      { english: "I have never been to Paris.", spanish: "Nunca he ido a París.", highlight: "have never been" },
+      { english: "She can usually speak in meetings.", spanish: "Ella usualmente puede hablar en juntas.", highlight: "can usually speak" },
+      { english: "We will always remember this day.", spanish: "Siempre recordaremos este día.", highlight: "will always remember" },
+      { english: "He doesn't often call his parents.", spanish: "Él no llama a sus padres a menudo.", highlight: "doesn't often call" },
+    ],
+  },
+  {
+    label: "Step 4: 'Sometimes' and 'usually' — the flexible ones",
+    labelEs: "Paso 4: 'Sometimes' y 'usually' — los flexibles",
+    description:
+      "'Sometimes' and 'usually' can ALSO start the sentence for emphasis or variety. 'Always' and 'never' CAN'T do this in normal speech. 'Sometimes I work late' is natural; 'Always I work' is wrong.",
+    descriptionEs:
+      "'Sometimes' y 'usually' TAMBIÉN pueden iniciar la oración para énfasis o variedad. 'Always' y 'never' NO pueden hacer esto en habla normal. 'Sometimes I work late' es natural; 'Always I work' es incorrecto.",
+    sentences: [
+      { english: "Sometimes I work late on Fridays.", spanish: "A veces trabajo tarde los viernes.", highlight: "Sometimes (start)" },
+      { english: "Usually we eat at home, but tonight we're going out.", spanish: "Usualmente comemos en casa, pero esta noche salimos.", highlight: "Usually (start)" },
+      { english: "I sometimes work from a coffee shop.", spanish: "A veces trabajo desde una cafetería.", highlight: "sometimes (middle)" },
+      { english: "We usually have lunch at noon.", spanish: "Usualmente almorzamos al mediodía.", highlight: "usually (middle)" },
+    ],
+  },
+];
+
+// ─── Section C: Frequency Phrases — Time Periods ─────────────────────────────
+
+export const powerVerbBlocks: SentenceBlock[] = [
+  {
+    label: "'Every X' — Every day, every week, every Monday",
+    labelEs: "'Every X' — Every day, every week, every Monday",
+    description:
+      "'Every + period' is the simplest way to say 100% frequency. Goes at the END of the sentence (or sometimes the start). NEVER use 'all the days' — say 'every day'.",
+    descriptionEs:
+      "'Every + período' es la forma más simple de decir frecuencia 100%. Va al FINAL de la oración (o a veces al inicio). NUNCA digas 'all the days' — di 'every day'.",
+    sentences: [
+      { english: "I drink coffee every morning.", spanish: "Tomo café cada mañana.", highlight: "every morning" },
+      { english: "She goes to the gym every other day.", spanish: "Ella va al gimnasio día de por medio.", highlight: "every other day" },
+      { english: "We have a team meeting every Tuesday.", spanish: "Tenemos junta de equipo cada martes.", highlight: "every Tuesday" },
+      { english: "He calls his mother every week.", spanish: "Él llama a su mamá cada semana.", highlight: "every week" },
+    ],
+  },
+  {
+    label: "'Once / twice / three times a [period]'",
+    labelEs: "'Once / twice / three times a [período]'",
+    description:
+      "Numerical frequency. 'Once' = one time. 'Twice' = two times. After two, switch to 'X times': three times, four times. End of sentence.",
+    descriptionEs:
+      "Frecuencia numérica. 'Once' = una vez. 'Twice' = dos veces. Después de dos, cambia a 'X times': three times, four times. Al final de la oración.",
+    sentences: [
+      { english: "I exercise three times a week.", spanish: "Hago ejercicio tres veces a la semana.", highlight: "three times a week" },
+      { english: "We meet once a month.", spanish: "Nos reunimos una vez al mes.", highlight: "once a month" },
+      { english: "She travels for work twice a year.", spanish: "Ella viaja por trabajo dos veces al año.", highlight: "twice a year" },
+      { english: "I check my email about ten times a day.", spanish: "Reviso mi correo unas diez veces al día.", highlight: "ten times a day" },
+    ],
+  },
+  {
+    label: "'On + day' / 'In + part of day'",
+    labelEs: "'On + día' / 'In + parte del día'",
+    description:
+      "'ON' for days: on Monday, on weekends, on weekdays. 'IN' for parts of the day: in the morning, in the afternoon. EXCEPTION: 'AT night', 'AT lunch'.",
+    descriptionEs:
+      "'ON' para días: on Monday, on weekends, on weekdays. 'IN' para partes del día: in the morning, in the afternoon. EXCEPCIÓN: 'AT night', 'AT lunch'.",
+    sentences: [
+      { english: "I usually go running in the morning.", spanish: "Usualmente salgo a correr en la mañana.", highlight: "in the morning" },
+      { english: "We don't work on weekends.", spanish: "No trabajamos los fines de semana.", highlight: "on weekends" },
+      { english: "She studies English at night.", spanish: "Ella estudia inglés en la noche.", highlight: "at night" },
+      { english: "Our team meets on Tuesdays and Thursdays.", spanish: "Nuestro equipo se reúne los martes y jueves.", highlight: "on Tuesdays" },
+    ],
+  },
+  {
+    label: "'How often' — Asking and Answering",
+    labelEs: "'How often' — Preguntar y Responder",
+    description:
+      "'How often do you…?' is the question. The answer can be a frequency adverb (usually, sometimes) OR a phrase (every day, twice a week). Both are correct.",
+    descriptionEs:
+      "'How often do you…?' es la pregunta. La respuesta puede ser un adverbio de frecuencia (usually, sometimes) O una frase (every day, twice a week). Ambas son correctas.",
+    sentences: [
+      { english: "How often do you exercise? — I usually exercise three times a week.", spanish: "¿Con qué frecuencia haces ejercicio? — Usualmente hago ejercicio tres veces a la semana.", highlight: "How often" },
+      { english: "How often does she travel? — She rarely travels.", spanish: "¿Con qué frecuencia viaja ella? — Ella casi nunca viaja.", highlight: "How often" },
+      { english: "How often do you check email? — Every hour.", spanish: "¿Con qué frecuencia revisas el correo? — Cada hora.", highlight: "How often" },
+      { english: "How often do you eat out? — About twice a month.", spanish: "¿Con qué frecuencia comes fuera? — Unas dos veces al mes.", highlight: "How often" },
+    ],
+  },
+];
+
+// ─── Section D: Boss Sentence — A Typical Week (Connector Challenge) ─────────
+
+export const connectorSentences = {
+  connectors: [
+    {
+      word: "usually",
+      wordEs: "usualmente",
+      example: "I usually wake up at 6:30.",
+      exampleEs: "Usualmente me despierto a las 6:30.",
+      use: "Goes BEFORE main verbs ('I usually wake up'). Means roughly 90% — your default behavior.",
+      useEs: "Va ANTES de verbos principales ('I usually wake up'). Significa ~90% — tu comportamiento por defecto.",
+    },
+    {
+      word: "always",
+      wordEs: "siempre",
+      example: "I always drink coffee first.",
+      exampleEs: "Siempre tomo café primero.",
+      use: "100%. Goes BEFORE main verbs, AFTER 'be'. NEVER at the end of the sentence.",
+      useEs: "100%. Va ANTES de verbos principales, DESPUÉS de 'be'. NUNCA al final de la oración.",
+    },
+    {
+      word: "every day",
+      wordEs: "cada día",
+      example: "I check my email every day.",
+      exampleEs: "Reviso mi correo cada día.",
+      use: "End-of-sentence frequency phrase. Same meaning as 'always' for repeated actions.",
+      useEs: "Frase de frecuencia al final de la oración. Mismo significado que 'always' para acciones repetidas.",
+    },
+    {
+      word: "three times a week",
+      wordEs: "tres veces a la semana",
+      example: "I exercise three times a week.",
+      exampleEs: "Hago ejercicio tres veces a la semana.",
+      use: "Numerical frequency. Goes at the end. After 'twice', switch to 'X times'.",
+      useEs: "Frecuencia numérica. Va al final. Después de 'twice', cambia a 'X times'.",
+    },
+    {
+      word: "sometimes",
+      wordEs: "a veces",
+      example: "Sometimes I work from a coffee shop.",
+      exampleEs: "A veces trabajo desde una cafetería.",
+      use: "~50%. The most flexible — can start the sentence OR go before the verb.",
+      useEs: "~50%. El más flexible — puede iniciar la oración O ir antes del verbo.",
+    },
+    {
+      word: "rarely",
+      wordEs: "casi nunca",
+      example: "I rarely watch TV.",
+      exampleEs: "Casi nunca veo televisión.",
+      use: "~10%. Goes BEFORE the main verb. Stronger than 'sometimes', weaker than 'never'.",
+      useEs: "~10%. Va ANTES del verbo principal. Más fuerte que 'sometimes', más débil que 'never'.",
+    },
+  ],
+  bossSentence: {
+    english:
+      "I usually wake up at 6:30, and I always drink coffee first. I check my email every day before work, and I exercise three times a week. Sometimes I work from a coffee shop, but I rarely work on weekends. My team has a meeting every Monday morning, and we never start late.",
+    spanish:
+      "Usualmente me despierto a las 6:30, y siempre tomo café primero. Reviso mi correo cada día antes del trabajo, y hago ejercicio tres veces a la semana. A veces trabajo desde una cafetería, pero casi nunca trabajo los fines de semana. Mi equipo tiene una junta cada lunes en la mañana, y nunca empezamos tarde.",
+    explanation:
+      "Six frequency expressions, six different positions: 'usually' before main verb, 'always' before main verb, 'every day' at end, 'three times a week' at end, 'sometimes' at start, 'rarely' before main verb, 'every Monday morning' at end, 'never' before main verb. This is what natural daily-life talk sounds like.",
+    explanationEs:
+      "Seis expresiones de frecuencia, seis posiciones diferentes: 'usually' antes del verbo principal, 'always' antes del verbo principal, 'every day' al final, 'three times a week' al final, 'sometimes' al inicio, 'rarely' antes del verbo principal, 'every Monday morning' al final, 'never' antes del verbo principal. Así suena hablar de la vida diaria de forma natural.",
+  },
+};
+
+// ─── Section E: Pronunciation Lab — Frequency Adverb Sounds ──────────────────
+
+export const pronunciationDrills: PronunciationDrillItem[] = [
+  {
+    word: "always",
+    spanishStress: "AL-WAYS (Spanish vowels)",
+    englishStress: "ALL-wayz (the 'a' is the 'aw' sound, like 'ball')",
+    tip: "First syllable sounds like 'ALL'. Second syllable rhymes with 'ways'. The final 's' sounds like 'z'.",
+    tipEs: "La primera sílaba suena como 'ALL'. La segunda rima con 'ways'. La 's' final suena como 'z'.",
+  },
+  {
+    word: "usually",
+    spanishStress: "U-SUAL-LY (3 syllables, Spanish vowels)",
+    englishStress: "YOO-zhuh-lee (3 syllables, soft 'zh' middle)",
+    tip: "Three syllables: YOO-zhuh-lee. The middle is a soft 'zh' (like the French 'j' in 'bonjour'). NOT 'oo-soo-AL-ly'.",
+    tipEs: "Tres sílabas: YOO-zhuh-lee. La parte media es 'zh' suave (como 'j' francesa en 'bonjour'). NO 'oo-soo-AL-ly'.",
+  },
+  {
+    word: "often",
+    spanishStress: "OF-TEN (Spanish 'o' and clear 't')",
+    englishStress: "OFF-en (silent 't' for most speakers)",
+    tip: "Most Americans drop the 't': 'OFF-en'. Both 'OFF-en' and 'OFF-ten' are correct. The 'o' sounds like 'aw' or 'ah'.",
+    tipEs: "La mayoría de americanos quita la 't': 'OFF-en'. Tanto 'OFF-en' como 'OFF-ten' son correctos. La 'o' suena como 'aw' o 'ah'.",
+  },
+  {
+    word: "sometimes",
+    spanishStress: "SOME-TIMES (Spanish vowels)",
+    englishStress: "SUM-tymez (rhymes with 'sum' + 'times')",
+    tip: "First part rhymes with the math word 'sum'. Second part is 'times' with a 'z' sound at the end.",
+    tipEs: "La primera parte rima con 'sum' (matemática). La segunda es 'times' con sonido 'z' al final.",
+  },
+  {
+    word: "rarely",
+    spanishStress: "RA-RE-LY (Spanish 'a' and rolled 'r')",
+    englishStress: "RAIR-lee (American 'r', 2 syllables)",
+    tip: "First syllable rhymes with 'air'. American 'r' — pulled back, NOT rolled. Two syllables only.",
+    tipEs: "La primera sílaba rima con 'air'. 'r' americana — se retrae, NO se rueda. Solo dos sílabas.",
+  },
+  {
+    word: "never",
+    spanishStress: "NE-VER (Spanish 'e' and rolled 'r')",
+    englishStress: "NEH-vur (short 'e', soft American 'r')",
+    tip: "Short 'e' like 'pen'. Final 'r' is soft American 'r'. Two syllables: NEH-vur.",
+    tipEs: "'e' corta como 'pen'. La 'r' final es 'r' americana suave. Dos sílabas: NEH-vur.",
+  },
+  {
+    word: "hardly ever",
+    spanishStress: "HARD-LY E-VER (4 distinct syllables)",
+    englishStress: "HARD-lee-EV-ur (linked, almost 3 beats)",
+    tip: "The 'y' of 'hardly' links to the 'e' of 'ever' — sounds like one phrase: 'HARD-lee-EV-ur'.",
+    tipEs: "La 'y' de 'hardly' se enlaza con la 'e' de 'ever' — suena como una frase: 'HARD-lee-EV-ur'.",
+  },
+  {
+    word: "every day",
+    spanishStress: "E-VE-RY DAY (4 syllables)",
+    englishStress: "EV-ree-DAY (3 syllables, middle 'e' drops)",
+    tip: "The middle 'e' often DROPS in fast speech: 'EV-ree' instead of 'EV-er-ee'. Then 'DAY' is stressed.",
+    tipEs: "La 'e' del medio a menudo DESAPARECE en habla rápida: 'EV-ree' en vez de 'EV-er-ee'. Luego 'DAY' acentuado.",
+  },
+];
+
+// ─── Section F: Vocabulary List for Self-Test ────────────────────────────────
+
+export const vocabularyList: VocabItem[] = [
+  // Frequency adverbs
+  { english: "always", spanish: "siempre", type: "marker" },
+  { english: "usually", spanish: "usualmente", type: "marker" },
+  { english: "often", spanish: "a menudo", type: "marker" },
+  { english: "sometimes", spanish: "a veces", type: "marker" },
+  { english: "rarely", spanish: "casi nunca", type: "marker" },
+  { english: "hardly ever", spanish: "casi nunca", type: "marker" },
+  { english: "never", spanish: "nunca", type: "marker" },
+  // Routine verbs
+  { english: "wake up", spanish: "despertarse", type: "verb" },
+  { english: "get up", spanish: "levantarse", type: "verb" },
+  { english: "take a shower", spanish: "ducharse", type: "verb" },
+  { english: "have breakfast", spanish: "desayunar", type: "verb" },
+  { english: "commute", spanish: "trasladarse al trabajo", type: "verb" },
+  { english: "have lunch", spanish: "almorzar", type: "verb" },
+  { english: "finish work", spanish: "terminar de trabajar", type: "verb" },
+  { english: "exercise", spanish: "hacer ejercicio", type: "verb" },
+  { english: "have dinner", spanish: "cenar", type: "verb" },
+  { english: "go to bed", spanish: "acostarse", type: "verb" },
+  // Time period expressions
+  { english: "every day", spanish: "todos los días", type: "marker" },
+  { english: "every weekend", spanish: "cada fin de semana", type: "marker" },
+  { english: "once a week", spanish: "una vez a la semana", type: "marker" },
+  { english: "twice a month", spanish: "dos veces al mes", type: "marker" },
+  { english: "three times a year", spanish: "tres veces al año", type: "marker" },
+  { english: "on Mondays", spanish: "los lunes", type: "marker" },
+  { english: "on weekends", spanish: "los fines de semana", type: "marker" },
+  { english: "in the morning", spanish: "en la mañana", type: "marker" },
+  { english: "at night", spanish: "en la noche", type: "marker" },
+  { english: "after work", spanish: "después del trabajo", type: "marker" },
+  // Useful phrases
+  { english: "I always drink coffee.", spanish: "Siempre tomo café.", type: "phrase" },
+  { english: "She is usually late.", spanish: "Ella usualmente llega tarde.", type: "phrase" },
+  { english: "We often have dinner together.", spanish: "A menudo cenamos juntos.", type: "phrase" },
+  { english: "He never eats breakfast.", spanish: "Él nunca desayuna.", type: "phrase" },
+  { english: "I have never been to Paris.", spanish: "Nunca he ido a París.", type: "phrase" },
+  { english: "I exercise three times a week.", spanish: "Hago ejercicio tres veces a la semana.", type: "phrase" },
+  { english: "How often do you travel?", spanish: "¿Con qué frecuencia viajas?", type: "phrase" },
+  { english: "Sometimes I work late.", spanish: "A veces trabajo tarde.", type: "phrase" },
+];

--- a/src/data/elementary/unit-9.ts
+++ b/src/data/elementary/unit-9.ts
@@ -1,0 +1,424 @@
+// Unit 9: "I Was Eating When…" — Past Continuous
+//
+// Pedagogical arc:
+// Section A — 3 waves: was/were forms, common -ing verbs, narrative time markers
+// Section B — Past continuous structure (was/were + verb-ing)
+// Section C — The classic combo: past continuous + past simple (one action interrupts another)
+// Section D — Boss Sentence: a real personal narrative
+// Section E — Pronunciation: was/were reduction in fast speech
+// Section F — Self-test of unit vocabulary
+
+export interface CognateWord {
+  english: string;
+  spanish: string;
+  category: string;
+  pronunciationNote?: string;
+  pronunciationNoteEs?: string;
+}
+
+export interface SentenceBlock {
+  label: string;
+  labelEs: string;
+  description: string;
+  descriptionEs: string;
+  sentences: {
+    english: string;
+    spanish: string;
+    highlight?: string;
+  }[];
+}
+
+export interface PronunciationDrillItem {
+  word: string;
+  spanishStress: string;
+  englishStress: string;
+  tip: string;
+  tipEs: string;
+}
+
+export interface VocabItem {
+  english: string;
+  spanish: string;
+  type: "verb" | "phrase" | "marker";
+}
+
+// ─── Section A: was/were, -ing verbs, narrative time markers ─────────────────
+
+export const cognateWaves = {
+  wave1: {
+    title: "Was / Were — The Backbone of Past Continuous",
+    titleEs: "Was / Were — La Base del Pasado Continuo",
+    description:
+      "Past continuous always starts with 'was' or 'were'. 'Was' goes with I/he/she/it. 'Were' goes with you/we/they. Memorize this pairing — it never changes.",
+    descriptionEs:
+      "El pasado continuo siempre empieza con 'was' o 'were'. 'Was' va con I/he/she/it. 'Were' va con you/we/they. Memoriza este emparejamiento — nunca cambia.",
+    words: [
+      { english: "I was", spanish: "yo estaba", category: "Subject + was/were" },
+      { english: "you were", spanish: "tú estabas", category: "Subject + was/were" },
+      { english: "he was", spanish: "él estaba", category: "Subject + was/were" },
+      { english: "she was", spanish: "ella estaba", category: "Subject + was/were" },
+      { english: "it was", spanish: "estaba (cosa)", category: "Subject + was/were" },
+      { english: "we were", spanish: "nosotros estábamos", category: "Subject + was/were" },
+      { english: "they were", spanish: "ellos estaban", category: "Subject + was/were" },
+      {
+        english: "wasn't",
+        spanish: "no estaba",
+        category: "Subject + was/were",
+        pronunciationNote: "Contraction of 'was not'. Sounds like 'WUZ-int'.",
+        pronunciationNoteEs: "Contracción de 'was not'. Suena como 'WUZ-int'.",
+      },
+      {
+        english: "weren't",
+        spanish: "no estaban",
+        category: "Subject + was/were",
+        pronunciationNote: "Contraction of 'were not'. Sounds like 'WURNT' (one syllable).",
+        pronunciationNoteEs: "Contracción de 'were not'. Suena como 'WURNT' (una sílaba).",
+      },
+    ] as CognateWord[],
+  },
+  wave2: {
+    title: "Common -ing Verbs in Storytelling",
+    titleEs: "Verbos -ing Comunes al Contar Historias",
+    description:
+      "These twelve verbs cover most past-continuous storytelling. Spelling rule: drop a final 'e' before -ing (write → writing); double a final consonant after a short vowel (run → running).",
+    descriptionEs:
+      "Estos doce verbos cubren la mayoría del pasado continuo al contar historias. Regla de escritura: quita la 'e' final antes de -ing (write → writing); duplica la consonante final después de vocal corta (run → running).",
+    words: [
+      { english: "eating", spanish: "comiendo", category: "-ing verb" },
+      { english: "drinking", spanish: "tomando", category: "-ing verb" },
+      { english: "working", spanish: "trabajando", category: "-ing verb" },
+      { english: "talking", spanish: "hablando", category: "-ing verb" },
+      {
+        english: "writing",
+        spanish: "escribiendo",
+        category: "-ing verb",
+        pronunciationNote: "Drop the 'e': write → writing (NOT 'writeing').",
+        pronunciationNoteEs: "Quita la 'e': write → writing (NO 'writeing').",
+      },
+      { english: "reading", spanish: "leyendo", category: "-ing verb" },
+      {
+        english: "running",
+        spanish: "corriendo",
+        category: "-ing verb",
+        pronunciationNote: "Double the 'n': run → running (NOT 'runing').",
+        pronunciationNoteEs: "Duplica la 'n': run → running (NO 'runing').",
+      },
+      { english: "driving", spanish: "manejando", category: "-ing verb" },
+      { english: "watching", spanish: "viendo", category: "-ing verb" },
+      { english: "listening", spanish: "escuchando", category: "-ing verb" },
+      { english: "studying", spanish: "estudiando", category: "-ing verb" },
+      { english: "sleeping", spanish: "durmiendo", category: "-ing verb" },
+    ] as CognateWord[],
+  },
+  wave3: {
+    title: "Narrative Time Markers — When Stories Pivot",
+    titleEs: "Marcadores Narrativos — Cuando la Historia Gira",
+    description:
+      "These connectors move stories from background ('I was eating') to interruption ('when she called'). Master them and your stories suddenly feel native.",
+    descriptionEs:
+      "Estos conectores mueven historias del fondo ('I was eating') a la interrupción ('when she called'). Domínalos y tus historias se sienten nativas.",
+    words: [
+      { english: "when", spanish: "cuando", category: "Time marker" },
+      { english: "while", spanish: "mientras", category: "Time marker" },
+      { english: "as", spanish: "mientras / cuando", category: "Time marker" },
+      { english: "suddenly", spanish: "de repente", category: "Time marker" },
+      { english: "at that moment", spanish: "en ese momento", category: "Time marker" },
+      { english: "just then", spanish: "justo entonces", category: "Time marker" },
+      { english: "all of a sudden", spanish: "de pronto", category: "Time marker" },
+      { english: "meanwhile", spanish: "mientras tanto", category: "Time marker" },
+      { english: "at 8 o'clock", spanish: "a las ocho", category: "Time marker" },
+      { english: "yesterday afternoon", spanish: "ayer en la tarde", category: "Time marker" },
+      { english: "this morning", spanish: "esta mañana", category: "Time marker" },
+      { english: "last night", spanish: "anoche", category: "Time marker" },
+    ] as CognateWord[],
+  },
+};
+
+// ─── Section B: Past Continuous Structure ────────────────────────────────────
+
+export const sentenceBlocks: SentenceBlock[] = [
+  {
+    label: "Step 1: Affirmative — was/were + verb-ing",
+    labelEs: "Paso 1: Afirmativo — was/were + verbo-ing",
+    description:
+      "Subject + was/were + verb-ing. Use for an action IN PROGRESS at a past moment. NOT for a single quick action — that's past simple.",
+    descriptionEs:
+      "Sujeto + was/were + verbo-ing. Úsalo para una acción EN PROGRESO en un momento pasado. NO para una acción única y rápida — eso es pasado simple.",
+    sentences: [
+      { english: "I was reading at 9 p.m. last night.", spanish: "Yo estaba leyendo a las 9 de la noche.", highlight: "was reading" },
+      { english: "She was working from home all morning.", spanish: "Ella estaba trabajando desde casa toda la mañana.", highlight: "was working" },
+      { english: "We were eating dinner when you called.", spanish: "Estábamos cenando cuando llamaste.", highlight: "were eating" },
+      { english: "They were studying for the test.", spanish: "Ellos estaban estudiando para el examen.", highlight: "were studying" },
+    ],
+  },
+  {
+    label: "Step 2: Negative — wasn't / weren't + verb-ing",
+    labelEs: "Paso 2: Negativo — wasn't / weren't + verbo-ing",
+    description:
+      "Add 'not' (or contract to wasn't/weren't) right after was/were. The -ing verb stays the same. NEVER 'I no was working' — that's a Spanish-style negation.",
+    descriptionEs:
+      "Agrega 'not' (o contrae a wasn't/weren't) justo después de was/were. El verbo -ing queda igual. NUNCA 'I no was working' — esa es negación al estilo español.",
+    sentences: [
+      { english: "I wasn't sleeping when you called.", spanish: "No estaba durmiendo cuando llamaste.", highlight: "wasn't sleeping" },
+      { english: "She wasn't listening to the meeting.", spanish: "Ella no estaba escuchando la junta.", highlight: "wasn't listening" },
+      { english: "We weren't talking about you.", spanish: "No estábamos hablando de ti.", highlight: "weren't talking" },
+      { english: "They weren't paying attention.", spanish: "Ellos no estaban poniendo atención.", highlight: "weren't paying" },
+    ],
+  },
+  {
+    label: "Step 3: Question — Was/Were + subject + verb-ing?",
+    labelEs: "Paso 3: Pregunta — Was/Were + sujeto + verbo-ing?",
+    description:
+      "Flip was/were to the front. NO 'do/did' needed (was/were already act as the helper). 'Were you sleeping?' — NOT 'Did you were sleeping?'.",
+    descriptionEs:
+      "Mueve was/were al frente. NO se necesita 'do/did' (was/were ya son el ayudante). 'Were you sleeping?' — NO 'Did you were sleeping?'.",
+    sentences: [
+      { english: "Were you working late last night?", spanish: "¿Estabas trabajando tarde anoche?", highlight: "Were you working" },
+      { english: "Was she crying when you arrived?", spanish: "¿Estaba ella llorando cuando llegaste?", highlight: "Was she crying" },
+      { english: "What were you doing at 7?", spanish: "¿Qué estabas haciendo a las 7?", highlight: "were you doing" },
+      { english: "Why was he waiting outside?", spanish: "¿Por qué estaba esperando afuera?", highlight: "was he waiting" },
+    ],
+  },
+  {
+    label: "Step 4: Past simple vs. past continuous — when to use which",
+    labelEs: "Paso 4: Pasado simple vs. continuo — cuándo usar cuál",
+    description:
+      "Past SIMPLE = one finished action ('I ate dinner'). Past CONTINUOUS = an action in progress ('I was eating dinner'). The continuous emphasizes that you were IN THE MIDDLE of it.",
+    descriptionEs:
+      "Pasado SIMPLE = una acción terminada ('I ate dinner'). Pasado CONTINUO = una acción en progreso ('I was eating dinner'). El continuo enfatiza que estabas EN MEDIO de hacerlo.",
+    sentences: [
+      { english: "I worked yesterday. (the whole day, completed)", spanish: "Trabajé ayer. (todo el día, completado)", highlight: "worked" },
+      { english: "I was working at 3 p.m. (in progress at that moment)", spanish: "Estaba trabajando a las 3 p.m. (en progreso en ese momento)", highlight: "was working" },
+      { english: "She studied for two hours. (finished)", spanish: "Ella estudió dos horas. (terminado)", highlight: "studied" },
+      { english: "She was studying when I arrived. (in progress when I came)", spanish: "Ella estaba estudiando cuando llegué. (en progreso cuando llegué)", highlight: "was studying" },
+    ],
+  },
+];
+
+// ─── Section C: The Interruption Pattern (Past Continuous + Past Simple) ─────
+
+export const powerVerbBlocks: SentenceBlock[] = [
+  {
+    label: "The Classic Combo — Continuous + Simple with 'when'",
+    labelEs: "La Combinación Clásica — Continuo + Simple con 'when'",
+    description:
+      "PAST CONTINUOUS = the longer, background action. PAST SIMPLE = the shorter action that interrupts it. Use 'when' before the SIMPLE action: 'I was eating WHEN she called'.",
+    descriptionEs:
+      "PASADO CONTINUO = la acción larga, de fondo. PASADO SIMPLE = la acción corta que interrumpe. Usa 'when' antes de la acción SIMPLE: 'I was eating WHEN she called'.",
+    sentences: [
+      { english: "I was eating dinner when she called.", spanish: "Estaba cenando cuando ella llamó.", highlight: "was eating / called" },
+      { english: "We were watching TV when the lights went out.", spanish: "Estábamos viendo tele cuando se fue la luz.", highlight: "were watching / went out" },
+      { english: "He was driving home when it started to rain.", spanish: "Él estaba manejando a casa cuando empezó a llover.", highlight: "was driving / started" },
+      { english: "She was reading when her phone rang.", spanish: "Ella estaba leyendo cuando sonó su teléfono.", highlight: "was reading / rang" },
+    ],
+  },
+  {
+    label: "'While' — for the longer (continuous) action",
+    labelEs: "'While' — para la acción más larga (continua)",
+    description:
+      "'While' goes with the PAST CONTINUOUS — the longer action. 'When' typically goes with the PAST SIMPLE — the interruption. Both sentences below mean the same thing.",
+    descriptionEs:
+      "'While' va con el PASADO CONTINUO — la acción más larga. 'When' va típicamente con el PASADO SIMPLE — la interrupción. Ambas oraciones significan lo mismo.",
+    sentences: [
+      { english: "While I was cooking, the doorbell rang.", spanish: "Mientras cocinaba, sonó el timbre.", highlight: "While + cooking" },
+      { english: "The doorbell rang while I was cooking.", spanish: "Sonó el timbre mientras cocinaba.", highlight: "while + cooking" },
+      { english: "While she was working, her cat jumped on the keyboard.", spanish: "Mientras ella trabajaba, su gato saltó al teclado.", highlight: "While + working" },
+      { english: "I met an old friend while I was waiting for the train.", spanish: "Me encontré con un viejo amigo mientras esperaba el tren.", highlight: "while + waiting" },
+    ],
+  },
+  {
+    label: "Two Continuous Actions at the Same Time",
+    labelEs: "Dos Acciones Continuas al Mismo Tiempo",
+    description:
+      "Use TWO past continuous verbs (with 'while' or 'as') when both actions were happening at the same moment, and BOTH are background — neither interrupts the other.",
+    descriptionEs:
+      "Usa DOS verbos en pasado continuo (con 'while' o 'as') cuando ambas acciones pasaban al mismo tiempo, y AMBAS son de fondo — ninguna interrumpe a la otra.",
+    sentences: [
+      { english: "While I was cooking, my husband was setting the table.", spanish: "Mientras cocinaba, mi esposo ponía la mesa.", highlight: "was cooking / was setting" },
+      { english: "She was working while the kids were playing outside.", spanish: "Ella trabajaba mientras los niños jugaban afuera.", highlight: "was working / were playing" },
+      { english: "I was driving as she was telling me the story.", spanish: "Yo manejaba mientras ella me contaba la historia.", highlight: "was driving / was telling" },
+      { english: "We were eating while they were arguing.", spanish: "Estábamos comiendo mientras ellos discutían.", highlight: "were eating / were arguing" },
+    ],
+  },
+  {
+    label: "'Suddenly' / 'All of a sudden' — Drama Triggers",
+    labelEs: "'Suddenly' / 'All of a sudden' — Disparadores de Drama",
+    description:
+      "Add 'suddenly' before the PAST SIMPLE interruption to make stories pop. This is the same beat that movie directors use: long shot of the background, then BAM — the event.",
+    descriptionEs:
+      "Agrega 'suddenly' antes de la interrupción en PASADO SIMPLE para que tus historias emocionen. Es el mismo ritmo que usan los directores de cine: plano largo del fondo, y luego ¡BAM! — el evento.",
+    sentences: [
+      { english: "I was walking home when suddenly I heard a noise.", spanish: "Iba caminando a casa cuando de repente oí un ruido.", highlight: "suddenly heard" },
+      { english: "We were laughing when all of a sudden the lights went out.", spanish: "Estábamos riéndonos cuando de pronto se fue la luz.", highlight: "all of a sudden went out" },
+      { english: "She was crossing the street when suddenly a dog appeared.", spanish: "Ella estaba cruzando la calle cuando de repente apareció un perro.", highlight: "suddenly appeared" },
+      { english: "He was sleeping when suddenly the alarm rang.", spanish: "Él estaba durmiendo cuando de repente sonó la alarma.", highlight: "suddenly rang" },
+    ],
+  },
+];
+
+// ─── Section D: Boss Sentence — A Real Personal Narrative ───────────────────
+
+export const connectorSentences = {
+  connectors: [
+    {
+      word: "was/were + verb-ing",
+      wordEs: "was/were + verbo-ing",
+      example: "I was walking home from work.",
+      exampleEs: "Iba caminando a casa después del trabajo.",
+      use: "Past continuous — the longer background action. Sets the scene for the story.",
+      useEs: "Pasado continuo — la acción larga de fondo. Pone la escena para la historia.",
+    },
+    {
+      word: "when",
+      wordEs: "cuando",
+      example: "…when my phone rang.",
+      exampleEs: "…cuando sonó mi teléfono.",
+      use: "Goes with the past simple — the short interruption. The pivot point of the story.",
+      useEs: "Va con el pasado simple — la interrupción corta. El punto de giro de la historia.",
+    },
+    {
+      word: "suddenly",
+      wordEs: "de repente",
+      example: "Suddenly, it started to rain.",
+      exampleEs: "De repente, empezó a llover.",
+      use: "Adds drama before a past simple action. Makes the interruption hit harder.",
+      useEs: "Agrega drama antes de una acción en pasado simple. Hace que la interrupción pegue más fuerte.",
+    },
+    {
+      word: "while",
+      wordEs: "mientras",
+      example: "While I was waiting, I called my friend.",
+      exampleEs: "Mientras esperaba, llamé a mi amigo.",
+      use: "Pairs with past continuous (the longer action). Often interchangeable with 'when' but feels longer.",
+      useEs: "Va con el pasado continuo (la acción más larga). A menudo intercambiable con 'when' pero se siente más larga.",
+    },
+    {
+      word: "at that moment",
+      wordEs: "en ese momento",
+      example: "…and at that moment, I realized something important.",
+      exampleEs: "…y en ese momento, me di cuenta de algo importante.",
+      use: "A narrative pivot for the inner shift — when something CHANGED in the speaker's understanding.",
+      useEs: "Un giro narrativo para el cambio interno — cuando algo CAMBIÓ en la comprensión del narrador.",
+    },
+    {
+      word: "after that",
+      wordEs: "después de eso",
+      example: "After that, I went home.",
+      exampleEs: "Después de eso, me fui a casa.",
+      use: "Closes the scene. Returns to past simple for the resolution.",
+      useEs: "Cierra la escena. Regresa al pasado simple para la resolución.",
+    },
+  ],
+  bossSentence: {
+    english:
+      "Last Tuesday, I was walking home from work when suddenly it started to rain. While I was looking for my umbrella, my phone rang. It was my old friend from college — she was visiting New York and wanted to meet for coffee. At that moment, I forgot all about the rain. After that, we spent two hours catching up.",
+    spanish:
+      "El martes pasado, iba caminando a casa después del trabajo cuando de repente empezó a llover. Mientras buscaba mi paraguas, sonó mi teléfono. Era mi vieja amiga de la universidad — estaba visitando Nueva York y quería tomar café conmigo. En ese momento, me olvidé de la lluvia. Después de eso, pasamos dos horas poniéndonos al día.",
+    explanation:
+      "Five sentences. Two past continuous verbs ('was walking', 'was looking'), three past simple verbs ('started', 'rang', 'forgot'), plus 'after that' for the resolution. Five different time markers (Last Tuesday, suddenly, While, At that moment, After that). This is exactly how native English speakers narrate a real memory.",
+    explanationEs:
+      "Cinco oraciones. Dos verbos en pasado continuo ('was walking', 'was looking'), tres verbos en pasado simple ('started', 'rang', 'forgot'), más 'after that' para la resolución. Cinco marcadores de tiempo diferentes (Last Tuesday, suddenly, While, At that moment, After that). Así narran un recuerdo real los hablantes nativos de inglés.",
+  },
+};
+
+// ─── Section E: Pronunciation Lab — Was/Were Reduction ───────────────────────
+
+export const pronunciationDrills: PronunciationDrillItem[] = [
+  {
+    word: "was (full)",
+    spanishStress: "WAS (Spanish-style)",
+    englishStress: "WUZ (full form, stressed)",
+    tip: "When 'was' is stressed (in negation, questions, or emphasis), it's pronounced WUZ. 'YES, I WUZ there!'",
+    tipEs: "Cuando 'was' va acentuado (en negación, preguntas o énfasis), se pronuncia WUZ. '¡Sí, YO ESTABA allí!'",
+  },
+  {
+    word: "was (reduced)",
+    spanishStress: "WAS (Spanish 'a')",
+    englishStress: "wuz / wəz (unstressed, almost a schwa)",
+    tip: "In normal sentences, 'was' is REDUCED to 'wuz' or even 'wəz'. 'I was working' sounds like 'I-wuz-WORKING'.",
+    tipEs: "En oraciones normales, 'was' se REDUCE a 'wuz' o incluso 'wəz'. 'I was working' suena como 'I-wuz-WORKING'.",
+  },
+  {
+    word: "were (full)",
+    spanishStress: "WERE (Spanish-style)",
+    englishStress: "WUR (rhymes with 'her')",
+    tip: "Stressed 'were' rhymes with 'her' or 'fur'. 'YES, we WUR there!'",
+    tipEs: "'Were' acentuado rima con 'her' o 'fur'. '¡Sí, NOSOTROS ESTÁBAMOS allí!'",
+  },
+  {
+    word: "were (reduced)",
+    spanishStress: "WE-RE (two syllables)",
+    englishStress: "wur / wər (one syllable, almost silent)",
+    tip: "Unstressed 'were' becomes nearly silent: 'wər'. 'They were eating' sounds like 'They-wər-EATING'.",
+    tipEs: "'Were' sin acento se vuelve casi silencioso: 'wər'. 'They were eating' suena como 'They-wər-EATING'.",
+  },
+  {
+    word: "wasn't",
+    spanishStress: "WAS NOT (two clear words)",
+    englishStress: "WUZ-int (two syllables, contracted)",
+    tip: "Always say 'WUZ-int', not 'was not' separated. The contracted form is the natural form.",
+    tipEs: "Siempre di 'WUZ-int', no 'was not' separado. La forma contraída es la forma natural.",
+  },
+  {
+    word: "weren't",
+    spanishStress: "WE-REN-T (three syllables)",
+    englishStress: "WURNT (one syllable)",
+    tip: "Just one syllable: WURNT. NOT 'wer-ent'. Sounds like 'aren't' but with a 'w'.",
+    tipEs: "Solo una sílaba: WURNT. NO 'wer-ent'. Suena como 'aren't' pero con 'w'.",
+  },
+  {
+    word: "verb + -ing endings",
+    spanishStress: "WORK-ING (clear -ing ending)",
+    englishStress: "WORK-in / WORK-een (often reduced to 'in')",
+    tip: "In casual speech, '-ing' often reduces to '-in': 'I was workin' late'. Both 'workin' and 'working' are accepted in conversation.",
+    tipEs: "En habla casual, '-ing' a menudo se reduce a '-in': 'I was workin' late'. Ambos 'workin' y 'working' son aceptados en conversación.",
+  },
+  {
+    word: "when / while linking",
+    spanishStress: "WHEN-SHE-CALLED (3 separate words)",
+    englishStress: "when-shee-CALLED (linked, stress on verb)",
+    tip: "The verb in past simple gets the stress: 'when she CALLED', 'while I was COOKING'. The connector and pronoun reduce.",
+    tipEs: "El verbo en pasado simple lleva el acento: 'when she CALLED', 'while I was COOKING'. El conector y el pronombre se reducen.",
+  },
+];
+
+// ─── Section F: Vocabulary List for Self-Test ────────────────────────────────
+
+export const vocabularyList: VocabItem[] = [
+  // was/were forms
+  { english: "was", spanish: "estaba (yo, él, ella, eso)", type: "marker" },
+  { english: "were", spanish: "estabas / estábamos / estaban", type: "marker" },
+  { english: "wasn't", spanish: "no estaba", type: "marker" },
+  { english: "weren't", spanish: "no estabas / estaban", type: "marker" },
+  // -ing verbs
+  { english: "eating", spanish: "comiendo", type: "verb" },
+  { english: "drinking", spanish: "tomando", type: "verb" },
+  { english: "working", spanish: "trabajando", type: "verb" },
+  { english: "talking", spanish: "hablando", type: "verb" },
+  { english: "writing", spanish: "escribiendo", type: "verb" },
+  { english: "reading", spanish: "leyendo", type: "verb" },
+  { english: "running", spanish: "corriendo", type: "verb" },
+  { english: "driving", spanish: "manejando", type: "verb" },
+  { english: "watching", spanish: "viendo", type: "verb" },
+  { english: "listening", spanish: "escuchando", type: "verb" },
+  { english: "studying", spanish: "estudiando", type: "verb" },
+  { english: "sleeping", spanish: "durmiendo", type: "verb" },
+  // Time markers
+  { english: "when", spanish: "cuando", type: "marker" },
+  { english: "while", spanish: "mientras", type: "marker" },
+  { english: "as", spanish: "mientras / cuando", type: "marker" },
+  { english: "suddenly", spanish: "de repente", type: "marker" },
+  { english: "at that moment", spanish: "en ese momento", type: "marker" },
+  { english: "all of a sudden", spanish: "de pronto", type: "marker" },
+  { english: "meanwhile", spanish: "mientras tanto", type: "marker" },
+  { english: "last night", spanish: "anoche", type: "marker" },
+  // Useful phrases
+  { english: "I was working when she called.", spanish: "Estaba trabajando cuando ella llamó.", type: "phrase" },
+  { english: "We were eating dinner.", spanish: "Estábamos cenando.", type: "phrase" },
+  { english: "What were you doing at 7?", spanish: "¿Qué estabas haciendo a las 7?", type: "phrase" },
+  { english: "Were you sleeping?", spanish: "¿Estabas durmiendo?", type: "phrase" },
+  { english: "She wasn't listening.", spanish: "Ella no estaba escuchando.", type: "phrase" },
+  { english: "While I was cooking, the phone rang.", spanish: "Mientras cocinaba, sonó el teléfono.", type: "phrase" },
+  { english: "Suddenly, it started to rain.", spanish: "De repente, empezó a llover.", type: "phrase" },
+  { english: "I was walking home.", spanish: "Iba caminando a casa.", type: "phrase" },
+];

--- a/src/data/elementary/units.ts
+++ b/src/data/elementary/units.ts
@@ -155,7 +155,7 @@ export const elementaryUnits: ElementaryUnit[] = [
     pronunciationFocus: "Question intonation patterns",
     pronunciationFocusEs: "Patrones de entonación en preguntas",
     icon: "MessageCircleQuestion",
-    published: false,
+    published: true,
   },
   {
     id: 8,
@@ -174,7 +174,7 @@ export const elementaryUnits: ElementaryUnit[] = [
     pronunciationFocus: "Stress on frequency adverbs",
     pronunciationFocusEs: "Acento en adverbios de frecuencia",
     icon: "Repeat",
-    published: false,
+    published: true,
   },
   {
     id: 9,
@@ -193,7 +193,7 @@ export const elementaryUnits: ElementaryUnit[] = [
     pronunciationFocus: "Reduced 'was' and 'were' in fast speech",
     pronunciationFocusEs: "Reducción de 'was' y 'were' en habla rápida",
     icon: "Pause",
-    published: false,
+    published: true,
   },
   {
     id: 10,
@@ -212,6 +212,6 @@ export const elementaryUnits: ElementaryUnit[] = [
     pronunciationFocus: "Natural rhythm and pacing in story telling",
     pronunciationFocusEs: "Ritmo natural y pausas al contar historias",
     icon: "Sparkles",
-    published: false,
+    published: true,
   },
 ];

--- a/src/pages/en/course/elementary/exam.astro
+++ b/src/pages/en/course/elementary/exam.astro
@@ -1,0 +1,76 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CourseExam from "@components/course/CourseExam";
+import { elementaryUnits } from "@data/elementary/units";
+import { examQuestions, examMeta, examTiers } from "@data/elementary/exam";
+import { ArrowLeft, GraduationCap } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/elementary/exam" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Final Exam: Tell Your Story (A2) | NY English Teacher"
+  description="Test your A2 English with 20 questions on past tense, future plans, comparatives, quantifiers, Wh-questions, and frequency adverbs. Free for Spanish speakers."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={0}
+    basePath="/en/course/elementary"
+    lang="en"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <GraduationCap class="w-4 h-4" />
+          Final Exam
+        </div>
+        <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Tell Your Story
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          You've completed all 10 units of the elementary course. Now prove it. 20 questions
+          covering past simple, future plans, comparatives, quantifiers, Wh-questions,
+          frequency adverbs, and past continuous — everything you've built across the entire
+          course.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <CourseExam
+        client:load
+        questions={examQuestions}
+        lang="en"
+        passingScore={examMeta.passingScore}
+        courseBasePath="/en/course/elementary"
+        tiers={examTiers}
+      />
+    </div>
+  </section>
+
+  <section class="py-8 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4 text-center">
+      <a href="/en/course/elementary/" class="inline-flex items-center gap-2 text-slate-500 hover:text-amber-600 transition-colors text-sm">
+        <ArrowLeft class="w-4 h-4" /> Back to Course Overview
+      </a>
+    </div>
+  </section>
+</Base>

--- a/src/pages/en/course/elementary/index.astro
+++ b/src/pages/en/course/elementary/index.astro
@@ -198,20 +198,22 @@ const firstUnitLabel = firstAvailableUnit
 
       <!-- Final Exam Card -->
       <div class="max-w-4xl mx-auto mt-6">
-        <div
-          class="flex items-center gap-4 p-5 rounded-xl border-2 border-dashed border-slate-300 bg-white opacity-75"
+        <a
+          href="/en/course/elementary/exam/"
+          class="flex items-center gap-4 p-5 rounded-xl border-2 border-amber-300 bg-amber-50 hover:shadow-md hover:border-amber-400 transition-all duration-200 cursor-pointer group"
         >
-          <div class="flex items-center justify-center w-12 h-12 rounded-xl shrink-0 bg-slate-100 text-slate-400">
+          <div class="flex items-center justify-center w-12 h-12 rounded-xl shrink-0 bg-amber-500 text-white">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           </div>
           <div>
-            <span class="text-xs font-bold uppercase tracking-wider text-slate-400">After Unit 10</span>
-            <h3 class="text-lg font-bold text-slate-600 mt-0.5">Final Exam <span class="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-400 ml-2 font-normal">Coming soon</span></h3>
-            <p class="text-sm text-slate-500 mt-1">20 questions covering all 10 units — past tense, future plans, comparatives, quantifiers, questions, and routines.</p>
+            <span class="text-xs font-bold uppercase tracking-wider text-amber-600">After Unit 10</span>
+            <h3 class="text-lg font-bold text-slate-900 mt-0.5">Final Exam</h3>
+            <p class="text-sm text-slate-600 mt-1">20 questions covering all 10 units — past tense, future plans, comparatives, quantifiers, questions, and routines.</p>
           </div>
-        </div>
+          <span class="ml-auto text-amber-600 font-semibold text-sm group-hover:translate-x-1 transition-transform">→</span>
+        </a>
       </div>
     </div>
   </section>

--- a/src/pages/en/course/elementary/unit-10.astro
+++ b/src/pages/en/course/elementary/unit-10.astro
@@ -1,0 +1,317 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CapstoneUploadForm from "@components/course/CapstoneUploadForm";
+import { elementaryUnits } from "@data/elementary/units";
+import { Sparkles, Calendar, Mic, ArrowLeft, CheckCircle2 } from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/elementary/unit-10" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const bookingLink =
+  "/en/book/?notes=" +
+  encodeURIComponent(
+    "I just completed the Elementary (A2) course and recorded my 60-second story. I would like live coaching feedback on my past tense, future plans, and pronunciation."
+  );
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unit 10: Tell Your Story — A2 Capstone | NY English Teacher"
+  description="The A2 capstone. Record a 60-second story combining past simple, past continuous, going to, and comparatives. Get personal feedback from Robert. Free."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={10}
+    basePath="/en/course/elementary"
+    lang="en"
+  />
+
+  <!-- Hero -->
+  <section
+    class="relative w-full overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-sky-950 pt-28 pb-16 md:pt-36 md:pb-24"
+  >
+    <div class="absolute inset-0 opacity-10 pointer-events-none">
+      <div class="absolute top-20 left-10 w-72 h-72 bg-sky-500 rounded-full blur-3xl"></div>
+      <div class="absolute bottom-10 right-10 w-96 h-96 bg-cyan-400 rounded-full blur-3xl"></div>
+    </div>
+    <div class="site-container mx-auto px-4 relative z-10 text-white">
+      <div class="max-w-3xl">
+        <a
+          href="/en/course/elementary/unit-9/"
+          class="inline-flex items-center gap-1.5 text-sm text-slate-400 hover:text-white transition-colors mb-6"
+        >
+          <ArrowLeft class="w-4 h-4" />
+          Back to Unit 9
+        </a>
+        <div
+          class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-sky-500/20 text-sky-300 text-sm font-semibold mb-6"
+        >
+          <Sparkles class="w-4 h-4" />
+          The Capstone
+        </div>
+        <h1
+          class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Tell Your Story.<br />
+          <span class="text-sky-400">In 60 Seconds.</span>
+        </h1>
+        <p class="text-xl text-slate-200 max-w-2xl leading-relaxed">
+          Nine units. Past simple, past continuous, going to, comparatives, quantifiers,
+          Wh-questions, frequency adverbs. Now combine them all into a 60-second story about
+          your real life — and Robert will listen personally.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- The Prompt -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <p class="text-[11px] font-mono uppercase tracking-[0.3em] text-sky-600 mb-4">
+          Your Assignment
+        </p>
+        <h2
+          class="text-2xl md:text-3xl font-bold text-slate-900 mb-6"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Record a 60-second autobiographical story.
+        </h2>
+        <div class="bg-slate-50 border-l-4 border-sky-400 rounded-r-xl p-6 md:p-8 mb-8">
+          <p class="text-lg text-slate-800 leading-relaxed font-medium mb-4">
+            Pick any 60-second story from your real life. Examples: a memorable trip, your
+            first day at a job, a funny family moment, the day you decided to learn English,
+            something unexpected that happened last week.
+          </p>
+          <p class="text-base text-slate-700 leading-relaxed">
+            <strong>The structure:</strong> set the scene with past continuous ('I was
+            walking…'), introduce the moment with past simple ('then suddenly…'), say what's
+            coming next with 'going to' ('next month I'm going to…'), and use at least one
+            comparative ('it was better than…').
+          </p>
+        </div>
+
+        <!-- The 5 ingredients -->
+        <h3 class="text-xl font-bold text-slate-900 mb-4">Five ingredients to include:</h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-3 mb-10">
+          {
+            [
+              { unit: "Unit 1-2", req: "At least 3 past simple verbs (regular AND irregular)" },
+              { unit: "Unit 3", req: "A time marker (yesterday, last week, two months ago)" },
+              { unit: "Unit 4", req: "One future plan with 'going to' or 'will'" },
+              { unit: "Unit 5", req: "One comparative ('better than', 'bigger than')" },
+              { unit: "Unit 8", req: "One frequency adverb ('I usually…', 'I often…')" },
+              { unit: "Unit 9", req: "One past continuous + interruption ('I was X-ing when…')" },
+            ].map((item) => (
+              <div class="flex items-start gap-3 p-4 bg-sky-50 rounded-xl border border-sky-100">
+                <CheckCircle2 class="w-5 h-5 text-sky-500 shrink-0 mt-0.5" />
+                <div>
+                  <p class="text-xs font-bold uppercase tracking-wider text-sky-600 mb-1">{item.unit}</p>
+                  <p class="text-sm text-slate-700 leading-relaxed">{item.req}</p>
+                </div>
+              </div>
+            ))
+          }
+        </div>
+
+        <!-- How to record -->
+        <div class="bg-sky-50 border border-sky-200 rounded-xl p-6">
+          <div class="flex items-center gap-2 mb-4">
+            <Mic class="w-5 h-5 text-sky-600" />
+            <p class="text-sm font-bold text-sky-800 uppercase tracking-wide">How to Record</p>
+          </div>
+          <ul class="space-y-2 text-sm text-sky-900 leading-relaxed">
+            <li><strong>iPhone:</strong> Open the Voice Memos app → tap the red button → save and export as M4A.</li>
+            <li><strong>Android:</strong> Use the built-in Voice Recorder app → export as MP3 or M4A.</li>
+            <li><strong>Computer:</strong> Use Zoom (record a meeting with yourself), Loom, or QuickTime audio recording.</li>
+          </ul>
+          <p class="text-xs text-sky-700 mt-4">
+            Any audio format works: MP3, M4A, WAV, or OGG. A 60-second voice recording is well
+            under 5 MB.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Submission — Upload form + Booking CTA -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <p class="text-[11px] font-mono uppercase tracking-[0.3em] text-sky-600 mb-4 text-center">
+          Submit Your Work
+        </p>
+        <h2
+          class="text-2xl md:text-3xl font-bold text-slate-900 mb-3 text-center"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Choose your path.
+        </h2>
+        <p class="text-slate-600 text-center mb-10">
+          Both options include personal feedback from Robert.
+        </p>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
+          <!-- Path A: Upload -->
+          <div>
+            <div class="flex items-center gap-2 mb-4">
+              <span class="w-6 h-6 rounded-full bg-sky-500 text-white text-xs font-bold flex items-center justify-center">A</span>
+              <h3 class="text-lg font-bold text-slate-900">Upload Your Recording</h3>
+            </div>
+            <p class="text-sm text-slate-600 mb-5 leading-relaxed">
+              Record on your phone or computer, then upload it here. Robert listens personally
+              and emails you detailed feedback within 48 hours.
+            </p>
+            <CapstoneUploadForm client:load lang="en" />
+          </div>
+
+          <!-- Path B: Strategy Session -->
+          <div class="md:mt-14">
+            <div class="flex items-center gap-2 mb-4">
+              <span class="w-6 h-6 rounded-full bg-slate-800 text-white text-xs font-bold flex items-center justify-center">B</span>
+              <h3 class="text-lg font-bold text-slate-900">Tell It Live with Robert</h3>
+              <span class="text-xs font-bold uppercase tracking-wider text-sky-600 bg-sky-50 border border-sky-200 px-2 py-0.5 rounded-full ml-auto">
+                Recommended
+              </span>
+            </div>
+            <p class="text-sm text-slate-600 mb-6 leading-relaxed">
+              Book a free 30-minute consultation. Tell your 60-second story live — then get
+              real-time coaching on past tense forms, pronunciation, and how to keep going
+              when you stumble. The fastest way to level up.
+            </p>
+            <div class="bg-white rounded-2xl border-2 border-sky-300 p-6 shadow-sm">
+              <div class="flex items-center gap-3 mb-4">
+                <Calendar class="w-6 h-6 text-sky-600" />
+                <div>
+                  <p class="text-sm font-bold text-slate-900">Free Consultation</p>
+                  <p class="text-xs text-slate-500">30 minutes · Google Meet · No prep required</p>
+                </div>
+              </div>
+              <p class="text-xs text-slate-500 mb-5 leading-relaxed">
+                Your session context is pre-filled — Robert will know you're coming from the
+                Elementary Course and have your story ready.
+              </p>
+              <Button href={bookingLink} variant="primary" size="lg" class="w-full">
+                <Calendar class="w-4 h-4" />
+                Book Your Free Session
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Robert's Coaching Reminders -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <p class="text-[11px] font-mono uppercase tracking-[0.3em] text-sky-600 mb-4">
+          Robert's Reminders
+        </p>
+        <h2
+          class="text-2xl font-bold text-slate-900 mb-8"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Four things I listen for.
+        </h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {
+            [
+              {
+                tip: "Past tense forms — irregular verbs especially. 'Went' not 'goed'. 'Saw' not 'seed'. (Units 1-2)",
+              },
+              {
+                tip: "Frequency adverb position — 'I usually…' BEFORE the verb, NEVER at the end. (Unit 8)",
+              },
+              {
+                tip: "Past continuous + interruption — set the scene with 'was X-ing', then drop the moment with past simple. (Unit 9)",
+              },
+              {
+                tip: "Don't stop. If you stumble, keep going. Native speakers stumble too. Fluency is not perfection — it's recovery.",
+              },
+            ].map((item) => (
+              <div class="flex items-start gap-3 p-5 bg-slate-50 rounded-xl border border-slate-100">
+                <CheckCircle2 class="w-5 h-5 text-sky-500 shrink-0 mt-0.5" />
+                <p class="text-sm text-slate-700 leading-relaxed">{item.tip}</p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Final exam CTA -->
+  <section class="py-16 md:py-20 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <p class="text-[11px] font-mono uppercase tracking-[0.3em] text-sky-600 mb-4">
+          One Last Thing
+        </p>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-4" style="font-family: 'Noto Sans KR', sans-serif;">
+          Take the final exam.
+        </h2>
+        <p class="text-lg text-slate-600 mb-8 leading-relaxed">
+          20 questions covering all 10 units. Test what you've learned and see exactly where
+          you stand before moving on to the intermediate course.
+        </p>
+        <Button href="/en/course/elementary/exam/" variant="primary" size="lg">
+          Start the Final Exam →
+        </Button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Bottom Encouragement -->
+  <section class="py-20 md:py-28 bg-slate-950 text-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-2xl mx-auto text-center">
+        <Sparkles class="w-10 h-10 text-sky-400 mx-auto mb-6" />
+        <h2
+          class="text-3xl md:text-4xl font-bold mb-6 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          This is not a test.<br />
+          <span class="text-sky-400">This is your voice in English.</span>
+        </h2>
+        <p class="text-lg text-slate-300 leading-relaxed">
+          Every drill, every sound, every correction across nine units built toward this. Hit
+          record. Tell your 60 seconds. Send it. The next conversation in your life will be
+          easier because of this one.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "LearningResource",
+  "name": "Elementary English Capstone — 60-Second Story Challenge",
+  "description": "Record a 60-second autobiographical story combining past simple, past continuous, going to, and comparatives. Submit it for personal feedback from Robert.",
+  "learningResourceType": "Assessment",
+  "educationalLevel": "A2",
+  "inLanguage": "en",
+  "url": "https://www.nyenglishteacher.com/en/course/elementary/unit-10/",
+  "isAccessibleForFree": true,
+  "isPartOf": {
+    "@type": "Course",
+    "name": "Free Elementary English Course (A2)",
+    "url": "https://www.nyenglishteacher.com/en/course/elementary/"
+  }
+})} />
+</Base>

--- a/src/pages/en/course/elementary/unit-7.astro
+++ b/src/pages/en/course/elementary/unit-7.astro
@@ -1,0 +1,295 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CognateDiscovery from "@components/course/CognateDiscovery";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import ConnectorChallenge from "@components/course/ConnectorChallenge";
+import SelfTest from "@components/course/SelfTest";
+import { elementaryUnits } from "@data/elementary/units";
+import {
+  cognateWaves,
+  sentenceBlocks,
+  powerVerbBlocks,
+  connectorSentences,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/elementary/unit-7";
+import {
+  MessageCircleQuestion,
+  Layers,
+  Zap,
+  Link2,
+  Volume2,
+  ClipboardCheck,
+  BookOpen,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/elementary/unit-7" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
+
+const nextUnit = elementaryUnits.find((u) => u.id === 8);
+const nextUnitPublished = nextUnit?.published ?? false;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unit 7: Asking Real Questions | Elementary English (A2)"
+  description="Wh-questions for Spanish speakers — where, when, why, how, how long, how often. Master the word order that turns small talk into real conversation."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={7}
+    basePath="/en/course/elementary"
+    lang="en"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-sky-400 text-sm font-semibold mb-3">
+          <MessageCircleQuestion class="w-4 h-4" />
+          Unit 7
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Asking Real Questions
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Where, When, Why, How, How long, How often. The questions that turn small talk into
+          real conversation — plus the word order that trips up every Spanish speaker. By the
+          end of this unit, you can interview someone, not just answer 'yes' or 'no'.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <nav class="bg-white border-b border-slate-200 sticky top-[52px] z-30 overflow-x-auto">
+    <div class="site-container mx-auto px-4">
+      <div class="flex items-center gap-1 py-2 text-sm whitespace-nowrap">
+        <a href="#vocabulary" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <BookOpen class="w-3.5 h-3.5" /> Wh-Words
+        </a>
+        <a href="#word-order" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Layers class="w-3.5 h-3.5" /> Word Order
+        </a>
+        <a href="#subject-object" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Zap class="w-3.5 h-3.5" /> Subject vs. Object
+        </a>
+        <a href="#boss" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Link2 class="w-3.5 h-3.5" /> Boss Sentence
+        </a>
+        <a href="#pronunciation" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Volume2 class="w-3.5 h-3.5" /> Pronunciation
+        </a>
+        <a href="#self-test" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <ClipboardCheck class="w-3.5 h-3.5" /> Self-Test
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <section id="vocabulary" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <BookOpen class="w-4 h-4" />
+            Section A
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            The 7 Wh-Words, How+X Compounds, and Topic Vocabulary
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Three waves. Wave 1: the seven core Wh-words (what, where, when, why, who, which,
+            how). Wave 2: the 'how + adjective' compounds (how long, how often, how much). Wave
+            3: the real topics people actually ask about. Tap any entry to hear it.
+          </p>
+        </div>
+        <CognateDiscovery client:visible waves={waveData} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="word-order" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Layers class="w-4 h-4" />
+            Section B
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Question Word Order — The Four Patterns
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Every Wh-question follows one of four patterns: Wh + BE, Wh + do/does + verb, Wh +
+            did + base verb (past), Wh + modal + base verb. Master these four and you can ask
+            ANY question correctly.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={sentenceBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="subject-object" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Zap class="w-4 h-4" />
+            Section C
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Subject vs. Object Questions — When to DROP 'do/did'
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Who called you?' vs. 'Who did you call?' — same words, opposite meanings. When
+            'who' or 'what' IS the subject, drop the helper verb. This single rule trips up
+            almost every Spanish speaker. Drill it until it's automatic.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={powerVerbBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="boss" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Link2 class="w-4 h-4" />
+            Section D
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            The Boss Sentence — A Real First Conversation
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Six questions, six different patterns, all in one natural conversation opener.
+            'Where are you from?' to 'What's your favorite thing about it?' — exactly what a
+            real first conversation in English sounds like, and exactly what you should be
+            ready to ASK back.
+          </p>
+        </div>
+        <ConnectorChallenge
+          client:visible
+          connectors={connectorSentences.connectors}
+          bossSentence={connectorSentences.bossSentence}
+          lang="en"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section id="pronunciation" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-rose-500 text-sm font-semibold mb-2">
+            <Volume2 class="w-4 h-4" />
+            Pronunciation Lab
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Question Sounds and Falling Intonation
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Wh' is just a 'w' sound. The 'w' is silent in 'who' and 'how'. 'Do you' merges
+            into 'd'YA'. 'Did you' merges into 'DID-juh'. And the biggest cultural shift:
+            English Wh-questions END with FALLING pitch — opposite of Spanish.
+          </p>
+        </div>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="self-test" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <ClipboardCheck class="w-4 h-4" />
+            Self-Test
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Test What You Learned
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Flashcard review of every Wh-word, How+X compound, and useful question phrase from
+            Unit 7. Switch between Spanish→English and English→Spanish modes.
+          </p>
+        </div>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-gradient-to-b from-slate-900 to-slate-800">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-2xl mx-auto text-center space-y-6">
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/20 text-emerald-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-bold text-white">Unit 7 Complete!</h2>
+        <p class="text-lg text-slate-100 leading-relaxed">
+          You can now drive a real conversation, not just answer one. Seven units down, three to
+          go. Next: routines and frequency adverbs — the quiet word-order trap that exposes
+          Spanish speakers in the first sentence.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center pt-4">
+          <a
+            href="/en/course/elementary/unit-6/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors"
+          >
+            ← Review Unit 6
+          </a>
+          {nextUnitPublished ? (
+            <a
+              href="/en/course/elementary/unit-8/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Continue to Unit 8 →
+            </a>
+          ) : (
+            <a
+              href="/en/course/elementary/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Course Overview
+            </a>
+          )}
+        </div>
+        <div class="pt-8 border-t border-slate-700 mt-8">
+          <p class="text-slate-200 text-sm mb-3">
+            Want personalized English coaching?
+          </p>
+          <a
+            href="/en/contact/"
+            class="text-sky-400 hover:text-sky-300 font-medium underline underline-offset-2"
+          >
+            Book a free consultation with Robert →
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/en/course/elementary/unit-8.astro
+++ b/src/pages/en/course/elementary/unit-8.astro
@@ -1,0 +1,295 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CognateDiscovery from "@components/course/CognateDiscovery";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import ConnectorChallenge from "@components/course/ConnectorChallenge";
+import SelfTest from "@components/course/SelfTest";
+import { elementaryUnits } from "@data/elementary/units";
+import {
+  cognateWaves,
+  sentenceBlocks,
+  powerVerbBlocks,
+  connectorSentences,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/elementary/unit-8";
+import {
+  Repeat,
+  Layers,
+  Zap,
+  Link2,
+  Volume2,
+  ClipboardCheck,
+  BookOpen,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/elementary/unit-8" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
+
+const nextUnit = elementaryUnits.find((u) => u.id === 9);
+const nextUnitPublished = nextUnit?.published ?? false;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unit 8: Daily Life and Frequency Adverbs | Elementary English (A2)"
+  description="Always, usually, often, sometimes, never — the position trap that exposes Spanish speakers. Master daily routines and the word-order rule. Free A2."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={8}
+    basePath="/en/course/elementary"
+    lang="en"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-sky-400 text-sm font-semibold mb-3">
+          <Repeat class="w-4 h-4" />
+          Unit 8
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Daily Life
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Always, usually, often, sometimes, never. Where they go in the sentence (Spanish
+          speakers always get this wrong) and how to describe a real daily routine — yours.
+          One position rule, three exceptions, and the natural rhythm of every-day English.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <nav class="bg-white border-b border-slate-200 sticky top-[52px] z-30 overflow-x-auto">
+    <div class="site-container mx-auto px-4">
+      <div class="flex items-center gap-1 py-2 text-sm whitespace-nowrap">
+        <a href="#vocabulary" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <BookOpen class="w-3.5 h-3.5" /> Adverbs
+        </a>
+        <a href="#position" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Layers class="w-3.5 h-3.5" /> Position Rules
+        </a>
+        <a href="#phrases" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Zap class="w-3.5 h-3.5" /> Frequency Phrases
+        </a>
+        <a href="#boss" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Link2 class="w-3.5 h-3.5" /> Boss Sentence
+        </a>
+        <a href="#pronunciation" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Volume2 class="w-3.5 h-3.5" /> Pronunciation
+        </a>
+        <a href="#self-test" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <ClipboardCheck class="w-3.5 h-3.5" /> Self-Test
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <section id="vocabulary" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <BookOpen class="w-4 h-4" />
+            Section A
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Frequency Adverbs, Routine Verbs, and Time Periods
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Three waves. Wave 1: the seven frequency adverbs from 100% (always) to 0% (never).
+            Wave 2: the daily routine verbs every adult uses. Wave 3: the time-period phrases
+            that go at the END of the sentence. Tap any entry to hear it.
+          </p>
+        </div>
+        <CognateDiscovery client:visible waves={waveData} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="position" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Layers class="w-4 h-4" />
+            Section B
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Position Rules — Where Frequency Adverbs Go
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            One main rule, three exceptions. Frequency adverbs go BEFORE the main verb — but
+            AFTER 'be', and BETWEEN auxiliary and main verb. 'Sometimes' and 'usually' can also
+            start the sentence. Drill each pattern until the right one comes out automatically.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={sentenceBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="phrases" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Zap class="w-4 h-4" />
+            Section C
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Frequency Phrases — Every Day, Twice a Week, On Mondays
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Every X', 'once / twice / X times a [period]', 'on + day', 'in + part of day'.
+            These phrases go at the END of the sentence (or sometimes the start). Pair them
+            with the right preposition: ON Mondays, IN the morning, AT night.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={powerVerbBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="boss" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Link2 class="w-4 h-4" />
+            Section D
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            The Boss Sentence — A Real Typical Week
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Four sentences. Eight different frequency expressions in eight different positions.
+            Mixing adverbs ('usually', 'always', 'rarely', 'never') with phrases ('every day',
+            'three times a week', 'every Monday morning'). This is what natural daily-life talk
+            sounds like.
+          </p>
+        </div>
+        <ConnectorChallenge
+          client:visible
+          connectors={connectorSentences.connectors}
+          bossSentence={connectorSentences.bossSentence}
+          lang="en"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section id="pronunciation" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-rose-500 text-sm font-semibold mb-2">
+            <Volume2 class="w-4 h-4" />
+            Pronunciation Lab
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Frequency Adverb Sounds — and the Silent T
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Usually' has THREE syllables and a soft 'zh' middle. 'Often' typically drops the
+            't' — 'OFF-en'. 'Rarely' uses American 'r'. 'Every day' fast-speech reduces the
+            middle 'e' to 'EV-ree'. Drill these and the rhythm of routine talk lands naturally.
+          </p>
+        </div>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="self-test" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <ClipboardCheck class="w-4 h-4" />
+            Self-Test
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Test What You Learned
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Flashcard review of every frequency adverb, routine verb, and useful phrase from
+            Unit 8. Switch between Spanish→English and English→Spanish modes.
+          </p>
+        </div>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-gradient-to-b from-slate-900 to-slate-800">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-2xl mx-auto text-center space-y-6">
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/20 text-emerald-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-bold text-white">Unit 8 Complete!</h2>
+        <p class="text-lg text-slate-100 leading-relaxed">
+          You can now describe a real day, week, or routine — with adverbs in the right
+          position, the right preposition for time, and the natural rhythm of native speech.
+          Eight units down, two to go. Next: past continuous — the storytelling power tool.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center pt-4">
+          <a
+            href="/en/course/elementary/unit-7/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors"
+          >
+            ← Review Unit 7
+          </a>
+          {nextUnitPublished ? (
+            <a
+              href="/en/course/elementary/unit-9/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Continue to Unit 9 →
+            </a>
+          ) : (
+            <a
+              href="/en/course/elementary/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Course Overview
+            </a>
+          )}
+        </div>
+        <div class="pt-8 border-t border-slate-700 mt-8">
+          <p class="text-slate-200 text-sm mb-3">
+            Want personalized English coaching?
+          </p>
+          <a
+            href="/en/contact/"
+            class="text-sky-400 hover:text-sky-300 font-medium underline underline-offset-2"
+          >
+            Book a free consultation with Robert →
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/en/course/elementary/unit-9.astro
+++ b/src/pages/en/course/elementary/unit-9.astro
@@ -1,0 +1,296 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CognateDiscovery from "@components/course/CognateDiscovery";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import ConnectorChallenge from "@components/course/ConnectorChallenge";
+import SelfTest from "@components/course/SelfTest";
+import { elementaryUnits } from "@data/elementary/units";
+import {
+  cognateWaves,
+  sentenceBlocks,
+  powerVerbBlocks,
+  connectorSentences,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/elementary/unit-9";
+import {
+  Pause,
+  Layers,
+  Zap,
+  Link2,
+  Volume2,
+  ClipboardCheck,
+  BookOpen,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/elementary/unit-9" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slug,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
+
+const nextUnit = elementaryUnits.find((u) => u.id === 10);
+const nextUnitPublished = nextUnit?.published ?? false;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unit 9: I Was Eating When… | Elementary English (A2)"
+  description="Past continuous for Spanish speakers — was/were + verb-ing. The narrative tool that turns flat past tense into real stories with interruptions. Free A2."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={9}
+    basePath="/en/course/elementary"
+    lang="en"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-sky-400 text-sm font-semibold mb-3">
+          <Pause class="w-4 h-4" />
+          Unit 9
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          I Was Eating When…
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Was/were + -ing. The tense that lets you say 'I was eating when she called' —
+          backgrounding one past action while another interrupts. The narrative power tool. By
+          the end of this unit, your past stories have texture, pacing, and a real pivot point.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <nav class="bg-white border-b border-slate-200 sticky top-[52px] z-30 overflow-x-auto">
+    <div class="site-container mx-auto px-4">
+      <div class="flex items-center gap-1 py-2 text-sm whitespace-nowrap">
+        <a href="#vocabulary" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <BookOpen class="w-3.5 h-3.5" /> Vocabulary
+        </a>
+        <a href="#structure" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Layers class="w-3.5 h-3.5" /> Structure
+        </a>
+        <a href="#interruption" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Zap class="w-3.5 h-3.5" /> Interruption
+        </a>
+        <a href="#boss" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Link2 class="w-3.5 h-3.5" /> Boss Sentence
+        </a>
+        <a href="#pronunciation" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Volume2 class="w-3.5 h-3.5" /> Pronunciation
+        </a>
+        <a href="#self-test" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <ClipboardCheck class="w-3.5 h-3.5" /> Self-Test
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <section id="vocabulary" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <BookOpen class="w-4 h-4" />
+            Section A
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Was/Were Forms, -ing Verbs, and Narrative Time Markers
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Three waves. Wave 1: was/were paired with each subject pronoun. Wave 2: the most
+            common -ing verbs in storytelling, plus the spelling rules. Wave 3: the narrative
+            time markers (when, while, suddenly, at that moment) that give past stories their
+            pacing.
+          </p>
+        </div>
+        <CognateDiscovery client:visible waves={waveData} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="structure" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Layers class="w-4 h-4" />
+            Section B
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Past Continuous Structure — Affirmative, Negative, Question
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Subject + was/were + verb-ing. Drill all three forms — affirmative ('I was working'),
+            negative ('I wasn't working'), question ('Were you working?') — plus the critical
+            difference between past simple and past continuous.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={sentenceBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="interruption" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Zap class="w-4 h-4" />
+            Section C
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            The Interruption Pattern — Past Continuous + Past Simple
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            The classic narrative combo. Long action in past continuous ('I was eating dinner').
+            Short action interrupts in past simple ('when she called'). Plus 'while' for two
+            simultaneous continuous actions, and 'suddenly' for dramatic interruptions.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={powerVerbBlocks} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="boss" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Link2 class="w-4 h-4" />
+            Section D
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            The Boss Sentence — A Real Personal Narrative
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Five sentences. Two past continuous verbs, three past simple verbs, five different
+            time markers. A real story arc with a setup, an interruption, a pivot, and a
+            resolution. This is exactly how native English speakers narrate a memory.
+          </p>
+        </div>
+        <ConnectorChallenge
+          client:visible
+          connectors={connectorSentences.connectors}
+          bossSentence={connectorSentences.bossSentence}
+          lang="en"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section id="pronunciation" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-rose-500 text-sm font-semibold mb-2">
+            <Volume2 class="w-4 h-4" />
+            Pronunciation Lab
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Was/Were Reduction — and the Music of Storytelling
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            In stress, 'was' = WUZ and 'were' = WUR. In normal speech they REDUCE almost to
+            silence: 'I was working' = 'I-wuz-WORKING'. Plus -ing reductions ('workin'),
+            wasn't/weren't contractions, and how the past simple verb gets the stress in
+            interruption sentences.
+          </p>
+        </div>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section id="self-test" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <ClipboardCheck class="w-4 h-4" />
+            Self-Test
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Test What You Learned
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Flashcard review of every was/were form, -ing verb, time marker, and useful phrase
+            from Unit 9. Switch between Spanish→English and English→Spanish modes.
+          </p>
+        </div>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="en" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-gradient-to-b from-slate-900 to-slate-800">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-2xl mx-auto text-center space-y-6">
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/20 text-emerald-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-bold text-white">Unit 9 Complete!</h2>
+        <p class="text-lg text-slate-100 leading-relaxed">
+          You can now narrate past stories like a native speaker — backgrounding the long
+          action, dropping in the interruption, and using time markers to control the pacing.
+          Nine units down. One left: the capstone, where you record YOUR story.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center pt-4">
+          <a
+            href="/en/course/elementary/unit-8/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors"
+          >
+            ← Review Unit 8
+          </a>
+          {nextUnitPublished ? (
+            <a
+              href="/en/course/elementary/unit-10/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Continue to Unit 10 →
+            </a>
+          ) : (
+            <a
+              href="/en/course/elementary/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Course Overview
+            </a>
+          )}
+        </div>
+        <div class="pt-8 border-t border-slate-700 mt-8">
+          <p class="text-slate-200 text-sm mb-3">
+            Want personalized English coaching?
+          </p>
+          <a
+            href="/en/contact/"
+            class="text-sky-400 hover:text-sky-300 font-medium underline underline-offset-2"
+          >
+            Book a free consultation with Robert →
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/elemental/examen.astro
+++ b/src/pages/es/curso/elemental/examen.astro
@@ -1,0 +1,76 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CourseExam from "@components/course/CourseExam";
+import { elementaryUnits } from "@data/elementary/units";
+import { examQuestions, examMeta, examTiers } from "@data/elementary/exam";
+import { ArrowLeft, GraduationCap } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/elementary/exam" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Examen Final: Cuenta Tu Historia (A2) | NY English Teacher"
+  description="Evalúa tu inglés A2 con 20 preguntas: pasado, planes futuros, comparativos, cuantificadores, preguntas Wh- y adverbios de frecuencia. Gratis."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={0}
+    basePath="/es/curso/elemental"
+    lang="es"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          <GraduationCap class="w-4 h-4" />
+          Examen Final
+        </div>
+        <h1 class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Cuenta Tu Historia
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Has completado las 10 unidades del curso elemental. Ahora demuéstralo. 20 preguntas
+          sobre pasado simple, planes futuros, comparativos, cuantificadores, preguntas Wh-,
+          adverbios de frecuencia y pasado continuo — todo lo que has construido en el curso
+          completo.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <CourseExam
+        client:load
+        questions={examQuestions}
+        lang="es"
+        passingScore={examMeta.passingScore}
+        courseBasePath="/es/curso/elemental"
+        tiers={examTiers}
+      />
+    </div>
+  </section>
+
+  <section class="py-8 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4 text-center">
+      <a href="/es/curso/elemental/" class="inline-flex items-center gap-2 text-slate-500 hover:text-amber-600 transition-colors text-sm">
+        <ArrowLeft class="w-4 h-4" /> Volver al Resumen del Curso
+      </a>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/elemental/index.astro
+++ b/src/pages/es/curso/elemental/index.astro
@@ -198,20 +198,22 @@ const firstUnitLabel = firstAvailableUnit
 
       <!-- Final Exam Card -->
       <div class="max-w-4xl mx-auto mt-6">
-        <div
-          class="flex items-center gap-4 p-5 rounded-xl border-2 border-dashed border-slate-300 bg-white opacity-75"
+        <a
+          href="/es/curso/elemental/examen/"
+          class="flex items-center gap-4 p-5 rounded-xl border-2 border-amber-300 bg-amber-50 hover:shadow-md hover:border-amber-400 transition-all duration-200 cursor-pointer group"
         >
-          <div class="flex items-center justify-center w-12 h-12 rounded-xl shrink-0 bg-slate-100 text-slate-400">
+          <div class="flex items-center justify-center w-12 h-12 rounded-xl shrink-0 bg-amber-500 text-white">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           </div>
           <div>
-            <span class="text-xs font-bold uppercase tracking-wider text-slate-400">Después de la Unidad 10</span>
-            <h3 class="text-lg font-bold text-slate-600 mt-0.5">Examen Final <span class="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-400 ml-2 font-normal">Próximamente</span></h3>
-            <p class="text-sm text-slate-500 mt-1">20 preguntas que cubren las 10 unidades — pasado, planes futuros, comparativos, cuantificadores, preguntas y rutinas.</p>
+            <span class="text-xs font-bold uppercase tracking-wider text-amber-600">Después de la Unidad 10</span>
+            <h3 class="text-lg font-bold text-slate-900 mt-0.5">Examen Final</h3>
+            <p class="text-sm text-slate-600 mt-1">20 preguntas que cubren las 10 unidades — pasado, planes futuros, comparativos, cuantificadores, preguntas y rutinas.</p>
           </div>
-        </div>
+          <span class="ml-auto text-amber-600 font-semibold text-sm group-hover:translate-x-1 transition-transform">→</span>
+        </a>
       </div>
     </div>
   </section>

--- a/src/pages/es/curso/elemental/unidad-10.astro
+++ b/src/pages/es/curso/elemental/unidad-10.astro
@@ -1,0 +1,317 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CapstoneUploadForm from "@components/course/CapstoneUploadForm";
+import { elementaryUnits } from "@data/elementary/units";
+import { Sparkles, Calendar, Mic, ArrowLeft, CheckCircle2 } from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/elementary/unit-10" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const bookingLink =
+  "/es/reservar/?notes=" +
+  encodeURIComponent(
+    "Acabo de completar el curso Elemental (A2) y grabé mi historia de 60 segundos. Me gustaría retroalimentación en vivo sobre mi pasado, planes futuros y pronunciación."
+  );
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unidad 10: Cuenta Tu Historia — Reto Final A2 | NY English"
+  description="El reto final A2. Graba una historia de 60 segundos combinando pasado simple, continuo, going to y comparativos. Recibe retroalimentación personal. Gratis."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={10}
+    basePath="/es/curso/elemental"
+    lang="es"
+  />
+
+  <!-- Hero -->
+  <section
+    class="relative w-full overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-sky-950 pt-28 pb-16 md:pt-36 md:pb-24"
+  >
+    <div class="absolute inset-0 opacity-10 pointer-events-none">
+      <div class="absolute top-20 left-10 w-72 h-72 bg-sky-500 rounded-full blur-3xl"></div>
+      <div class="absolute bottom-10 right-10 w-96 h-96 bg-cyan-400 rounded-full blur-3xl"></div>
+    </div>
+    <div class="site-container mx-auto px-4 relative z-10 text-white">
+      <div class="max-w-3xl">
+        <a
+          href="/es/curso/elemental/unidad-9/"
+          class="inline-flex items-center gap-1.5 text-sm text-slate-400 hover:text-white transition-colors mb-6"
+        >
+          <ArrowLeft class="w-4 h-4" />
+          Volver a Unidad 9
+        </a>
+        <div
+          class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-sky-500/20 text-sky-300 text-sm font-semibold mb-6"
+        >
+          <Sparkles class="w-4 h-4" />
+          El Reto Final
+        </div>
+        <h1
+          class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Cuenta Tu Historia.<br />
+          <span class="text-sky-400">En 60 Segundos.</span>
+        </h1>
+        <p class="text-xl text-slate-200 max-w-2xl leading-relaxed">
+          Nueve unidades. Pasado simple, pasado continuo, going to, comparativos, cuantificadores,
+          preguntas Wh-, adverbios de frecuencia. Ahora combínalos todos en una historia de 60
+          segundos sobre tu vida real — y Robert escuchará personalmente.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- The Prompt -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <p class="text-[11px] font-mono uppercase tracking-[0.3em] text-sky-600 mb-4">
+          Tu Tarea
+        </p>
+        <h2
+          class="text-2xl md:text-3xl font-bold text-slate-900 mb-6"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Graba una historia autobiográfica de 60 segundos.
+        </h2>
+        <div class="bg-slate-50 border-l-4 border-sky-400 rounded-r-xl p-6 md:p-8 mb-8">
+          <p class="text-lg text-slate-800 leading-relaxed font-medium mb-4">
+            Elige cualquier historia de 60 segundos de tu vida real. Ejemplos: un viaje
+            memorable, tu primer día en un trabajo, un momento gracioso en familia, el día que
+            decidiste aprender inglés, algo inesperado que pasó la semana pasada.
+          </p>
+          <p class="text-base text-slate-700 leading-relaxed">
+            <strong>La estructura:</strong> arma la escena con pasado continuo ('I was
+            walking…'), introduce el momento con pasado simple ('then suddenly…'), di qué
+            sigue con 'going to' ('next month I'm going to…'), y usa al menos un comparativo
+            ('it was better than…').
+          </p>
+        </div>
+
+        <!-- The 6 ingredients -->
+        <h3 class="text-xl font-bold text-slate-900 mb-4">Seis ingredientes para incluir:</h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-3 mb-10">
+          {
+            [
+              { unit: "Unidad 1-2", req: "Al menos 3 verbos en pasado simple (regulares Y irregulares)" },
+              { unit: "Unidad 3", req: "Un marcador de tiempo (yesterday, last week, two months ago)" },
+              { unit: "Unidad 4", req: "Un plan futuro con 'going to' o 'will'" },
+              { unit: "Unidad 5", req: "Un comparativo ('better than', 'bigger than')" },
+              { unit: "Unidad 8", req: "Un adverbio de frecuencia ('I usually…', 'I often…')" },
+              { unit: "Unidad 9", req: "Un pasado continuo + interrupción ('I was X-ing when…')" },
+            ].map((item) => (
+              <div class="flex items-start gap-3 p-4 bg-sky-50 rounded-xl border border-sky-100">
+                <CheckCircle2 class="w-5 h-5 text-sky-500 shrink-0 mt-0.5" />
+                <div>
+                  <p class="text-xs font-bold uppercase tracking-wider text-sky-600 mb-1">{item.unit}</p>
+                  <p class="text-sm text-slate-700 leading-relaxed">{item.req}</p>
+                </div>
+              </div>
+            ))
+          }
+        </div>
+
+        <!-- How to record -->
+        <div class="bg-sky-50 border border-sky-200 rounded-xl p-6">
+          <div class="flex items-center gap-2 mb-4">
+            <Mic class="w-5 h-5 text-sky-600" />
+            <p class="text-sm font-bold text-sky-800 uppercase tracking-wide">Cómo Grabar</p>
+          </div>
+          <ul class="space-y-2 text-sm text-sky-900 leading-relaxed">
+            <li><strong>iPhone:</strong> Abre la app Voice Memos → toca el botón rojo → guarda y exporta como M4A.</li>
+            <li><strong>Android:</strong> Usa la app Grabador de Voz integrada → exporta como MP3 o M4A.</li>
+            <li><strong>Computadora:</strong> Usa Zoom (graba una reunión contigo mismo), Loom, o QuickTime audio.</li>
+          </ul>
+          <p class="text-xs text-sky-700 mt-4">
+            Cualquier formato de audio funciona: MP3, M4A, WAV, u OGG. Una grabación de voz
+            de 60 segundos pesa muy por debajo de 5 MB.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Submission — Upload form + Booking CTA -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <p class="text-[11px] font-mono uppercase tracking-[0.3em] text-sky-600 mb-4 text-center">
+          Envía Tu Trabajo
+        </p>
+        <h2
+          class="text-2xl md:text-3xl font-bold text-slate-900 mb-3 text-center"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Elige tu camino.
+        </h2>
+        <p class="text-slate-600 text-center mb-10">
+          Ambas opciones incluyen retroalimentación personal de Robert.
+        </p>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
+          <!-- Path A: Upload -->
+          <div>
+            <div class="flex items-center gap-2 mb-4">
+              <span class="w-6 h-6 rounded-full bg-sky-500 text-white text-xs font-bold flex items-center justify-center">A</span>
+              <h3 class="text-lg font-bold text-slate-900">Sube Tu Grabación</h3>
+            </div>
+            <p class="text-sm text-slate-600 mb-5 leading-relaxed">
+              Graba en tu celular o computadora, luego súbela aquí. Robert escucha
+              personalmente y te envía retroalimentación detallada por correo en 48 horas.
+            </p>
+            <CapstoneUploadForm client:load lang="es" />
+          </div>
+
+          <!-- Path B: Strategy Session -->
+          <div class="md:mt-14">
+            <div class="flex items-center gap-2 mb-4">
+              <span class="w-6 h-6 rounded-full bg-slate-800 text-white text-xs font-bold flex items-center justify-center">B</span>
+              <h3 class="text-lg font-bold text-slate-900">Cuéntala En Vivo con Robert</h3>
+              <span class="text-xs font-bold uppercase tracking-wider text-sky-600 bg-sky-50 border border-sky-200 px-2 py-0.5 rounded-full ml-auto">
+                Recomendada
+              </span>
+            </div>
+            <p class="text-sm text-slate-600 mb-6 leading-relaxed">
+              Reserva una consulta gratuita de 30 minutos. Cuenta tu historia de 60 segundos
+              en vivo — y recibe coaching en tiempo real sobre formas del pasado,
+              pronunciación y cómo seguir cuando te trabes. La forma más rápida de avanzar.
+            </p>
+            <div class="bg-white rounded-2xl border-2 border-sky-300 p-6 shadow-sm">
+              <div class="flex items-center gap-3 mb-4">
+                <Calendar class="w-6 h-6 text-sky-600" />
+                <div>
+                  <p class="text-sm font-bold text-slate-900">Consulta Gratuita</p>
+                  <p class="text-xs text-slate-500">30 minutos · Google Meet · Sin preparación</p>
+                </div>
+              </div>
+              <p class="text-xs text-slate-500 mb-5 leading-relaxed">
+                El contexto de tu sesión está pre-llenado — Robert sabrá que vienes del Curso
+                Elemental y que tienes tu historia lista.
+              </p>
+              <Button href={bookingLink} variant="primary" size="lg" class="w-full">
+                <Calendar class="w-4 h-4" />
+                Reserva Tu Sesión Gratuita
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Robert's Coaching Reminders -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <p class="text-[11px] font-mono uppercase tracking-[0.3em] text-sky-600 mb-4">
+          Recordatorios de Robert
+        </p>
+        <h2
+          class="text-2xl font-bold text-slate-900 mb-8"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Cuatro cosas que escucho.
+        </h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {
+            [
+              {
+                tip: "Formas del pasado — verbos irregulares especialmente. 'Went' no 'goed'. 'Saw' no 'seed'. (Unidades 1-2)",
+              },
+              {
+                tip: "Posición del adverbio de frecuencia — 'I usually…' ANTES del verbo, NUNCA al final. (Unidad 8)",
+              },
+              {
+                tip: "Pasado continuo + interrupción — pon la escena con 'was X-ing', luego suelta el momento con pasado simple. (Unidad 9)",
+              },
+              {
+                tip: "No te detengas. Si te trabas, sigue. Los nativos también se traban. La fluidez no es perfección — es recuperación.",
+              },
+            ].map((item) => (
+              <div class="flex items-start gap-3 p-5 bg-slate-50 rounded-xl border border-slate-100">
+                <CheckCircle2 class="w-5 h-5 text-sky-500 shrink-0 mt-0.5" />
+                <p class="text-sm text-slate-700 leading-relaxed">{item.tip}</p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Final exam CTA -->
+  <section class="py-16 md:py-20 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <p class="text-[11px] font-mono uppercase tracking-[0.3em] text-sky-600 mb-4">
+          Una Última Cosa
+        </p>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-4" style="font-family: 'Noto Sans KR', sans-serif;">
+          Toma el examen final.
+        </h2>
+        <p class="text-lg text-slate-600 mb-8 leading-relaxed">
+          20 preguntas sobre las 10 unidades. Evalúa lo que aprendiste y mira exactamente
+          dónde estás antes de seguir al curso intermedio.
+        </p>
+        <Button href="/es/curso/elemental/examen/" variant="primary" size="lg">
+          Empezar el Examen Final →
+        </Button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Bottom Encouragement -->
+  <section class="py-20 md:py-28 bg-slate-950 text-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-2xl mx-auto text-center">
+        <Sparkles class="w-10 h-10 text-sky-400 mx-auto mb-6" />
+        <h2
+          class="text-3xl md:text-4xl font-bold mb-6 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Esto no es una prueba.<br />
+          <span class="text-sky-400">Es tu voz en inglés.</span>
+        </h2>
+        <p class="text-lg text-slate-300 leading-relaxed">
+          Cada práctica, cada sonido, cada corrección en nueve unidades construyó hacia esto.
+          Dale rec. Cuenta tus 60 segundos. Envíalo. La próxima conversación de tu vida será
+          más fácil gracias a esta.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "LearningResource",
+  "name": "Reto Final del Curso Elemental — Historia de 60 Segundos",
+  "description": "Graba una historia autobiográfica de 60 segundos combinando pasado simple, pasado continuo, going to y comparativos. Recibe retroalimentación personal de Robert.",
+  "learningResourceType": "Assessment",
+  "educationalLevel": "A2",
+  "inLanguage": "es",
+  "url": "https://www.nyenglishteacher.com/es/curso/elemental/unidad-10/",
+  "isAccessibleForFree": true,
+  "isPartOf": {
+    "@type": "Course",
+    "name": "Curso Gratis de Inglés Elemental (A2)",
+    "url": "https://www.nyenglishteacher.com/es/curso/elemental/"
+  }
+})} />
+</Base>

--- a/src/pages/es/curso/elemental/unidad-7.astro
+++ b/src/pages/es/curso/elemental/unidad-7.astro
@@ -1,0 +1,297 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CognateDiscovery from "@components/course/CognateDiscovery";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import ConnectorChallenge from "@components/course/ConnectorChallenge";
+import SelfTest from "@components/course/SelfTest";
+import { elementaryUnits } from "@data/elementary/units";
+import {
+  cognateWaves,
+  sentenceBlocks,
+  powerVerbBlocks,
+  connectorSentences,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/elementary/unit-7";
+import {
+  MessageCircleQuestion,
+  Layers,
+  Zap,
+  Link2,
+  Volume2,
+  ClipboardCheck,
+  BookOpen,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/elementary/unit-7" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
+
+const nextUnit = elementaryUnits.find((u) => u.id === 8);
+const nextUnitPublished = nextUnit?.published ?? false;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unidad 7: Haciendo Preguntas Reales | Inglés Elemental (A2)"
+  description="Preguntas Wh- para hispanohablantes — where, when, why, how, how long, how often. Domina el orden que convierte la charla en conversación real. Lección A2."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={7}
+    basePath="/es/curso/elemental"
+    lang="es"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-sky-400 text-sm font-semibold mb-3">
+          <MessageCircleQuestion class="w-4 h-4" />
+          Unidad 7
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Haciendo Preguntas Reales
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Where, When, Why, How, How long, How often. Las preguntas que convierten la charla en
+          conversación real — más el orden de palabras que confunde a todos los hispanohablantes.
+          Al terminar esta unidad, puedes entrevistar a alguien, no solo responder 'sí' o 'no'.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <nav class="bg-white border-b border-slate-200 sticky top-[52px] z-30 overflow-x-auto">
+    <div class="site-container mx-auto px-4">
+      <div class="flex items-center gap-1 py-2 text-sm whitespace-nowrap">
+        <a href="#vocabulary" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <BookOpen class="w-3.5 h-3.5" /> Palabras Wh-
+        </a>
+        <a href="#word-order" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Layers class="w-3.5 h-3.5" /> Orden de Palabras
+        </a>
+        <a href="#subject-object" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Zap class="w-3.5 h-3.5" /> Sujeto vs. Objeto
+        </a>
+        <a href="#boss" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Link2 class="w-3.5 h-3.5" /> Oración Maestra
+        </a>
+        <a href="#pronunciation" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Volume2 class="w-3.5 h-3.5" /> Pronunciación
+        </a>
+        <a href="#self-test" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <ClipboardCheck class="w-3.5 h-3.5" /> Auto-Test
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <section id="vocabulary" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <BookOpen class="w-4 h-4" />
+            Sección A
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Las 7 Palabras Wh-, Compuestas con How+X y Vocabulario Temático
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Tres olas. Ola 1: las siete palabras Wh- básicas (what, where, when, why, who, which,
+            how). Ola 2: las compuestas 'how + adjetivo' (how long, how often, how much). Ola 3:
+            los temas reales sobre los que la gente realmente pregunta. Toca cualquier entrada
+            para escucharla.
+          </p>
+        </div>
+        <CognateDiscovery client:visible waves={waveData} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="word-order" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Layers class="w-4 h-4" />
+            Sección B
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Orden de Palabras en Preguntas — Los Cuatro Patrones
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Cada pregunta Wh- sigue uno de cuatro patrones: Wh + BE, Wh + do/does + verbo, Wh +
+            did + verbo base (pasado), Wh + modal + verbo base. Domina estos cuatro y podrás
+            hacer CUALQUIER pregunta correctamente.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={sentenceBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="subject-object" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Zap class="w-4 h-4" />
+            Sección C
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Preguntas de Sujeto vs. de Objeto — Cuándo QUITAR 'do/did'
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Who called you?' vs. 'Who did you call?' — mismas palabras, significados opuestos.
+            Cuando 'who' o 'what' ES el sujeto, quitas el verbo ayudante. Esta única regla
+            confunde a casi todos los hispanohablantes. Practícala hasta que sea automática.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={powerVerbBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="boss" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Link2 class="w-4 h-4" />
+            Sección D
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            La Oración Maestra — Una Primera Conversación Real
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Seis preguntas, seis patrones diferentes, todas en un abre-conversaciones natural.
+            De 'Where are you from?' a 'What's your favorite thing about it?' — exactamente lo
+            que suena una primera conversación real en inglés, y exactamente lo que debes estar
+            listo para PREGUNTAR de regreso.
+          </p>
+        </div>
+        <ConnectorChallenge
+          client:visible
+          connectors={connectorSentences.connectors}
+          bossSentence={connectorSentences.bossSentence}
+          lang="es"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section id="pronunciation" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-rose-500 text-sm font-semibold mb-2">
+            <Volume2 class="w-4 h-4" />
+            Laboratorio de Pronunciación
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Sonidos de Preguntas y Entonación Descendente
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Wh' es solo el sonido 'w'. La 'w' es muda en 'who' y 'how'. 'Do you' se junta en
+            'd'YA'. 'Did you' se junta en 'DID-juh'. Y el cambio cultural más grande: las
+            preguntas Wh- en inglés TERMINAN con tono BAJANDO — opuesto al español.
+          </p>
+        </div>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="self-test" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <ClipboardCheck class="w-4 h-4" />
+            Auto-Evaluación
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Evalúa Lo que Aprendiste
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Repaso tipo flashcard de cada palabra Wh-, compuesta How+X y frase de pregunta útil
+            de la Unidad 7. Cambia entre los modos español→inglés e inglés→español.
+          </p>
+        </div>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-gradient-to-b from-slate-900 to-slate-800">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-2xl mx-auto text-center space-y-6">
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/20 text-emerald-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-bold text-white">¡Unidad 7 Completada!</h2>
+        <p class="text-lg text-slate-100 leading-relaxed">
+          Ahora puedes dirigir una conversación real, no solo responderla. Siete unidades
+          terminadas, tres por venir. Sigue: rutinas y adverbios de frecuencia — la trampa
+          silenciosa de orden de palabras que delata a los hispanohablantes en la primera
+          oración.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center pt-4">
+          <a
+            href="/es/curso/elemental/unidad-6/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors"
+          >
+            ← Repasar Unidad 6
+          </a>
+          {nextUnitPublished ? (
+            <a
+              href="/es/curso/elemental/unidad-8/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Continuar a Unidad 8 →
+            </a>
+          ) : (
+            <a
+              href="/es/curso/elemental/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Vista General del Curso
+            </a>
+          )}
+        </div>
+        <div class="pt-8 border-t border-slate-700 mt-8">
+          <p class="text-slate-200 text-sm mb-3">
+            ¿Quieres coaching personalizado de inglés?
+          </p>
+          <a
+            href="/es/contact/"
+            class="text-sky-400 hover:text-sky-300 font-medium underline underline-offset-2"
+          >
+            Reserva una consulta gratuita con Robert →
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/elemental/unidad-8.astro
+++ b/src/pages/es/curso/elemental/unidad-8.astro
@@ -1,0 +1,298 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CognateDiscovery from "@components/course/CognateDiscovery";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import ConnectorChallenge from "@components/course/ConnectorChallenge";
+import SelfTest from "@components/course/SelfTest";
+import { elementaryUnits } from "@data/elementary/units";
+import {
+  cognateWaves,
+  sentenceBlocks,
+  powerVerbBlocks,
+  connectorSentences,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/elementary/unit-8";
+import {
+  Repeat,
+  Layers,
+  Zap,
+  Link2,
+  Volume2,
+  ClipboardCheck,
+  BookOpen,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/elementary/unit-8" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
+
+const nextUnit = elementaryUnits.find((u) => u.id === 9);
+const nextUnitPublished = nextUnit?.published ?? false;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unidad 8: La Vida Diaria y Adverbios de Frecuencia | Inglés A2"
+  description="Always, usually, often, sometimes, never — la trampa de posición que delata a los hispanohablantes. Domina rutinas y la regla de orden. Lección A2 gratis."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={8}
+    basePath="/es/curso/elemental"
+    lang="es"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-sky-400 text-sm font-semibold mb-3">
+          <Repeat class="w-4 h-4" />
+          Unidad 8
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          La Vida Diaria
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Always, usually, often, sometimes, never. Dónde van en la oración (los hispanohablantes
+          siempre lo confunden) y cómo describir una rutina diaria real — la tuya. Una regla de
+          posición, tres excepciones, y el ritmo natural del inglés cotidiano.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <nav class="bg-white border-b border-slate-200 sticky top-[52px] z-30 overflow-x-auto">
+    <div class="site-container mx-auto px-4">
+      <div class="flex items-center gap-1 py-2 text-sm whitespace-nowrap">
+        <a href="#vocabulary" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <BookOpen class="w-3.5 h-3.5" /> Adverbios
+        </a>
+        <a href="#position" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Layers class="w-3.5 h-3.5" /> Reglas de Posición
+        </a>
+        <a href="#phrases" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Zap class="w-3.5 h-3.5" /> Frases de Frecuencia
+        </a>
+        <a href="#boss" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Link2 class="w-3.5 h-3.5" /> Oración Maestra
+        </a>
+        <a href="#pronunciation" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Volume2 class="w-3.5 h-3.5" /> Pronunciación
+        </a>
+        <a href="#self-test" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <ClipboardCheck class="w-3.5 h-3.5" /> Auto-Test
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <section id="vocabulary" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <BookOpen class="w-4 h-4" />
+            Sección A
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Adverbios de Frecuencia, Verbos de Rutina y Períodos de Tiempo
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Tres olas. Ola 1: los siete adverbios de frecuencia, de 100% (always) a 0% (never).
+            Ola 2: los verbos de rutina diaria que todo adulto usa. Ola 3: las frases de
+            período que van al FINAL de la oración. Toca cualquier entrada para escucharla.
+          </p>
+        </div>
+        <CognateDiscovery client:visible waves={waveData} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="position" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Layers class="w-4 h-4" />
+            Sección B
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Reglas de Posición — Dónde Van los Adverbios de Frecuencia
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Una regla principal, tres excepciones. Los adverbios de frecuencia van ANTES del
+            verbo principal — pero DESPUÉS de 'be', y ENTRE el auxiliar y el verbo principal.
+            'Sometimes' y 'usually' también pueden iniciar la oración. Practica cada patrón
+            hasta que el correcto salga automático.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={sentenceBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="phrases" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Zap class="w-4 h-4" />
+            Sección C
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Frases de Frecuencia — Every Day, Twice a Week, On Mondays
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Every X', 'once / twice / X times a [período]', 'on + día', 'in + parte del día'.
+            Estas frases van al FINAL de la oración (o a veces al inicio). Combínalas con la
+            preposición correcta: ON Mondays, IN the morning, AT night.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={powerVerbBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="boss" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Link2 class="w-4 h-4" />
+            Sección D
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            La Oración Maestra — Una Semana Típica Real
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Cuatro oraciones. Ocho expresiones de frecuencia diferentes en ocho posiciones
+            distintas. Mezclando adverbios ('usually', 'always', 'rarely', 'never') con frases
+            ('every day', 'three times a week', 'every Monday morning'). Así suena hablar de la
+            vida diaria de forma natural.
+          </p>
+        </div>
+        <ConnectorChallenge
+          client:visible
+          connectors={connectorSentences.connectors}
+          bossSentence={connectorSentences.bossSentence}
+          lang="es"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section id="pronunciation" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-rose-500 text-sm font-semibold mb-2">
+            <Volume2 class="w-4 h-4" />
+            Laboratorio de Pronunciación
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Sonidos de Adverbios de Frecuencia — y la T Muda
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            'Usually' tiene TRES sílabas y una 'zh' suave en medio. 'Often' típicamente quita
+            la 't' — 'OFF-en'. 'Rarely' usa la 'r' americana. 'Every day' en habla rápida
+            reduce la 'e' del medio a 'EV-ree'. Practica estos y el ritmo de hablar de rutina
+            cae natural.
+          </p>
+        </div>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="self-test" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <ClipboardCheck class="w-4 h-4" />
+            Auto-Evaluación
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Evalúa Lo que Aprendiste
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Repaso tipo flashcard de cada adverbio de frecuencia, verbo de rutina y frase útil
+            de la Unidad 8. Cambia entre los modos español→inglés e inglés→español.
+          </p>
+        </div>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-gradient-to-b from-slate-900 to-slate-800">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-2xl mx-auto text-center space-y-6">
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/20 text-emerald-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-bold text-white">¡Unidad 8 Completada!</h2>
+        <p class="text-lg text-slate-100 leading-relaxed">
+          Ahora puedes describir un día, semana o rutina real — con los adverbios en la posición
+          correcta, la preposición correcta para el tiempo, y el ritmo natural del habla nativa.
+          Ocho unidades terminadas, dos por venir. Sigue: pasado continuo — la herramienta
+          narrativa.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center pt-4">
+          <a
+            href="/es/curso/elemental/unidad-7/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors"
+          >
+            ← Repasar Unidad 7
+          </a>
+          {nextUnitPublished ? (
+            <a
+              href="/es/curso/elemental/unidad-9/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Continuar a Unidad 9 →
+            </a>
+          ) : (
+            <a
+              href="/es/curso/elemental/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Vista General del Curso
+            </a>
+          )}
+        </div>
+        <div class="pt-8 border-t border-slate-700 mt-8">
+          <p class="text-slate-200 text-sm mb-3">
+            ¿Quieres coaching personalizado de inglés?
+          </p>
+          <a
+            href="/es/contact/"
+            class="text-sky-400 hover:text-sky-300 font-medium underline underline-offset-2"
+          >
+            Reserva una consulta gratuita con Robert →
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/elemental/unidad-9.astro
+++ b/src/pages/es/curso/elemental/unidad-9.astro
@@ -1,0 +1,298 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import CourseProgress from "@components/course/CourseProgress";
+import CognateDiscovery from "@components/course/CognateDiscovery";
+import SentenceBuilder from "@components/course/SentenceBuilder";
+import PronunciationDrill from "@components/course/PronunciationDrill";
+import ConnectorChallenge from "@components/course/ConnectorChallenge";
+import SelfTest from "@components/course/SelfTest";
+import { elementaryUnits } from "@data/elementary/units";
+import {
+  cognateWaves,
+  sentenceBlocks,
+  powerVerbBlocks,
+  connectorSentences,
+  pronunciationDrills,
+  vocabularyList,
+} from "@data/elementary/unit-9";
+import {
+  Pause,
+  Layers,
+  Zap,
+  Link2,
+  Volume2,
+  ClipboardCheck,
+  BookOpen,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/elementary/unit-9" as const;
+
+const progressUnits = elementaryUnits.map((u) => ({
+  id: u.id,
+  slug: u.slugEs,
+  title: u.title,
+  titleEs: u.titleEs,
+}));
+
+const waveData = [cognateWaves.wave1, cognateWaves.wave2, cognateWaves.wave3];
+
+const nextUnit = elementaryUnits.find((u) => u.id === 10);
+const nextUnitPublished = nextUnit?.published ?? false;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Unidad 9: Estaba Comiendo Cuando… | Inglés Elemental (A2)"
+  description="Pasado continuo para hispanohablantes — was/were + verbo-ing. La herramienta que convierte el pasado plano en historias con interrupciones. Lección A2."
+>
+  <CourseProgress
+    client:load
+    units={progressUnits}
+    currentUnit={9}
+    basePath="/es/curso/elemental"
+    lang="es"
+  />
+
+  <section class="bg-gradient-to-b from-slate-900 to-slate-800 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-sky-400 text-sm font-semibold mb-3">
+          <Pause class="w-4 h-4" />
+          Unidad 9
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Estaba Comiendo Cuando…
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Was/were + -ing. El tiempo que te permite decir 'I was eating when she called' — poner
+          una acción pasada de fondo mientras otra la interrumpe. La herramienta narrativa. Al
+          terminar esta unidad, tus historias en pasado tienen textura, ritmo y un punto de
+          giro real.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <nav class="bg-white border-b border-slate-200 sticky top-[52px] z-30 overflow-x-auto">
+    <div class="site-container mx-auto px-4">
+      <div class="flex items-center gap-1 py-2 text-sm whitespace-nowrap">
+        <a href="#vocabulary" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <BookOpen class="w-3.5 h-3.5" /> Vocabulario
+        </a>
+        <a href="#structure" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Layers class="w-3.5 h-3.5" /> Estructura
+        </a>
+        <a href="#interruption" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Zap class="w-3.5 h-3.5" /> Interrupción
+        </a>
+        <a href="#boss" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Link2 class="w-3.5 h-3.5" /> Oración Maestra
+        </a>
+        <a href="#pronunciation" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <Volume2 class="w-3.5 h-3.5" /> Pronunciación
+        </a>
+        <a href="#self-test" class="px-3 py-1.5 rounded-full hover:bg-sky-50 text-slate-600 hover:text-sky-600 transition-colors flex items-center gap-1.5">
+          <ClipboardCheck class="w-3.5 h-3.5" /> Auto-Test
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <section id="vocabulary" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <BookOpen class="w-4 h-4" />
+            Sección A
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Formas de Was/Were, Verbos -ing y Marcadores Narrativos
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Tres olas. Ola 1: was/were emparejados con cada pronombre sujeto. Ola 2: los verbos
+            -ing más comunes al contar historias, más las reglas de escritura. Ola 3: los
+            marcadores narrativos (when, while, suddenly, at that moment) que dan ritmo a las
+            historias en pasado.
+          </p>
+        </div>
+        <CognateDiscovery client:visible waves={waveData} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="structure" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Layers class="w-4 h-4" />
+            Sección B
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Estructura del Pasado Continuo — Afirmativo, Negativo, Pregunta
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Sujeto + was/were + verbo-ing. Practica las tres formas — afirmativo ('I was
+            working'), negativo ('I wasn't working'), pregunta ('Were you working?') — más la
+            diferencia crítica entre pasado simple y pasado continuo.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={sentenceBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="interruption" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Zap class="w-4 h-4" />
+            Sección C
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            El Patrón de Interrupción — Pasado Continuo + Pasado Simple
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            La combinación narrativa clásica. Acción larga en pasado continuo ('I was eating
+            dinner'). Acción corta interrumpe en pasado simple ('when she called'). Más 'while'
+            para dos acciones continuas simultáneas, y 'suddenly' para interrupciones
+            dramáticas.
+          </p>
+        </div>
+        <SentenceBuilder client:visible blocks={powerVerbBlocks} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="boss" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <Link2 class="w-4 h-4" />
+            Sección D
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            La Oración Maestra — Una Narrativa Personal Real
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Cinco oraciones. Dos verbos en pasado continuo, tres en pasado simple, cinco
+            marcadores de tiempo distintos. Un arco real con planteamiento, interrupción, giro y
+            resolución. Así narran un recuerdo los hablantes nativos de inglés.
+          </p>
+        </div>
+        <ConnectorChallenge
+          client:visible
+          connectors={connectorSentences.connectors}
+          bossSentence={connectorSentences.bossSentence}
+          lang="es"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section id="pronunciation" class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-rose-500 text-sm font-semibold mb-2">
+            <Volume2 class="w-4 h-4" />
+            Laboratorio de Pronunciación
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Reducción de Was/Were — y la Música de Contar Historias
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Acentuados, 'was' = WUZ y 'were' = WUR. En habla normal se REDUCEN casi al silencio:
+            'I was working' = 'I-wuz-WORKING'. Más reducciones de -ing ('workin'), contracciones
+            wasn't/weren't, y cómo el verbo en pasado simple lleva el acento en oraciones de
+            interrupción.
+          </p>
+        </div>
+        <PronunciationDrill client:visible drills={pronunciationDrills} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section id="self-test" class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="mb-8">
+          <div class="flex items-center gap-2 text-sky-600 text-sm font-semibold mb-2">
+            <ClipboardCheck class="w-4 h-4" />
+            Auto-Evaluación
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3">
+            Evalúa Lo que Aprendiste
+          </h2>
+          <p class="text-lg text-slate-600 leading-relaxed">
+            Repaso tipo flashcard de cada forma was/were, verbo -ing, marcador de tiempo y
+            frase útil de la Unidad 9. Cambia entre los modos español→inglés e inglés→español.
+          </p>
+        </div>
+        <SelfTest client:visible vocabulary={vocabularyList} lang="es" />
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 md:py-20 bg-gradient-to-b from-slate-900 to-slate-800">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-2xl mx-auto text-center space-y-6">
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/20 text-emerald-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-bold text-white">¡Unidad 9 Completada!</h2>
+        <p class="text-lg text-slate-100 leading-relaxed">
+          Ahora puedes narrar historias en pasado como un nativo — poniendo la acción larga de
+          fondo, soltando la interrupción y usando marcadores de tiempo para controlar el
+          ritmo. Nueve unidades terminadas. Queda una: el reto final, donde grabas TU historia.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center pt-4">
+          <a
+            href="/es/curso/elemental/unidad-8/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-slate-700 text-slate-300 font-medium hover:bg-slate-600 transition-colors"
+          >
+            ← Repasar Unidad 8
+          </a>
+          {nextUnitPublished ? (
+            <a
+              href="/es/curso/elemental/unidad-10/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Continuar a Unidad 10 →
+            </a>
+          ) : (
+            <a
+              href="/es/curso/elemental/"
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500 text-white font-semibold hover:bg-sky-400 transition-colors shadow-lg"
+            >
+              Vista General del Curso
+            </a>
+          )}
+        </div>
+        <div class="pt-8 border-t border-slate-700 mt-8">
+          <p class="text-slate-200 text-sm mb-3">
+            ¿Quieres coaching personalizado de inglés?
+          </p>
+          <a
+            href="/es/contact/"
+            class="text-sky-400 hover:text-sky-300 font-medium underline underline-offset-2"
+          >
+            Reserva una consulta gratuita con Robert →
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary

Wraps up the **"Tell Your Story" A2 elementary course** with the final four units, the capstone, and a 20-question final exam. Ships EN + ES for everything.

- **Unit 7** — Asking Real Questions (Wh-questions, word order, subject vs. object, How+X compounds)
- **Unit 8** — Daily Life (frequency adverbs + position rules, time-period phrases, daily routine verbs)
- **Unit 9** — I Was Eating When... (past continuous + interruption pattern, was/were reduction, narrative time markers)
- **Unit 10** — Capstone: 60-second autobiographical story upload + booking CTA, with six required ingredients spanning Units 1-9
- **Final Exam** — 20 questions across all 10 units, tier feedback (Outstanding 90%+, Passed 70%+, Keep Practicing)

## Audits performed

- **TTS voice wiring**: verified `AudioButton` → `/api/tts/synthesize` defaults to `en-US-AvaNeural` for English audio on both EN and ES pages (correct: we're teaching English; audio always plays English text). All course components pass `lang` prop down properly.
- **Exam questions**: each of the 20 has exactly one correct answer (verified via source parsing). Wording audited for unambiguity — fixed Q3, Q5, Q16, Q18 where wrong options were grammatically valid English with different meaning.
- **Sitemap**: bidirectional hreflang now correctly pairs `/en/course/<x>/unit-N/` ↔ `/es/curso/<x-es>/unidad-N/` for all 5 courses (beginners, elementary, intermediate, advanced, executive). Also covers exam pages and the executive capstone. Previously each unit URL only had a self-referencing en-US or es-MX entry — fixed at the `astro.config.mjs` level.
- **SEO meta-description gate**: all 9 new pages within 120-160 char range; build passes.

## Test plan

- [ ] After merge to main, Vercel deploys and `/en/course/elementary/` shows all 10 units + final exam unlocked
- [ ] Click into Unit 7 — verify all 6 sections render (Wh-Words, Word Order, Subject vs. Object, Boss Sentence, Pronunciation, Self-Test) and audio plays via Azure TTS
- [ ] Same spot-check on Units 8, 9, 10 (EN + ES)
- [ ] Take the Final Exam end-to-end — all 20 questions display with one correct answer each, tier feedback shows correctly at 100%, 75%, 50%
- [ ] Submit a test capstone audio file via Unit 10's upload form
- [ ] Check the deployed sitemap.xml at `/sitemap-0.xml` and confirm a course unit URL has both `en-US` and `es-MX` hreflang alternates

🤖 Generated with [Claude Code](https://claude.com/claude-code)