### PR TITLE
fix: replace all undefined Tailwind primary color scale utilities site-wide

### DIFF
--- a/src/components/chat/ChatEmbed.astro
+++ b/src/components/chat/ChatEmbed.astro
@@ -113,13 +113,13 @@ const t = copy[lang];
       <div class="flex flex-wrap justify-center gap-4">
         <a
           href={lang === 'en' ? '/en/book/' : '/es/book/'}
-          class="inline-block px-6 py-3 bg-primary-600 text-white font-medium rounded-lg hover:bg-primary-700 transition-colors"
+          class="inline-block px-6 py-3 bg-primary text-white font-medium rounded-lg hover:bg-primary-dark transition-colors"
         >
           {lang === 'en' ? 'Book a Free Strategy Session' : 'Reservar Sesión Gratuita'}
         </a>
         <a
           href={lang === 'en' ? '/en/assessments/' : '/es/assessments/'}
-          class="inline-block px-6 py-3 border border-primary-600 text-primary-600 font-medium rounded-lg hover:bg-primary-50 transition-colors"
+          class="inline-block px-6 py-3 border border-primary text-primary font-medium rounded-lg hover:bg-gray-50 transition-colors"
         >
           {lang === 'en' ? 'Take a Free Assessment' : 'Tomar Evaluación Gratuita'}
         </a>

