### PR TITLE
fix(blog): registro post — remove Iberian markers, smooth for Mexican Spanish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,32 @@ Professional English coaching and training platform for Robert Cushman's "NY Eng
 
 **Live Site**: https://www.nyenglishteacher.com
 
+## Spanish Content — Mexican Professional Spanish ONLY (CRITICAL)
+
+**All Spanish content on this site must be Mexican Professional Spanish** (`es-MX`). The audience is Mexico-based corporate professionals. Iberian/Spain Spanish reads as foreign and damages credibility — flagged by a native Mexican reviewer (Julio Aldana, 2026-05-03) on the "registro" blog post.
+
+**When translating EN → ES, the prompt must explicitly say "Mexican Professional Spanish"** — never just "Spanish" or "Latin American Spanish" (still ambiguous).
+
+**Forbidden Iberian markers — never appear in our ES content:**
+- `vosotros` / `vuestro` / vosotros conjugations (`habláis`, `tenéis`, `sois`, `vosotras`) — Mexico uses `ustedes` for ALL plural; possessive `su / sus`. Never include `vosotros` even as a contrastive example — Mexicans don't think of it as part of their language.
+- `vale` (as "okay") → use `está bien`, `de acuerdo`, `ok`
+- `coger` (to take/grab) — vulgar in Mexico → use `tomar`, `agarrar`, `recoger`
+- `móvil` → `celular` · `ordenador` → `computadora` · `coche` → `carro`/`auto` · `conducir` → `manejar` · `aparcar` → `estacionar`
+- `jersey` → `suéter` · `gafas` → `lentes` · `patata` → `papa` · `zumo` → `jugo` · `ascensor` → `elevador` · `piso` (apartment) → `departamento`
+- Spain slang: `tío/tía` (as friend), `guay`, `molar`, `flipar`, `chaval` — none of this in professional MX
+- `Vd.` abbreviation → Mexico writes `Ud.` if abbreviating; spelling out `usted` is more common in formal copy
+- `leísmo` (using `le` for direct objects of people) — Mexican standard is `lo/la` as direct object, `le` only as indirect object
+
+**Mexican-preferred phrasings:**
+- "Right now": `ahora mismo` (formal), `ahorita` (slightly more colloquial / common in MX speech)
+- "Approximately": `aproximadamente`, `como` — Spain often uses `unos/unas`
+- "Take a look": `revisar`, `echar un ojo`, `ver` — Spain's `echar un vistazo` is understood but less natural in MX professional copy
+- Diminutives (`ahorita`, `un momentito`) are warmer in MX professional speech — fine in casual register, avoid in C-suite copy unless tone calls for warmth
+
+**When auditing existing ES content for Iberian drift**, grep for: `vosotros`, `vosotras`, `vuestr`, `vale\.`, `coger`, `móvil`, `ordenador`, `coche`, `aparcar`, `habéis`, `sois`, `tenéis`, `gafas`, `jersey`, `patata`, `zumo`, `tío\b`. Any hit → fix on the spot.
+
+The site's hreflang is already `es-MX` (`src/lib/i18n.ts` `getHreflangCode`). The variant is committed at the technical layer; the content layer must match.
+
 ## Tech Stack
 
 - **Framework**: Astro 5.5 with React 19 for interactive components
@@ -228,3 +254,7 @@ The `@vercel/analytics` npm package is installed but we use the direct script ta
 ## Marketing Plan
 
 See **[SEO-MARKETING-PLAN.md](./SEO-MARKETING-PLAN.md)** for the full content roadmap, completed work log, and upcoming initiatives. Claude should consult this file at the start of every session and update it as work is completed.
+
+## Session Logs
+
+Every working session creates / updates a log at `docs/session-logs/YYYY-MM-DD-NNN.md` (NNN = zero-padded sequence number for that day). See the global CLAUDE.md "Session Logs" section for the required format. Logs are committed to the repo. The log captures: accomplishments (with PR numbers), technical debt accumulated, work remaining, future ideas, files touched, and lessons/surprises. Updated as work happens, not just at session end.

