### PR TITLE
feat(course): Lesson 3 — Present Perfect (the high-stakes lesson)

### DIFF
--- a/src/data/past-tenses/lessons.ts
+++ b/src/data/past-tenses/lessons.ts
@@ -80,7 +80,7 @@ export const pastTenseLessons: PastTenseLesson[] = [
     subtitle: "The tense Mexicans miss most. A thread from past to now.",
     subtitleEs: "El tiempo que los mexicanos más omiten. Un hilo del pasado al presente.",
     icon: "Link",
-    available: false,
+    available: true,
   },
   {
     id: 4,

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -141,6 +141,7 @@ export type TKey =
   | "course/past-tenses"
   | "course/past-tenses/lesson-1"
   | "course/past-tenses/lesson-2"
+  | "course/past-tenses/lesson-3"
   | "corporate/for-hr"
   | "meme-portfolio"
   | "site-index";
@@ -297,6 +298,7 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/past-tenses": "/en/course/past-tenses/",
     "course/past-tenses/lesson-1": "/en/course/past-tenses/lesson-1/",
     "course/past-tenses/lesson-2": "/en/course/past-tenses/lesson-2/",
+    "course/past-tenses/lesson-3": "/en/course/past-tenses/lesson-3/",
     "corporate/for-hr": "/en/for-hr-managers/",
     "meme-portfolio": "/en/meme-portfolio/all/",
     "site-index": "/en/site-index/",
@@ -457,6 +459,7 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/past-tenses": "/es/curso/tiempos-del-pasado/",
     "course/past-tenses/lesson-1": "/es/curso/tiempos-del-pasado/leccion-1/",
     "course/past-tenses/lesson-2": "/es/curso/tiempos-del-pasado/leccion-2/",
+    "course/past-tenses/lesson-3": "/es/curso/tiempos-del-pasado/leccion-3/",
     "corporate/for-hr": "/es/para-rh/",
     "meme-portfolio": "/es/meme-portfolio/all/",
     "site-index": "/es/indice-del-sitio/",
@@ -546,6 +549,7 @@ export function getAllTKeys(): TKey[] {
     "course/past-tenses",
     "course/past-tenses/lesson-1",
     "course/past-tenses/lesson-2",
+    "course/past-tenses/lesson-3",
     "category/startup-founders",
     "category/tech-english",
     "category/logistics-english",

--- a/src/pages/en/course/past-tenses/lesson-2.astro
+++ b/src/pages/en/course/past-tenses/lesson-2.astro
@@ -321,9 +321,10 @@ const tkey = "course/past-tenses/lesson-2" as const;
 
         <div class="text-center">
           <p class="text-slate-600 mb-6">Next up: <strong class="text-slate-900">the thread to now</strong> — the tense that bleeds the past into the present and trips up Mexican professionals more than any other.</p>
-          <div class="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-slate-200 text-slate-500 font-medium cursor-not-allowed">
-            Lesson 3: Present Perfect — Coming Soon
-          </div>
+          <Button href="/en/course/past-tenses/lesson-3/" variant="primary" size="lg">
+            Lesson 3: Present Perfect
+            <ArrowRight class="w-5 h-5 ml-1" />
+          </Button>
           <div class="mt-6 flex flex-wrap gap-4 justify-center">
             <a
               href="/en/course/past-tenses/lesson-1/"

--- a/src/pages/en/course/past-tenses/lesson-3.astro
+++ b/src/pages/en/course/past-tenses/lesson-3.astro
@@ -1,0 +1,413 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import AudioButton from "@components/course/AudioButton";
+import {
+  ArrowRight,
+  Link as LinkIcon,
+  Sparkles,
+  AlertTriangle,
+  Eye,
+  CheckCircle2,
+  XCircle,
+  Clock,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/past-tenses/lesson-3" as const;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Lesson 3: Present Perfect — The Thread to Now | NY English Teacher"
+  description="The third lesson — and the most important. Master the tense Mexican professionals miss most: when 'I have done it' beats 'I did it' and why it matters."
+>
+  <!-- Lesson hero -->
+  <section class="bg-gradient-to-b from-slate-900 to-emerald-950 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-emerald-400 text-sm font-semibold mb-3">
+          <LinkIcon class="w-4 h-4" />
+          Lesson 3 of 5 — The Big One
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Present Perfect
+        </h1>
+        <p class="text-2xl text-emerald-300 italic font-light mb-4">It happened — but it still matters now.</p>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          This is the tense Mexican professionals miss more than any other.
+          In Spanish, the simple past does almost everything: <em class="text-white not-italic">"¿Ya comiste?"</em>
+          can mean both "Did you eat?" and "Have you eaten?" In English, those two questions paint different pictures —
+          and using the wrong one quietly signals "non-native" in every meeting you walk into.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-emerald-500/20 text-emerald-300 text-sm font-medium">
+            <LinkIcon class="w-3.5 h-3.5" /> The Thread to Now
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-emerald-500/20 text-emerald-300 text-sm font-medium">
+            <Clock class="w-3.5 h-3.5" /> Open Time Windows
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-emerald-500/20 text-emerald-300 text-sm font-medium">
+            <AlertTriangle class="w-3.5 h-3.5" /> Spanish-Speaker Traps
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 1: The Mental Picture -->
+  <section class="py-16 md:py-20 bg-white" id="section-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Mental Picture</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">Before any grammar. Just the image.</p>
+
+        <div class="space-y-6 text-lg text-slate-700 leading-relaxed">
+          <p>
+            Past Simple was a closed box. Past Continuous was a movie running.
+            Present Perfect is something else entirely: <strong>a thread that runs from somewhere in the past all the way to where you're standing right now.</strong>
+          </p>
+          <p>
+            Something happened. Maybe an hour ago, maybe years ago. <em>When</em> it happened isn't the point. The point is that whatever happened <strong>still touches the present</strong> — the time window hasn't closed yet, or the action started in the past and is still going, or the experience lives inside you and shapes who you are right now.
+          </p>
+          <p>
+            That's why this tense uses the auxiliary <em>have/has</em>: it literally <em>"has"</em> the past attached to the present moment. The form is <strong><em>have/has + past participle</em></strong> (have done, has sent, have lived).
+          </p>
+
+          <div class="rounded-2xl border-2 border-emerald-300 bg-emerald-50 p-8 my-8">
+            <div class="flex items-center gap-3 mb-4">
+              <Eye class="w-6 h-6 text-emerald-700" />
+              <h3 class="text-xl font-bold text-slate-900">Your Mental Image</h3>
+            </div>
+            <p class="text-slate-800 mb-3">A thread from past to now. An open door. Footprints leading to where you're standing.</p>
+            <p class="text-slate-700 text-base">If the past event still connects to the present — the time window is still open, the action is still going, or the experience shapes who you are now — that's Present Perfect. If the moment is sealed off in finished time, that's Past Simple (Lesson 1).</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2: Three Uses -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Three Reasons to Use It</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">Three different threads, three different shapes — all pointing at "still connected to now." Tap the speaker to hear each one.</p>
+
+        <div class="space-y-5">
+          <!-- Use 1: Open time window -->
+          <div class="bg-white rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-slate-900 text-white px-5 py-3">
+              <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Use 1 — The Time Window Is Still Open</p>
+            </div>
+            <div class="p-6">
+              <div class="flex items-center gap-3 mb-3">
+                <p class="text-lg text-slate-800 flex-1"><em>"I have sent three emails this morning."</em></p>
+                <AudioButton client:visible text="I have sent three emails this morning." lang="en-US" size="sm" />
+              </div>
+              <p class="text-sm text-slate-600">
+                If it's still morning when you say this, "this morning" hasn't closed yet — you might send more before noon. The thread runs from each sent email forward into the still-open morning. <strong class="text-emerald-700">Present Perfect.</strong>
+              </p>
+              <div class="mt-3 bg-amber-50 border border-amber-200 rounded-lg p-3">
+                <p class="text-sm text-amber-700 mb-2">
+                  <strong>Compare:</strong> if you say it at 5pm, the morning is over — sealed time:
+                </p>
+                <div class="flex items-center gap-3">
+                  <p class="text-sm text-amber-900 italic flex-1">"I sent three emails this morning."</p>
+                  <AudioButton client:visible text="I sent three emails this morning." lang="en-US" size="sm" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Use 2: Started in past, still going -->
+          <div class="bg-white rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-slate-900 text-white px-5 py-3">
+              <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Use 2 — It Started in the Past and Is Still Going</p>
+            </div>
+            <div class="p-6">
+              <div class="flex items-center gap-3 mb-3">
+                <p class="text-lg text-slate-800 flex-1"><em>"I have worked at this company for ten years."</em></p>
+                <AudioButton client:visible text="I have worked at this company for ten years." lang="en-US" size="sm" />
+              </div>
+              <p class="text-sm text-slate-600">
+                You started ten years ago and you're still there today — the thread is unbroken. This is where Mexican professionals get tripped up most: in Spanish you might say <em>"trabajo aquí desde hace diez años"</em> (present tense), but in English the form is <em>have worked</em>, not <em>work</em>. <strong class="text-emerald-700">Present Perfect.</strong>
+              </p>
+              <div class="mt-3 bg-amber-50 border border-amber-200 rounded-lg p-3">
+                <p class="text-sm text-amber-700 mb-2">
+                  <strong>Compare:</strong> if you left the company, the thread breaks — sealed time:
+                </p>
+                <div class="flex items-center gap-3">
+                  <p class="text-sm text-amber-900 italic flex-1">"I worked at that company for ten years."</p>
+                  <AudioButton client:visible text="I worked at that company for ten years." lang="en-US" size="sm" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Use 3: Life experience -->
+          <div class="bg-white rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-slate-900 text-white px-5 py-3">
+              <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Use 3 — A Life Experience That Still Lives in You</p>
+            </div>
+            <div class="p-6">
+              <div class="flex items-center gap-3 mb-3">
+                <p class="text-lg text-slate-800 flex-1"><em>"Have you ever been to Chicago?"</em></p>
+                <AudioButton client:visible text="Have you ever been to Chicago?" lang="en-US" size="sm" />
+              </div>
+              <p class="text-sm text-slate-600">
+                You're not asking <em>when</em> they went — you're asking whether the experience exists in their life at all. The trip is in their memory bank, shaping who they are now. The word <em>"ever"</em> is the giveaway: the question covers their entire lifetime up to this moment. <strong class="text-emerald-700">Present Perfect.</strong>
+              </p>
+              <div class="mt-3 bg-amber-50 border border-amber-200 rounded-lg p-3">
+                <p class="text-sm text-amber-700 mb-2">
+                  <strong>Compare:</strong> if you know they went and you're asking <em>when</em> — that's a closed-time question:
+                </p>
+                <div class="flex items-center gap-3">
+                  <p class="text-sm text-amber-900 italic flex-1">"When did you go to Chicago?"</p>
+                  <AudioButton client:visible text="When did you go to Chicago?" lang="en-US" size="sm" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3: Words That Signal Present Perfect -->
+  <section class="py-16 md:py-20 bg-white" id="section-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Words That Signal the Thread</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">When you hear or write these words, you're almost always in Present Perfect territory. They each anchor the past event to the present moment.</p>
+
+        <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">today</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">this morning (still morning)</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">this week / month / year</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">for + duration</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">since + start point</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">ever / never</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">already</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">just</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">yet (in questions/negatives)</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">so far</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">lately / recently</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">in my life</div>
+        </div>
+
+        <div class="mt-8 grid md:grid-cols-2 gap-4">
+          <div class="bg-emerald-50 border border-emerald-200 rounded-xl p-5">
+            <p class="text-sm font-bold text-emerald-800 uppercase tracking-wide mb-2">"For" — How Long</p>
+            <p class="text-slate-700 text-sm mb-3"><em>For</em> + a duration. Answers "how long has the thread been running?"</p>
+            <div class="flex items-center gap-2">
+              <p class="text-sm text-slate-800 italic flex-1">"I have lived here for five years."</p>
+              <AudioButton client:visible text="I have lived here for five years." lang="en-US" size="sm" />
+            </div>
+          </div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-xl p-5">
+            <p class="text-sm font-bold text-emerald-800 uppercase tracking-wide mb-2">"Since" — Starting Point</p>
+            <p class="text-slate-700 text-sm mb-3"><em>Since</em> + a moment in time. Answers "when did the thread start?"</p>
+            <div class="flex items-center gap-2">
+              <p class="text-sm text-slate-800 italic flex-1">"I have lived here since 2020."</p>
+              <AudioButton client:visible text="I have lived here since 2020." lang="en-US" size="sm" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 4: Spanish-Speaker Traps -->
+  <section class="py-16 md:py-20 bg-slate-50" id="section-4">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">4</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Spanish Speaker's Traps</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">These are the highest-stakes traps in the entire course. Mexican professionals miss Present Perfect more than any other tense in English meetings. Tap the speaker on each correct version to hear the right form.</p>
+
+        <div class="space-y-5">
+          <!-- Trap 1: Simple-past default -->
+          <div class="bg-white rounded-xl border border-slate-200 p-6">
+            <h3 class="font-bold text-slate-900 mb-3">Trap 1 — Defaulting to Past Simple when the time window is still open</h3>
+            <div class="space-y-2">
+              <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Did you eat lunch?"</em> (asked at noon, when lunch is still possible)</span></p>
+              <div class="flex items-start gap-2">
+                <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+                <span class="text-slate-800 flex-1"><em>"<strong>Have you eaten</strong> lunch?"</em></span>
+                <AudioButton client:visible text="Have you eaten lunch?" lang="en-US" size="sm" />
+              </div>
+            </div>
+            <p class="text-sm text-slate-600 mt-3">In Mexico, <em>"¿Ya comiste?"</em> works for both situations. In English they're different pictures. <strong>"Did you eat?"</strong> implies the lunch window is closed — meeting's over, they missed their chance. <strong>"Have you eaten?"</strong> implies it's still possible — the thread is still open. American colleagues will form a subtle impression based on which one you choose. This is the single most common Mexican-speaker tell in US business meetings.</p>
+          </div>
+
+          <!-- Trap 2: For vs Since -->
+          <div class="bg-white rounded-xl border border-slate-200 p-6">
+            <h3 class="font-bold text-slate-900 mb-3">Trap 2 — Mixing up "for" and "since"</h3>
+            <div class="space-y-2">
+              <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"I have worked here since five years."</em></span></p>
+              <div class="flex items-start gap-2">
+                <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+                <span class="text-slate-800 flex-1"><em>"I have worked here <strong>for</strong> five years."</em></span>
+                <AudioButton client:visible text="I have worked here for five years." lang="en-US" size="sm" />
+              </div>
+              <p class="text-sm text-slate-500 mt-1 ml-7">or, with the same meaning:</p>
+              <div class="flex items-start gap-2">
+                <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+                <span class="text-slate-800 flex-1"><em>"I have worked here <strong>since</strong> 2020."</em></span>
+                <AudioButton client:visible text="I have worked here since 2020." lang="en-US" size="sm" />
+              </div>
+            </div>
+            <p class="text-sm text-slate-600 mt-3">Spanish uses <em>"desde hace cinco años"</em> which has a literal "since" feel — so the Spanish-speaker brain reaches for <em>"since"</em> in English. But in English, <em>since</em> needs a <strong>starting point</strong> (2020, March, my graduation), not a <strong>duration</strong> (five years). When the number is a duration, the word is <em>for</em>.</p>
+          </div>
+
+          <!-- Trap 3: Present Perfect with closed time -->
+          <div class="bg-white rounded-xl border border-slate-200 p-6">
+            <h3 class="font-bold text-slate-900 mb-3">Trap 3 — Using Present Perfect with closed-time words</h3>
+            <div class="space-y-2">
+              <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Yesterday I have called you."</em></span></p>
+              <div class="flex items-start gap-2">
+                <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+                <span class="text-slate-800 flex-1"><em>"Yesterday I <strong>called</strong> you."</em></span>
+                <AudioButton client:visible text="Yesterday I called you." lang="en-US" size="sm" />
+              </div>
+            </div>
+            <p class="text-sm text-slate-600 mt-3">This is the same closed-time rule from Lesson 1, seen from the other direction. Words like <em>yesterday, last week, in 2019, two days ago, when I was a kid</em> all <strong>close the box</strong>. They cannot share a sentence with Present Perfect, because the moment is sealed off from now — the thread can't reach across. If a closed-time word is in the sentence, use Past Simple. Always.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 5: Check Yourself -->
+  <section class="py-16 md:py-20 bg-white" id="section-5">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">5</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Check Yourself</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">Five scenes. Pick the tense, then notice the <em>why</em>. The pattern is what trains your instinct.</p>
+
+        <div class="space-y-4">
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>1.</strong> <em>"She ___ (worked / has worked) here since 2020."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>Answer: has worked.</strong> "Since 2020" + still working there = the thread is still running. Present Perfect.</p>
+            </div>
+          </details>
+
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>2.</strong> <em>"I ___ (called / have called) him yesterday."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>Answer: called.</strong> "Yesterday" is a closed-time word. The box is sealed. Past Simple is the only correct choice here — even though Spanish would let you say <em>"lo he llamado ayer"</em> in some regions, English doesn't.</p>
+            </div>
+          </details>
+
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>3.</strong> <em>"___ (Did you ever / Have you ever) visited Cancún?"</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>Answer: Have you ever.</strong> "Ever" covers their entire lifetime up to now. Life-experience question = Present Perfect.</p>
+            </div>
+          </details>
+
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>4.</strong> <em>"We ___ (finished / have finished) the project last Friday."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>Answer: finished.</strong> "Last Friday" is a closed-time word. Past Simple. (If it were "We have finished the project" with no time word, that would be Present Perfect — meaning it's done and the result still matters now.)</p>
+            </div>
+          </details>
+
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>5.</strong> <em>"He ___ (sent / has sent) three emails today, and he might send more."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>Answer: has sent.</strong> "Today" is still open AND he might send more — the thread is unmistakably alive. Classic Present Perfect.</p>
+            </div>
+          </details>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Recap + next -->
+  <section class="py-16 md:py-20 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-3xl font-bold text-slate-900 mb-6 text-center">The Recap</h2>
+        <div class="bg-white rounded-2xl border border-slate-200 p-8 mb-10">
+          <ul class="space-y-3 text-slate-700">
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Present Perfect = a thread from past to now.</strong> The event still touches the present.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Form:</strong> <em>have/has + past participle</em> (have done, has sent, have lived).</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Three reasons to use it:</strong> the time window is still open · the action started in the past and is still going · the experience lives in you.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>"For" + duration, "since" + starting point.</strong> Never reverse them.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Never share a sentence with closed-time words</strong> (yesterday, last week, in 2019). Those force Past Simple.</span></li>
+          </ul>
+        </div>
+
+        <div class="bg-emerald-50 border-2 border-emerald-300 rounded-2xl p-6 mb-10">
+          <div class="flex items-start gap-3">
+            <Sparkles class="w-6 h-6 text-emerald-700 shrink-0 mt-0.5" />
+            <div>
+              <h3 class="font-bold text-slate-900 mb-2">The Mexican Professional Test</h3>
+              <p class="text-slate-700 text-sm">For one week, every time you reach for <em>"Did you..."</em> in English, pause and ask: "Is the time window still open? Is the result still alive?" If either answer is yes, switch to <em>"Have you..."</em>. This single habit will move your English from "competent" to "fluent-sounding" faster than any other change you can make.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="text-center">
+          <p class="text-slate-600 mb-6">Next up: <strong class="text-slate-900">the layered past</strong> — when one past event happened before another, and you need to mark which came first.</p>
+          <div class="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-slate-200 text-slate-500 font-medium cursor-not-allowed">
+            Lesson 4: Past Perfect — Coming Soon
+          </div>
+          <div class="mt-6 flex flex-wrap gap-4 justify-center">
+            <a
+              href="/en/course/past-tenses/lesson-2/"
+              class="text-sm text-slate-500 hover:text-emerald-700 underline underline-offset-2"
+            >
+              ← Lesson 2: Past Continuous
+            </a>
+            <span class="text-slate-300">|</span>
+            <a
+              href="/en/course/past-tenses/"
+              class="text-sm text-emerald-700 hover:text-emerald-800 underline underline-offset-2"
+            >
+              Course overview
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/tiempos-del-pasado/leccion-2.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/leccion-2.astro
@@ -321,9 +321,10 @@ const tkey = "course/past-tenses/lesson-2" as const;
 
         <div class="text-center">
           <p class="text-slate-600 mb-6">A continuación: <strong class="text-slate-900">el hilo hacia el ahora</strong> — el tiempo que cuela el pasado en el presente y al que los profesionales mexicanos le tropiezan más que a cualquier otro.</p>
-          <div class="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-slate-200 text-slate-500 font-medium cursor-not-allowed">
-            Lección 3: Present Perfect — Próximamente
-          </div>
+          <Button href="/es/curso/tiempos-del-pasado/leccion-3/" variant="primary" size="lg">
+            Lección 3: Present Perfect
+            <ArrowRight class="w-5 h-5 ml-1" />
+          </Button>
           <div class="mt-6 flex flex-wrap gap-4 justify-center">
             <a
               href="/es/curso/tiempos-del-pasado/leccion-1/"

--- a/src/pages/es/curso/tiempos-del-pasado/leccion-3.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/leccion-3.astro
@@ -1,0 +1,413 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import AudioButton from "@components/course/AudioButton";
+import {
+  ArrowRight,
+  Link as LinkIcon,
+  Sparkles,
+  AlertTriangle,
+  Eye,
+  CheckCircle2,
+  XCircle,
+  Clock,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/past-tenses/lesson-3" as const;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Lección 3: Present Perfect — El hilo hacia el ahora | NY English Teacher"
+  description="La tercera lección — y la más importante. Domina el tiempo que los mexicanos más omiten: cuándo 'I have done it' le gana a 'I did it' y por qué importa."
+>
+  <!-- Hero de la lección -->
+  <section class="bg-gradient-to-b from-slate-900 to-emerald-950 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-emerald-400 text-sm font-semibold mb-3">
+          <LinkIcon class="w-4 h-4" />
+          Lección 3 de 5 — La más importante
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Present Perfect <span class="text-emerald-400 text-2xl md:text-3xl font-normal">(Presente Perfecto)</span>
+        </h1>
+        <p class="text-2xl text-emerald-300 italic font-light mb-4">Sucedió — pero todavía importa ahora.</p>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
+          Este es el tiempo que los profesionales mexicanos omiten más que cualquier otro.
+          En español, el pasado simple hace casi todo: <em class="text-white not-italic">"¿Ya comiste?"</em>
+          puede significar tanto "Did you eat?" como "Have you eaten?" En inglés, esas dos preguntas pintan imágenes distintas —
+          y usar la incorrecta calladamente delata "no nativo" en cada junta a la que entras.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-emerald-500/20 text-emerald-300 text-sm font-medium">
+            <LinkIcon class="w-3.5 h-3.5" /> El hilo hacia el ahora
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-emerald-500/20 text-emerald-300 text-sm font-medium">
+            <Clock class="w-3.5 h-3.5" /> Ventanas de tiempo abiertas
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-emerald-500/20 text-emerald-300 text-sm font-medium">
+            <AlertTriangle class="w-3.5 h-3.5" /> Trampas del hispanohablante
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Sección 1: La imagen mental -->
+  <section class="py-16 md:py-20 bg-white" id="seccion-1">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">La imagen mental</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">Antes de cualquier gramática. Solo la imagen.</p>
+
+        <div class="space-y-6 text-lg text-slate-700 leading-relaxed">
+          <p>
+            El Past Simple era una caja cerrada. El Past Continuous era una película corriendo.
+            El Present Perfect es algo completamente distinto: <strong>un hilo que va desde algún punto del pasado hasta donde estás parado ahora mismo.</strong>
+          </p>
+          <p>
+            Algo sucedió. Tal vez hace una hora, tal vez hace años. <em>Cuándo</em> sucedió no es el punto. El punto es que lo que sea que sucedió <strong>aún toca el presente</strong> — la ventana de tiempo no se ha cerrado, o la acción empezó en el pasado y sigue, o la experiencia vive dentro de ti y moldea quién eres ahora.
+          </p>
+          <p>
+            Por eso este tiempo usa el auxiliar <em>have/has</em>: literalmente <em>"has"</em> ("tienes") el pasado pegado al momento presente. La forma es <strong><em>have/has + participio pasado</em></strong> (have done, has sent, have lived).
+          </p>
+
+          <div class="rounded-2xl border-2 border-emerald-300 bg-emerald-50 p-8 my-8">
+            <div class="flex items-center gap-3 mb-4">
+              <Eye class="w-6 h-6 text-emerald-700" />
+              <h3 class="text-xl font-bold text-slate-900">Tu imagen mental</h3>
+            </div>
+            <p class="text-slate-800 mb-3">Un hilo del pasado al ahora. Una puerta abierta. Huellas que llegan hasta donde estás parado.</p>
+            <p class="text-slate-700 text-base">Si el evento pasado aún conecta con el presente — la ventana de tiempo sigue abierta, la acción sigue ocurriendo, o la experiencia moldea quién eres ahora — eso es Present Perfect. Si el momento está sellado en tiempo terminado, eso es Past Simple (Lección 1).</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Sección 2: Los tres usos -->
+  <section class="py-16 md:py-20 bg-slate-50" id="seccion-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Las tres razones para usarlo</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">Tres hilos distintos, tres formas diferentes — todas apuntando a "aún conectado al ahora". Toca la bocina para escuchar cada una.</p>
+
+        <div class="space-y-5">
+          <!-- Uso 1: Ventana de tiempo abierta -->
+          <div class="bg-white rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-slate-900 text-white px-5 py-3">
+              <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Uso 1 — La ventana de tiempo sigue abierta</p>
+            </div>
+            <div class="p-6">
+              <div class="flex items-center gap-3 mb-3">
+                <p class="text-lg text-slate-800 flex-1"><em>"I have sent three emails this morning."</em></p>
+                <AudioButton client:visible text="I have sent three emails this morning." lang="en-US" size="sm" />
+              </div>
+              <p class="text-sm text-slate-600">
+                Si todavía es de mañana cuando lo dices, "this morning" no se ha cerrado — podrías mandar más antes del mediodía. El hilo corre desde cada email enviado hacia adelante, hacia la mañana que sigue abierta. <strong class="text-emerald-700">Present Perfect.</strong>
+              </p>
+              <div class="mt-3 bg-amber-50 border border-amber-200 rounded-lg p-3">
+                <p class="text-sm text-amber-700 mb-2">
+                  <strong>Compara:</strong> si lo dices a las 5pm, la mañana ya terminó — tiempo sellado:
+                </p>
+                <div class="flex items-center gap-3">
+                  <p class="text-sm text-amber-900 italic flex-1">"I sent three emails this morning."</p>
+                  <AudioButton client:visible text="I sent three emails this morning." lang="en-US" size="sm" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Uso 2: Empezó en el pasado, sigue ocurriendo -->
+          <div class="bg-white rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-slate-900 text-white px-5 py-3">
+              <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Uso 2 — Empezó en el pasado y sigue ocurriendo</p>
+            </div>
+            <div class="p-6">
+              <div class="flex items-center gap-3 mb-3">
+                <p class="text-lg text-slate-800 flex-1"><em>"I have worked at this company for ten years."</em></p>
+                <AudioButton client:visible text="I have worked at this company for ten years." lang="en-US" size="sm" />
+              </div>
+              <p class="text-sm text-slate-600">
+                Empezaste hace diez años y sigues ahí hoy — el hilo no se ha roto. Aquí es donde los profesionales mexicanos más se tropiezan: en español dirías <em>"trabajo aquí desde hace diez años"</em> (tiempo presente), pero en inglés la forma es <em>have worked</em>, no <em>work</em>. <strong class="text-emerald-700">Present Perfect.</strong>
+              </p>
+              <div class="mt-3 bg-amber-50 border border-amber-200 rounded-lg p-3">
+                <p class="text-sm text-amber-700 mb-2">
+                  <strong>Compara:</strong> si te saliste de la empresa, el hilo se rompe — tiempo sellado:
+                </p>
+                <div class="flex items-center gap-3">
+                  <p class="text-sm text-amber-900 italic flex-1">"I worked at that company for ten years."</p>
+                  <AudioButton client:visible text="I worked at that company for ten years." lang="en-US" size="sm" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Uso 3: Experiencia de vida -->
+          <div class="bg-white rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-slate-900 text-white px-5 py-3">
+              <p class="text-xs font-bold uppercase tracking-wider text-emerald-400">Uso 3 — Una experiencia de vida que sigue viva en ti</p>
+            </div>
+            <div class="p-6">
+              <div class="flex items-center gap-3 mb-3">
+                <p class="text-lg text-slate-800 flex-1"><em>"Have you ever been to Chicago?"</em></p>
+                <AudioButton client:visible text="Have you ever been to Chicago?" lang="en-US" size="sm" />
+              </div>
+              <p class="text-sm text-slate-600">
+                No estás preguntando <em>cuándo</em> fue — estás preguntando si la experiencia existe en su vida, punto. El viaje está en su memoria, moldeando quién es ahora. La palabra <em>"ever"</em> es la pista: la pregunta cubre toda su vida hasta este momento. <strong class="text-emerald-700">Present Perfect.</strong>
+              </p>
+              <div class="mt-3 bg-amber-50 border border-amber-200 rounded-lg p-3">
+                <p class="text-sm text-amber-700 mb-2">
+                  <strong>Compara:</strong> si sabes que sí fue y estás preguntando <em>cuándo</em> — esa es una pregunta de tiempo cerrado:
+                </p>
+                <div class="flex items-center gap-3">
+                  <p class="text-sm text-amber-900 italic flex-1">"When did you go to Chicago?"</p>
+                  <AudioButton client:visible text="When did you go to Chicago?" lang="en-US" size="sm" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Sección 3: Palabras que señalan el hilo -->
+  <section class="py-16 md:py-20 bg-white" id="seccion-3">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Palabras que señalan el hilo</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">Cuando escuches o escribas estas palabras, casi siempre estás en territorio del Present Perfect. Cada una ancla el evento pasado al momento presente.</p>
+
+        <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">today</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">this morning (sigue siendo mañana)</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">this week / month / year</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">for + duración</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">since + punto inicial</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">ever / never</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">already</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">just</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">yet (preguntas/negativos)</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">so far</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">lately / recently</div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-center text-emerald-800 font-medium">in my life</div>
+        </div>
+
+        <div class="mt-8 grid md:grid-cols-2 gap-4">
+          <div class="bg-emerald-50 border border-emerald-200 rounded-xl p-5">
+            <p class="text-sm font-bold text-emerald-800 uppercase tracking-wide mb-2">"For" — cuánto tiempo</p>
+            <p class="text-slate-700 text-sm mb-3"><em>For</em> + una duración. Responde "¿cuánto tiempo lleva corriendo el hilo?"</p>
+            <div class="flex items-center gap-2">
+              <p class="text-sm text-slate-800 italic flex-1">"I have lived here for five years."</p>
+              <AudioButton client:visible text="I have lived here for five years." lang="en-US" size="sm" />
+            </div>
+          </div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-xl p-5">
+            <p class="text-sm font-bold text-emerald-800 uppercase tracking-wide mb-2">"Since" — punto de inicio</p>
+            <p class="text-slate-700 text-sm mb-3"><em>Since</em> + un momento en el tiempo. Responde "¿cuándo empezó el hilo?"</p>
+            <div class="flex items-center gap-2">
+              <p class="text-sm text-slate-800 italic flex-1">"I have lived here since 2020."</p>
+              <AudioButton client:visible text="I have lived here since 2020." lang="en-US" size="sm" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Sección 4: Trampas del hispanohablante -->
+  <section class="py-16 md:py-20 bg-slate-50" id="seccion-4">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">4</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Trampas del hispanohablante</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">Estas son las trampas más críticas de todo el curso. Los profesionales mexicanos omiten el Present Perfect más que cualquier otro tiempo en juntas en inglés. Toca la bocina en cada versión correcta para escuchar cómo suena.</p>
+
+        <div class="space-y-5">
+          <!-- Trampa 1 -->
+          <div class="bg-white rounded-xl border border-slate-200 p-6">
+            <h3 class="font-bold text-slate-900 mb-3">Trampa 1 — Usar Past Simple por default cuando la ventana de tiempo sigue abierta</h3>
+            <div class="space-y-2">
+              <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Did you eat lunch?"</em> (preguntado al mediodía, cuando aún hay tiempo de comer)</span></p>
+              <div class="flex items-start gap-2">
+                <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+                <span class="text-slate-800 flex-1"><em>"<strong>Have you eaten</strong> lunch?"</em></span>
+                <AudioButton client:visible text="Have you eaten lunch?" lang="en-US" size="sm" />
+              </div>
+            </div>
+            <p class="text-sm text-slate-600 mt-3">En México, <em>"¿Ya comiste?"</em> sirve para ambas situaciones. En inglés son imágenes distintas. <strong>"Did you eat?"</strong> implica que la ventana de la comida está cerrada — ya acabó la junta, perdió su oportunidad. <strong>"Have you eaten?"</strong> implica que todavía es posible — el hilo sigue abierto. Los colegas estadounidenses forman una impresión sutil basada en cuál elijas. Esta es la señal más común de "no nativo" mexicano en juntas de negocios en EE.UU.</p>
+          </div>
+
+          <!-- Trampa 2 -->
+          <div class="bg-white rounded-xl border border-slate-200 p-6">
+            <h3 class="font-bold text-slate-900 mb-3">Trampa 2 — Confundir "for" y "since"</h3>
+            <div class="space-y-2">
+              <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"I have worked here since five years."</em></span></p>
+              <div class="flex items-start gap-2">
+                <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+                <span class="text-slate-800 flex-1"><em>"I have worked here <strong>for</strong> five years."</em></span>
+                <AudioButton client:visible text="I have worked here for five years." lang="en-US" size="sm" />
+              </div>
+              <p class="text-sm text-slate-500 mt-1 ml-7">o, con el mismo significado:</p>
+              <div class="flex items-start gap-2">
+                <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+                <span class="text-slate-800 flex-1"><em>"I have worked here <strong>since</strong> 2020."</em></span>
+                <AudioButton client:visible text="I have worked here since 2020." lang="en-US" size="sm" />
+              </div>
+            </div>
+            <p class="text-sm text-slate-600 mt-3">El español usa <em>"desde hace cinco años"</em> que tiene un sentido literal de "since" — entonces el cerebro hispanohablante alcanza <em>"since"</em> en inglés. Pero en inglés, <em>since</em> necesita un <strong>punto de inicio</strong> (2020, marzo, mi graduación), no una <strong>duración</strong> (cinco años). Cuando el número es una duración, la palabra es <em>for</em>.</p>
+          </div>
+
+          <!-- Trampa 3 -->
+          <div class="bg-white rounded-xl border border-slate-200 p-6">
+            <h3 class="font-bold text-slate-900 mb-3">Trampa 3 — Usar Present Perfect con palabras de tiempo cerrado</h3>
+            <div class="space-y-2">
+              <p class="flex items-start gap-2"><XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" /><span class="text-slate-800"><em>"Yesterday I have called you."</em></span></p>
+              <div class="flex items-start gap-2">
+                <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+                <span class="text-slate-800 flex-1"><em>"Yesterday I <strong>called</strong> you."</em></span>
+                <AudioButton client:visible text="Yesterday I called you." lang="en-US" size="sm" />
+              </div>
+            </div>
+            <p class="text-sm text-slate-600 mt-3">Esta es la misma regla de tiempo cerrado de la Lección 1, vista desde el otro lado. Palabras como <em>yesterday, last week, in 2019, two days ago, when I was a kid</em> todas <strong>cierran la caja</strong>. No pueden compartir oración con Present Perfect, porque el momento está sellado, separado del ahora — el hilo no puede cruzar. Si una palabra de tiempo cerrado aparece en la oración, usa Past Simple. Siempre.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Sección 5: Revísate -->
+  <section class="py-16 md:py-20 bg-white" id="seccion-5">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500 text-white text-sm font-bold">5</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Revísate</h2>
+        </div>
+        <p class="text-slate-500 mb-8 ml-11">Cinco escenas. Escoge el tiempo, luego nota el <em>porqué</em>. El patrón es lo que entrena tu instinto.</p>
+
+        <div class="space-y-4">
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>1.</strong> <em>"She ___ (worked / has worked) here since 2020."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>Respuesta: has worked.</strong> "Since 2020" + sigue trabajando ahí = el hilo sigue corriendo. Present Perfect.</p>
+            </div>
+          </details>
+
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>2.</strong> <em>"I ___ (called / have called) him yesterday."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>Respuesta: called.</strong> "Yesterday" es una palabra de tiempo cerrado. La caja está sellada. Past Simple es la única opción correcta aquí — aunque el español permite <em>"lo he llamado ayer"</em> en algunas regiones, el inglés no.</p>
+            </div>
+          </details>
+
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>3.</strong> <em>"___ (Did you ever / Have you ever) visited Cancún?"</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>Respuesta: Have you ever.</strong> "Ever" cubre toda su vida hasta ahora. Pregunta de experiencia de vida = Present Perfect.</p>
+            </div>
+          </details>
+
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>4.</strong> <em>"We ___ (finished / have finished) the project last Friday."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>Respuesta: finished.</strong> "Last Friday" es una palabra de tiempo cerrado. Past Simple. (Si fuera "We have finished the project" sin palabra de tiempo, sería Present Perfect — significando que está terminado y el resultado todavía importa ahora.)</p>
+            </div>
+          </details>
+
+          <details class="bg-slate-50 rounded-xl border border-slate-200 group">
+            <summary class="cursor-pointer p-5 list-none font-medium text-slate-900 flex items-center justify-between">
+              <span><strong>5.</strong> <em>"He ___ (sent / has sent) three emails today, and he might send more."</em></span>
+              <span class="text-emerald-600 text-sm group-open:rotate-180 transition-transform">▼</span>
+            </summary>
+            <div class="px-5 pb-5 border-t border-slate-200 pt-4">
+              <p class="text-slate-800"><strong>Respuesta: has sent.</strong> "Today" sigue abierto Y podría mandar más — el hilo está inconfundiblemente vivo. Present Perfect clásico.</p>
+            </div>
+          </details>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Recap + siguiente -->
+  <section class="py-16 md:py-20 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-3xl font-bold text-slate-900 mb-6 text-center">El resumen</h2>
+        <div class="bg-white rounded-2xl border border-slate-200 p-8 mb-10">
+          <ul class="space-y-3 text-slate-700">
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Present Perfect = un hilo del pasado al ahora.</strong> El evento todavía toca el presente.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Forma:</strong> <em>have/has + participio pasado</em> (have done, has sent, have lived).</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Tres razones para usarlo:</strong> la ventana de tiempo sigue abierta · la acción empezó en el pasado y sigue · la experiencia vive en ti.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>"For" + duración, "since" + punto de inicio.</strong> Nunca los inviertas.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Nunca compartir oración con palabras de tiempo cerrado</strong> (yesterday, last week, in 2019). Esas obligan a Past Simple.</span></li>
+          </ul>
+        </div>
+
+        <div class="bg-emerald-50 border-2 border-emerald-300 rounded-2xl p-6 mb-10">
+          <div class="flex items-start gap-3">
+            <Sparkles class="w-6 h-6 text-emerald-700 shrink-0 mt-0.5" />
+            <div>
+              <h3 class="font-bold text-slate-900 mb-2">La prueba del profesional mexicano</h3>
+              <p class="text-slate-700 text-sm">Durante una semana, cada vez que vayas a usar <em>"Did you..."</em> en inglés, pausa y pregúntate: "¿La ventana de tiempo sigue abierta? ¿El resultado sigue vivo?" Si la respuesta a cualquiera de las dos es sí, cámbialo a <em>"Have you..."</em>. Este solo hábito moverá tu inglés de "competente" a "sonar fluido" más rápido que cualquier otro cambio que puedas hacer.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="text-center">
+          <p class="text-slate-600 mb-6">A continuación: <strong class="text-slate-900">el pasado en capas</strong> — cuando un evento pasado sucedió antes que otro, y necesitas marcar cuál vino primero.</p>
+          <div class="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-slate-200 text-slate-500 font-medium cursor-not-allowed">
+            Lección 4: Past Perfect — Próximamente
+          </div>
+          <div class="mt-6 flex flex-wrap gap-4 justify-center">
+            <a
+              href="/es/curso/tiempos-del-pasado/leccion-2/"
+              class="text-sm text-slate-500 hover:text-emerald-700 underline underline-offset-2"
+            >
+              ← Lección 2: Past Continuous
+            </a>
+            <span class="text-slate-300">|</span>
+            <a
+              href="/es/curso/tiempos-del-pasado/"
+              class="text-sm text-emerald-700 hover:text-emerald-800 underline underline-offset-2"
+            >
+              Resumen del curso
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary
Third lesson in the Past Tenses master class — and the highest-value lesson for Mexican professionals. Present Perfect framed as **"a thread from past to now"** — the tense that bleeds the past into the present.

This is pedagogically the most important lesson in the entire course because Mexican Spanish defaults to simple past for situations English requires Present Perfect. <em>"¿Ya comiste?"</em> serves as both "Did you eat?" and "Have you eaten?" — with different implications in English meetings that quietly mark non-native speakers.

## Three uses, three side-by-side compare/contrast pairs
Each "use" card shows the Present Perfect version AND its Past Simple counterpart so students see the shift directly:
1. **Time window still open** (this morning, while it's still morning)
2. **Started in past, still going** (for 10 years, still here)
3. **Life experience** (Have you ever been to...)

## Three Spanish-Speaker traps
1. **Past-Simple default for open time windows** — the "Did you eat?" vs "Have you eaten?" tell
2. **for vs since confusion** — Spanish *"desde hace cinco años"* leads to "since five years" instead of "for five years"
3. **Present Perfect with closed-time words** — mirror of the Lesson 1 trap

## Capstone callout
Added "The Mexican Professional Test" — a one-week habit Robert can prescribe to corporate clients: for one week, every time you reach for *"Did you..."* in English, pause and ask "Is the time window still open?" If yes, switch to *"Have you..."*.

## Wiring
- \`src/data/past-tenses/lessons.ts\` — lesson-3 \`available: true\`
- \`src/lib/i18n.ts\` — new TKey + EN/ES routes; sitemap auto-emits hreflang alternates
- Lesson 2 forward navigation upgraded from "Coming Soon" to active Button (EN + ES)
- 10 AudioButtons per language version (more than Lessons 1-2 due to compare/contrast pattern)

## Test plan
- [x] \`npm run build\` clean (0 errors, sitemap valid, meta gate passes)
- [x] Both Lesson 3 pages render with audio buttons

## Preview URLs (Ctrl+Click)
- https://ny-eng-git-feat-past-tenses-lesson-3-rcushmaniii-projects.vercel.app/en/course/past-tenses/lesson-3/
- https://ny-eng-git-feat-past-tenses-lesson-3-rcushmaniii-projects.vercel.app/es/curso/tiempos-del-pasado/leccion-3/
- Landing (Lesson 3 card should now be active): https://ny-eng-git-feat-past-tenses-lesson-3-rcushmaniii-projects.vercel.app/en/course/past-tenses/
- Lesson 2 forward link: https://ny-eng-git-feat-past-tenses-lesson-3-rcushmaniii-projects.vercel.app/en/course/past-tenses/lesson-2/

🤖 Generated with [Claude Code](https://claude.com/claude-code)