### PR TITLE
fix(seo): ES pronunciation post — add 2nd inlink (Ahrefs 2026-05-16)

### DIFF
--- a/src/content/blog/es/errores-ingles-negocios-profesionales-mexicanos.md
+++ b/src/content/blog/es/errores-ingles-negocios-profesionales-mexicanos.md
@@ -349,6 +349,7 @@ Si trabajas en tech y tratas con equipos internacionales todos los días, el [co
 - [7 frases de email que te hacen sonar junior](/es/blog/frases-email-que-te-hacen-sonar-junior/) — Más patrones que minan tu autoridad profesional en la comunicación escrita.
 - [5 formas prácticas de mejorar tu inglés de negocios](/es/blog/5-formas-practicas-mejorar-ingles-negocios/) — Estrategias concretas para comunicar con claridad y confianza.
 - [El costo real del inglés débil en empresas mexicanas](/es/blog/costo-real-ingles-debil-empresas-mexicanas/) — Cuánto le cuestan estos errores a tu empresa en ingresos y oportunidades.
+- [50 palabras en inglés que los profesionales mexicanos pronuncian mal](/es/blog/palabras-en-ingles-que-profesionales-mexicanos-pronuncian-mal/) — Guía fonética para corregir los patrones de pronunciación que delatan tu acento en reuniones de negocios.
 
 ---
 


### PR DESCRIPTION
## Summary

Latest Ahrefs crawl (2026-05-16) flagged `/es/blog/palabras-en-ingles-que-profesionales-mexicanos-pronuncian-mal/` as having only one dofollow inlink. Cross-link it from the related ES "10 Business English mistakes" post.

The other 12 pages on the same crawl's "one inlink" list were already addressed in PR #172 (merged today); they will clear on the next Ahrefs recrawl.

## Test plan

- [ ] After merge, request a fresh Ahrefs crawl
- [ ] Confirm the ES pronunciation post moves to 2+ dofollow inlinks
- [ ] Confirm the other 12 pages drop off the issue list

🤖 Generated with [Claude Code](https://claude.com/claude-code)