--- a/docs/session-logs/2026-05-03-001.md
+++ b/docs/session-logs/2026-05-03-001.md
@@ -1,0 +1,74 @@
+# Session: A2 course completion (Units 7-10 + exam) and Spanish-variant correction
+
+**Date:** 2026-05-03
+**Branches/PRs:** PR #135 (merged), branch `feat/a2-units-7-10-and-final-exam` (deleted post-merge); follow-up branch for registro blog ES/EN fix in progress
+**Status:** in-progress
+
+## Accomplishments
+
+- **PR #135 merged** — shipped the final four A2 elementary course units + capstone + 20-question final exam, EN and ES (~4,500 lines added across 18 files):
+  - Unit 7 — Asking Real Questions (Wh-questions, word order, subject vs. object, How+X compounds)
+  - Unit 8 — Daily Life (frequency adverbs + position rules, time-period phrases, daily routine verbs)
+  - Unit 9 — I Was Eating When... (past continuous + interruption pattern, was/were reduction)
+  - Unit 10 — Capstone (60-second story upload + booking CTA + final-exam CTA)
+  - Final Exam — 20 questions across all 10 units, tier feedback (Outstanding 90%+, Passed 70%+, Keep Practicing)
+- **Pre-ship audits performed**:
+  - TTS voice wiring verified (`/api/tts/synthesize` defaults to `en-US-AvaNeural`; correct on both EN and ES pages — audio always speaks the English target text).
+  - Exam questions audited — exactly one correct answer each, fixed Q3, Q5, Q16, Q18 where wrong options were grammatically valid English with different meaning.
+  - Sitemap meta-description gate passing (all 9 new pages 120-160 chars).
+- **Sitemap site-wide fix** in `astro.config.mjs` — added a course-unit handler so `/en/course/<x>/unit-N/` and `/es/curso/<x-es>/unidad-N/` now have bidirectional `xhtml:link` hreflang. This previously affected ALL 5 courses (beginners, elementary, intermediate, advanced, executive) — every unit URL in the sitemap had only a self-referencing entry. Fixed at the serializer level so all courses benefit, not just A2.
+- **Post-publish SEO submission** (after Vercel deploy went live):
+  - Sitemap resubmitted to Google Search Console (errors: 0).
+  - All 10 new URLs submitted via IndexNow (Bing/Yandex/DuckDuckGo/Seznam/Naver) — all HTTP 200.
+  - All 10 new URLs submitted to Bing Webmaster Tools API — all HTTP 200.
+- **Mexican Spanish standard locked in** after Julio Aldana's feedback that the registro blog post reads "like a blog from Spain":
+  - New global rule added to `~/CLAUDE.md` ("Spanish Content Standard — Mexican Professional Spanish") with the forbidden Iberian markers list, Mexican-preferred phrasings, and the audit grep pattern.
+  - New project rule mirrored in `ny-eng/CLAUDE.md`.
+  - Memory file `feedback_mexican_spanish.md` created and indexed in `MEMORY.md`.
+- **Session log protocol established** in global CLAUDE.md with required format and update cadence; project CLAUDE.md points at it.
+
+## Technical Debt Accumulated
+
+- **Pre-existing `Connector` type mismatch** in `ConnectorChallenge.tsx` — the component declares `example` as `{english, spanish}` but every elementary unit's data file passes a flat string. Fails 18 type-check warnings (Units 1-9 EN + ES, applies to all elementary units, not just the new ones). Not introduced this session — Units 1-6 shipped with the same drift. Build still passes because the runtime is permissive. Done-right would be reconciling the type with the data shape (probably easier to update the type since the runtime works with strings).
+- **A2 course Iberian-Spanish risk** — the registro blog post drift suggests other ES content (course units, blog backlog, services pages) could carry similar tone-level Iberian patterns that aren't grep-detectable. Hard markers swept clean (only the registro post and EN sibling have hits), but soft drift requires per-file tone review. Tracked under "Work Remaining" below.
+- **Schema.org Course JSON-LD** is on the elementary index page but NOT on individual unit pages. Other courses follow the same pattern (so it's site-wide consistent), but unit pages would benefit from `LearningResource` schema for SEO. Unit 10 capstone has `LearningResource`; Units 1-9 don't.
+
+## Work Remaining
+
+- **Step 1 (this session, in progress):** fix the registro blog post (EN + ES) — remove the "Ustedes versus vosotros" reference, smooth the prose for Mexican Professional Spanish. Branch + PR + merge as a single small change.
+- **Step 2 (separate PR, next session):** staged tone-review audit for Iberian → Mexican Spanish drift. Tier breakdown:
+  - Tier 1 (highest priority): top-traffic blog posts — the 5 posts retrofitted in PRs #131-#133 + executive/registro pair. Soft tone review for Iberian phrasing.
+  - Tier 2: course landing pages (`/es/curso/{course}/`) and Unit 1 of each course (entry points where first impressions form).
+  - Tier 3: services pages (`/es/servicios/...`).
+  - Tier 4: lower-traffic blog backlog.
+  - Each tier shipped as its own PR so Robert can review the diffs and Julio can spot-check.
+- **Validate the new sitemap hreflang in production** after Vercel deploys this session's CLAUDE.md / blog fix — check that `/en/course/elementary/unit-7/` returns both en-US and es-MX `xhtml:link` entries in the LIVE sitemap, not just the local build.
+- **Consider** running `gsc-index-status.mjs` against the 10 new A2 URLs in 24-72 hours to confirm Google indexed them.
+
+## Future Ideas
+
+- **Translation prompt template** — could create a reusable prompt scaffold (in `docs/` or `scripts/`) for "translate EN → MX Spanish" that bakes in the forbidden-markers list and Mexican-preferred phrasings. Would prevent regression in future translation work.
+- **CI-level Iberian-Spanish gate** — could add a build-time grep for the forbidden-markers list, failing the build if any hit appears in `src/content/blog/es/` or `src/data/`. Same shape as the existing meta-description SEO gate. Cheap insurance against drift.
+- **Schema.org `LearningResource` per unit page** — could add structured data to each unit (Units 1-9 across all 5 courses), positioning the course in the same way as the executive capstone. SEO upside; small lift since the pattern is already established on the capstone.
+- **Content audit dashboard** — a one-page report (script + markdown output) showing per-page Iberian-marker hits, meta-description length compliance, missing hreflang, etc. Would catch drift faster than ad-hoc grepping.
+
+## Files Touched
+
+- `astro.config.mjs` — added courseTranslations + courseLeafTranslations maps and the course-unit branch in the sitemap serializer for bidirectional hreflang.
+- `src/data/elementary/units.ts` — flipped `published: true` for units 7, 8, 9, 10.
+- `src/data/elementary/unit-7.ts`, `unit-8.ts`, `unit-9.ts`, `exam.ts` — new data files.
+- `src/pages/en/course/elementary/{unit-7,unit-8,unit-9,unit-10,exam}.astro` — 5 new EN pages.
+- `src/pages/es/curso/elemental/{unidad-7,unidad-8,unidad-9,unidad-10,examen}.astro` — 5 new ES pages.
+- `src/pages/{en/course/elementary,es/curso/elemental}/index.astro` — replaced "Coming soon" final-exam card with active link.
+- `~/CLAUDE.md` — added Spanish Content Standard + Session Logs sections.
+- `ny-eng/CLAUDE.md` — added Mexican Professional Spanish (CRITICAL) section + Session Logs pointer.
+- `~/.claude/projects/.../memory/feedback_mexican_spanish.md` — new feedback memory.
+- `~/.claude/projects/.../memory/MEMORY.md` — added pointer to the new memory.
+
+## Lessons / Surprises
+
+- **TTS voice was correctly wired all along** — `AudioButton.tsx` defaults to `en-US` and the `/api/tts/synthesize` endpoint hardcodes `en-US-AvaNeural` / `es-MX-DaliaNeural`. Audio always plays the English target text on both EN and ES pages, which is the right pedagogy for an English-learning course.
+- **Sitemap hreflang for course units was a SITE-WIDE pre-existing gap** — every unit URL in every course only had a self-referencing entry until I added the course-unit handler. Worth checking other content types (resources, services subpages) for the same drift pattern in a future session.
+- **`getAllTKeys()` only returns top-level course keys**, not unit keys — that's why the existing serializer didn't generate cross-language hreflang for unit pages. Fixing it via regex pattern handler (rather than expanding `getAllTKeys` with 50+ entries) keeps the change small and matches the existing blog/category handler pattern.
+- **"Translate to Spanish" prompts default to Iberian/neutral patterns** in LLM output. The variant must be explicitly pinned to "Mexican Professional Spanish" — not just "Spanish" or "Latin American Spanish." This was the root cause of the registro blog post issue Julio caught.
+- **Vercel Hobby plan deployment count** — pre-existing concern from CLAUDE.md (100/day limit, 27 connected projects). This session: 1 production deploy for PR #135 + likely 1 more for the registro fix + 1 more for tier audits = manageable, but worth tracking when batching Tier 2-4 audits as separate PRs.

--- a/src/content/blog/en/english-register-for-spanish-speakers.md
+++ b/src/content/blog/en/english-register-for-spanish-speakers.md
@@ -22,7 +22,7 @@ You're on a board update with your US parent company. Your English is fine — b
 
 Your English didn't break. The controls did.
 
-In Spanish, register lives in your grammar. Tú versus usted. Ustedes versus vosotros. The subjunctive as a softening device — *quisiera, podría, hubiera*. The conditional cushion. The diminutive that takes the edge off a request without weakening it. You have been switching registers effortlessly for thirty years. The intuition is wired in.
+In Spanish, register lives in your grammar. Tú versus usted. The subjunctive as a softening device — *quisiera, podría, hubiera*. The conditional cushion. The diminutive that takes the edge off a request without weakening it — *un momentito, tantito, ahorita*. You have been switching registers effortlessly for thirty years. The intuition is wired in.
 
 In English, those controls do not exist. The same calibration work is done through completely different mechanics — and nobody ever taught them to you, because if you had grown up in English you would have absorbed them by osmosis the same way you absorbed *tú* and *usted*.
 

--- a/src/content/blog/es/registro-en-ingles-para-hispanohablantes.md
+++ b/src/content/blog/es/registro-en-ingles-para-hispanohablantes.md
@@ -22,7 +22,7 @@ Estás en una junta de actualización con la matriz en Estados Unidos. Tu inglé
 
 Tu inglés no se rompió. Los controles sí.
 
-En español, el registro vive en tu gramática. Tú versus usted. Ustedes versus vosotros. El subjuntivo como dispositivo suavizador — *quisiera, podría, hubiera*. La almohadilla del condicional. El diminutivo que le quita el filo a una petición sin debilitarla. Has estado cambiando de registro sin esfuerzo durante treinta años. La intuición está cableada.
+En español, el registro vive en tu gramática. Tú versus usted. El subjuntivo como mecanismo para suavizar — *quisiera, podría, hubiera*. El cojín del condicional. El diminutivo que le quita el filo a una petición sin debilitarla — *un momentito, tantito, ahorita*. Llevas treinta años cambiando de registro sin esfuerzo. La intuición está cableada.
 
 En inglés, esos controles no existen. El mismo trabajo de calibración se hace a través de mecánicas completamente distintas — y nadie te las enseñó, porque si hubieras crecido en inglés las habrías absorbido por ósmosis igual que absorbiste *tú* y *usted*.
 


### PR DESCRIPTION
## Summary

Native MX reviewer (Julio Aldana) flagged `/es/blog/registro-en-ingles-para-hispanohablantes/` as reading "like a blog from Spain." Root cause: the EN article includes "Ustedes versus vosotros" as a Spanish register marker, and the ES translation inherited the reference. Mexicans never use vosotros — including it as part of "your" Spanish is the giveaway.

## Content fixes

**EN + ES (same surgical change):**
- Remove "Ustedes versus vosotros" from the Spanish grammar list. Kept "Tú versus usted" since that distinction IS active in Mexican usage.
- Add Mexican-specific diminutive examples (`un momentito, tantito, ahorita`) — concrete MX register markers the audience actually uses.

**ES-only smoothing for Mexican Professional Spanish:**
- `dispositivo suavizador` → `mecanismo para suavizar` (less stiff/Iberian)
- `almohadilla del condicional` → `cojín del condicional` (more natural MX metaphor)
- `Has estado cambiando ... durante treinta años` → `Llevas treinta años cambiando` (more natural MX phrasing for ongoing duration)

## Standards updates (so this doesn't regress)

- **Project CLAUDE.md** — new "Spanish Content — Mexican Professional Spanish ONLY (CRITICAL)" section with forbidden Iberian markers list (vosotros, vale, coger, móvil-as-cellphone, ordenador, etc.), MX-preferred phrasings, and the audit grep pattern.
- **Global `~/CLAUDE.md`** — same standard scoped across all CushLabs ES content. Most CushLabs work targets MX audiences; this is a one-time fix that prevents future translation prompts from defaulting to neutral/Iberian patterns.
- **Memory** — `feedback_mexican_spanish.md` indexed in `MEMORY.md` so it loads on every session boot.

## Session-log convention

New convention: `docs/session-logs/YYYY-MM-DD-NNN.md` per working session. Captures accomplishments, technical debt, work remaining, future ideas, files touched, and lessons. Format documented in global CLAUDE.md. First log: `docs/session-logs/2026-05-03-001.md` (covers PR #135 + this fix).

## Audit scope (separate PRs to follow)

Grep for hard Iberian markers (`vosotros`, `vuestr`, `habéis`, `tenéis`, `coger`, `móvil`-as-noun, `ordenador`, `aparcar`, `chaval`, `guay` Spain-slang sense) across `src/` returned only the registro post (EN+ES) plus two false positives. **Hard Iberian drift is contained to this one piece of content.**

Soft tone drift (sentence rhythm, vocabulary leanings) likely exists in other ES content but isn't grep-detectable. Tracked in the session log under "Work Remaining" — Tier 1 audit (top-traffic blog posts) is the next planned PR.

## Test plan

- [ ] After Vercel deploy, view `/es/blog/registro-en-ingles-para-hispanohablantes/` and confirm no `vosotros` reference, new MX diminutive examples present
- [ ] Send link to Julio for confirmation that the Iberian feel is gone
- [ ] Confirm `/en/blog/english-register-for-spanish-speakers/` still reads naturally (the change is small)
- [ ] Spot-check that future `/translate to Spanish` prompts in this repo will see the new CLAUDE.md rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)