### PR TITLE
fix: testimonials filter button text invisible (primary-600 undefined)

### DIFF
--- a/src/components/sections/TestimonialsGrid.astro
+++ b/src/components/sections/TestimonialsGrid.astro
@@ -71,8 +71,8 @@ const availableIndustries = Object.entries(testimonialsByIndustry)
                   class:list={[
                     'inline-block px-4 py-2 rounded-full text-sm font-medium transition-colors duration-200 border',
                     isActive
-                      ? 'bg-primary-600 text-white border-primary-600 shadow-sm'
-                      : 'bg-white text-gray-700 border-gray-300 hover:bg-primary-50 hover:border-primary-400 hover:text-primary-700',
+                      ? 'bg-primary text-white border-primary shadow-sm'
+                      : 'bg-white text-gray-700 border-gray-300 hover:border-primary hover:text-primary',
                   ]}
                   aria-current={isActive ? 'page' : undefined}
                 >


### PR DESCRIPTION
The Tailwind config only defines primary.DEFAULT/light/dark — numbered shades (primary-600, primary-50, primary-400, primary-700) were never generated. The active filter pill used bg-primary-600 text-white, so the background was transparent and white text was invisible against the white page background. Replaced with bg-primary/border-primary (valid) and simplified hover to hover:border-primary hover:text-primary.