### PR TITLE
fix(corporate): polish pricing, quiz CTA, FAQ anchors, footer label

### DIFF
--- a/src/components/sections/Challenge.astro
+++ b/src/components/sections/Challenge.astro
@@ -66,9 +66,15 @@ const backgroundClasses = {
         <!-- Quiz CTA -->
         {content.quizCta && (
           <div class="mt-8 p-6 bg-blue-50 rounded-lg border-l-4 border-blue-600">
-            <p class="text-blue-900 font-bold">
-              {content.quizCta.text} <a href={content.quizCta.link} class="text-blue-600 underline hover:text-blue-800 ml-1">{content.quizCta.linkLabel}</a>
+            <p class="text-blue-900 font-bold mb-4">
+              {content.quizCta.text}
             </p>
+            <a
+              href={content.quizCta.link}
+              class="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-3 rounded-lg shadow-sm transition-colors"
+            >
+              {content.quizCta.linkLabel}
+            </a>
           </div>
         )}
       </div>

--- a/src/components/sections/ServiceFAQ.astro
+++ b/src/components/sections/ServiceFAQ.astro
@@ -9,6 +9,15 @@ export interface Props {
 
 const { faqs, lang } = Astro.props;
 const heading = lang === "es" ? "Preguntas Frecuentes" : "Frequently Asked Questions";
+
+const slugify = (s: string) =>
+  s
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
 ---
 
 <FAQSchema faqs={faqs} />
@@ -17,8 +26,11 @@ const heading = lang === "es" ? "Preguntas Frecuentes" : "Frequently Asked Quest
   <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
     <h2 class="text-3xl font-bold text-gray-900 text-center mb-10">{heading}</h2>
     <div class="space-y-4">
-      {faqs.map((faq, index) => (
-        <details class="group bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+      {faqs.map((faq) => (
+        <details
+          id={`faq-${slugify(faq.question)}`}
+          class="group bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden scroll-mt-24"
+        >
           <summary class="flex items-center justify-between cursor-pointer px-6 py-4 text-left font-semibold text-gray-900 hover:bg-gray-50 transition-colors">
             <span class="pr-4">{faq.question}</span>
             <span class="flex-shrink-0 text-primary transition-transform group-open:rotate-45 text-xl font-bold">+</span>

--- a/src/data/footer/en.ts
+++ b/src/data/footer/en.ts
@@ -24,7 +24,7 @@ export const footerContentEn = (siteConfig: { companyName: string }) => {
             href: routes.en.resources ?? "/en/resources/",
           },
           { name: "FAQs", href: "/en/faqs/" },
-          { name: "Try my AI English Coach", href: "/en/chat/" },
+          { name: "Try my AI Practice Chat", href: "/en/chat/" },
           { name: "Blog", href: routes.en.blog },
           { name: "Benchmark Assessment", href: "/en/assessments/" },
           { name: "Executive Memes", href: "/en/meme-portfolio/all/" },

--- a/src/data/footer/es.ts
+++ b/src/data/footer/es.ts
@@ -27,7 +27,7 @@ export const footerContentEs = (siteConfig: { companyName: string }) => {
             href: routes.es.recursos ?? "/es/recursos/",
           },
           { name: "Preguntas Frecuentes", href: "/es/faqs/" },
-          { name: "Prueba mi Coach de Inglés con IA", href: "/es/chat/" },
+          { name: "Prueba mi Chat de Práctica con IA", href: "/es/chat/" },
           { name: "Blog", href: routes.es.blog },
           { name: "Evaluación de Referencia", href: "/es/assessments/" },
           { name: "Memes Ejecutivos", href: "/es/meme-portfolio/all/" },

--- a/src/pages/en/services/corporate-package.astro
+++ b/src/pages/en/services/corporate-package.astro
@@ -211,17 +211,17 @@ const faqs = serviceFaqs["corporate-package"]?.en || [];
             <tr class="border-b border-gray-100">
               <td class="py-3">Conservative (12 sessions)</td>
               <td class="text-right py-3">7,200 MXN</td>
-              <td class="text-right py-3">~36,000 MXN</td>
+              <td class="text-right py-3">≈ 36,000 MXN</td>
             </tr>
             <tr class="border-b border-gray-100">
               <td class="py-3">Moderate (14–15 sessions)</td>
               <td class="text-right py-3">8,400 – 9,000 MXN</td>
-              <td class="text-right py-3">~42,000–45,000 MXN</td>
+              <td class="text-right py-3">≈ 42,000–45,000 MXN</td>
             </tr>
             <tr>
               <td class="py-3">Intensive (17 sessions)</td>
               <td class="text-right py-3">10,200 MXN</td>
-              <td class="text-right py-3">~51,000 MXN</td>
+              <td class="text-right py-3">≈ 51,000 MXN</td>
             </tr>
           </tbody>
         </table>

--- a/src/pages/es/servicios/paquete-corporativo.astro
+++ b/src/pages/es/servicios/paquete-corporativo.astro
@@ -147,17 +147,17 @@ const faqs = serviceFaqs["corporate-package"]?.es || [];
             <tr class="border-b border-gray-100">
               <td class="py-3">Conservador (12 sesiones)</td>
               <td class="text-right py-3">7,200 MXN</td>
-              <td class="text-right py-3">~36,000 MXN</td>
+              <td class="text-right py-3">≈ 36,000 MXN</td>
             </tr>
             <tr class="border-b border-gray-100">
               <td class="py-3">Moderado (14–15 sesiones)</td>
               <td class="text-right py-3">8,400 – 9,000 MXN</td>
-              <td class="text-right py-3">~42,000–45,000 MXN</td>
+              <td class="text-right py-3">≈ 42,000–45,000 MXN</td>
             </tr>
             <tr>
               <td class="py-3">Intensivo (17 sesiones)</td>
               <td class="text-right py-3">10,200 MXN</td>
-              <td class="text-right py-3">~51,000 MXN</td>
+              <td class="text-right py-3">≈ 51,000 MXN</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
## Summary
Four small polish fixes from an external review of `/en/services/corporate-package/`:

- **Pricing table** — replace `~` prefix with `≈` on the 5-Person Team column so totals don't read as negative at a glance. Applied to EN and ES.
- **Quiz CTA button** — promote the inline underlined "Start the Quiz →" link in the Challenge component to a proper blue button. Improves micro-conversion across the 18 service pages that use this component.
- **FAQ anchor IDs** — `ServiceFAQ.astro` now generates `id="faq-<slug>"` on each `<details>` so individual FAQ answers can be deep-linked / shared.
- **Footer label** — "Try my AI English Coach" → "Try my AI Practice Chat" (EN + ES). Removes the brief tension a buyer might feel between this link and the corporate page's "Sessions are never AI-recorded" copy. The AI tool is a separate self-serve surface, not the human coaching.

Skipped from the review:
- More social proof / second testimonial — wait until a real second client lands.
- GDPR privacy link on lead-magnet form — out of scope; audience is Mexico-based.
- Hero H1 above the fold — viewport-dependent; needs a real device check before changing.
- Chat widget overlap — global widget change, out of scope here.

## Test plan
- [ ] Preview EN corporate page: pricing table renders `≈ 36,000 MXN`, `≈ 42,000–45,000 MXN`, `≈ 51,000 MXN`
- [ ] Preview ES corporate page: same `≈` formatting
- [ ] Quiz CTA in the "Problem" section renders as a solid blue button, not underlined text
- [ ] Inspect FAQ `<details>` elements — each has `id="faq-..."`; clicking the URL with `#faq-...` opens and scrolls to that question
- [ ] Footer "Resources" column shows "Try my AI Practice Chat" (EN) / "Prueba mi Chat de Práctica con IA" (ES)
- [ ] Spot-check 2–3 other service pages (e.g., `/en/services/executive-english/`, `/en/services/startup-founders/`) — quiz CTA button styling looks correct there too

🤖 Generated with [Claude Code](https://claude.com/claude-code)