### PR TITLE
docs(audit): Tier 1-4 Mexican Spanish audit — site-wide clean

### DIFF
--- a/docs/session-logs/2026-05-04-001.md
+++ b/docs/session-logs/2026-05-04-001.md
@@ -1,0 +1,60 @@
+# Session: Mexican Spanish audit (Tier 1 & 2) — site-wide sweep
+
+**Date:** 2026-05-04
+**Branches/PRs:** PR #136 (merged 2026-05-03 — registro fix + standards); current branch `fix/tier1-mexican-spanish-audit` (audit-results-only PR)
+**Status:** completed
+
+## Accomplishments
+
+Full Iberian-drift audit across the entire ES content surface. Result: **the registro blog post (fixed in PR #136) was the only instance of Iberian-Spanish drift on the site.** The rest of the ES content was already in solid Mexican Professional Spanish.
+
+**Tier 1 — Top-traffic blog posts (5 files audited):**
+- `por-que-ingles-ejecutivo-acelera-tu-carrera.md` — clean ✓
+- `presencia-ejecutiva-en-videollamadas.md` — clean ✓ (uses MX-specific filler "como que" in examples)
+- `guia-comunicacion-laboral-mexico-estados-unidos.md` — clean ✓ (written from MX perspective with proper terminology — aguinaldo, IMSS, T-MEC, Nuevo León/Jalisco hubs)
+- `costo-real-ingles-debil-empresas-mexicanas.md` — clean ✓ (real MX-based testimonials and case studies — Guadalajara, Monterrey, CDMX)
+- `manual-comunicacion-ejecutiva.md` — clean ✓ (uses `elevador` not Spain's `ascensor`)
+
+**Tier 2 — Course landing pages + course data (swept):**
+- All 5 ES course landing pages (`/es/curso/{principiantes,elemental,intermedio,avanzado,ejecutivo}/index.astro`) — clean ✓
+- All ES course unit data files in `src/data/` — clean ✓
+- All ES course unit pages (units 1-10 across all 5 courses, including the A2 units shipped in PR #135 yesterday) — clean ✓
+
+**Tier 3 — Services + resources pages:** clean ✓ (no hits across `src/pages/es/`)
+
+**Tier 4 — Blog backlog:** clean ✓ (full sweep across 32 ES blog posts)
+
+**Audit method (documented for repeatability):**
+- Hard Iberian markers (`vosotros`, `vuestr`, `habéis`, `tenéis`, `sois`, `coger`, `aparcar`, `chaval`, `ordenador`, `móvil` as cellphone noun, `gafas`, `jersey`, `patata`, `zumo`, `ascensor`, `tío` as friend, `Vd.`)
+- Soft Iberian markers (`vale.`, `estupendo`, `fenomenal`, `echar un vistazo`, `venga`, `mola`, `currar`, `hace falta`)
+- All checked with word boundaries (`\b...\b`) to avoid false positives like `escoger` matching `coger`
+- False positives confirmed and excluded: `móvil` as adjective for "mobile app" (universal Spanish), `guay` as phonetic transcription for English `way` in pronunciation guides
+
+## Technical Debt Accumulated
+
+- **Tier 1-4 audit only catches grep-detectable markers, not stylistic drift**: it remains theoretically possible that some content has a slightly literary/Iberian-leaning *tone* without using forbidden markers. The Tier 1-4 sweep cannot detect this. The mitigation is that future translations will use the new CLAUDE.md "Mexican Professional Spanish" rule explicitly in the prompt, which steers the model away from neutral/Iberian patterns. If Julio (or another native MX reviewer) flags additional content, that becomes the next data point.
+- **No automated CI gate yet** — the forbidden-markers list is enforced by manual grep + the CLAUDE.md rule. A build-time check (script that fails the build on any forbidden-marker hit in `src/content/blog/es/` or `src/data/`) would prevent regression. Tracked under "Future Ideas" in 2026-05-03-001.md.
+
+## Work Remaining
+
+- **Open: deploy + verify Julio's feedback is addressed.** Send the live registro post (https://www.nyenglishteacher.com/es/blog/registro-en-ingles-para-hispanohablantes/) to Julio for confirmation that the Iberian feel is gone.
+- **Optional: ship the CI-level Iberian-Spanish gate** (Future Idea from 2026-05-03-001.md). Modeled on the existing meta-description SEO gate. Cheap insurance.
+- **Optional: translation prompt template** (also from 2026-05-03-001.md). Reusable scaffold for "translate EN → MX Spanish" that bakes in the forbidden-markers list — would prevent future authors/contributors from regressing the standard.
+
+## Future Ideas
+
+- **MX Spanish style guide doc** (`docs/style/mexican-spanish.md`) — beyond the forbidden-markers list, document positive style guidance (preferred sentence rhythm, MX professional tone calibration, when to use diminutives, etc.). Could be the single source of truth that CLAUDE.md links to instead of duplicating.
+- **Periodic re-audit cadence** — quarterly grep against the forbidden-markers list. Cheap to run, catches any drift introduced by future translation work before it accumulates.
+
+## Files Touched
+
+- `docs/session-logs/2026-05-04-001.md` (this file) — new audit log
+
+No content files needed changes — the registro fix in PR #136 was the complete remediation.
+
+## Lessons / Surprises
+
+- **The grep-based audit was much faster than expected.** Word-boundaried regex against the forbidden list cleared all 32 blog posts + 50+ course pages + services/resources in a single pass. The cost-benefit of scripting this as a permanent CI check is favorable.
+- **Robert's authors knew their audience.** Most ES content was written by people who understood Mexican Spanish — the registro post was an outlier specifically because the EN sibling included the "Ustedes versus vosotros" reference and the translation faithfully reproduced it. The pedagogical accuracy issue (vosotros isn't part of MX Spanish) was the root cause, not a generalized translator-defaulting-to-Iberian problem.
+- **Julio's instinct was sharper than the surface evidence.** He flagged "Spain feel" from a single page, and the grep audit confirmed only one Iberian marker on that page — but his review still drove a useful site-wide standards lock-in, even though no other content needed remediation. The lesson: native-speaker review catches not just what's wrong but also confirms what's right.
+- **Two-stage Spanish translation prompts work**: First stage outputs neutral/Iberian-leaning Spanish, second stage with explicit "Mexican Professional Spanish, no vosotros, no Iberian markers" cleans it up. The new CLAUDE.md rule should make the second stage automatic for future work.


### PR DESCRIPTION
## Summary

Full Iberian-drift audit across the entire ES content surface (blog posts, course pages, course data, services, resources). **Result: site-wide clean.** The registro blog post (fixed yesterday in PR #136) was the only instance of Iberian-Spanish drift on the site.

## What was checked

- **Tier 1 — 5 top-traffic blog posts** (executive English, video calls, MX-US workplace guide, real cost, communication playbook): all clean ✓
- **Tier 2 — Course landing pages + course unit data** (5 courses × 10 units × 2 languages, plus all `src/data/` ES content): all clean ✓
- **Tier 3 — Services + resources pages**: all clean ✓
- **Tier 4 — Blog backlog** (32 ES posts total): all clean ✓

## Audit method (now documented for repeatability)

Grep against word-boundaried forbidden markers:
- Hard: `vosotros`, `vuestr`, `habéis`, `tenéis`, `sois`, `coger`, `aparcar`, `chaval`, `ordenador`, `móvil` (as cellphone), `gafas`, `jersey`, `patata`, `zumo`, `ascensor`, `tío` (as friend), `Vd.`
- Soft: `vale.`, `estupendo`, `fenomenal`, `echar un vistazo`, `venga`, `mola`, `currar`, `hace falta`
- False positives confirmed/excluded: `móvil` as adjective for "mobile app" (universal Spanish), `guay` as phonetic transcription for English `way` in pronunciation guides, `escoger` matching `coger` (word-boundary fix)

## Why ship this

This PR contains no content/code changes — just the audit log. Shipping it gives Robert a permanent record that the site was reviewed end-to-end after Julio's feedback, plus a documented method that can be re-run quarterly as a regression check.

## Lesson

Most ES content was already written by people who understood Mexican Spanish. The registro post was an outlier specifically because its EN sibling included the "Ustedes versus vosotros" reference and the translation faithfully reproduced it. The pedagogical accuracy issue (vosotros isn't part of MX Spanish) was the root cause, not generalized translator drift.

## Test plan

- [ ] After merge, verify `docs/session-logs/2026-05-04-001.md` is visible on the GitHub repo so the audit record is preserved.
- [ ] (Optional) Send live registro post (https://www.nyenglishteacher.com/es/blog/registro-en-ingles-para-hispanohablantes/) to Julio for native-speaker confirmation that the Iberian feel is gone.
- [ ] (Optional next session) Build a CI-level Iberian-marker gate so future regressions fail the build automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)