### PR TITLE
chore: add Dependabot ignore rules for lint ecosystem majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,22 @@ updates:
       - dependencies
     commit-message:
       prefix: "deps:"
+    ignore:
+      # Lint toolchain — the eslint ecosystem (eslint, @eslint/js,
+      # @typescript-eslint/*, eslint-plugin-*) must move as a single
+      # coordinated upgrade because peerDependencies cross-couple them.
+      # Dependabot proposing major bumps individually breaks `npm install`
+      # with ERESOLVE every time. When ready to upgrade, do it manually
+      # in one PR that bumps all of them together. See PRs #137 and #140
+      # (closed 2026-05-04) for prior incidents.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@eslint/js"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@typescript-eslint/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint-plugin-*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
## Summary

Prevents the recurring failure where Dependabot proposes major-version bumps on individual packages in the eslint ecosystem and breaks \`npm install\` (and Vercel previews).

## Background

On 2026-05-04, two Dependabot PRs failed Vercel preview builds with the same root cause:

- **#137** — \`@eslint/js\` 9.39.2 → 10.0.1 (closed)
- **#140** — \`eslint\` 8.57.1 → 10.3.0 (closed)

Both broke \`npm install\` with ERESOLVE because the lint toolchain cross-couples through peerDependencies:

- \`@eslint/js@10\` peer-requires \`eslint@^10\`
- \`@typescript-eslint/eslint-plugin@7.18.0\` peer-requires \`eslint@^6 || ^7 || >=8 <10\`

Bumping any one of these alone is impossible. They have to move together.

## What this changes

Adds \`ignore\` rules to \`.github/dependabot.yml\` so Dependabot only proposes minor/patch updates for:

- \`eslint\`
- \`@eslint/js\`
- \`@typescript-eslint/*\` (parser, eslint-plugin, type-utils, utils)
- \`eslint-plugin-*\` (eslint-plugin-astro, etc.)

Major-version bumps in this ecosystem must be done manually as a single coordinated PR that moves all four package families together — and that PR should also verify that downstream peers like \`eslint-plugin-astro\` support the new major.

## Test plan

- [x] YAML syntax valid (existing format preserved)
- [ ] Next Dependabot run (Monday) does not re-propose \`eslint\` or \`@eslint/js\` major bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)