### PR TITLE
feat(course): Past Tenses master class MVP (landing + Lesson 1)

### DIFF
--- a/src/data/past-tenses/lessons.ts
+++ b/src/data/past-tenses/lessons.ts
@@ -1,0 +1,169 @@
+// Past Tenses Master Class — "Feel the Story" method for Mexican English learners
+// MVP scope: 5 lessons + 5 bonuses planned; only Lesson 1 is built and available in the MVP.
+
+export interface PastTenseLesson {
+  id: number;
+  slug: string;
+  slugEs: string;
+  title: string;
+  titleEs: string;
+  tense: string;
+  tenseEs: string;
+  subtitle: string;
+  subtitleEs: string;
+  icon: string;
+  available: boolean;
+}
+
+export interface PastTenseBonus {
+  id: number;
+  slug: string;
+  slugEs: string;
+  title: string;
+  titleEs: string;
+  description: string;
+  descriptionEs: string;
+  icon: string;
+  available: boolean;
+}
+
+export const pastTensesInfo = {
+  title: "Master English Past Tenses",
+  titleEs: "Domina los Tiempos del Pasado en Inglés",
+  tagline: "Feel the Story. Don't Think the Rules.",
+  taglineEs: "Siente la historia. No pienses en las reglas.",
+  description:
+    "A focused master class for Mexican professionals who know the rules but freeze in conversation. Learn to visualize the scene — and the right past tense becomes obvious.",
+  descriptionEs:
+    "Una clase magistral enfocada para profesionales mexicanos que conocen las reglas pero se congelan al hablar. Aprende a visualizar la escena — y el tiempo correcto del pasado se vuelve obvio.",
+  basePath: {
+    en: "/en/course/past-tenses",
+    es: "/es/curso/tiempos-del-pasado",
+  },
+};
+
+export const pastTenseLessons: PastTenseLesson[] = [
+  {
+    id: 1,
+    slug: "lesson-1",
+    slugEs: "leccion-1",
+    title: "Past Simple",
+    titleEs: "Pasado Simple",
+    tense: "It happened. It's done.",
+    tenseEs: "Sucedió. Está terminado.",
+    subtitle: "Single moments, completed actions, finished time",
+    subtitleEs: "Momentos únicos, acciones completas, tiempo terminado",
+    icon: "Clock",
+    available: true,
+  },
+  {
+    id: 2,
+    slug: "lesson-2",
+    slugEs: "leccion-2",
+    title: "Past Continuous",
+    titleEs: "Pasado Continuo",
+    tense: "It was happening when…",
+    tenseEs: "Estaba sucediendo cuando…",
+    subtitle: "Background scenes, actions in progress, interruptions",
+    subtitleEs: "Escenas de fondo, acciones en progreso, interrupciones",
+    icon: "Film",
+    available: false,
+  },
+  {
+    id: 3,
+    slug: "lesson-3",
+    slugEs: "leccion-3",
+    title: "Present Perfect",
+    titleEs: "Presente Perfecto",
+    tense: "It happened — but it still matters now.",
+    tenseEs: "Sucedió — pero todavía importa ahora.",
+    subtitle: "The tense Mexicans miss most. A thread from past to now.",
+    subtitleEs: "El tiempo que los mexicanos más omiten. Un hilo del pasado al presente.",
+    icon: "Link",
+    available: false,
+  },
+  {
+    id: 4,
+    slug: "lesson-4",
+    slugEs: "leccion-4",
+    title: "Past Perfect",
+    titleEs: "Pasado Perfecto",
+    tense: "It happened before that other thing.",
+    tenseEs: "Sucedió antes que esa otra cosa.",
+    subtitle: "Two past events, one earlier than the other",
+    subtitleEs: "Dos eventos pasados, uno antes que el otro",
+    icon: "Layers",
+    available: false,
+  },
+  {
+    id: 5,
+    slug: "lesson-5",
+    slugEs: "leccion-5",
+    title: "The Story Flow Map",
+    titleEs: "El Mapa del Flujo de la Historia",
+    tense: "Putting all four together — like a native.",
+    tenseEs: "Combinando los cuatro — como un nativo.",
+    subtitle: "Choose the right tense in real time, mid-sentence",
+    subtitleEs: "Elige el tiempo correcto en tiempo real, a mitad de frase",
+    icon: "Map",
+    available: false,
+  },
+];
+
+export const pastTenseBonuses: PastTenseBonus[] = [
+  {
+    id: 1,
+    slug: "cheat-sheet",
+    slugEs: "guia-rapida",
+    title: "The One-Page Cheat Sheet",
+    titleEs: "La Guía Rápida de Una Página",
+    description: "Every past tense, every trigger, every story-flow rule — on one printable page.",
+    descriptionEs: "Cada tiempo del pasado, cada disparador, cada regla del flujo de historia — en una página imprimible.",
+    icon: "FileText",
+    available: false,
+  },
+  {
+    id: 2,
+    slug: "top-10-confused-pairs",
+    slugEs: "top-10-pares-confundidos",
+    title: "Top 10 Most Confused Verb Pairs",
+    titleEs: "Top 10 Pares de Verbos Más Confundidos",
+    description: "say/tell, do/make, lay/lie, rise/raise, and the seven others that trip up intermediate Mexican speakers.",
+    descriptionEs: "say/tell, do/make, lay/lie, rise/raise y los otros siete que confunden a hispanohablantes intermedios.",
+    icon: "AlertCircle",
+    available: false,
+  },
+  {
+    id: 3,
+    slug: "knew-vs-found-out",
+    slugEs: "knew-vs-found-out",
+    title: '"Knew" vs "Found Out"',
+    titleEs: '"Knew" vs "Found Out"',
+    description: "The English equivalent of sabía vs supe. Same trap, same solution.",
+    descriptionEs: 'El equivalente en inglés de "sabía vs supe". La misma trampa, la misma solución.',
+    icon: "Lightbulb",
+    available: false,
+  },
+  {
+    id: 4,
+    slug: "story-openers",
+    slugEs: "frases-iniciales",
+    title: "30 Story Openers in English",
+    titleEs: "30 Frases para Empezar una Historia en Inglés",
+    description: '"Back when I was at…", "I remember when…", "The other day…" — ready-made launchpads native speakers actually use.',
+    descriptionEs: '"Back when I was at…", "I remember when…", "The other day…" — frases iniciales reales que usan los nativos.',
+    icon: "Mic",
+    available: false,
+  },
+  {
+    id: 5,
+    slug: "there-was-vs-there-has-been",
+    slugEs: "there-was-vs-there-has-been",
+    title: '"There Was" vs "There Has Been"',
+    titleEs: '"There Was" vs "There Has Been"',
+    description: "The English equivalent of hubo vs había. Why one closes the story and the other keeps it open.",
+    descriptionEs: 'El equivalente en inglés de "hubo vs había". Por qué uno cierra la historia y el otro la deja abierta.',
+    icon: "MessageSquare",
+    available: false,
+  },
+];