--- a/src/components/sections/Faqs.astro
+++ b/src/components/sections/Faqs.astro
@@ -129,7 +129,7 @@ const textColor = getTextColor(background);
 
 <style>
     .faq-item button:hover svg {
-        color: var(--color-primary-600);
+        color: var(--color-primary);
     }
     
     .answer-wrapper {

--- a/src/components/sections/MemeGallery.astro
+++ b/src/components/sections/MemeGallery.astro
@@ -50,7 +50,7 @@ const baseUrl = lang === "en" ? "/en/meme-portfolio/" : "/es/meme-portfolio/";
         <div class="relative">
           <select
             id="role-filter"
-            class="bg-white border border-gray-300 rounded-md px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500 font-sans"
+            class="bg-white border border-gray-300 rounded-md px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary font-sans"
             style="font-family: NotoSansKR, ui-sans-serif, system-ui, sans-serif;"
           >
             {Object.entries(labels).map(([key, label]) => (
@@ -89,7 +89,7 @@ const baseUrl = lang === "en" ? "/en/meme-portfolio/" : "/es/meme-portfolio/";
         </p>
         <a
           href={`${baseUrl}all/`}
-          class="inline-block px-6 py-3 bg-primary-600 text-white font-medium rounded-lg hover:bg-primary-700 transition-colors"
+          class="inline-block px-6 py-3 bg-primary text-white font-medium rounded-lg hover:bg-primary-dark transition-colors"
         >
           {lang === "en" ? "View All Memes" : "Ver Todos los Memes"}
         </a>

--- a/src/components/sections/Testimonials-titan.astro
+++ b/src/components/sections/Testimonials-titan.astro
@@ -128,8 +128,8 @@ const paddingClass = getPaddingClass({ padding, paddingTop, paddingBottom });
 
     {
       cta && (
-        <div class="mt-16 bg-gradient-to-r from-primary-500 to-secondary-500 rounded-2xl p-8 md:p-12 relative overflow-hidden">
-          <div class="absolute inset-0 bg-gradient-to-r from-primary-600/30 to-secondary-600/30 backdrop-blur-sm" />
+        <div class="mt-16 bg-gradient-to-r from-primary to-secondary rounded-2xl p-8 md:p-12 relative overflow-hidden">
+          <div class="absolute inset-0 bg-gradient-to-r from-primary/30 to-secondary/30 backdrop-blur-sm" />
           <div class="relative z-10 flex flex-col xl:flex-row xl:items-center xl:justify-between gap-4">
             <div class="text-center md:text-left">
               <h3

--- a/src/components/sections/TestimonialsGrid.astro
+++ b/src/components/sections/TestimonialsGrid.astro
@@ -109,7 +109,7 @@ const availableIndustries = Object.entries(testimonialsByIndustry)
         </p>
         <a 
           href={baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`}
-          class="inline-block px-6 py-3 bg-primary-600 text-white font-medium rounded-lg hover:bg-primary-700 transition-colors"
+          class="inline-block px-6 py-3 bg-primary text-white font-medium rounded-lg hover:bg-primary-dark transition-colors"
         >
           {lang === 'en' ? 'View All Testimonials' : 'Ver Todos los Testimonios'}
         </a>

--- a/src/components/ui/ExpandableTestimonialCard.astro
+++ b/src/components/ui/ExpandableTestimonialCard.astro
@@ -38,7 +38,7 @@ const hasShortContent = !!testimonial.shortContent;
       <blockquote class="mb-6 italic text-gray-700 dark:text-gray-300 short-content">
         "{testimonial.shortContent}" 
         <span 
-          class="text-primary-600 hover:text-primary-800 font-medium text-sm toggle-content-btn cursor-pointer"
+          class="text-primary hover:text-primary-dark font-medium text-sm toggle-content-btn cursor-pointer"
           data-action="expand"
           data-lang={testimonial.link?.includes('/es/') ? 'es' : 'en'}
         >
@@ -48,7 +48,7 @@ const hasShortContent = !!testimonial.shortContent;
       <blockquote class="mb-6 italic text-gray-700 dark:text-gray-300 full-content hidden">
         "{testimonial.content}" 
         <span 
-          class="text-primary-600 hover:text-primary-800 font-medium text-sm toggle-content-btn cursor-pointer"
+          class="text-primary hover:text-primary-dark font-medium text-sm toggle-content-btn cursor-pointer"
           data-action="collapse"
           data-lang={testimonial.link?.includes('/es/') ? 'es' : 'en'}
         >
@@ -97,7 +97,7 @@ const hasShortContent = !!testimonial.shortContent;
     <div class="mt-4 text-right">
       <a 
         href={testimonial.link?.endsWith('/') ? testimonial.link : `${testimonial.link}/`} 
-        class="text-primary-600 hover:text-primary-800 font-medium inline-flex items-center"
+        class="text-primary hover:text-primary-dark font-medium inline-flex items-center"
         {...(testimonial.link.startsWith('http') ? {
           target: "_blank",
           rel: "noopener noreferrer"

--- a/src/components/ui/TestimonialCard.astro
+++ b/src/components/ui/TestimonialCard.astro
@@ -69,7 +69,7 @@ const stars = "★".repeat(testimonial.stars || 5);
     <div class="mt-4 text-right">
       <a 
         href={testimonial.link?.endsWith('/') ? testimonial.link : `${testimonial.link}/`} 
-        class="text-primary-600 hover:text-primary-800 font-medium inline-flex items-center"
+        class="text-primary hover:text-primary-dark font-medium inline-flex items-center"
         {...(testimonial.link.startsWith('http') ? {
           target: "_blank",
           rel: "noopener noreferrer"

--- a/src/pages/en/assessments/index.astro
+++ b/src/pages/en/assessments/index.astro
@@ -239,13 +239,13 @@ const description =
           No email required. Your results appear instantly — with a personalized gap analysis and recommended next steps.
         </p>
         <div class="flex flex-wrap justify-center gap-4 text-sm">
-          <a href="/en/testimonials/" class="text-primary-600 hover:text-primary-800 underline">
+          <a href="/en/testimonials/" class="text-primary hover:text-primary-dark underline">
             See Client Results
           </a>
-          <a href="/en/services/" class="text-primary-600 hover:text-primary-800 underline">
+          <a href="/en/services/" class="text-primary hover:text-primary-dark underline">
             Explore Coaching Services
           </a>
-          <a href="/en/blog/" class="text-primary-600 hover:text-primary-800 underline">
+          <a href="/en/blog/" class="text-primary hover:text-primary-dark underline">
             Read the Blog
           </a>
         </div>

--- a/src/pages/en/testimonials/[industry].astro
+++ b/src/pages/en/testimonials/[industry].astro
@@ -99,23 +99,23 @@ const serviceLink = matchingService ? `/en/services/${matchingService.slug}/` : 
           </p>
           <a
             href={serviceLink}
-            class="inline-block px-6 py-3 bg-primary-600 text-white font-medium rounded-lg hover:bg-primary-700 transition-colors"
+            class="inline-block px-6 py-3 bg-primary text-white font-medium rounded-lg hover:bg-primary-dark transition-colors"
           >
             Explore {matchingService.label} Coaching
           </a>
         </div>
       )}
       <div class="flex flex-wrap justify-center gap-4 text-sm">
-        <a href="/en/testimonials/" class="text-primary-600 hover:text-primary-800 underline">
+        <a href="/en/testimonials/" class="text-primary hover:text-primary-dark underline">
           All Success Stories
         </a>
-        <a href="/en/services/" class="text-primary-600 hover:text-primary-800 underline">
+        <a href="/en/services/" class="text-primary hover:text-primary-dark underline">
           View All Services
         </a>
-        <a href="/en/assessments/" class="text-primary-600 hover:text-primary-800 underline">
+        <a href="/en/assessments/" class="text-primary hover:text-primary-dark underline">
           Take a Free Assessment
         </a>
-        <a href="/en/book/" class="text-primary-600 hover:text-primary-800 underline">
+        <a href="/en/book/" class="text-primary hover:text-primary-dark underline">
           Book a Strategy Session
         </a>
       </div>

--- a/src/pages/en/testimonials/index.astro
+++ b/src/pages/en/testimonials/index.astro
@@ -29,13 +29,13 @@ const description =
             <div class="flex flex-wrap justify-center gap-4">
                 <a
                     href="/en/book/"
-                    class="inline-block px-6 py-3 bg-primary-600 text-white font-medium rounded-lg hover:bg-primary-700 transition-colors"
+                    class="inline-block px-6 py-3 bg-primary text-white font-medium rounded-lg hover:bg-primary-dark transition-colors"
                 >
                     Book a Free Strategy Session
                 </a>
                 <a
                     href="/en/assessments/"
-                    class="inline-block px-6 py-3 border border-primary-600 text-primary-600 font-medium rounded-lg hover:bg-primary-50 transition-colors"
+                    class="inline-block px-6 py-3 border border-primary text-primary font-medium rounded-lg hover:bg-gray-50 transition-colors"
                 >
                     Take a Free Assessment
                 </a>

--- a/src/pages/es/testimonios/[industry].astro
+++ b/src/pages/es/testimonios/[industry].astro
@@ -99,23 +99,23 @@ const serviceLink = matchingService ? `/es/servicios/${matchingService.esSlug}/`
           </p>
           <a
             href={serviceLink}
-            class="inline-block px-6 py-3 bg-primary-600 text-white font-medium rounded-lg hover:bg-primary-700 transition-colors"
+            class="inline-block px-6 py-3 bg-primary text-white font-medium rounded-lg hover:bg-primary-dark transition-colors"
           >
             Explorar Coaching para {matchingService.esLabel}
           </a>
         </div>
       )}
       <div class="flex flex-wrap justify-center gap-4 text-sm">
-        <a href="/es/testimonios/" class="text-primary-600 hover:text-primary-800 underline">
+        <a href="/es/testimonios/" class="text-primary hover:text-primary-dark underline">
           Todas las Historias
         </a>
-        <a href="/es/servicios/" class="text-primary-600 hover:text-primary-800 underline">
+        <a href="/es/servicios/" class="text-primary hover:text-primary-dark underline">
           Ver Todos los Servicios
         </a>
-        <a href="/es/assessments/" class="text-primary-600 hover:text-primary-800 underline">
+        <a href="/es/assessments/" class="text-primary hover:text-primary-dark underline">
           Evaluación Gratuita
         </a>
-        <a href="/es/book/" class="text-primary-600 hover:text-primary-800 underline">
+        <a href="/es/book/" class="text-primary hover:text-primary-dark underline">
           Reservar Sesión
         </a>
       </div>


### PR DESCRIPTION
The Tailwind config only defines primary.DEFAULT/light/dark — numbered variants (primary-50 through primary-900) were never generated. This caused invisible button text (bg-primary-600 + text-white = white on white), missing link colors, and broken gradients across 11 files.

## Files fixed
- `src/components/chat/ChatEmbed.astro`
- `src/components/sections/Faqs.astro` (CSS var)
- `src/components/sections/MemeGallery.astro`
- `src/components/sections/Testimonials-titan.astro` (gradient)
- `src/components/sections/TestimonialsGrid.astro`
- `src/components/ui/ExpandableTestimonialCard.astro`
- `src/components/ui/TestimonialCard.astro`
- `src/pages/en/assessments/index.astro`
- `src/pages/en/testimonials/[industry].astro`
- `src/pages/en/testimonials/index.astro`
- `src/pages/es/testimonios/[industry].astro`