--- a/src/data/past-tenses/lessons.ts
+++ b/src/data/past-tenses/lessons.ts
@@ -30,7 +30,7 @@ export interface PastTenseBonus {
 export const pastTensesInfo = {
   title: "Master English Past Tenses",
   titleEs: "Domina los Tiempos del Pasado en Inglés",
-  tagline: "Feel the Story. Don't Think the Rules.",
+  tagline: "Feel the Story. Don't Think About the Rules.",
   taglineEs: "Siente la historia. No pienses en las reglas.",
   description:
     "A focused master class for Mexican professionals who know the rules but freeze in conversation. Learn to visualize the scene — and the right past tense becomes obvious.",

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -138,6 +138,8 @@ export type TKey =
   | "course/executive/unit-9"
   | "course/executive/unit-10"
   | "course/executive/capstone"
+  | "course/past-tenses"
+  | "course/past-tenses/lesson-1"
   | "corporate/for-hr"
   | "meme-portfolio"
   | "site-index";
@@ -291,6 +293,8 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/executive/unit-9": "/en/course/executive/unit-9/",
     "course/executive/unit-10": "/en/course/executive/unit-10/",
     "course/executive/capstone": "/en/course/executive/capstone/",
+    "course/past-tenses": "/en/course/past-tenses/",
+    "course/past-tenses/lesson-1": "/en/course/past-tenses/lesson-1/",
     "corporate/for-hr": "/en/for-hr-managers/",
     "meme-portfolio": "/en/meme-portfolio/all/",
     "site-index": "/en/site-index/",
@@ -448,6 +452,8 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/executive/unit-9": "/es/curso/ejecutivo/unidad-9/",
     "course/executive/unit-10": "/es/curso/ejecutivo/unidad-10/",
     "course/executive/capstone": "/es/curso/ejecutivo/reto-final/",
+    "course/past-tenses": "/es/curso/tiempos-del-pasado/",
+    "course/past-tenses/lesson-1": "/es/curso/tiempos-del-pasado/leccion-1/",
     "corporate/for-hr": "/es/para-rh/",
     "meme-portfolio": "/es/meme-portfolio/all/",
     "site-index": "/es/indice-del-sitio/",
@@ -534,6 +540,8 @@ export function getAllTKeys(): TKey[] {
     "course/intermediate",
     "course/advanced",
     "course/executive",
+    "course/past-tenses",
+    "course/past-tenses/lesson-1",
     "category/startup-founders",
     "category/tech-english",
     "category/logistics-english",

--- a/src/pages/en/course/past-tenses/index.astro
+++ b/src/pages/en/course/past-tenses/index.astro
@@ -42,7 +42,7 @@ const iconMap: Record<string, any> = {
   lang={lang}
   tkey={tkey}
   title="Master English Past Tenses | Free Course for Spanish Speakers"
-  description="Free master class for Mexican professionals. Stop thinking the rules — learn to feel the story. A 4-tense method for English past tenses."
+  description="Free master class for Mexican professionals. Don't think about the rules — feel the story. A 4-tense method for English past tenses."
 >
   <!-- Hero -->
   <section class="relative w-full overflow-hidden bg-gradient-to-br from-slate-900 via-emerald-950 to-slate-900 pt-32 pb-20 md:pt-40 md:pb-28">
@@ -61,7 +61,7 @@ const iconMap: Record<string, any> = {
           style="font-family: 'Noto Sans KR', sans-serif;"
         >
           Master English Past Tenses.<br />
-          <span class="text-emerald-400">Feel the story. Don't think the rules.</span>
+          <span class="text-emerald-400">Feel the story. Don't think about the rules.</span>
         </h1>
         <p class="text-xl text-slate-300 mb-8 max-w-2xl leading-relaxed">
           You know the rules. You can recite them. But in a real meeting, in a real conversation,
@@ -102,7 +102,7 @@ const iconMap: Record<string, any> = {
             <div class="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-red-100 text-red-600 mb-4">
               <Brain class="w-6 h-6" />
             </div>
-            <h3 class="text-xl font-bold text-slate-900 mb-3">The Old Way: Think the Rules</h3>
+            <h3 class="text-xl font-bold text-slate-900 mb-3">The Old Way: Think About the Rules</h3>
             <ul class="space-y-2 text-slate-700">
               <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> "Is this a finished action or an ongoing state?"</li>
               <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> "Do I need 'have done' or 'did' here?"</li>

--- a/src/pages/en/course/past-tenses/index.astro
+++ b/src/pages/en/course/past-tenses/index.astro
@@ -1,0 +1,332 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import { pastTenseLessons, pastTenseBonuses, pastTensesInfo } from "@data/past-tenses/lessons";
+import {
+  ArrowRight,
+  Sparkles,
+  Clock,
+  Film,
+  Link as LinkIcon,
+  Layers,
+  Map,
+  FileText,
+  AlertCircle,
+  Lightbulb,
+  Mic,
+  MessageSquare,
+  Eye,
+  Brain,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/past-tenses" as const;
+
+const iconMap: Record<string, any> = {
+  Clock,
+  Film,
+  Link: LinkIcon,
+  Layers,
+  Map,
+  FileText,
+  AlertCircle,
+  Lightbulb,
+  Mic,
+  MessageSquare,
+};
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Master English Past Tenses | Free Course for Spanish Speakers"
+  description="Free master class for Mexican professionals. Stop thinking the rules — learn to feel the story. A 4-tense method for English past tenses."
+>
+  <!-- Hero -->
+  <section class="relative w-full overflow-hidden bg-gradient-to-br from-slate-900 via-emerald-950 to-slate-900 pt-32 pb-20 md:pt-40 md:pb-28">
+    <div class="absolute inset-0 opacity-10">
+      <div class="absolute top-20 left-10 w-72 h-72 bg-emerald-500 rounded-full blur-3xl"></div>
+      <div class="absolute bottom-10 right-20 w-96 h-96 bg-teal-500 rounded-full blur-3xl"></div>
+    </div>
+    <div class="site-container mx-auto px-4 relative z-10 text-white">
+      <div class="max-w-3xl">
+        <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-emerald-500/20 text-emerald-300 text-sm font-semibold mb-6">
+          <Sparkles class="w-4 h-4" />
+          Free Master Class — The 4-Tense Method
+        </div>
+        <h1
+          class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Master English Past Tenses.<br />
+          <span class="text-emerald-400">Feel the story. Don't think the rules.</span>
+        </h1>
+        <p class="text-xl text-slate-300 mb-8 max-w-2xl leading-relaxed">
+          You know the rules. You can recite them. But in a real meeting, in a real conversation,
+          you still freeze — and end up saying <em class="text-white not-italic">"I did the report"</em>
+          when the situation actually calls for <em class="text-white not-italic">"I have done the report."</em>
+          This course rewires the way you choose past tenses — by seeing the story instead of running grammar in your head.
+        </p>
+        <div class="flex flex-wrap gap-4">
+          <Button href="/en/course/past-tenses/lesson-1/" variant="primary" size="lg">
+            Start Lesson 1 — Free
+            <ArrowRight class="w-5 h-5 ml-1" />
+          </Button>
+          <a
+            href="/en/course/intermediate/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            Looking for the full B1-B2 course?
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- The Shift: Think vs Feel -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="text-center mb-12">
+          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">The Shift That Changes Everything</h2>
+          <p class="text-lg text-slate-600 max-w-2xl mx-auto">
+            Native speakers don't run grammar calculations when they tell a story. They see the scene in their mind — and the right tense follows automatically. You can train yourself to do the same.
+          </p>
+        </div>
+
+        <div class="grid md:grid-cols-2 gap-6">
+          <!-- Old way -->
+          <div class="rounded-2xl border-2 border-red-200 bg-red-50/50 p-8">
+            <div class="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-red-100 text-red-600 mb-4">
+              <Brain class="w-6 h-6" />
+            </div>
+            <h3 class="text-xl font-bold text-slate-900 mb-3">The Old Way: Think the Rules</h3>
+            <ul class="space-y-2 text-slate-700">
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> "Is this a finished action or an ongoing state?"</li>
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> "Do I need 'have done' or 'did' here?"</li>
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Mid-sentence freeze. Switch to Spanish. Lose the room.</li>
+            </ul>
+          </div>
+
+          <!-- New way -->
+          <div class="rounded-2xl border-2 border-emerald-300 bg-emerald-50 p-8">
+            <div class="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-emerald-100 text-emerald-600 mb-4">
+              <Eye class="w-6 h-6" />
+            </div>
+            <h3 class="text-xl font-bold text-slate-900 mb-3">The New Way: Feel the Story</h3>
+            <ul class="space-y-2 text-slate-700">
+              <li class="flex gap-2"><span class="text-emerald-600 shrink-0">✓</span> See the scene play in your mind, like a movie.</li>
+              <li class="flex gap-2"><span class="text-emerald-600 shrink-0">✓</span> Notice if the moment is closed, open, or layered.</li>
+              <li class="flex gap-2"><span class="text-emerald-600 shrink-0">✓</span> The tense matches the picture — automatically.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Pain points -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-6 text-center">Sound Familiar?</h2>
+        <p class="text-center text-slate-600 mb-10">If any of these hit close to home, this course was built for you.</p>
+        <div class="grid md:grid-cols-2 gap-4">
+          <div class="bg-white rounded-xl p-5 border border-slate-200 italic text-slate-700">"I know the rules but I still get it wrong when I speak."</div>
+          <div class="bg-white rounded-xl p-5 border border-slate-200 italic text-slate-700">"In a meeting with US clients, I default to simple past for everything."</div>
+          <div class="bg-white rounded-xl p-5 border border-slate-200 italic text-slate-700">"I overthink every sentence — and then I lose the thread of what I was saying."</div>
+          <div class="bg-white rounded-xl p-5 border border-slate-200 italic text-slate-700">"Sometimes 'I went' and 'I have gone' both seem right and I just have to guess."</div>
+          <div class="bg-white rounded-xl p-5 border border-slate-200 italic text-slate-700">"I freeze mid-sentence and start second-guessing if it should be 'did' or 'have done.'"</div>
+          <div class="bg-white rounded-xl p-5 border border-slate-200 italic text-slate-700">"I've been studying English for years and still can't tell a story without stopping."</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Lessons grid -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="text-center mb-12">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">5 Focused Lessons. One Method.</h2>
+        <p class="text-lg text-slate-600 max-w-2xl mx-auto">
+          Four tenses, plus the capstone that ties them together. Each lesson trains the same instinct from a different angle.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
+        {pastTenseLessons.map((lesson) => {
+          const Icon = iconMap[lesson.icon];
+          const href = lesson.available ? `/en/course/past-tenses/${lesson.slug}/` : undefined;
+          return (
+            <a
+              href={href}
+              class:list={[
+                "group flex items-start gap-4 p-5 rounded-xl border transition-all duration-200",
+                lesson.available
+                  ? "bg-emerald-50 border-emerald-300 hover:shadow-md hover:border-emerald-400 cursor-pointer"
+                  : "bg-white border-slate-200 opacity-75",
+              ]}
+            >
+              <div
+                class:list={[
+                  "flex items-center justify-center w-12 h-12 rounded-xl shrink-0",
+                  lesson.available ? "bg-emerald-500 text-white" : "bg-slate-100 text-slate-400",
+                ]}
+              >
+                {Icon && <Icon class="w-6 h-6" />}
+              </div>
+              <div class="flex-1">
+                <div class="flex items-center gap-2">
+                  <span
+                    class:list={[
+                      "text-xs font-bold uppercase tracking-wider",
+                      lesson.available ? "text-emerald-700" : "text-slate-400",
+                    ]}
+                  >
+                    Lesson {lesson.id}
+                  </span>
+                  {!lesson.available && (
+                    <span class="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-400">Coming soon</span>
+                  )}
+                </div>
+                <h3
+                  class:list={[
+                    "text-lg font-bold mt-0.5",
+                    lesson.available ? "text-slate-900" : "text-slate-600",
+                  ]}
+                >
+                  {lesson.title}
+                </h3>
+                <p class="text-sm font-medium text-slate-700 mt-1 italic">{lesson.tense}</p>
+                <p class="text-xs text-slate-500 mt-1">{lesson.subtitle}</p>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <!-- Bonuses preview -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="text-center mb-12">
+          <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-emerald-100 text-emerald-700 text-sm font-semibold mb-4">
+            <Sparkles class="w-4 h-4" />
+            Bonus Resources
+          </div>
+          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">Five Bonus Resources</h2>
+          <p class="text-lg text-slate-600 max-w-2xl mx-auto">
+            Compact reference guides for the verb pairs and patterns that trip up Spanish speakers most. Released as the lessons go live.
+          </p>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {pastTenseBonuses.map((bonus) => {
+            const Icon = iconMap[bonus.icon];
+            return (
+              <div class="bg-white rounded-xl p-5 border border-slate-200 flex items-start gap-4">
+                <div class="flex items-center justify-center w-10 h-10 rounded-lg shrink-0 bg-slate-100 text-slate-500">
+                  {Icon && <Icon class="w-5 h-5" />}
+                </div>
+                <div class="flex-1">
+                  <div class="flex items-center gap-2">
+                    <span class="text-xs font-bold uppercase tracking-wider text-slate-400">Bonus {bonus.id}</span>
+                    <span class="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-400">Coming soon</span>
+                  </div>
+                  <h3 class="text-base font-bold text-slate-900 mt-0.5">{bonus.title}</h3>
+                  <p class="text-sm text-slate-600 mt-1">{bonus.description}</p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Why this works -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-6 text-center">Why a Visual Method Works</h2>
+        <div class="space-y-6 text-lg text-slate-700 leading-relaxed">
+          <p>
+            Spanish past tense choice is mostly aspectual — preterite vs. imperfect, perfective vs. imperfective.
+            Rule-based. Largely predictable. <strong>English is different.</strong>
+          </p>
+          <p>
+            English past choice depends on two relationships your grammar book never visualized for you:
+            the relationship between the past event and <em>now</em> (Present Perfect),
+            and the relationship between the past event and <em>another past event</em> (Past Perfect).
+            Those are spatial, not grammatical. They're easier to see than to memorize.
+          </p>
+          <p>
+            That's what this course teaches: a mental picture for each tense, a story-flow framework for choosing between them,
+            and the specific verb pairs Mexican professionals miss most — <em>knew vs. found out</em>,
+            <em>there was vs. there has been</em>, <em>did vs. have done</em>.
+          </p>
+        </div>
+        <div class="mt-10 text-center">
+          <Button href="/en/course/past-tenses/lesson-1/" variant="primary" size="lg">
+            Start Lesson 1 — Free
+            <ArrowRight class="w-5 h-5 ml-1" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Cross-link to other courses -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-2xl font-bold text-slate-900 mb-4">Where Does This Fit?</h2>
+        <p class="text-lg text-slate-600 leading-relaxed mb-6">
+          This is a <strong>focused master class</strong> — one topic, done thoroughly.
+          For a full level course, check the four-tier series: <strong>Elemental → Intermediate → Advanced → Executive</strong>.
+          For 1-on-1 corporate coaching, see the Business English program.
+        </p>
+        <div class="flex flex-wrap gap-3 justify-center">
+          <a
+            href="/en/courses/"
+            class="text-emerald-700 hover:text-emerald-800 font-medium underline underline-offset-2"
+          >
+            See all courses
+          </a>
+          <span class="text-slate-300">|</span>
+          <a
+            href="/en/services/corporate-package/"
+            class="text-emerald-700 hover:text-emerald-800 font-medium underline underline-offset-2"
+          >
+            Corporate coaching program
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "Course",
+    "name": "Master English Past Tenses — Free Master Class",
+    "description": "A focused 5-lesson master class teaching English past tenses through visualization rather than rule-memorization. Built for Mexican professionals who freeze in conversation despite knowing the rules.",
+    "provider": {
+      "@type": "Person",
+      "name": "Robert Cushman",
+      "url": "https://www.nyenglishteacher.com/en/about/"
+    },
+    "educationalLevel": "Intermediate to Advanced",
+    "inLanguage": "en",
+    "url": "https://www.nyenglishteacher.com/en/course/past-tenses/",
+    "isAccessibleForFree": true,
+    "hasCourseInstance": {
+      "@type": "CourseInstance",
+      "courseMode": "online",
+      "inLanguage": "en"
+    }
+  })} />
+</Base>

--- a/src/pages/en/course/past-tenses/lesson-1.astro
+++ b/src/pages/en/course/past-tenses/lesson-1.astro
@@ -3,6 +3,7 @@ export const prerender = true;
 
 import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
+import AudioButton from "@components/course/AudioButton";
 import {
   ArrowRight,
   Clock,
@@ -51,7 +52,7 @@ const tkey = "course/past-tenses/lesson-1" as const;
             <Lock class="w-3.5 h-3.5" /> Closed Time
           </span>
           <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-emerald-500/20 text-emerald-300 text-sm font-medium">
-            <AlertTriangle class="w-3.5 h-3.5" /> Mexican Trap
+            <AlertTriangle class="w-3.5 h-3.5" /> Spanish-Speaker Traps
           </span>
         </div>
       </div>
@@ -97,7 +98,7 @@ const tkey = "course/past-tenses/lesson-1" as const;
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">2</span>
           <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Story Scenes</h2>
         </div>
-        <p class="text-slate-500 mb-8 ml-11">Three scenes. Three different shapes of "closed time."</p>
+        <p class="text-slate-500 mb-8 ml-11">Three scenes. Three different shapes of "closed time." Tap the speaker to hear each sentence read aloud.</p>
 
         <div class="space-y-5">
           <!-- Scene 1: A single moment -->
@@ -106,7 +107,10 @@ const tkey = "course/past-tenses/lesson-1" as const;
               <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Scene 1 — A Single Moment</p>
             </div>
             <div class="p-6">
-              <p class="text-lg text-slate-800 mb-3"><em>"I called the client yesterday."</em></p>
+              <div class="flex items-center gap-3 mb-3">
+                <p class="text-lg text-slate-800 flex-1"><em>"I called the client yesterday."</em></p>
+                <AudioButton client:visible text="I called the client yesterday." lang="en-US" size="sm" />
+              </div>
               <p class="text-sm text-slate-600">
                 Picture it: yesterday, one phone call. One specific moment. Done. The time word "yesterday" seals the box — there is no way for that call to keep happening today. <strong class="text-emerald-700">Past Simple.</strong>
               </p>
@@ -119,13 +123,22 @@ const tkey = "course/past-tenses/lesson-1" as const;
               <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Scene 2 — A Long Stretch, But Closed</p>
             </div>
             <div class="p-6">
-              <p class="text-lg text-slate-800 mb-3"><em>"I worked at Telmex for eight years."</em></p>
+              <div class="flex items-center gap-3 mb-3">
+                <p class="text-lg text-slate-800 flex-1"><em>"I worked at Telmex for eight years."</em></p>
+                <AudioButton client:visible text="I worked at Telmex for eight years." lang="en-US" size="sm" />
+              </div>
               <p class="text-sm text-slate-600">
                 Eight years is a long time. But the picture is still a closed chapter — you don't work there anymore. The whole period is one sealed box. <strong class="text-emerald-700">Past Simple.</strong>
               </p>
-              <p class="text-sm text-amber-700 mt-3 bg-amber-50 border border-amber-200 rounded-lg p-3">
-                <strong>Watch this trap:</strong> If you <em>still work there</em>, the box isn't closed — it bleeds into now. That's <em>"I have worked at Telmex for eight years."</em> A different tense. We'll get there in Lesson 3.
-              </p>
+              <div class="mt-3 bg-amber-50 border border-amber-200 rounded-lg p-3">
+                <p class="text-sm text-amber-700 mb-2">
+                  <strong>Watch this trap:</strong> If you <em>still work there</em>, the box isn't closed — it bleeds into now. That's a different tense (Lesson 3):
+                </p>
+                <div class="flex items-center gap-3">
+                  <p class="text-sm text-amber-900 italic flex-1">"I have worked at Telmex for eight years."</p>
+                  <AudioButton client:visible text="I have worked at Telmex for eight years." lang="en-US" size="sm" />
+                </div>
+              </div>
             </div>
           </div>
 
@@ -135,7 +148,10 @@ const tkey = "course/past-tenses/lesson-1" as const;
               <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Scene 3 — A Sequence of Snapshots</p>
             </div>
             <div class="p-6">
-              <p class="text-lg text-slate-800 mb-3"><em>"He arrived at nine, opened his laptop, sent three emails, and left."</em></p>
+              <div class="flex items-center gap-3 mb-3">
+                <p class="text-lg text-slate-800 flex-1"><em>"He arrived at nine, opened his laptop, sent three emails, and left."</em></p>
+                <AudioButton client:visible text="He arrived at nine, opened his laptop, sent three emails, and left." lang="en-US" size="sm" />
+              </div>
               <p class="text-sm text-slate-600">
                 Four closed boxes in a row. Each one a snapshot. The whole sequence is in the past, narrated as completed events one after another. This is how native speakers tell stories — Past Simple verbs strung together like a film strip. <strong class="text-emerald-700">Past Simple, four times.</strong>
               </p>
@@ -181,9 +197,9 @@ const tkey = "course/past-tenses/lesson-1" as const;
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-2">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">4</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Mexican Trap</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Spanish Speaker's Traps</h2>
         </div>
-        <p class="text-slate-500 mb-8 ml-11">Three specific mistakes Spanish speakers make with Past Simple. Spot them in your own speech.</p>
+        <p class="text-slate-500 mb-8 ml-11">Three specific mistakes Spanish speakers make with Past Simple — pan-Hispanic, not Mexico-specific. Spot them in your own speech. Tap the speaker on each correct version to hear the right form.</p>
 
         <div class="space-y-5">
           <!-- Trap 1 -->
@@ -191,7 +207,11 @@ const tkey = "course/past-tenses/lesson-1" as const;
             <h3 class="font-bold text-slate-900 mb-3">Trap 1 — Using present instead of past</h3>
             <div class="space-y-2">
               <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Last year I work in Monterrey."</em></span></p>
-              <p class="flex items-start gap-2"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Last year I <strong>worked</strong> in Monterrey."</em></span></p>
+              <div class="flex items-start gap-2">
+                <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+                <span class="text-slate-800 flex-1"><em>"Last year I <strong>worked</strong> in Monterrey."</em></span>
+                <AudioButton client:visible text="Last year I worked in Monterrey." lang="en-US" size="sm" />
+              </div>
             </div>
             <p class="text-sm text-slate-600 mt-3">"Last year" seals the box. The verb must move to the past form. In Spanish you would naturally say <em>"trabajé"</em> — don't leave the English verb in present form just because the time marker is doing the heavy lifting.</p>
           </div>
@@ -201,7 +221,11 @@ const tkey = "course/past-tenses/lesson-1" as const;
             <h3 class="font-bold text-slate-900 mb-3">Trap 2 — Wrong perfect with a specific past time</h3>
             <div class="space-y-2">
               <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Yesterday I have sent the report."</em></span></p>
-              <p class="flex items-start gap-2"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Yesterday I <strong>sent</strong> the report."</em></span></p>
+              <div class="flex items-start gap-2">
+                <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+                <span class="text-slate-800 flex-1"><em>"Yesterday I <strong>sent</strong> the report."</em></span>
+                <AudioButton client:visible text="Yesterday I sent the report." lang="en-US" size="sm" />
+              </div>
             </div>
             <p class="text-sm text-slate-600 mt-3">"Have sent" lives in Present Perfect (Lesson 3), and Present Perfect <strong>cannot</strong> share a sentence with a sealed-time word like "yesterday." The two pictures contradict each other. When a finished time is named, use Past Simple — full stop.</p>
           </div>
@@ -211,7 +235,11 @@ const tkey = "course/past-tenses/lesson-1" as const;
             <h3 class="font-bold text-slate-900 mb-3">Trap 3 — Forgetting the irregular forms</h3>
             <div class="space-y-2">
               <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"I goed to the meeting and telled him."</em></span></p>
-              <p class="flex items-start gap-2"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"I <strong>went</strong> to the meeting and <strong>told</strong> him."</em></span></p>
+              <div class="flex items-start gap-2">
+                <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+                <span class="text-slate-800 flex-1"><em>"I <strong>went</strong> to the meeting and <strong>told</strong> him."</em></span>
+                <AudioButton client:visible text="I went to the meeting and told him." lang="en-US" size="sm" />
+              </div>
             </div>
             <p class="text-sm text-slate-600 mt-3">English past forms are unfair — most add <em>-ed</em>, but a few hundred high-frequency verbs change shape entirely: <em>go → went, tell → told, see → saw, take → took, get → got</em>. There is no rule that predicts them. You memorize the top ~50 and the rest you absorb from listening. Use the Bonus #2 cheat sheet when it's released.</p>
           </div>

--- a/src/pages/en/course/past-tenses/lesson-1.astro
+++ b/src/pages/en/course/past-tenses/lesson-1.astro
@@ -1,0 +1,319 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import {
+  ArrowRight,
+  Clock,
+  Camera,
+  Lock,
+  AlertTriangle,
+  Eye,
+  CheckCircle2,
+  XCircle,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/past-tenses/lesson-1" as const;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Lesson 1: Past Simple — It Happened. It's Done. | NY English Teacher"
+  description="The first tense in the Master Past Tenses course. Learn to feel the closed-box moment — and stop overthinking when to use 'I worked' vs 'I have worked.'"
+>
+  <!-- Lesson hero -->
+  <section class="bg-gradient-to-b from-slate-900 to-emerald-950 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-emerald-400 text-sm font-semibold mb-3">
+          <Clock class="w-4 h-4" />
+          Lesson 1 of 5
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Past Simple
+        </h1>
+        <p class="text-2xl text-emerald-300 italic font-light mb-4">It happened. It's done.</p>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          This is the foundation. The closed box. The snapshot.
+          Before you can master the trickier tenses, you have to feel exactly what Past Simple is doing — and just as importantly, what it isn't.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-emerald-500/20 text-emerald-300 text-sm font-medium">
+            <Camera class="w-3.5 h-3.5" /> The Snapshot
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-emerald-500/20 text-emerald-300 text-sm font-medium">
+            <Lock class="w-3.5 h-3.5" /> Closed Time
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-emerald-500/20 text-emerald-300 text-sm font-medium">
+            <AlertTriangle class="w-3.5 h-3.5" /> Mexican Trap
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 1: The Mental Picture -->
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Mental Picture</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">Before any grammar. Just the image.</p>
+
+        <div class="space-y-6 text-lg text-slate-700 leading-relaxed">
+          <p>
+            Close your eyes for a second. Picture this: you walk into a room, do something, walk out, and close the door behind you. The room is sealed. Whatever happened in there is over. It belongs to <em>before</em> — not to right now.
+          </p>
+          <p>
+            <strong>That is Past Simple.</strong> A door closed. A box sealed. A photograph from a moment that is no longer happening. The action might have taken a second ("I sneezed") or eight years ("I worked at Telmex"), but the time is locked. It does not bleed into the present.
+          </p>
+
+          <div class="rounded-2xl border-2 border-emerald-300 bg-emerald-50 p-8 my-8">
+            <div class="flex items-center gap-3 mb-4">
+              <Eye class="w-6 h-6 text-emerald-700" />
+              <h3 class="text-xl font-bold text-slate-900">Your Mental Image</h3>
+            </div>
+            <p class="text-slate-800 mb-3">A snapshot. A closed door. A finished chapter. The time window is shut.</p>
+            <p class="text-slate-700 text-base">If you can see the moment as <em>sealed off</em> from now, Past Simple is the right tense. If the moment still connects to now — that's Lesson 3.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2: Story Scenes -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Story Scenes</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">Three scenes. Three different shapes of "closed time."</p>
+
+        <div class="space-y-5">
+          <!-- Scene 1: A single moment -->
+          <div class="bg-white rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-slate-900 text-white px-5 py-3">
+              <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Scene 1 — A Single Moment</p>
+            </div>
+            <div class="p-6">
+              <p class="text-lg text-slate-800 mb-3"><em>"I called the client yesterday."</em></p>
+              <p class="text-sm text-slate-600">
+                Picture it: yesterday, one phone call. One specific moment. Done. The time word "yesterday" seals the box — there is no way for that call to keep happening today. <strong class="text-emerald-700">Past Simple.</strong>
+              </p>
+            </div>
+          </div>
+
+          <!-- Scene 2: A long stretch -->
+          <div class="bg-white rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-slate-900 text-white px-5 py-3">
+              <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Scene 2 — A Long Stretch, But Closed</p>
+            </div>
+            <div class="p-6">
+              <p class="text-lg text-slate-800 mb-3"><em>"I worked at Telmex for eight years."</em></p>
+              <p class="text-sm text-slate-600">
+                Eight years is a long time. But the picture is still a closed chapter — you don't work there anymore. The whole period is one sealed box. <strong class="text-emerald-700">Past Simple.</strong>
+              </p>
+              <p class="text-sm text-amber-700 mt-3 bg-amber-50 border border-amber-200 rounded-lg p-3">
+                <strong>Watch this trap:</strong> If you <em>still work there</em>, the box isn't closed — it bleeds into now. That's <em>"I have worked at Telmex for eight years."</em> A different tense. We'll get there in Lesson 3.
+              </p>
+            </div>
+          </div>
+
+          <!-- Scene 3: A sequence -->
+          <div class="bg-white rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-slate-900 text-white px-5 py-3">
+              <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Scene 3 — A Sequence of Snapshots</p>
+            </div>
+            <div class="p-6">
+              <p class="text-lg text-slate-800 mb-3"><em>"He arrived at nine, opened his laptop, sent three emails, and left."</em></p>
+              <p class="text-sm text-slate-600">
+                Four closed boxes in a row. Each one a snapshot. The whole sequence is in the past, narrated as completed events one after another. This is how native speakers tell stories — Past Simple verbs strung together like a film strip. <strong class="text-emerald-700">Past Simple, four times.</strong>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3: Time Markers -->
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Words That Seal the Box</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">When these words appear in a sentence, the time is closed — and Past Simple is almost always the right choice.</p>
+
+        <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">yesterday</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">last week</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">last year</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">in 2019</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">two days ago</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">when I was a kid</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">at 9am</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">on Monday</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">that morning</div>
+        </div>
+
+        <p class="text-slate-600 text-sm mt-6">
+          The rule of thumb: <strong>if the sentence names a specific finished time</strong>, the box is closed and Past Simple does the work. If the time is fuzzy or still connected to now (no time marker at all, or words like <em>just</em>, <em>already</em>, <em>ever</em>) — that's a signal for a different tense.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 4: The Mexican Trap -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-4">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">4</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Mexican Trap</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">Three specific mistakes Spanish speakers make with Past Simple. Spot them in your own speech.</p>
+
+        <div class="space-y-5">
+          <!-- Trap 1 -->
+          <div class="bg-white rounded-xl border border-slate-200 p-6">
+            <h3 class="font-bold text-slate-900 mb-3">Trap 1 — Using present instead of past</h3>
+            <div class="space-y-2">
+              <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Last year I work in Monterrey."</em></span></p>
+              <p class="flex items-start gap-2"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Last year I <strong>worked</strong> in Monterrey."</em></span></p>
+            </div>
+            <p class="text-sm text-slate-600 mt-3">"Last year" seals the box. The verb must move to the past form. In Spanish you would naturally say <em>"trabajé"</em> — don't leave the English verb in present form just because the time marker is doing the heavy lifting.</p>
+          </div>
+
+          <!-- Trap 2 -->
+          <div class="bg-white rounded-xl border border-slate-200 p-6">
+            <h3 class="font-bold text-slate-900 mb-3">Trap 2 — Wrong perfect with a specific past time</h3>
+            <div class="space-y-2">
+              <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Yesterday I have sent the report."</em></span></p>
+              <p class="flex items-start gap-2"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Yesterday I <strong>sent</strong> the report."</em></span></p>
+            </div>
+            <p class="text-sm text-slate-600 mt-3">"Have sent" lives in Present Perfect (Lesson 3), and Present Perfect <strong>cannot</strong> share a sentence with a sealed-time word like "yesterday." The two pictures contradict each other. When a finished time is named, use Past Simple — full stop.</p>
+          </div>
+
+          <!-- Trap 3 -->
+          <div class="bg-white rounded-xl border border-slate-200 p-6">
+            <h3 class="font-bold text-slate-900 mb-3">Trap 3 — Forgetting the irregular forms</h3>
+            <div class="space-y-2">
+              <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"I goed to the meeting and telled him."</em></span></p>
+              <p class="flex items-start gap-2"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"I <strong>went</strong> to the meeting and <strong>told</strong> him."</em></span></p>
+            </div>
+            <p class="text-sm text-slate-600 mt-3">English past forms are unfair — most add <em>-ed</em>, but a few hundred high-frequency verbs change shape entirely: <em>go → went, tell → told, see → saw, take → took, get → got</em>. There is no rule that predicts them. You memorize the top ~50 and the rest you absorb from listening. Use the Bonus #2 cheat sheet when it's released.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 5: Check Yourself -->
+  <section class="py-16 md:py-20 bg-white" id="section-5">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">5</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Check Yourself</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">Five quick scenes. Pick the right tense — then check. The goal isn't to get them all right; the goal is to notice <em>why</em>.</p>
+
+        <div class="space-y-4">
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>1.</strong> <em>"I ___ (have/had) lunch with the CEO last Tuesday."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>Answer: had.</strong> "Last Tuesday" seals the box. Past Simple.</p>
+            </div>
+          </details>
+
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>2.</strong> <em>"She ___ (sent/has sent) three emails this morning."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>Tricky.</strong> If the morning is over → <em>sent</em>. If it's still morning → <em>has sent</em>. The same fact, two different mental pictures. This is the heart of Lesson 3.</p>
+            </div>
+          </details>
+
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>3.</strong> <em>"When I ___ (was/am) at Cemex, the team ___ (work/worked) overtime almost every Friday."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>was / worked.</strong> "When I was at Cemex" tells us the whole period is closed. The repeated Friday overtime lives inside that closed box.</p>
+            </div>
+          </details>
+
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>4.</strong> <em>"He ___ (go/went) to the airport, ___ (check/checked) in, and ___ (board/boarded) the plane without saying a word."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>went / checked / boarded.</strong> Three snapshots in a row — the classic sequence-of-Past-Simple pattern that drives narration.</p>
+            </div>
+          </details>
+
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>5.</strong> <em>"I ___ (lived/have lived) in Guadalajara for five years."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>Both are possible — and they mean different things.</strong> "I lived in Guadalajara for five years" = you don't live there anymore (closed box). "I have lived in Guadalajara for five years" = you still live there (Lesson 3). Same English words. Different mental picture.</p>
+            </div>
+          </details>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Recap + next -->
+  <section class="py-16 md:py-20 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-3xl font-bold text-slate-900 mb-6 text-center">The Recap</h2>
+        <div class="bg-white rounded-2xl border border-slate-200 p-8 mb-10">
+          <ul class="space-y-3 text-slate-700">
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Past Simple = closed box.</strong> The action and its time are sealed off from now.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Specific past time words</strong> (yesterday, last week, in 2019, when I was a kid) almost always require Past Simple.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Sequences of finished events</strong> are strings of Past Simple verbs — "he arrived, opened, sent, left."</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>If the moment still connects to now</strong> — that's a different tense (Lesson 3).</span></li>
+          </ul>
+        </div>
+
+        <div class="text-center">
+          <p class="text-slate-600 mb-6">Next up: <strong class="text-slate-900">the background scene</strong> — what you do when the action wasn't a snapshot but a movie running in the background.</p>
+          <div class="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-slate-200 text-slate-500 font-medium cursor-not-allowed">
+            Lesson 2: Past Continuous — Coming Soon
+          </div>
+          <div class="mt-6">
+            <a
+              href="/en/course/past-tenses/"
+              class="text-sm text-emerald-700 hover:text-emerald-800 underline underline-offset-2"
+            >
+              ← Back to course overview
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/tiempos-del-pasado/index.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/index.astro
@@ -1,0 +1,332 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import { pastTenseLessons, pastTenseBonuses } from "@data/past-tenses/lessons";
+import {
+  ArrowRight,
+  Sparkles,
+  Clock,
+  Film,
+  Link as LinkIcon,
+  Layers,
+  Map,
+  FileText,
+  AlertCircle,
+  Lightbulb,
+  Mic,
+  MessageSquare,
+  Eye,
+  Brain,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/past-tenses" as const;
+
+const iconMap: Record<string, any> = {
+  Clock,
+  Film,
+  Link: LinkIcon,
+  Layers,
+  Map,
+  FileText,
+  AlertCircle,
+  Lightbulb,
+  Mic,
+  MessageSquare,
+};
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Domina los Tiempos del Pasado en Inglés | Curso Gratuito"
+  description="Clase magistral gratuita. Deja de pensar en reglas — aprende a sentir la historia. Un método de 4 tiempos para dominar los pasados en inglés."
+>
+  <!-- Hero -->
+  <section class="relative w-full overflow-hidden bg-gradient-to-br from-slate-900 via-emerald-950 to-slate-900 pt-32 pb-20 md:pt-40 md:pb-28">
+    <div class="absolute inset-0 opacity-10">
+      <div class="absolute top-20 left-10 w-72 h-72 bg-emerald-500 rounded-full blur-3xl"></div>
+      <div class="absolute bottom-10 right-20 w-96 h-96 bg-teal-500 rounded-full blur-3xl"></div>
+    </div>
+    <div class="site-container mx-auto px-4 relative z-10 text-white">
+      <div class="max-w-3xl">
+        <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-emerald-500/20 text-emerald-300 text-sm font-semibold mb-6">
+          <Sparkles class="w-4 h-4" />
+          Clase Magistral Gratuita — El Método de 4 Tiempos
+        </div>
+        <h1
+          class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Domina los Tiempos del Pasado en Inglés.<br />
+          <span class="text-emerald-400">Siente la historia. No pienses en las reglas.</span>
+        </h1>
+        <p class="text-xl text-slate-300 mb-8 max-w-2xl leading-relaxed">
+          Conoces las reglas. Las puedes recitar. Pero en una junta real, en una conversación real,
+          aún te congelas — y terminas diciendo <em class="text-white not-italic">"I did the report"</em>
+          cuando la situación pide <em class="text-white not-italic">"I have done the report."</em>
+          Este curso reconecta cómo eliges los tiempos del pasado — viendo la escena en lugar de correr la gramática en tu cabeza.
+        </p>
+        <div class="flex flex-wrap gap-4">
+          <Button href="/es/curso/tiempos-del-pasado/leccion-1/" variant="primary" size="lg">
+            Empieza la Lección 1 — Gratis
+            <ArrowRight class="w-5 h-5 ml-1" />
+          </Button>
+          <a
+            href="/es/curso/intermedio/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            ¿Buscas el curso completo B1-B2?
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- El cambio: pensar vs sentir -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="text-center mb-12">
+          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">El cambio que lo transforma todo</h2>
+          <p class="text-lg text-slate-600 max-w-2xl mx-auto">
+            Los nativos no hacen cálculos gramaticales cuando cuentan una historia. Ven la escena en su mente — y el tiempo correcto sale solo. Tú también puedes entrenar ese instinto.
+          </p>
+        </div>
+
+        <div class="grid md:grid-cols-2 gap-6">
+          <!-- Forma antigua -->
+          <div class="rounded-2xl border-2 border-red-200 bg-red-50/50 p-8">
+            <div class="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-red-100 text-red-600 mb-4">
+              <Brain class="w-6 h-6" />
+            </div>
+            <h3 class="text-xl font-bold text-slate-900 mb-3">La forma antigua: Pensar en las reglas</h3>
+            <ul class="space-y-2 text-slate-700">
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> "¿Esta acción está terminada o sigue en curso?"</li>
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> "¿Necesito 'have done' o 'did' aquí?"</li>
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Te congelas a la mitad. Te pasas al español. Pierdes la junta.</li>
+            </ul>
+          </div>
+
+          <!-- Forma nueva -->
+          <div class="rounded-2xl border-2 border-emerald-300 bg-emerald-50 p-8">
+            <div class="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-emerald-100 text-emerald-600 mb-4">
+              <Eye class="w-6 h-6" />
+            </div>
+            <h3 class="text-xl font-bold text-slate-900 mb-3">La forma nueva: Sentir la historia</h3>
+            <ul class="space-y-2 text-slate-700">
+              <li class="flex gap-2"><span class="text-emerald-600 shrink-0">✓</span> Visualizas la escena en tu mente, como una película.</li>
+              <li class="flex gap-2"><span class="text-emerald-600 shrink-0">✓</span> Notas si el momento está cerrado, abierto, o tiene capas.</li>
+              <li class="flex gap-2"><span class="text-emerald-600 shrink-0">✓</span> El tiempo verbal sale automáticamente — coincide con la imagen.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Dolores -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-6 text-center">¿Te suena familiar?</h2>
+        <p class="text-center text-slate-600 mb-10">Si cualquiera de estas frases te resuena, este curso es para ti.</p>
+        <div class="grid md:grid-cols-2 gap-4">
+          <div class="bg-white rounded-xl p-5 border border-slate-200 italic text-slate-700">"Me sé las reglas pero igual me equivoco al hablar."</div>
+          <div class="bg-white rounded-xl p-5 border border-slate-200 italic text-slate-700">"En juntas con clientes de EE.UU., uso el pasado simple para todo por default."</div>
+          <div class="bg-white rounded-xl p-5 border border-slate-200 italic text-slate-700">"Pienso demasiado cada oración — y se me pierde el hilo de lo que estaba diciendo."</div>
+          <div class="bg-white rounded-xl p-5 border border-slate-200 italic text-slate-700">"A veces 'I went' y 'I have gone' parecen correctos los dos y termino adivinando."</div>
+          <div class="bg-white rounded-xl p-5 border border-slate-200 italic text-slate-700">"Me congelo a la mitad y me pongo a cuestionar si debe ser 'did' o 'have done.'"</div>
+          <div class="bg-white rounded-xl p-5 border border-slate-200 italic text-slate-700">"Llevo años estudiando inglés y aún no puedo contar una historia sin pararme."</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Lecciones -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="text-center mb-12">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">5 lecciones enfocadas. Un solo método.</h2>
+        <p class="text-lg text-slate-600 max-w-2xl mx-auto">
+          Cuatro tiempos, más la lección final que los une. Cada lección entrena el mismo instinto desde un ángulo distinto.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
+        {pastTenseLessons.map((lesson) => {
+          const Icon = iconMap[lesson.icon];
+          const href = lesson.available ? `/es/curso/tiempos-del-pasado/${lesson.slugEs}/` : undefined;
+          return (
+            <a
+              href={href}
+              class:list={[
+                "group flex items-start gap-4 p-5 rounded-xl border transition-all duration-200",
+                lesson.available
+                  ? "bg-emerald-50 border-emerald-300 hover:shadow-md hover:border-emerald-400 cursor-pointer"
+                  : "bg-white border-slate-200 opacity-75",
+              ]}
+            >
+              <div
+                class:list={[
+                  "flex items-center justify-center w-12 h-12 rounded-xl shrink-0",
+                  lesson.available ? "bg-emerald-500 text-white" : "bg-slate-100 text-slate-400",
+                ]}
+              >
+                {Icon && <Icon class="w-6 h-6" />}
+              </div>
+              <div class="flex-1">
+                <div class="flex items-center gap-2">
+                  <span
+                    class:list={[
+                      "text-xs font-bold uppercase tracking-wider",
+                      lesson.available ? "text-emerald-700" : "text-slate-400",
+                    ]}
+                  >
+                    Lección {lesson.id}
+                  </span>
+                  {!lesson.available && (
+                    <span class="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-400">Próximamente</span>
+                  )}
+                </div>
+                <h3
+                  class:list={[
+                    "text-lg font-bold mt-0.5",
+                    lesson.available ? "text-slate-900" : "text-slate-600",
+                  ]}
+                >
+                  {lesson.titleEs} <span class="font-normal text-slate-500 text-base">({lesson.title})</span>
+                </h3>
+                <p class="text-sm font-medium text-slate-700 mt-1 italic">{lesson.tenseEs}</p>
+                <p class="text-xs text-slate-500 mt-1">{lesson.subtitleEs}</p>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <!-- Bonos -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="text-center mb-12">
+          <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-emerald-100 text-emerald-700 text-sm font-semibold mb-4">
+            <Sparkles class="w-4 h-4" />
+            Recursos Adicionales
+          </div>
+          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">Cinco recursos extra</h2>
+          <p class="text-lg text-slate-600 max-w-2xl mx-auto">
+            Guías de referencia compactas para los pares de verbos y patrones que más confunden a los hispanohablantes. Se irán publicando conforme avancen las lecciones.
+          </p>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {pastTenseBonuses.map((bonus) => {
+            const Icon = iconMap[bonus.icon];
+            return (
+              <div class="bg-white rounded-xl p-5 border border-slate-200 flex items-start gap-4">
+                <div class="flex items-center justify-center w-10 h-10 rounded-lg shrink-0 bg-slate-100 text-slate-500">
+                  {Icon && <Icon class="w-5 h-5" />}
+                </div>
+                <div class="flex-1">
+                  <div class="flex items-center gap-2">
+                    <span class="text-xs font-bold uppercase tracking-wider text-slate-400">Bono {bonus.id}</span>
+                    <span class="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-400">Próximamente</span>
+                  </div>
+                  <h3 class="text-base font-bold text-slate-900 mt-0.5">{bonus.titleEs}</h3>
+                  <p class="text-sm text-slate-600 mt-1">{bonus.descriptionEs}</p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Por qué funciona -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-6 text-center">Por qué funciona un método visual</h2>
+        <div class="space-y-6 text-lg text-slate-700 leading-relaxed">
+          <p>
+            En español, la elección entre tiempos del pasado es principalmente aspectual — pretérito vs. imperfecto, perfectivo vs. imperfectivo.
+            Es algo basado en reglas y bastante predecible. <strong>El inglés es distinto.</strong>
+          </p>
+          <p>
+            La elección en inglés depende de dos relaciones que ningún libro de gramática te visualizó:
+            la relación entre el evento pasado y <em>el ahora</em> (Present Perfect),
+            y la relación entre el evento pasado y <em>otro evento pasado</em> (Past Perfect).
+            Son espaciales, no gramaticales. Son más fáciles de ver que de memorizar.
+          </p>
+          <p>
+            Eso es lo que enseña este curso: una imagen mental para cada tiempo, un mapa de flujo de historia para escoger entre ellos,
+            y los pares de verbos específicos que los profesionales mexicanos más confunden — <em>knew vs. found out</em>,
+            <em>there was vs. there has been</em>, <em>did vs. have done</em>.
+          </p>
+        </div>
+        <div class="mt-10 text-center">
+          <Button href="/es/curso/tiempos-del-pasado/leccion-1/" variant="primary" size="lg">
+            Empieza la Lección 1 — Gratis
+            <ArrowRight class="w-5 h-5 ml-1" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Enlace cruzado -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-2xl font-bold text-slate-900 mb-4">¿Dónde encaja esto?</h2>
+        <p class="text-lg text-slate-600 leading-relaxed mb-6">
+          Esta es una <strong>clase magistral enfocada</strong> — un solo tema, a fondo.
+          Si buscas un curso completo por nivel, revisa la serie de cuatro niveles: <strong>Elemental → Intermedio → Avanzado → Ejecutivo</strong>.
+          Para coaching corporativo 1-a-1, ve el programa de Inglés de Negocios.
+        </p>
+        <div class="flex flex-wrap gap-3 justify-center">
+          <a
+            href="/es/cursos/"
+            class="text-emerald-700 hover:text-emerald-800 font-medium underline underline-offset-2"
+          >
+            Ver todos los cursos
+          </a>
+          <span class="text-slate-300">|</span>
+          <a
+            href="/es/servicios/paquete-corporativo/"
+            class="text-emerald-700 hover:text-emerald-800 font-medium underline underline-offset-2"
+          >
+            Programa corporativo
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "Course",
+    "name": "Domina los Tiempos del Pasado en Inglés — Clase Magistral Gratuita",
+    "description": "Una clase magistral de 5 lecciones enfocada en los tiempos del pasado en inglés a través de la visualización en lugar de memorizar reglas. Diseñada para profesionales mexicanos que se congelan al hablar a pesar de conocer las reglas.",
+    "provider": {
+      "@type": "Person",
+      "name": "Robert Cushman",
+      "url": "https://www.nyenglishteacher.com/es/about/"
+    },
+    "educationalLevel": "Intermedio a Avanzado",
+    "inLanguage": "es",
+    "url": "https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/",
+    "isAccessibleForFree": true,
+    "hasCourseInstance": {
+      "@type": "CourseInstance",
+      "courseMode": "online",
+      "inLanguage": "es"
+    }
+  })} />
+</Base>

--- a/src/pages/es/curso/tiempos-del-pasado/leccion-1.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/leccion-1.astro
@@ -1,0 +1,319 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import {
+  ArrowRight,
+  Clock,
+  Camera,
+  Lock,
+  AlertTriangle,
+  Eye,
+  CheckCircle2,
+  XCircle,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/past-tenses/lesson-1" as const;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Lección 1: Past Simple — Sucedió. Está terminado. | NY English Teacher"
+  description="Primera lección del curso de tiempos del pasado en inglés. Aprende a sentir el momento cerrado — sin atorarte entre 'I worked' y 'I have worked.'"
+>
+  <!-- Hero de la lección -->
+  <section class="bg-gradient-to-b from-slate-900 to-emerald-950 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-emerald-400 text-sm font-semibold mb-3">
+          <Clock class="w-4 h-4" />
+          Lección 1 de 5
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Past Simple <span class="text-emerald-400 text-2xl md:text-3xl font-normal">(Pasado Simple)</span>
+        </h1>
+        <p class="text-2xl text-emerald-300 italic font-light mb-4">Sucedió. Está terminado.</p>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Esta es la base. La caja cerrada. La foto del momento.
+          Antes de dominar los tiempos más complicados, tienes que sentir exactamente qué hace el Past Simple — y, casi más importante, qué no hace.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-emerald-500/20 text-emerald-300 text-sm font-medium">
+            <Camera class="w-3.5 h-3.5" /> La foto del momento
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-emerald-500/20 text-emerald-300 text-sm font-medium">
+            <Lock class="w-3.5 h-3.5" /> Tiempo cerrado
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-emerald-500/20 text-emerald-300 text-sm font-medium">
+            <AlertTriangle class="w-3.5 h-3.5" /> Trampas mexicanas
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Sección 1: La imagen mental -->
+  <section class="py-16 md:py-20 bg-white" id="seccion-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">La imagen mental</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">Antes de cualquier gramática. Solo la imagen.</p>
+
+        <div class="space-y-6 text-lg text-slate-700 leading-relaxed">
+          <p>
+            Cierra los ojos un segundo. Visualiza esto: entras a un cuarto, haces algo, sales, y cierras la puerta detrás de ti. El cuarto queda sellado. Lo que haya pasado adentro está terminado. Pertenece al <em>antes</em> — no al ahora.
+          </p>
+          <p>
+            <strong>Eso es Past Simple.</strong> Una puerta cerrada. Una caja sellada. Una fotografía de un momento que ya no está ocurriendo. La acción pudo durar un segundo (<em>"I sneezed"</em>) u ocho años (<em>"I worked at Telmex"</em>), pero el tiempo está cerrado. No se cuela al presente.
+          </p>
+
+          <div class="rounded-2xl border-2 border-emerald-300 bg-emerald-50 p-8 my-8">
+            <div class="flex items-center gap-3 mb-4">
+              <Eye class="w-6 h-6 text-emerald-700" />
+              <h3 class="text-xl font-bold text-slate-900">Tu imagen mental</h3>
+            </div>
+            <p class="text-slate-800 mb-3">Una foto. Una puerta cerrada. Un capítulo terminado. La ventana de tiempo está sellada.</p>
+            <p class="text-slate-700 text-base">Si puedes ver el momento como <em>aislado</em> del ahora, Past Simple es el tiempo correcto. Si el momento aún conecta con el ahora — eso es la Lección 3.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Sección 2: Escenas de la historia -->
+  <section class="py-16 md:py-20 bg-slate-50" id="seccion-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Escenas de la historia</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">Tres escenas. Tres formas distintas de "tiempo cerrado".</p>
+
+        <div class="space-y-5">
+          <!-- Escena 1 -->
+          <div class="bg-white rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-slate-900 text-white px-5 py-3">
+              <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Escena 1 — Un momento único</p>
+            </div>
+            <div class="p-6">
+              <p class="text-lg text-slate-800 mb-3"><em>"I called the client yesterday."</em></p>
+              <p class="text-sm text-slate-600">
+                Visualízalo: ayer, una llamada. Un momento específico. Listo. La palabra "yesterday" sella la caja — esa llamada no puede seguir ocurriendo hoy. <strong class="text-emerald-700">Past Simple.</strong>
+              </p>
+            </div>
+          </div>
+
+          <!-- Escena 2 -->
+          <div class="bg-white rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-slate-900 text-white px-5 py-3">
+              <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Escena 2 — Un período largo, pero cerrado</p>
+            </div>
+            <div class="p-6">
+              <p class="text-lg text-slate-800 mb-3"><em>"I worked at Telmex for eight years."</em></p>
+              <p class="text-sm text-slate-600">
+                Ocho años es mucho tiempo. Pero la imagen sigue siendo un capítulo terminado — ya no trabajas ahí. Todo el período es una caja sellada. <strong class="text-emerald-700">Past Simple.</strong>
+              </p>
+              <p class="text-sm text-amber-700 mt-3 bg-amber-50 border border-amber-200 rounded-lg p-3">
+                <strong>Cuidado con esta trampa:</strong> si <em>todavía trabajas ahí</em>, la caja no está cerrada — se cuela al ahora. Eso es <em>"I have worked at Telmex for eight years."</em> Otro tiempo. Llegamos a eso en la Lección 3.
+              </p>
+            </div>
+          </div>
+
+          <!-- Escena 3 -->
+          <div class="bg-white rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-slate-900 text-white px-5 py-3">
+              <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Escena 3 — Una secuencia de fotos</p>
+            </div>
+            <div class="p-6">
+              <p class="text-lg text-slate-800 mb-3"><em>"He arrived at nine, opened his laptop, sent three emails, and left."</em></p>
+              <p class="text-sm text-slate-600">
+                Cuatro cajas cerradas, una tras otra. Cada una es una foto. Toda la secuencia está en el pasado, narrada como eventos terminados uno tras otro. Así cuentan historias los nativos — verbos en Past Simple encadenados como una tira de película. <strong class="text-emerald-700">Past Simple, cuatro veces.</strong>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Sección 3: Palabras que cierran la caja -->
+  <section class="py-16 md:py-20 bg-white" id="seccion-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Palabras que cierran la caja</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">Cuando aparecen estas palabras en una oración, el tiempo está cerrado — y Past Simple casi siempre es la opción correcta.</p>
+
+        <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">yesterday</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">last week</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">last year</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">in 2019</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">two days ago</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">when I was a kid</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">at 9am</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">on Monday</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">that morning</div>
+        </div>
+
+        <p class="text-slate-600 text-sm mt-6">
+          Regla práctica: <strong>si la oración menciona un tiempo específico ya terminado</strong>, la caja está cerrada y el Past Simple hace el trabajo. Si el tiempo es difuso o aún conecta con el ahora (sin marcador de tiempo, o con palabras como <em>just</em>, <em>already</em>, <em>ever</em>) — esa es la señal de otro tiempo.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Sección 4: Trampas del hispanohablante -->
+  <section class="py-16 md:py-20 bg-slate-50" id="seccion-4">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">4</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Trampas del hispanohablante</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">Tres errores específicos que cometemos con Past Simple. Identifícalos en tu propia forma de hablar.</p>
+
+        <div class="space-y-5">
+          <!-- Trampa 1 -->
+          <div class="bg-white rounded-xl border border-slate-200 p-6">
+            <h3 class="font-bold text-slate-900 mb-3">Trampa 1 — Usar presente en lugar de pasado</h3>
+            <div class="space-y-2">
+              <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Last year I work in Monterrey."</em></span></p>
+              <p class="flex items-start gap-2"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Last year I <strong>worked</strong> in Monterrey."</em></span></p>
+            </div>
+            <p class="text-sm text-slate-600 mt-3">"Last year" cierra la caja. El verbo se tiene que mover a la forma del pasado. En español dirías naturalmente <em>"trabajé"</em> — no dejes el verbo en inglés en presente solo porque la palabra de tiempo carga el sentido.</p>
+          </div>
+
+          <!-- Trampa 2 -->
+          <div class="bg-white rounded-xl border border-slate-200 p-6">
+            <h3 class="font-bold text-slate-900 mb-3">Trampa 2 — Usar el perfecto cuando hay tiempo pasado específico</h3>
+            <div class="space-y-2">
+              <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Yesterday I have sent the report."</em></span></p>
+              <p class="flex items-start gap-2"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Yesterday I <strong>sent</strong> the report."</em></span></p>
+            </div>
+            <p class="text-sm text-slate-600 mt-3">"Have sent" vive en el Present Perfect (Lección 3), y el Present Perfect <strong>no puede</strong> compartir oración con una palabra de tiempo cerrado como "yesterday". Las dos imágenes se contradicen. Cuando se menciona un tiempo terminado, va Past Simple — sin discusión.</p>
+          </div>
+
+          <!-- Trampa 3 -->
+          <div class="bg-white rounded-xl border border-slate-200 p-6">
+            <h3 class="font-bold text-slate-900 mb-3">Trampa 3 — Olvidar las formas irregulares</h3>
+            <div class="space-y-2">
+              <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"I goed to the meeting and telled him."</em></span></p>
+              <p class="flex items-start gap-2"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"I <strong>went</strong> to the meeting and <strong>told</strong> him."</em></span></p>
+            </div>
+            <p class="text-sm text-slate-600 mt-3">Las formas del pasado en inglés son injustas — la mayoría agregan <em>-ed</em>, pero unos cientos de verbos de alta frecuencia cambian de forma completamente: <em>go → went, tell → told, see → saw, take → took, get → got</em>. No hay regla que los prediga. Memorizas los 50 más comunes y el resto los absorbes escuchando. Usa la hoja de referencia del Bono #2 cuando se publique.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Sección 5: Revísate -->
+  <section class="py-16 md:py-20 bg-white" id="seccion-5">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">5</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Revísate</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">Cinco escenas rápidas. Escoge el tiempo correcto — luego verifica. La meta no es atinarle a todas; la meta es notar el <em>porqué</em>.</p>
+
+        <div class="space-y-4">
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>1.</strong> <em>"I ___ (have/had) lunch with the CEO last Tuesday."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>Respuesta: had.</strong> "Last Tuesday" cierra la caja. Va en Past Simple.</p>
+            </div>
+          </details>
+
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>2.</strong> <em>"She ___ (sent/has sent) three emails this morning."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>Capciosa.</strong> Si la mañana ya terminó → <em>sent</em>. Si sigue siendo de mañana → <em>has sent</em>. El mismo hecho, dos imágenes mentales distintas. Este es el corazón de la Lección 3.</p>
+            </div>
+          </details>
+
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>3.</strong> <em>"When I ___ (was/am) at Cemex, the team ___ (work/worked) overtime almost every Friday."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>was / worked.</strong> "When I was at Cemex" nos dice que todo ese período está cerrado. El overtime repetido de los viernes vive dentro de esa caja cerrada.</p>
+            </div>
+          </details>
+
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>4.</strong> <em>"He ___ (go/went) to the airport, ___ (check/checked) in, and ___ (board/boarded) the plane without saying a word."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>went / checked / boarded.</strong> Tres fotos seguidas — el patrón clásico de secuencia en Past Simple que impulsa la narración.</p>
+            </div>
+          </details>
+
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>5.</strong> <em>"I ___ (lived/have lived) in Guadalajara for five years."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>Las dos son posibles — y significan cosas distintas.</strong> "I lived in Guadalajara for five years" = ya no vives ahí (caja cerrada). "I have lived in Guadalajara for five years" = sigues viviendo ahí (Lección 3). Las mismas palabras en inglés. Imagen mental diferente.</p>
+            </div>
+          </details>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Recap + siguiente -->
+  <section class="py-16 md:py-20 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-3xl font-bold text-slate-900 mb-6 text-center">El resumen</h2>
+        <div class="bg-white rounded-2xl border border-slate-200 p-8 mb-10">
+          <ul class="space-y-3 text-slate-700">
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Past Simple = caja cerrada.</strong> La acción y su tiempo están sellados, separados del ahora.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Las palabras de tiempo pasado específico</strong> (yesterday, last week, in 2019, when I was a kid) casi siempre exigen Past Simple.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Las secuencias de eventos terminados</strong> son cadenas de verbos en Past Simple — "he arrived, opened, sent, left."</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Si el momento aún conecta con el ahora</strong> — eso es otro tiempo (Lección 3).</span></li>
+          </ul>
+        </div>
+
+        <div class="text-center">
+          <p class="text-slate-600 mb-6">A continuación: <strong class="text-slate-900">la escena de fondo</strong> — qué hacer cuando la acción no era una foto sino una película corriendo de fondo.</p>
+          <div class="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-slate-200 text-slate-500 font-medium cursor-not-allowed">
+            Lección 2: Past Continuous — Próximamente
+          </div>
+          <div class="mt-6">
+            <a
+              href="/es/curso/tiempos-del-pasado/"
+              class="text-sm text-emerald-700 hover:text-emerald-800 underline underline-offset-2"
+            >
+              ← Volver al resumen del curso
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/tiempos-del-pasado/leccion-1.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/leccion-1.astro
@@ -3,6 +3,7 @@ export const prerender = true;
 
 import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
+import AudioButton from "@components/course/AudioButton";
 import {
   ArrowRight,
   Clock,
@@ -51,7 +52,7 @@ const tkey = "course/past-tenses/lesson-1" as const;
             <Lock class="w-3.5 h-3.5" /> Tiempo cerrado
           </span>
           <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-emerald-500/20 text-emerald-300 text-sm font-medium">
-            <AlertTriangle class="w-3.5 h-3.5" /> Trampas mexicanas
+            <AlertTriangle class="w-3.5 h-3.5" /> Trampas del hispanohablante
           </span>
         </div>
       </div>
@@ -97,7 +98,7 @@ const tkey = "course/past-tenses/lesson-1" as const;
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">2</span>
           <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Escenas de la historia</h2>
         </div>
-        <p class="text-slate-500 mb-8 ml-11">Tres escenas. Tres formas distintas de "tiempo cerrado".</p>
+        <p class="text-slate-500 mb-8 ml-11">Tres escenas. Tres formas distintas de "tiempo cerrado". Toca la bocina para escuchar cada oración en inglés.</p>
 
         <div class="space-y-5">
           <!-- Escena 1 -->
@@ -106,7 +107,10 @@ const tkey = "course/past-tenses/lesson-1" as const;
               <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Escena 1 — Un momento único</p>
             </div>
             <div class="p-6">
-              <p class="text-lg text-slate-800 mb-3"><em>"I called the client yesterday."</em></p>
+              <div class="flex items-center gap-3 mb-3">
+                <p class="text-lg text-slate-800 flex-1"><em>"I called the client yesterday."</em></p>
+                <AudioButton client:visible text="I called the client yesterday." lang="en-US" size="sm" />
+              </div>
               <p class="text-sm text-slate-600">
                 Visualízalo: ayer, una llamada. Un momento específico. Listo. La palabra "yesterday" sella la caja — esa llamada no puede seguir ocurriendo hoy. <strong class="text-emerald-700">Past Simple.</strong>
               </p>
@@ -119,13 +123,22 @@ const tkey = "course/past-tenses/lesson-1" as const;
               <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Escena 2 — Un período largo, pero cerrado</p>
             </div>
             <div class="p-6">
-              <p class="text-lg text-slate-800 mb-3"><em>"I worked at Telmex for eight years."</em></p>
+              <div class="flex items-center gap-3 mb-3">
+                <p class="text-lg text-slate-800 flex-1"><em>"I worked at Telmex for eight years."</em></p>
+                <AudioButton client:visible text="I worked at Telmex for eight years." lang="en-US" size="sm" />
+              </div>
               <p class="text-sm text-slate-600">
                 Ocho años es mucho tiempo. Pero la imagen sigue siendo un capítulo terminado — ya no trabajas ahí. Todo el período es una caja sellada. <strong class="text-emerald-700">Past Simple.</strong>
               </p>
-              <p class="text-sm text-amber-700 mt-3 bg-amber-50 border border-amber-200 rounded-lg p-3">
-                <strong>Cuidado con esta trampa:</strong> si <em>todavía trabajas ahí</em>, la caja no está cerrada — se cuela al ahora. Eso es <em>"I have worked at Telmex for eight years."</em> Otro tiempo. Llegamos a eso en la Lección 3.
-              </p>
+              <div class="mt-3 bg-amber-50 border border-amber-200 rounded-lg p-3">
+                <p class="text-sm text-amber-700 mb-2">
+                  <strong>Cuidado con esta trampa:</strong> si <em>todavía trabajas ahí</em>, la caja no está cerrada — se cuela al ahora. Eso es otro tiempo (Lección 3):
+                </p>
+                <div class="flex items-center gap-3">
+                  <p class="text-sm text-amber-900 italic flex-1">"I have worked at Telmex for eight years."</p>
+                  <AudioButton client:visible text="I have worked at Telmex for eight years." lang="en-US" size="sm" />
+                </div>
+              </div>
             </div>
           </div>
 
@@ -135,7 +148,10 @@ const tkey = "course/past-tenses/lesson-1" as const;
               <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Escena 3 — Una secuencia de fotos</p>
             </div>
             <div class="p-6">
-              <p class="text-lg text-slate-800 mb-3"><em>"He arrived at nine, opened his laptop, sent three emails, and left."</em></p>
+              <div class="flex items-center gap-3 mb-3">
+                <p class="text-lg text-slate-800 flex-1"><em>"He arrived at nine, opened his laptop, sent three emails, and left."</em></p>
+                <AudioButton client:visible text="He arrived at nine, opened his laptop, sent three emails, and left." lang="en-US" size="sm" />
+              </div>
               <p class="text-sm text-slate-600">
                 Cuatro cajas cerradas, una tras otra. Cada una es una foto. Toda la secuencia está en el pasado, narrada como eventos terminados uno tras otro. Así cuentan historias los nativos — verbos en Past Simple encadenados como una tira de película. <strong class="text-emerald-700">Past Simple, cuatro veces.</strong>
               </p>
@@ -183,7 +199,7 @@ const tkey = "course/past-tenses/lesson-1" as const;
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">4</span>
           <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Trampas del hispanohablante</h2>
         </div>
-        <p class="text-slate-500 mb-8 ml-11">Tres errores específicos que cometemos con Past Simple. Identifícalos en tu propia forma de hablar.</p>
+        <p class="text-slate-500 mb-8 ml-11">Tres errores específicos que cometen los hispanohablantes con Past Simple — son comunes a todo el mundo hispanohablante, no solo México. Identifícalos en tu propia forma de hablar. Toca la bocina en la versión correcta para escuchar cómo suena.</p>
 
         <div class="space-y-5">
           <!-- Trampa 1 -->
@@ -191,7 +207,11 @@ const tkey = "course/past-tenses/lesson-1" as const;
             <h3 class="font-bold text-slate-900 mb-3">Trampa 1 — Usar presente en lugar de pasado</h3>
             <div class="space-y-2">
               <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Last year I work in Monterrey."</em></span></p>
-              <p class="flex items-start gap-2"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Last year I <strong>worked</strong> in Monterrey."</em></span></p>
+              <div class="flex items-start gap-2">
+                <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+                <span class="text-slate-800 flex-1"><em>"Last year I <strong>worked</strong> in Monterrey."</em></span>
+                <AudioButton client:visible text="Last year I worked in Monterrey." lang="en-US" size="sm" />
+              </div>
             </div>
             <p class="text-sm text-slate-600 mt-3">"Last year" cierra la caja. El verbo se tiene que mover a la forma del pasado. En español dirías naturalmente <em>"trabajé"</em> — no dejes el verbo en inglés en presente solo porque la palabra de tiempo carga el sentido.</p>
           </div>
@@ -201,7 +221,11 @@ const tkey = "course/past-tenses/lesson-1" as const;
             <h3 class="font-bold text-slate-900 mb-3">Trampa 2 — Usar el perfecto cuando hay tiempo pasado específico</h3>
             <div class="space-y-2">
               <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Yesterday I have sent the report."</em></span></p>
-              <p class="flex items-start gap-2"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Yesterday I <strong>sent</strong> the report."</em></span></p>
+              <div class="flex items-start gap-2">
+                <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+                <span class="text-slate-800 flex-1"><em>"Yesterday I <strong>sent</strong> the report."</em></span>
+                <AudioButton client:visible text="Yesterday I sent the report." lang="en-US" size="sm" />
+              </div>
             </div>
             <p class="text-sm text-slate-600 mt-3">"Have sent" vive en el Present Perfect (Lección 3), y el Present Perfect <strong>no puede</strong> compartir oración con una palabra de tiempo cerrado como "yesterday". Las dos imágenes se contradicen. Cuando se menciona un tiempo terminado, va Past Simple — sin discusión.</p>
           </div>
@@ -211,7 +235,11 @@ const tkey = "course/past-tenses/lesson-1" as const;
             <h3 class="font-bold text-slate-900 mb-3">Trampa 3 — Olvidar las formas irregulares</h3>
             <div class="space-y-2">
               <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"I goed to the meeting and telled him."</em></span></p>
-              <p class="flex items-start gap-2"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"I <strong>went</strong> to the meeting and <strong>told</strong> him."</em></span></p>
+              <div class="flex items-start gap-2">
+                <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+                <span class="text-slate-800 flex-1"><em>"I <strong>went</strong> to the meeting and <strong>told</strong> him."</em></span>
+                <AudioButton client:visible text="I went to the meeting and told him." lang="en-US" size="sm" />
+              </div>
             </div>
             <p class="text-sm text-slate-600 mt-3">Las formas del pasado en inglés son injustas — la mayoría agregan <em>-ed</em>, pero unos cientos de verbos de alta frecuencia cambian de forma completamente: <em>go → went, tell → told, see → saw, take → took, get → got</em>. No hay regla que los prediga. Memorizas los 50 más comunes y el resto los absorbes escuchando. Usa la hoja de referencia del Bono #2 cuando se publique.</p>
           </div>


### PR DESCRIPTION
## Summary
A focused, free master class for Mexican professionals built around a visualization-first pedagogy: **"Feel the story. Don't think the rules."** Distinct from the existing 4-level course series — single-topic, deep treatment of one of the biggest pain points for Mexican corporate English learners.

This MVP ships the **landing page + Lesson 1 (Past Simple)** in both languages. Lessons 2–5 and 5 bonus resources appear as "Coming soon" stubs on the landing page so the structure is visible without committing to content quality you haven't reviewed yet.

## Pages added
- \`/en/course/past-tenses/\` — Landing
- \`/en/course/past-tenses/lesson-1/\` — Lesson 1: Past Simple
- \`/es/curso/tiempos-del-pasado/\` — Landing (Mexican Professional Spanish)
- \`/es/curso/tiempos-del-pasado/leccion-1/\` — Lesson 1 (Mexican Professional Spanish)

## Pedagogical approach (sample from Lesson 1)
Each tense gets a **mental image** first:
- Past Simple = closed box / sealed door / snapshot
- Past Continuous = background film running
- Present Perfect = thread from past to now
- Past Perfect = a layer beneath another past event

Then **story scenes** drawn from Mexican corporate life (Telmex, Cemex, client calls), then a **Mexican-specific trap section** addressing the errors Spanish speakers actually make (using present for past, wrong perfect with specific past times, irregular verb forms).

## Visual identity
Emerald accent on slate gradient — distinct from the amber (Intermediate) and violet (Advanced) palettes. Lesson cards, story-scene cards, and check-yourself \`<details>\` panels are all CSS-only (no new React components needed).

## What I deliberately did NOT do
- Did not wire the course into the \`/en/courses/\` index or main navigation. The MVP needs your voice review before site-wide promotion.
- Did not build Lessons 2–5 or the 5 bonuses. Once you approve the voice/structure, those slot in cleanly using the same template.
- Did not duplicate Paul's branding or content — pedagogy was reverse-engineered to English past tenses, copy is original.

## Test plan
- [x] \`npm run build\` clean (0 errors, sitemap validator passes, meta-description-gate passes)
- [x] Verified all 4 pages render in \`dist/\`
- [x] Verified sitemap.xml emits correct hreflang alternates between EN↔ES pairs
- [ ] Visual QA on Vercel preview — desktop + mobile
- [ ] Voice review: does the "feel the story" framing read true in Robert's coaching voice?
- [ ] Mexican Professional Spanish review: any Iberian drift in ES copy?

🤖 Generated with [Claude Code](https://claude.com/claude-code)