### PR TITLE
feat(course): Past Tenses promo + Bonus 1 (cheat sheet)

### DIFF
--- a/src/data/past-tenses/lessons.ts
+++ b/src/data/past-tenses/lessons.ts
@@ -120,7 +120,7 @@ export const pastTenseBonuses: PastTenseBonus[] = [
     description: "Every past tense, every trigger, every story-flow rule — on one printable page.",
     descriptionEs: "Cada tiempo del pasado, cada disparador, cada regla del flujo de historia — en una página imprimible.",
     icon: "FileText",
-    available: false,
+    available: true,
   },
   {
     id: 2,

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -144,6 +144,7 @@ export type TKey =
   | "course/past-tenses/lesson-3"
   | "course/past-tenses/lesson-4"
   | "course/past-tenses/lesson-5"
+  | "course/past-tenses/cheat-sheet"
   | "corporate/for-hr"
   | "meme-portfolio"
   | "site-index";
@@ -303,6 +304,7 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/past-tenses/lesson-3": "/en/course/past-tenses/lesson-3/",
     "course/past-tenses/lesson-4": "/en/course/past-tenses/lesson-4/",
     "course/past-tenses/lesson-5": "/en/course/past-tenses/lesson-5/",
+    "course/past-tenses/cheat-sheet": "/en/course/past-tenses/cheat-sheet/",
     "corporate/for-hr": "/en/for-hr-managers/",
     "meme-portfolio": "/en/meme-portfolio/all/",
     "site-index": "/en/site-index/",
@@ -466,6 +468,7 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/past-tenses/lesson-3": "/es/curso/tiempos-del-pasado/leccion-3/",
     "course/past-tenses/lesson-4": "/es/curso/tiempos-del-pasado/leccion-4/",
     "course/past-tenses/lesson-5": "/es/curso/tiempos-del-pasado/leccion-5/",
+    "course/past-tenses/cheat-sheet": "/es/curso/tiempos-del-pasado/guia-rapida/",
     "corporate/for-hr": "/es/para-rh/",
     "meme-portfolio": "/es/meme-portfolio/all/",
     "site-index": "/es/indice-del-sitio/",
@@ -558,6 +561,7 @@ export function getAllTKeys(): TKey[] {
     "course/past-tenses/lesson-3",
     "course/past-tenses/lesson-4",
     "course/past-tenses/lesson-5",
+    "course/past-tenses/cheat-sheet",
     "category/startup-founders",
     "category/tech-english",
     "category/logistics-english",

--- a/src/pages/en/course/advanced/index.astro
+++ b/src/pages/en/course/advanced/index.astro
@@ -229,6 +229,46 @@ const iconMap: Record<string, any> = {
       </div>
     </div>
   </section>
+
+  <!-- Targeted Master Class -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <a
+          href="/en/course/past-tenses/"
+          class="group block bg-gradient-to-br from-slate-900 via-emerald-950 to-slate-900 rounded-2xl border border-emerald-700/40 overflow-hidden hover:shadow-xl hover:border-emerald-500 transition-all duration-200"
+        >
+          <div class="grid md:grid-cols-3 gap-0">
+            <div class="md:col-span-2 p-7 md:p-8 text-white">
+              <div class="flex items-center gap-2 text-emerald-300 text-xs font-bold uppercase tracking-wider mb-3">
+                <Sparkles class="w-3.5 h-3.5" />
+                Free Master Class · Refines Past-Tense Precision
+              </div>
+              <h3 class="text-xl md:text-2xl font-bold mb-2" style="font-family: 'Noto Sans KR', sans-serif;">
+                "I went" vs "I have gone" — still guessing?
+              </h3>
+              <p class="text-emerald-100 text-sm md:text-base leading-relaxed mb-4">
+                Even at C1, the wrong past tense gives you away in the first thirty seconds.
+                The 5-lesson <strong class="text-white">Past Tenses Master Class</strong> replaces rule-running
+                with story-visualization — so the right tense surfaces automatically, mid-sentence.
+              </p>
+              <span class="inline-flex items-center gap-1 text-amber-400 font-semibold text-sm group-hover:gap-2 transition-all">
+                Open the master class
+                <ArrowRight class="w-4 h-4" />
+              </span>
+            </div>
+            <div class="bg-emerald-950/40 p-7 md:p-8 flex items-center justify-center border-t md:border-t-0 md:border-l border-emerald-700/30">
+              <div class="text-center">
+                <div class="text-4xl font-bold text-emerald-300 mb-1">5</div>
+                <div class="text-emerald-100 text-sm">lessons<br />4 tenses + flow map</div>
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+    </div>
+  </section>
+
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@type": "Course",

--- a/src/pages/en/course/intermediate/index.astro
+++ b/src/pages/en/course/intermediate/index.astro
@@ -264,6 +264,45 @@ const iconMap: Record<string, any> = {
     </div>
   </section>
 
+  <!-- Targeted Master Class -->
+  <section class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <a
+          href="/en/course/past-tenses/"
+          class="group block bg-gradient-to-br from-slate-900 via-emerald-950 to-slate-900 rounded-2xl border border-emerald-700/40 overflow-hidden hover:shadow-xl hover:border-emerald-500 transition-all duration-200"
+        >
+          <div class="grid md:grid-cols-3 gap-0">
+            <div class="md:col-span-2 p-7 md:p-8 text-white">
+              <div class="flex items-center gap-2 text-emerald-300 text-xs font-bold uppercase tracking-wider mb-3">
+                <Sparkles class="w-3.5 h-3.5" />
+                Free Master Class · Pairs With This Course
+              </div>
+              <h3 class="text-xl md:text-2xl font-bold mb-2" style="font-family: 'Noto Sans KR', sans-serif;">
+                Stuck choosing between "I did" and "I have done"?
+              </h3>
+              <p class="text-emerald-100 text-sm md:text-base leading-relaxed mb-4">
+                The past-tense choice is the #1 thing B1-B2 Spanish speakers freeze on in real conversation.
+                Take the 5-lesson <strong class="text-white">Past Tenses Master Class</strong> alongside this course —
+                visualize the scene, choose the tense automatically.
+              </p>
+              <span class="inline-flex items-center gap-1 text-amber-400 font-semibold text-sm group-hover:gap-2 transition-all">
+                Open the master class
+                <ArrowRight class="w-4 h-4" />
+              </span>
+            </div>
+            <div class="bg-emerald-950/40 p-7 md:p-8 flex items-center justify-center border-t md:border-t-0 md:border-l border-emerald-700/30">
+              <div class="text-center">
+                <div class="text-4xl font-bold text-emerald-300 mb-1">5</div>
+                <div class="text-emerald-100 text-sm">lessons<br />4 tenses + flow map</div>
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+    </div>
+  </section>
+
   <script type="application/ld+json" set:html={JSON.stringify({
   "@context": "https://schema.org",
   "@type": "Course",

--- a/src/pages/en/course/past-tenses/cheat-sheet.astro
+++ b/src/pages/en/course/past-tenses/cheat-sheet.astro
@@ -1,0 +1,390 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import {
+  ArrowRight,
+  ArrowLeft,
+  Clock,
+  Film,
+  Link as LinkIcon,
+  Layers,
+  Map,
+  FileText,
+  Printer,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  Lightbulb,
+  Eye,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/past-tenses/cheat-sheet" as const;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Past Tenses Cheat Sheet (One Page) | NY English Teacher"
+  description="The entire Past Tenses Master Class on one printable page. Every tense, every trigger, every Spanish-speaker trap — a free reference for Mexican professionals."
+>
+  <!-- Hero -->
+  <section class="bg-gradient-to-b from-slate-900 to-emerald-950 pt-28 pb-12 md:pt-32 md:pb-16 print:hidden">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-emerald-400 text-sm font-semibold mb-3">
+          <FileText class="w-4 h-4" />
+          Bonus 1 · Master Class Cheat Sheet
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          The One-Page Cheat Sheet
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed mb-6">
+          Every past tense. Every trigger word. Every Spanish-speaker trap.
+          One reference you can keep open in another tab — or print and stick on the wall.
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <button
+            onclick="window.print()"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold text-sm transition-colors"
+          >
+            <Printer class="w-4 h-4" />
+            Print this page
+          </button>
+          <a
+            href="/en/course/past-tenses/"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            <ArrowLeft class="w-4 h-4" />
+            Back to the master class
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Print-only header -->
+  <div class="hidden print:block py-4 border-b-2 border-slate-300">
+    <h1 class="text-2xl font-bold text-slate-900">English Past Tenses — Cheat Sheet</h1>
+    <p class="text-sm text-slate-600">nyenglishteacher.com — free for Mexican professionals</p>
+  </div>
+
+  <!-- The 4 Tenses, Compact -->
+  <section class="py-12 md:py-16 bg-white print:py-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-5xl mx-auto">
+        <div class="text-center mb-10 print:mb-4 print:text-left">
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-2 print:text-xl">The Four Past Tenses, At a Glance</h2>
+          <p class="text-slate-600 print:hidden">Mental picture · when to use · trigger words · the trap Mexicans fall into.</p>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-5 print:gap-3">
+
+          <!-- Past Simple -->
+          <div class="rounded-2xl border-2 border-emerald-300 bg-emerald-50/60 p-6 print:p-3 print:rounded-md print:break-inside-avoid">
+            <div class="flex items-start gap-3 mb-3">
+              <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-emerald-500 text-white shrink-0 print:w-7 print:h-7">
+                <Clock class="w-5 h-5" />
+              </div>
+              <div class="flex-1">
+                <h3 class="text-lg font-bold text-slate-900 print:text-base">Past Simple</h3>
+                <p class="text-sm text-emerald-700 italic">It happened. It's done.</p>
+              </div>
+            </div>
+            <div class="space-y-2.5 text-sm text-slate-700 print:text-xs">
+              <p><strong class="text-slate-900">Picture:</strong> a closed box. A snapshot. The time is sealed.</p>
+              <p><strong class="text-slate-900">Form:</strong> <code class="text-xs bg-white px-1.5 py-0.5 rounded">subject + V<sub>2</sub></code> · <em>worked, went, ate, did</em></p>
+              <p><strong class="text-slate-900">Triggers:</strong> yesterday · last week · in 2019 · when I was 20 · ago</p>
+              <div class="bg-white rounded p-2.5 border border-emerald-200">
+                <p class="text-xs text-emerald-700 font-semibold mb-1">EXAMPLES</p>
+                <p>"I <strong>worked</strong> at Telmex for eight years."</p>
+                <p>"She <strong>quit</strong> last Friday."</p>
+              </div>
+              <div class="bg-red-50 rounded p-2.5 border border-red-200">
+                <p class="text-xs text-red-700 font-semibold mb-1 flex items-center gap-1"><AlertTriangle class="w-3 h-3" /> MEXICAN TRAP</p>
+                <p class="text-slate-700">Using Past Simple for everything. If the time is <em>open</em> ("this morning" — and it's still morning), you probably need Present Perfect.</p>
+              </div>
+            </div>
+            <a href="/en/course/past-tenses/lesson-1/" class="inline-flex items-center gap-1 mt-3 text-emerald-700 hover:text-emerald-900 text-sm font-medium print:hidden">
+              Full lesson <ArrowRight class="w-3.5 h-3.5" />
+            </a>
+          </div>
+
+          <!-- Past Continuous -->
+          <div class="rounded-2xl border-2 border-emerald-300 bg-emerald-50/60 p-6 print:p-3 print:rounded-md print:break-inside-avoid">
+            <div class="flex items-start gap-3 mb-3">
+              <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-emerald-500 text-white shrink-0 print:w-7 print:h-7">
+                <Film class="w-5 h-5" />
+              </div>
+              <div class="flex-1">
+                <h3 class="text-lg font-bold text-slate-900 print:text-base">Past Continuous</h3>
+                <p class="text-sm text-emerald-700 italic">It was happening when…</p>
+              </div>
+            </div>
+            <div class="space-y-2.5 text-sm text-slate-700 print:text-xs">
+              <p><strong class="text-slate-900">Picture:</strong> a movie playing. The camera is rolling. Then something interrupts.</p>
+              <p><strong class="text-slate-900">Form:</strong> <code class="text-xs bg-white px-1.5 py-0.5 rounded">was/were + V-ing</code> · <em>was working, were eating</em></p>
+              <p><strong class="text-slate-900">Triggers:</strong> when… · while… · as… · at 3pm yesterday · all morning</p>
+              <div class="bg-white rounded p-2.5 border border-emerald-200">
+                <p class="text-xs text-emerald-700 font-semibold mb-1">EXAMPLES</p>
+                <p>"I <strong>was driving</strong> home when she <strong>called</strong>."</p>
+                <p>"We <strong>were having</strong> dinner at 8."</p>
+              </div>
+              <div class="bg-red-50 rounded p-2.5 border border-red-200">
+                <p class="text-xs text-red-700 font-semibold mb-1 flex items-center gap-1"><AlertTriangle class="w-3 h-3" /> MEXICAN TRAP</p>
+                <p class="text-slate-700">Using it for finished, single actions. "I <em>was watching</em> the movie last night" sounds wrong — you watched <em>the whole movie</em>, that's Past Simple.</p>
+              </div>
+            </div>
+            <a href="/en/course/past-tenses/lesson-2/" class="inline-flex items-center gap-1 mt-3 text-emerald-700 hover:text-emerald-900 text-sm font-medium print:hidden">
+              Full lesson <ArrowRight class="w-3.5 h-3.5" />
+            </a>
+          </div>
+
+          <!-- Present Perfect -->
+          <div class="rounded-2xl border-2 border-emerald-400 bg-emerald-100/60 p-6 print:p-3 print:rounded-md print:break-inside-avoid">
+            <div class="flex items-start gap-3 mb-3">
+              <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-emerald-600 text-white shrink-0 print:w-7 print:h-7">
+                <LinkIcon class="w-5 h-5" />
+              </div>
+              <div class="flex-1">
+                <h3 class="text-lg font-bold text-slate-900 print:text-base">Present Perfect <span class="text-xs font-semibold text-emerald-700 ml-1">★ high-stakes</span></h3>
+                <p class="text-sm text-emerald-700 italic">It happened — but it still matters now.</p>
+              </div>
+            </div>
+            <div class="space-y-2.5 text-sm text-slate-700 print:text-xs">
+              <p><strong class="text-slate-900">Picture:</strong> a thread from the past <em>into</em> the present. The time isn't closed — it bleeds into now.</p>
+              <p><strong class="text-slate-900">Form:</strong> <code class="text-xs bg-white px-1.5 py-0.5 rounded">have/has + V<sub>3</sub></code> · <em>have worked, has gone, have done</em></p>
+              <p><strong class="text-slate-900">Triggers:</strong> already · yet · ever · never · just · since · for · this week (still going) · so far</p>
+              <div class="bg-white rounded p-2.5 border border-emerald-300">
+                <p class="text-xs text-emerald-700 font-semibold mb-1">EXAMPLES</p>
+                <p>"I <strong>have done</strong> the report." (it's ready <em>now</em>)</p>
+                <p>"She <strong>has lived</strong> here since 2018." (still does)</p>
+                <p>"<strong>Have</strong> you <strong>seen</strong> the email?" (any time up to now)</p>
+              </div>
+              <div class="bg-red-50 rounded p-2.5 border border-red-200">
+                <p class="text-xs text-red-700 font-semibold mb-1 flex items-center gap-1"><AlertTriangle class="w-3 h-3" /> MEXICAN TRAP</p>
+                <p class="text-slate-700"><strong>The big one.</strong> Mexicans default to Past Simple here. "I did the report" sounds finished-and-gone. Use Present Perfect when the action <em>still matters now</em>.</p>
+              </div>
+            </div>
+            <a href="/en/course/past-tenses/lesson-3/" class="inline-flex items-center gap-1 mt-3 text-emerald-700 hover:text-emerald-900 text-sm font-medium print:hidden">
+              Full lesson <ArrowRight class="w-3.5 h-3.5" />
+            </a>
+          </div>
+
+          <!-- Past Perfect -->
+          <div class="rounded-2xl border-2 border-emerald-300 bg-emerald-50/60 p-6 print:p-3 print:rounded-md print:break-inside-avoid">
+            <div class="flex items-start gap-3 mb-3">
+              <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-emerald-500 text-white shrink-0 print:w-7 print:h-7">
+                <Layers class="w-5 h-5" />
+              </div>
+              <div class="flex-1">
+                <h3 class="text-lg font-bold text-slate-900 print:text-base">Past Perfect</h3>
+                <p class="text-sm text-emerald-700 italic">It happened before <em>that</em> other thing.</p>
+              </div>
+            </div>
+            <div class="space-y-2.5 text-sm text-slate-700 print:text-xs">
+              <p><strong class="text-slate-900">Picture:</strong> two layers. The first event sits <em>below</em> the second past event.</p>
+              <p><strong class="text-slate-900">Form:</strong> <code class="text-xs bg-white px-1.5 py-0.5 rounded">had + V<sub>3</sub></code> · <em>had worked, had gone, had eaten</em></p>
+              <p><strong class="text-slate-900">Triggers:</strong> by the time… · before… · after… · already had… · when she arrived, I had already…</p>
+              <div class="bg-white rounded p-2.5 border border-emerald-200">
+                <p class="text-xs text-emerald-700 font-semibold mb-1">EXAMPLES</p>
+                <p>"When I got there, the meeting <strong>had started</strong>."</p>
+                <p>"She <strong>had finished</strong> before I asked."</p>
+              </div>
+              <div class="bg-red-50 rounded p-2.5 border border-red-200">
+                <p class="text-xs text-red-700 font-semibold mb-1 flex items-center gap-1"><AlertTriangle class="w-3 h-3" /> MEXICAN TRAP</p>
+                <p class="text-slate-700">Overusing it. You only need Past Perfect when the order isn't obvious from context. If you already said "first…, then…" — just use Past Simple twice.</p>
+              </div>
+            </div>
+            <a href="/en/course/past-tenses/lesson-4/" class="inline-flex items-center gap-1 mt-3 text-emerald-700 hover:text-emerald-900 text-sm font-medium print:hidden">
+              Full lesson <ArrowRight class="w-3.5 h-3.5" />
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Story Flow Map -->
+  <section class="py-12 md:py-16 bg-slate-50 print:bg-white print:py-3 print:break-inside-avoid">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="flex items-center gap-3 mb-6 print:mb-3">
+          <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-amber-500 text-white shrink-0">
+            <Map class="w-5 h-5" />
+          </div>
+          <div>
+            <h2 class="text-2xl md:text-3xl font-bold text-slate-900 print:text-xl">The Story Flow Decision Tree</h2>
+            <p class="text-sm text-slate-600 print:hidden">Three questions, in order. The right tense falls out at the end.</p>
+          </div>
+        </div>
+
+        <div class="rounded-2xl border-2 border-slate-300 bg-white p-6 md:p-8 print:p-3 print:rounded-md print:border print:border-slate-400">
+          <ol class="space-y-5 print:space-y-3">
+            <li class="flex gap-4 print:gap-2">
+              <span class="flex items-center justify-center w-8 h-8 rounded-full bg-amber-500 text-white text-sm font-bold shrink-0 print:w-6 print:h-6 print:text-xs">1</span>
+              <div class="flex-1">
+                <p class="font-semibold text-slate-900 mb-1 print:text-sm">Does the action still matter <em>now</em>?</p>
+                <p class="text-sm text-slate-600 print:text-xs">→ Yes? <strong class="text-emerald-700">Present Perfect.</strong> ("I have finished.")</p>
+                <p class="text-sm text-slate-600 print:text-xs">→ No, the time is closed? Continue to Q2.</p>
+              </div>
+            </li>
+            <li class="flex gap-4 print:gap-2">
+              <span class="flex items-center justify-center w-8 h-8 rounded-full bg-amber-500 text-white text-sm font-bold shrink-0 print:w-6 print:h-6 print:text-xs">2</span>
+              <div class="flex-1">
+                <p class="font-semibold text-slate-900 mb-1 print:text-sm">Is something interrupting an action in progress?</p>
+                <p class="text-sm text-slate-600 print:text-xs">→ Yes? <strong class="text-emerald-700">Past Continuous + Past Simple.</strong> ("I was driving when she called.")</p>
+                <p class="text-sm text-slate-600 print:text-xs">→ No? Continue to Q3.</p>
+              </div>
+            </li>
+            <li class="flex gap-4 print:gap-2">
+              <span class="flex items-center justify-center w-8 h-8 rounded-full bg-amber-500 text-white text-sm font-bold shrink-0 print:w-6 print:h-6 print:text-xs">3</span>
+              <div class="flex-1">
+                <p class="font-semibold text-slate-900 mb-1 print:text-sm">Did one past event happen <em>before</em> another past event — and is the order non-obvious?</p>
+                <p class="text-sm text-slate-600 print:text-xs">→ Yes? <strong class="text-emerald-700">Past Perfect + Past Simple.</strong> ("By the time I arrived, she had left.")</p>
+                <p class="text-sm text-slate-600 print:text-xs">→ No? <strong class="text-emerald-700">Past Simple.</strong> ("I worked. She quit. We moved on.")</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Trigger Words Table -->
+  <section class="py-12 md:py-16 bg-white print:py-3 print:break-inside-avoid">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="flex items-center gap-3 mb-6 print:mb-3">
+          <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-emerald-500 text-white shrink-0">
+            <Eye class="w-5 h-5" />
+          </div>
+          <div>
+            <h2 class="text-2xl md:text-3xl font-bold text-slate-900 print:text-xl">Trigger Words Quick-Reference</h2>
+            <p class="text-sm text-slate-600 print:hidden">When you hear one of these, the tense often picks itself.</p>
+          </div>
+        </div>
+
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm border-collapse">
+            <thead>
+              <tr class="border-b-2 border-slate-300">
+                <th class="text-left py-2 px-3 font-bold text-slate-900 print:text-xs">Trigger</th>
+                <th class="text-left py-2 px-3 font-bold text-slate-900 print:text-xs">Usually wants</th>
+                <th class="text-left py-2 px-3 font-bold text-slate-900 print:text-xs">Why</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-200 print:text-xs">
+              <tr><td class="py-2 px-3 font-mono text-emerald-700">yesterday, last week, in 2019, ago</td><td class="py-2 px-3"><strong>Past Simple</strong></td><td class="py-2 px-3 text-slate-600">Closed time</td></tr>
+              <tr><td class="py-2 px-3 font-mono text-emerald-700">when, while, as, at 3pm</td><td class="py-2 px-3"><strong>Past Continuous</strong> (often)</td><td class="py-2 px-3 text-slate-600">Action in progress / background</td></tr>
+              <tr><td class="py-2 px-3 font-mono text-emerald-700">already, yet, just, ever, never</td><td class="py-2 px-3"><strong>Present Perfect</strong></td><td class="py-2 px-3 text-slate-600">Past with relevance to now</td></tr>
+              <tr><td class="py-2 px-3 font-mono text-emerald-700">since, for (+ duration)</td><td class="py-2 px-3"><strong>Present Perfect</strong></td><td class="py-2 px-3 text-slate-600">Action started in past, still continuing</td></tr>
+              <tr><td class="py-2 px-3 font-mono text-emerald-700">this morning / today / this week (still ongoing)</td><td class="py-2 px-3"><strong>Present Perfect</strong></td><td class="py-2 px-3 text-slate-600">Open time period</td></tr>
+              <tr><td class="py-2 px-3 font-mono text-emerald-700">this morning (and it's now afternoon)</td><td class="py-2 px-3"><strong>Past Simple</strong></td><td class="py-2 px-3 text-slate-600">Time period is now closed</td></tr>
+              <tr><td class="py-2 px-3 font-mono text-emerald-700">by the time, before, after, already had</td><td class="py-2 px-3"><strong>Past Perfect</strong></td><td class="py-2 px-3 text-slate-600">Two past events, earlier one</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- The Top Verb-Pair Traps Preview -->
+  <section class="py-12 md:py-16 bg-slate-50 print:bg-white print:py-3 print:break-inside-avoid">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="flex items-center gap-3 mb-6 print:mb-3">
+          <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-amber-500 text-white shrink-0">
+            <Lightbulb class="w-5 h-5" />
+          </div>
+          <div>
+            <h2 class="text-2xl md:text-3xl font-bold text-slate-900 print:text-xl">The Three Spanish Mirrors</h2>
+            <p class="text-sm text-slate-600 print:hidden">If you can spot these in Spanish, English's tense choice follows automatically.</p>
+          </div>
+        </div>
+
+        <div class="grid md:grid-cols-3 gap-4 print:gap-2">
+          <div class="bg-white rounded-xl border border-slate-200 p-5 print:p-2 print:rounded-md print:break-inside-avoid">
+            <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">Knew vs. Found out</p>
+            <p class="text-sm text-slate-700 mb-2"><strong>Spanish:</strong> <em>sabía</em> (state) vs. <em>supe</em> (moment of discovery)</p>
+            <p class="text-sm text-slate-700"><strong>English:</strong> "I <strong>knew</strong> she was leaving" (ongoing state). "I <strong>found out</strong> she was leaving" (one moment of discovery — never "I knew it yesterday").</p>
+          </div>
+          <div class="bg-white rounded-xl border border-slate-200 p-5 print:p-2 print:rounded-md print:break-inside-avoid">
+            <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">There was vs. There has been</p>
+            <p class="text-sm text-slate-700 mb-2"><strong>Spanish:</strong> <em>hubo</em> (closed) vs. <em>ha habido</em> (still relevant)</p>
+            <p class="text-sm text-slate-700"><strong>English:</strong> "There <strong>was</strong> a problem last week" (closed). "There <strong>has been</strong> a problem this morning" (still here, still mine to fix).</p>
+          </div>
+          <div class="bg-white rounded-xl border border-slate-200 p-5 print:p-2 print:rounded-md print:break-inside-avoid">
+            <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">Did vs. Have done</p>
+            <p class="text-sm text-slate-700 mb-2"><strong>Spanish:</strong> <em>hice</em> vs. <em>he hecho</em> — the same instinct works.</p>
+            <p class="text-sm text-slate-700"><strong>English:</strong> "I <strong>did</strong> the report yesterday" (closed). "I <strong>have done</strong> the report" (it's on your desk now — relevant).</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Save / Share footer -->
+  <section class="py-12 md:py-16 bg-emerald-950 text-white print:hidden">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-2xl md:text-3xl font-bold mb-3" style="font-family: 'Noto Sans KR', sans-serif;">Keep It Close</h2>
+        <p class="text-emerald-100 mb-6 max-w-2xl mx-auto">
+          Bookmark this page. Print it. Pin it next to your monitor for the next meeting with US clients.
+          Then take the five lessons — the cheat sheet starts making sense once you've felt the stories.
+        </p>
+        <div class="flex flex-wrap gap-3 justify-center">
+          <button
+            onclick="window.print()"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold transition-colors"
+          >
+            <Printer class="w-5 h-5" />
+            Print this page
+          </button>
+          <a
+            href="/en/course/past-tenses/lesson-1/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-white/10 hover:bg-white/20 text-white font-semibold transition-colors"
+          >
+            Start the course from Lesson 1
+            <ArrowRight class="w-5 h-5" />
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <style is:global>
+    @media print {
+      header, footer, nav { display: none !important; }
+      body { background: white !important; color: black !important; }
+      a { text-decoration: none !important; color: #064e3b !important; }
+      code { background: #f1f5f9 !important; color: #064e3b !important; }
+    }
+  </style>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    "name": "English Past Tenses — One-Page Cheat Sheet",
+    "description": "Compact, printable reference covering Past Simple, Past Continuous, Present Perfect, and Past Perfect — including trigger words, the Story Flow decision tree, and the three Spanish-mirror verb pairs.",
+    "learningResourceType": "Cheat sheet",
+    "educationalLevel": "Intermediate to Advanced",
+    "inLanguage": "en",
+    "isAccessibleForFree": true,
+    "url": "https://www.nyenglishteacher.com/en/course/past-tenses/cheat-sheet/",
+    "isPartOf": {
+      "@type": "Course",
+      "name": "Master English Past Tenses — Free Master Class",
+      "url": "https://www.nyenglishteacher.com/en/course/past-tenses/"
+    },
+    "author": {
+      "@type": "Person",
+      "name": "Robert Cushman",
+      "url": "https://www.nyenglishteacher.com/en/about/"
+    }
+  })} />
+</Base>

--- a/src/pages/en/course/past-tenses/index.astro
+++ b/src/pages/en/course/past-tenses/index.astro
@@ -227,20 +227,30 @@ const iconMap: Record<string, any> = {
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           {pastTenseBonuses.map((bonus) => {
             const Icon = iconMap[bonus.icon];
+            const href = bonus.available ? `/en/course/past-tenses/${bonus.slug}/` : undefined;
+            const cardClasses = bonus.available
+              ? "bg-white rounded-xl p-5 border border-emerald-300 flex items-start gap-4 hover:shadow-md hover:border-emerald-400 transition-all duration-200 cursor-pointer"
+              : "bg-white rounded-xl p-5 border border-slate-200 flex items-start gap-4";
+            const iconBg = bonus.available
+              ? "bg-emerald-500 text-white"
+              : "bg-slate-100 text-slate-500";
+            const Tag = bonus.available ? "a" : "div";
             return (
-              <div class="bg-white rounded-xl p-5 border border-slate-200 flex items-start gap-4">
-                <div class="flex items-center justify-center w-10 h-10 rounded-lg shrink-0 bg-slate-100 text-slate-500">
+              <Tag href={href} class={cardClasses}>
+                <div class:list={["flex items-center justify-center w-10 h-10 rounded-lg shrink-0", iconBg]}>
                   {Icon && <Icon class="w-5 h-5" />}
                 </div>
                 <div class="flex-1">
                   <div class="flex items-center gap-2">
-                    <span class="text-xs font-bold uppercase tracking-wider text-slate-400">Bonus {bonus.id}</span>
-                    <span class="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-400">Coming soon</span>
+                    <span class:list={["text-xs font-bold uppercase tracking-wider", bonus.available ? "text-emerald-700" : "text-slate-400"]}>Bonus {bonus.id}</span>
+                    {!bonus.available && (
+                      <span class="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-400">Coming soon</span>
+                    )}
                   </div>
                   <h3 class="text-base font-bold text-slate-900 mt-0.5">{bonus.title}</h3>
                   <p class="text-sm text-slate-600 mt-1">{bonus.description}</p>
                 </div>
-              </div>
+              </Tag>
             );
           })}
         </div>

--- a/src/pages/en/courses/index.astro
+++ b/src/pages/en/courses/index.astro
@@ -16,6 +16,12 @@ import {
   ArrowRight,
   CheckCircle2,
   GraduationCap,
+  Target,
+  Clock,
+  Film,
+  Link as LinkIcon,
+  Layers,
+  Map,
 } from "lucide-astro";
 
 const lang = "en";
@@ -314,6 +320,76 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
         </a>
       </div>
 
+      <!-- Targeted Master Classes -->
+      <div class="max-w-7xl mx-auto mt-20">
+        <div class="text-center mb-10">
+          <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-emerald-100 text-emerald-700 text-sm font-semibold mb-3">
+            <Target class="w-4 h-4" />
+            Targeted Master Classes
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-2">
+            One topic. Done thoroughly.
+          </h2>
+          <p class="text-slate-600 max-w-2xl mx-auto">
+            Focused short courses on the specific things Mexican professionals freeze on — even after years of study. Take one in an afternoon.
+          </p>
+        </div>
+
+        <a
+          href="/en/course/past-tenses/"
+          class="group block bg-gradient-to-br from-slate-900 via-emerald-950 to-slate-900 rounded-2xl border border-emerald-700/40 overflow-hidden hover:shadow-2xl hover:border-emerald-500 transition-all duration-200"
+        >
+          <div class="grid md:grid-cols-5 gap-0">
+            <div class="md:col-span-3 p-8 md:p-10 text-white">
+              <div class="flex items-center gap-2 text-emerald-300 text-xs font-bold uppercase tracking-wider mb-3">
+                <Sparkles class="w-3.5 h-3.5" />
+                Master Class · Level B1–C1
+              </div>
+              <h3 class="text-2xl md:text-3xl font-bold mb-3" style="font-family: 'Noto Sans KR', sans-serif;">
+                Master English Past Tenses
+              </h3>
+              <p class="text-emerald-100 text-base leading-relaxed mb-5">
+                You know the rules. You can recite them. But in a real meeting you still freeze — and say <em class="not-italic text-white">"I did the report"</em> when the situation actually calls for <em class="not-italic text-white">"I have done the report."</em> This master class rewires past-tense choice through visualization, not rule-memorization.
+              </p>
+              <div class="flex flex-wrap gap-x-6 gap-y-2 text-sm text-emerald-100 mb-6">
+                <span class="inline-flex items-center gap-1.5"><CheckCircle2 class="w-4 h-4 text-emerald-400" /> 5 focused lessons</span>
+                <span class="inline-flex items-center gap-1.5"><CheckCircle2 class="w-4 h-4 text-emerald-400" /> The 4-tense method</span>
+                <span class="inline-flex items-center gap-1.5"><CheckCircle2 class="w-4 h-4 text-emerald-400" /> Built for Mexican speakers</span>
+              </div>
+              <span class="inline-flex items-center gap-1 text-amber-400 font-semibold text-sm group-hover:gap-2 transition-all">
+                Start the master class
+                <ArrowRight class="w-4 h-4" />
+              </span>
+            </div>
+            <div class="md:col-span-2 bg-emerald-950/40 p-8 md:p-10 border-t md:border-t-0 md:border-l border-emerald-700/30">
+              <p class="text-xs font-bold uppercase tracking-wider text-emerald-300 mb-4">What you'll learn</p>
+              <ul class="space-y-3 text-emerald-50 text-sm">
+                <li class="flex items-start gap-3">
+                  <Clock class="w-4 h-4 text-emerald-400 shrink-0 mt-0.5" />
+                  <span><strong class="text-white">Past Simple</strong> — closed moments, finished time</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <Film class="w-4 h-4 text-emerald-400 shrink-0 mt-0.5" />
+                  <span><strong class="text-white">Past Continuous</strong> — background scenes, interruptions</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <LinkIcon class="w-4 h-4 text-emerald-400 shrink-0 mt-0.5" />
+                  <span><strong class="text-white">Present Perfect</strong> — past with a thread to now</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <Layers class="w-4 h-4 text-emerald-400 shrink-0 mt-0.5" />
+                  <span><strong class="text-white">Past Perfect</strong> — the layer below another past</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <Map class="w-4 h-4 text-emerald-400 shrink-0 mt-0.5" />
+                  <span><strong class="text-white">Story Flow Map</strong> — choose tenses in real time</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </a>
+      </div>
+
       <!-- Which one? -->
       <div class="max-w-3xl mx-auto mt-16 text-center">
         <h3 class="text-2xl font-bold text-slate-900 mb-3">Not sure which one to start?</h3>
@@ -378,6 +454,15 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
         "@type": "Course",
         "name": "Executive English Course (C1-C2)",
         "url": "https://www.nyenglishteacher.com/en/course/executive/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 6,
+      "item": {
+        "@type": "Course",
+        "name": "Master English Past Tenses (Free Master Class)",
+        "url": "https://www.nyenglishteacher.com/en/course/past-tenses/"
       }
     }
   ]

--- a/src/pages/es/curso/avanzado/index.astro
+++ b/src/pages/es/curso/avanzado/index.astro
@@ -220,6 +220,45 @@ const iconMap: Record<string, any> = {
     </div>
   </section>
 
+  <!-- Clase Magistral Enfocada -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <a
+          href="/es/curso/tiempos-del-pasado/"
+          class="group block bg-gradient-to-br from-slate-900 via-emerald-950 to-slate-900 rounded-2xl border border-emerald-700/40 overflow-hidden hover:shadow-xl hover:border-emerald-500 transition-all duration-200"
+        >
+          <div class="grid md:grid-cols-3 gap-0">
+            <div class="md:col-span-2 p-7 md:p-8 text-white">
+              <div class="flex items-center gap-2 text-emerald-300 text-xs font-bold uppercase tracking-wider mb-3">
+                <Sparkles class="w-3.5 h-3.5" />
+                Clase Magistral Gratis · Refina la Precisión del Pasado
+              </div>
+              <h3 class="text-xl md:text-2xl font-bold mb-2" style="font-family: 'Noto Sans KR', sans-serif;">
+                "I went" vs "I have gone" — ¿todavía adivinando?
+              </h3>
+              <p class="text-emerald-100 text-sm md:text-base leading-relaxed mb-4">
+                Incluso en C1, el tiempo pasado equivocado te delata en los primeros treinta segundos.
+                La <strong class="text-white">Clase Magistral de Tiempos del Pasado</strong> de 5 lecciones reemplaza
+                el correr reglas con visualizar la historia — el tiempo correcto surge solo, a mitad de frase.
+              </p>
+              <span class="inline-flex items-center gap-1 text-amber-400 font-semibold text-sm group-hover:gap-2 transition-all">
+                Abrir la clase magistral
+                <ArrowRight class="w-4 h-4" />
+              </span>
+            </div>
+            <div class="bg-emerald-950/40 p-7 md:p-8 flex items-center justify-center border-t md:border-t-0 md:border-l border-emerald-700/30">
+              <div class="text-center">
+                <div class="text-4xl font-bold text-emerald-300 mb-1">5</div>
+                <div class="text-emerald-100 text-sm">lecciones<br />4 tiempos + mapa</div>
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+    </div>
+  </section>
+
   <script type="application/ld+json" set:html={JSON.stringify({
   "@context": "https://schema.org",
   "@type": "Course",

--- a/src/pages/es/curso/intermedio/index.astro
+++ b/src/pages/es/curso/intermedio/index.astro
@@ -264,6 +264,45 @@ const iconMap: Record<string, any> = {
     </div>
   </section>
 
+  <!-- Clase Magistral Enfocada -->
+  <section class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <a
+          href="/es/curso/tiempos-del-pasado/"
+          class="group block bg-gradient-to-br from-slate-900 via-emerald-950 to-slate-900 rounded-2xl border border-emerald-700/40 overflow-hidden hover:shadow-xl hover:border-emerald-500 transition-all duration-200"
+        >
+          <div class="grid md:grid-cols-3 gap-0">
+            <div class="md:col-span-2 p-7 md:p-8 text-white">
+              <div class="flex items-center gap-2 text-emerald-300 text-xs font-bold uppercase tracking-wider mb-3">
+                <Sparkles class="w-3.5 h-3.5" />
+                Clase Magistral Gratis · Combina con Este Curso
+              </div>
+              <h3 class="text-xl md:text-2xl font-bold mb-2" style="font-family: 'Noto Sans KR', sans-serif;">
+                ¿Atorado entre "I did" y "I have done"?
+              </h3>
+              <p class="text-emerald-100 text-sm md:text-base leading-relaxed mb-4">
+                Elegir el tiempo pasado correcto es lo que más congela a los hispanohablantes B1-B2 en conversación real.
+                Toma la <strong class="text-white">Clase Magistral de Tiempos del Pasado</strong> de 5 lecciones junto con este curso —
+                visualiza la escena, elige el tiempo automáticamente.
+              </p>
+              <span class="inline-flex items-center gap-1 text-amber-400 font-semibold text-sm group-hover:gap-2 transition-all">
+                Abrir la clase magistral
+                <ArrowRight class="w-4 h-4" />
+              </span>
+            </div>
+            <div class="bg-emerald-950/40 p-7 md:p-8 flex items-center justify-center border-t md:border-t-0 md:border-l border-emerald-700/30">
+              <div class="text-center">
+                <div class="text-4xl font-bold text-emerald-300 mb-1">5</div>
+                <div class="text-emerald-100 text-sm">lecciones<br />4 tiempos + mapa</div>
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+    </div>
+  </section>
+
   <script type="application/ld+json" set:html={JSON.stringify({
   "@context": "https://schema.org",
   "@type": "Course",

--- a/src/pages/es/curso/tiempos-del-pasado/guia-rapida.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/guia-rapida.astro
@@ -1,0 +1,388 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import {
+  ArrowRight,
+  ArrowLeft,
+  Clock,
+  Film,
+  Link as LinkIcon,
+  Layers,
+  Map,
+  FileText,
+  Printer,
+  AlertTriangle,
+  Lightbulb,
+  Eye,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/past-tenses/cheat-sheet" as const;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Guía Rápida — Tiempos del Pasado en Inglés (Una Página) | NY English Teacher"
+  description="Clase magistral de tiempos del pasado en inglés, en una página imprimible. Cada tiempo, palabra clave y trampa para hispanohablantes — gratis."
+>
+  <!-- Hero -->
+  <section class="bg-gradient-to-b from-slate-900 to-emerald-950 pt-28 pb-12 md:pt-32 md:pb-16 print:hidden">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-emerald-400 text-sm font-semibold mb-3">
+          <FileText class="w-4 h-4" />
+          Bono 1 · Guía Rápida de la Clase Magistral
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          La Guía Rápida de Una Página
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed mb-6">
+          Cada tiempo del pasado. Cada palabra clave. Cada trampa para hispanohablantes.
+          Una referencia para tener abierta en otra pestaña — o imprimirla y pegarla en la pared.
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <button
+            onclick="window.print()"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold text-sm transition-colors"
+          >
+            <Printer class="w-4 h-4" />
+            Imprimir esta página
+          </button>
+          <a
+            href="/es/curso/tiempos-del-pasado/"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            <ArrowLeft class="w-4 h-4" />
+            Volver a la clase magistral
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Print-only header -->
+  <div class="hidden print:block py-4 border-b-2 border-slate-300">
+    <h1 class="text-2xl font-bold text-slate-900">Tiempos del Pasado en Inglés — Guía Rápida</h1>
+    <p class="text-sm text-slate-600">nyenglishteacher.com — gratis para profesionales mexicanos</p>
+  </div>
+
+  <!-- Los 4 tiempos, compactos -->
+  <section class="py-12 md:py-16 bg-white print:py-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-5xl mx-auto">
+        <div class="text-center mb-10 print:mb-4 print:text-left">
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-2 print:text-xl">Los Cuatro Tiempos del Pasado, de un Vistazo</h2>
+          <p class="text-slate-600 print:hidden">Imagen mental · cuándo usarlo · palabras clave · la trampa donde caen los mexicanos.</p>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-5 print:gap-3">
+
+          <!-- Past Simple -->
+          <div class="rounded-2xl border-2 border-emerald-300 bg-emerald-50/60 p-6 print:p-3 print:rounded-md print:break-inside-avoid">
+            <div class="flex items-start gap-3 mb-3">
+              <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-emerald-500 text-white shrink-0 print:w-7 print:h-7">
+                <Clock class="w-5 h-5" />
+              </div>
+              <div class="flex-1">
+                <h3 class="text-lg font-bold text-slate-900 print:text-base">Pasado Simple <span class="text-xs font-normal text-slate-500">(Past Simple)</span></h3>
+                <p class="text-sm text-emerald-700 italic">Sucedió. Está terminado.</p>
+              </div>
+            </div>
+            <div class="space-y-2.5 text-sm text-slate-700 print:text-xs">
+              <p><strong class="text-slate-900">Imagen:</strong> una caja cerrada. Una foto. El tiempo está sellado.</p>
+              <p><strong class="text-slate-900">Forma:</strong> <code class="text-xs bg-white px-1.5 py-0.5 rounded">sujeto + V<sub>2</sub></code> · <em>worked, went, ate, did</em></p>
+              <p><strong class="text-slate-900">Disparadores:</strong> yesterday · last week · in 2019 · when I was 20 · ago</p>
+              <div class="bg-white rounded p-2.5 border border-emerald-200">
+                <p class="text-xs text-emerald-700 font-semibold mb-1">EJEMPLOS</p>
+                <p>"I <strong>worked</strong> at Telmex for eight years."</p>
+                <p>"She <strong>quit</strong> last Friday."</p>
+              </div>
+              <div class="bg-red-50 rounded p-2.5 border border-red-200">
+                <p class="text-xs text-red-700 font-semibold mb-1 flex items-center gap-1"><AlertTriangle class="w-3 h-3" /> TRAMPA MEXICANA</p>
+                <p class="text-slate-700">Usar Pasado Simple para todo. Si el tiempo está <em>abierto</em> ("this morning" — y todavía es la mañana), probablemente necesitas Presente Perfecto.</p>
+              </div>
+            </div>
+            <a href="/es/curso/tiempos-del-pasado/leccion-1/" class="inline-flex items-center gap-1 mt-3 text-emerald-700 hover:text-emerald-900 text-sm font-medium print:hidden">
+              Lección completa <ArrowRight class="w-3.5 h-3.5" />
+            </a>
+          </div>
+
+          <!-- Past Continuous -->
+          <div class="rounded-2xl border-2 border-emerald-300 bg-emerald-50/60 p-6 print:p-3 print:rounded-md print:break-inside-avoid">
+            <div class="flex items-start gap-3 mb-3">
+              <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-emerald-500 text-white shrink-0 print:w-7 print:h-7">
+                <Film class="w-5 h-5" />
+              </div>
+              <div class="flex-1">
+                <h3 class="text-lg font-bold text-slate-900 print:text-base">Pasado Continuo <span class="text-xs font-normal text-slate-500">(Past Continuous)</span></h3>
+                <p class="text-sm text-emerald-700 italic">Estaba sucediendo cuando…</p>
+              </div>
+            </div>
+            <div class="space-y-2.5 text-sm text-slate-700 print:text-xs">
+              <p><strong class="text-slate-900">Imagen:</strong> una película corriendo. La cámara rueda. Luego algo interrumpe.</p>
+              <p><strong class="text-slate-900">Forma:</strong> <code class="text-xs bg-white px-1.5 py-0.5 rounded">was/were + V-ing</code> · <em>was working, were eating</em></p>
+              <p><strong class="text-slate-900">Disparadores:</strong> when… · while… · as… · at 3pm yesterday · all morning</p>
+              <div class="bg-white rounded p-2.5 border border-emerald-200">
+                <p class="text-xs text-emerald-700 font-semibold mb-1">EJEMPLOS</p>
+                <p>"I <strong>was driving</strong> home when she <strong>called</strong>."</p>
+                <p>"We <strong>were having</strong> dinner at 8."</p>
+              </div>
+              <div class="bg-red-50 rounded p-2.5 border border-red-200">
+                <p class="text-xs text-red-700 font-semibold mb-1 flex items-center gap-1"><AlertTriangle class="w-3 h-3" /> TRAMPA MEXICANA</p>
+                <p class="text-slate-700">Usarlo para acciones terminadas, únicas. "I <em>was watching</em> the movie last night" suena mal — viste <em>la película completa</em>, eso es Pasado Simple.</p>
+              </div>
+            </div>
+            <a href="/es/curso/tiempos-del-pasado/leccion-2/" class="inline-flex items-center gap-1 mt-3 text-emerald-700 hover:text-emerald-900 text-sm font-medium print:hidden">
+              Lección completa <ArrowRight class="w-3.5 h-3.5" />
+            </a>
+          </div>
+
+          <!-- Present Perfect -->
+          <div class="rounded-2xl border-2 border-emerald-400 bg-emerald-100/60 p-6 print:p-3 print:rounded-md print:break-inside-avoid">
+            <div class="flex items-start gap-3 mb-3">
+              <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-emerald-600 text-white shrink-0 print:w-7 print:h-7">
+                <LinkIcon class="w-5 h-5" />
+              </div>
+              <div class="flex-1">
+                <h3 class="text-lg font-bold text-slate-900 print:text-base">Presente Perfecto <span class="text-xs font-semibold text-emerald-700 ml-1">★ alto riesgo</span><br/><span class="text-xs font-normal text-slate-500">(Present Perfect)</span></h3>
+                <p class="text-sm text-emerald-700 italic">Sucedió — pero todavía importa ahora.</p>
+              </div>
+            </div>
+            <div class="space-y-2.5 text-sm text-slate-700 print:text-xs">
+              <p><strong class="text-slate-900">Imagen:</strong> un hilo del pasado <em>hacia</em> el presente. El tiempo no está cerrado — entra hasta el ahora.</p>
+              <p><strong class="text-slate-900">Forma:</strong> <code class="text-xs bg-white px-1.5 py-0.5 rounded">have/has + V<sub>3</sub></code> · <em>have worked, has gone, have done</em></p>
+              <p><strong class="text-slate-900">Disparadores:</strong> already · yet · ever · never · just · since · for · this week (sigue corriendo) · so far</p>
+              <div class="bg-white rounded p-2.5 border border-emerald-300">
+                <p class="text-xs text-emerald-700 font-semibold mb-1">EJEMPLOS</p>
+                <p>"I <strong>have done</strong> the report." (está listo <em>ahora</em>)</p>
+                <p>"She <strong>has lived</strong> here since 2018." (todavía vive aquí)</p>
+                <p>"<strong>Have</strong> you <strong>seen</strong> the email?" (en cualquier momento hasta ahora)</p>
+              </div>
+              <div class="bg-red-50 rounded p-2.5 border border-red-200">
+                <p class="text-xs text-red-700 font-semibold mb-1 flex items-center gap-1"><AlertTriangle class="w-3 h-3" /> TRAMPA MEXICANA</p>
+                <p class="text-slate-700"><strong>La grande.</strong> Los mexicanos caen en Pasado Simple aquí. "I did the report" suena terminado-y-cerrado. Usa Presente Perfecto cuando la acción <em>todavía importa ahora</em>.</p>
+              </div>
+            </div>
+            <a href="/es/curso/tiempos-del-pasado/leccion-3/" class="inline-flex items-center gap-1 mt-3 text-emerald-700 hover:text-emerald-900 text-sm font-medium print:hidden">
+              Lección completa <ArrowRight class="w-3.5 h-3.5" />
+            </a>
+          </div>
+
+          <!-- Past Perfect -->
+          <div class="rounded-2xl border-2 border-emerald-300 bg-emerald-50/60 p-6 print:p-3 print:rounded-md print:break-inside-avoid">
+            <div class="flex items-start gap-3 mb-3">
+              <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-emerald-500 text-white shrink-0 print:w-7 print:h-7">
+                <Layers class="w-5 h-5" />
+              </div>
+              <div class="flex-1">
+                <h3 class="text-lg font-bold text-slate-900 print:text-base">Pasado Perfecto <span class="text-xs font-normal text-slate-500">(Past Perfect)</span></h3>
+                <p class="text-sm text-emerald-700 italic">Sucedió antes que <em>esa</em> otra cosa.</p>
+              </div>
+            </div>
+            <div class="space-y-2.5 text-sm text-slate-700 print:text-xs">
+              <p><strong class="text-slate-900">Imagen:</strong> dos capas. El primer evento queda <em>debajo</em> del segundo evento pasado.</p>
+              <p><strong class="text-slate-900">Forma:</strong> <code class="text-xs bg-white px-1.5 py-0.5 rounded">had + V<sub>3</sub></code> · <em>had worked, had gone, had eaten</em></p>
+              <p><strong class="text-slate-900">Disparadores:</strong> by the time… · before… · after… · already had… · when she arrived, I had already…</p>
+              <div class="bg-white rounded p-2.5 border border-emerald-200">
+                <p class="text-xs text-emerald-700 font-semibold mb-1">EJEMPLOS</p>
+                <p>"When I got there, the meeting <strong>had started</strong>."</p>
+                <p>"She <strong>had finished</strong> before I asked."</p>
+              </div>
+              <div class="bg-red-50 rounded p-2.5 border border-red-200">
+                <p class="text-xs text-red-700 font-semibold mb-1 flex items-center gap-1"><AlertTriangle class="w-3 h-3" /> TRAMPA MEXICANA</p>
+                <p class="text-slate-700">Usarlo de más. Solo necesitas Pasado Perfecto cuando el orden no es obvio por contexto. Si ya dijiste "first…, then…" — usa Pasado Simple dos veces.</p>
+              </div>
+            </div>
+            <a href="/es/curso/tiempos-del-pasado/leccion-4/" class="inline-flex items-center gap-1 mt-3 text-emerald-700 hover:text-emerald-900 text-sm font-medium print:hidden">
+              Lección completa <ArrowRight class="w-3.5 h-3.5" />
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Decision tree -->
+  <section class="py-12 md:py-16 bg-slate-50 print:bg-white print:py-3 print:break-inside-avoid">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="flex items-center gap-3 mb-6 print:mb-3">
+          <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-amber-500 text-white shrink-0">
+            <Map class="w-5 h-5" />
+          </div>
+          <div>
+            <h2 class="text-2xl md:text-3xl font-bold text-slate-900 print:text-xl">El Árbol de Decisión del Flujo de Historia</h2>
+            <p class="text-sm text-slate-600 print:hidden">Tres preguntas, en orden. El tiempo correcto cae al final.</p>
+          </div>
+        </div>
+
+        <div class="rounded-2xl border-2 border-slate-300 bg-white p-6 md:p-8 print:p-3 print:rounded-md print:border print:border-slate-400">
+          <ol class="space-y-5 print:space-y-3">
+            <li class="flex gap-4 print:gap-2">
+              <span class="flex items-center justify-center w-8 h-8 rounded-full bg-amber-500 text-white text-sm font-bold shrink-0 print:w-6 print:h-6 print:text-xs">1</span>
+              <div class="flex-1">
+                <p class="font-semibold text-slate-900 mb-1 print:text-sm">¿La acción todavía importa <em>ahora</em>?</p>
+                <p class="text-sm text-slate-600 print:text-xs">→ ¿Sí? <strong class="text-emerald-700">Presente Perfecto.</strong> ("I have finished.")</p>
+                <p class="text-sm text-slate-600 print:text-xs">→ ¿No, el tiempo está cerrado? Sigue a la Q2.</p>
+              </div>
+            </li>
+            <li class="flex gap-4 print:gap-2">
+              <span class="flex items-center justify-center w-8 h-8 rounded-full bg-amber-500 text-white text-sm font-bold shrink-0 print:w-6 print:h-6 print:text-xs">2</span>
+              <div class="flex-1">
+                <p class="font-semibold text-slate-900 mb-1 print:text-sm">¿Algo está interrumpiendo una acción en progreso?</p>
+                <p class="text-sm text-slate-600 print:text-xs">→ ¿Sí? <strong class="text-emerald-700">Pasado Continuo + Pasado Simple.</strong> ("I was driving when she called.")</p>
+                <p class="text-sm text-slate-600 print:text-xs">→ ¿No? Sigue a la Q3.</p>
+              </div>
+            </li>
+            <li class="flex gap-4 print:gap-2">
+              <span class="flex items-center justify-center w-8 h-8 rounded-full bg-amber-500 text-white text-sm font-bold shrink-0 print:w-6 print:h-6 print:text-xs">3</span>
+              <div class="flex-1">
+                <p class="font-semibold text-slate-900 mb-1 print:text-sm">¿Un evento pasado sucedió <em>antes</em> que otro evento pasado — y el orden no es obvio?</p>
+                <p class="text-sm text-slate-600 print:text-xs">→ ¿Sí? <strong class="text-emerald-700">Pasado Perfecto + Pasado Simple.</strong> ("By the time I arrived, she had left.")</p>
+                <p class="text-sm text-slate-600 print:text-xs">→ ¿No? <strong class="text-emerald-700">Pasado Simple.</strong> ("I worked. She quit. We moved on.")</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Trigger words table -->
+  <section class="py-12 md:py-16 bg-white print:py-3 print:break-inside-avoid">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="flex items-center gap-3 mb-6 print:mb-3">
+          <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-emerald-500 text-white shrink-0">
+            <Eye class="w-5 h-5" />
+          </div>
+          <div>
+            <h2 class="text-2xl md:text-3xl font-bold text-slate-900 print:text-xl">Palabras Clave de Referencia Rápida</h2>
+            <p class="text-sm text-slate-600 print:hidden">Cuando escuchas una de éstas, el tiempo a menudo se elige solo.</p>
+          </div>
+        </div>
+
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm border-collapse">
+            <thead>
+              <tr class="border-b-2 border-slate-300">
+                <th class="text-left py-2 px-3 font-bold text-slate-900 print:text-xs">Palabra clave</th>
+                <th class="text-left py-2 px-3 font-bold text-slate-900 print:text-xs">Usualmente pide</th>
+                <th class="text-left py-2 px-3 font-bold text-slate-900 print:text-xs">Por qué</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-200 print:text-xs">
+              <tr><td class="py-2 px-3 font-mono text-emerald-700">yesterday, last week, in 2019, ago</td><td class="py-2 px-3"><strong>Pasado Simple</strong></td><td class="py-2 px-3 text-slate-600">Tiempo cerrado</td></tr>
+              <tr><td class="py-2 px-3 font-mono text-emerald-700">when, while, as, at 3pm</td><td class="py-2 px-3"><strong>Pasado Continuo</strong> (a menudo)</td><td class="py-2 px-3 text-slate-600">Acción en progreso / fondo</td></tr>
+              <tr><td class="py-2 px-3 font-mono text-emerald-700">already, yet, just, ever, never</td><td class="py-2 px-3"><strong>Presente Perfecto</strong></td><td class="py-2 px-3 text-slate-600">Pasado con relevancia ahora</td></tr>
+              <tr><td class="py-2 px-3 font-mono text-emerald-700">since, for (+ duración)</td><td class="py-2 px-3"><strong>Presente Perfecto</strong></td><td class="py-2 px-3 text-slate-600">Empezó en pasado, sigue ahora</td></tr>
+              <tr><td class="py-2 px-3 font-mono text-emerald-700">this morning / today / this week (sigue corriendo)</td><td class="py-2 px-3"><strong>Presente Perfecto</strong></td><td class="py-2 px-3 text-slate-600">Periodo abierto</td></tr>
+              <tr><td class="py-2 px-3 font-mono text-emerald-700">this morning (y ya es la tarde)</td><td class="py-2 px-3"><strong>Pasado Simple</strong></td><td class="py-2 px-3 text-slate-600">El periodo ya está cerrado</td></tr>
+              <tr><td class="py-2 px-3 font-mono text-emerald-700">by the time, before, after, already had</td><td class="py-2 px-3"><strong>Pasado Perfecto</strong></td><td class="py-2 px-3 text-slate-600">Dos eventos pasados, el anterior</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Three Spanish mirrors -->
+  <section class="py-12 md:py-16 bg-slate-50 print:bg-white print:py-3 print:break-inside-avoid">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="flex items-center gap-3 mb-6 print:mb-3">
+          <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-amber-500 text-white shrink-0">
+            <Lightbulb class="w-5 h-5" />
+          </div>
+          <div>
+            <h2 class="text-2xl md:text-3xl font-bold text-slate-900 print:text-xl">Los Tres Espejos del Español</h2>
+            <p class="text-sm text-slate-600 print:hidden">Si los detectas en español, el tiempo en inglés se elige automáticamente.</p>
+          </div>
+        </div>
+
+        <div class="grid md:grid-cols-3 gap-4 print:gap-2">
+          <div class="bg-white rounded-xl border border-slate-200 p-5 print:p-2 print:rounded-md print:break-inside-avoid">
+            <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">Knew vs. Found out</p>
+            <p class="text-sm text-slate-700 mb-2"><strong>Español:</strong> <em>sabía</em> (estado) vs. <em>supe</em> (momento de descubrir)</p>
+            <p class="text-sm text-slate-700"><strong>Inglés:</strong> "I <strong>knew</strong> she was leaving" (estado continuo). "I <strong>found out</strong> she was leaving" (un momento de descubrimiento — nunca "I knew it yesterday").</p>
+          </div>
+          <div class="bg-white rounded-xl border border-slate-200 p-5 print:p-2 print:rounded-md print:break-inside-avoid">
+            <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">There was vs. There has been</p>
+            <p class="text-sm text-slate-700 mb-2"><strong>Español:</strong> <em>hubo</em> (cerrado) vs. <em>ha habido</em> (todavía relevante)</p>
+            <p class="text-sm text-slate-700"><strong>Inglés:</strong> "There <strong>was</strong> a problem last week" (cerrado). "There <strong>has been</strong> a problem this morning" (todavía aquí, todavía me toca resolverlo).</p>
+          </div>
+          <div class="bg-white rounded-xl border border-slate-200 p-5 print:p-2 print:rounded-md print:break-inside-avoid">
+            <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">Did vs. Have done</p>
+            <p class="text-sm text-slate-700 mb-2"><strong>Español:</strong> <em>hice</em> vs. <em>he hecho</em> — el mismo instinto funciona.</p>
+            <p class="text-sm text-slate-700"><strong>Inglés:</strong> "I <strong>did</strong> the report yesterday" (cerrado). "I <strong>have done</strong> the report" (está en tu escritorio ahora — relevante).</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Save / share -->
+  <section class="py-12 md:py-16 bg-emerald-950 text-white print:hidden">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-2xl md:text-3xl font-bold mb-3" style="font-family: 'Noto Sans KR', sans-serif;">Tenla a la Mano</h2>
+        <p class="text-emerald-100 mb-6 max-w-2xl mx-auto">
+          Guarda esta página en favoritos. Imprímela. Pégala junto al monitor para la próxima junta con clientes en EE.UU.
+          Luego toma las cinco lecciones — la guía rápida empieza a tener sentido una vez que sentiste las historias.
+        </p>
+        <div class="flex flex-wrap gap-3 justify-center">
+          <button
+            onclick="window.print()"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold transition-colors"
+          >
+            <Printer class="w-5 h-5" />
+            Imprimir esta página
+          </button>
+          <a
+            href="/es/curso/tiempos-del-pasado/leccion-1/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-white/10 hover:bg-white/20 text-white font-semibold transition-colors"
+          >
+            Empezar el curso desde la Lección 1
+            <ArrowRight class="w-5 h-5" />
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <style is:global>
+    @media print {
+      header, footer, nav { display: none !important; }
+      body { background: white !important; color: black !important; }
+      a { text-decoration: none !important; color: #064e3b !important; }
+      code { background: #f1f5f9 !important; color: #064e3b !important; }
+    }
+  </style>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    "name": "Tiempos del Pasado en Ingles — Guia Rapida de Una Pagina",
+    "description": "Referencia compacta e imprimible que cubre Past Simple, Past Continuous, Present Perfect y Past Perfect — incluyendo palabras clave, el arbol de decision del flujo de historia y los tres pares de verbos espejo del espanol.",
+    "learningResourceType": "Cheat sheet",
+    "educationalLevel": "Intermedio a Avanzado",
+    "inLanguage": "es",
+    "isAccessibleForFree": true,
+    "url": "https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/guia-rapida/",
+    "isPartOf": {
+      "@type": "Course",
+      "name": "Domina los Tiempos del Pasado en Ingles — Clase Magistral Gratis",
+      "url": "https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/"
+    },
+    "author": {
+      "@type": "Person",
+      "name": "Robert Cushman",
+      "url": "https://www.nyenglishteacher.com/es/about/"
+    }
+  })} />
+</Base>

--- a/src/pages/es/curso/tiempos-del-pasado/index.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/index.astro
@@ -227,20 +227,30 @@ const iconMap: Record<string, any> = {
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           {pastTenseBonuses.map((bonus) => {
             const Icon = iconMap[bonus.icon];
+            const href = bonus.available ? `/es/curso/tiempos-del-pasado/${bonus.slugEs}/` : undefined;
+            const cardClasses = bonus.available
+              ? "bg-white rounded-xl p-5 border border-emerald-300 flex items-start gap-4 hover:shadow-md hover:border-emerald-400 transition-all duration-200 cursor-pointer"
+              : "bg-white rounded-xl p-5 border border-slate-200 flex items-start gap-4";
+            const iconBg = bonus.available
+              ? "bg-emerald-500 text-white"
+              : "bg-slate-100 text-slate-500";
+            const Tag = bonus.available ? "a" : "div";
             return (
-              <div class="bg-white rounded-xl p-5 border border-slate-200 flex items-start gap-4">
-                <div class="flex items-center justify-center w-10 h-10 rounded-lg shrink-0 bg-slate-100 text-slate-500">
+              <Tag href={href} class={cardClasses}>
+                <div class:list={["flex items-center justify-center w-10 h-10 rounded-lg shrink-0", iconBg]}>
                   {Icon && <Icon class="w-5 h-5" />}
                 </div>
                 <div class="flex-1">
                   <div class="flex items-center gap-2">
-                    <span class="text-xs font-bold uppercase tracking-wider text-slate-400">Bono {bonus.id}</span>
-                    <span class="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-400">Próximamente</span>
+                    <span class:list={["text-xs font-bold uppercase tracking-wider", bonus.available ? "text-emerald-700" : "text-slate-400"]}>Bono {bonus.id}</span>
+                    {!bonus.available && (
+                      <span class="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-400">Próximamente</span>
+                    )}
                   </div>
                   <h3 class="text-base font-bold text-slate-900 mt-0.5">{bonus.titleEs}</h3>
                   <p class="text-sm text-slate-600 mt-1">{bonus.descriptionEs}</p>
                 </div>
-              </div>
+              </Tag>
             );
           })}
         </div>

--- a/src/pages/es/cursos/index.astro
+++ b/src/pages/es/cursos/index.astro
@@ -16,6 +16,12 @@ import {
   ArrowRight,
   CheckCircle2,
   GraduationCap,
+  Target,
+  Clock,
+  Film,
+  Link as LinkIcon,
+  Layers,
+  Map,
 } from "lucide-astro";
 
 const lang = "es";
@@ -315,6 +321,76 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
         </a>
       </div>
 
+      <!-- Clases Magistrales Enfocadas -->
+      <div class="max-w-7xl mx-auto mt-20">
+        <div class="text-center mb-10">
+          <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-emerald-100 text-emerald-700 text-sm font-semibold mb-3">
+            <Target class="w-4 h-4" />
+            Clases Magistrales Enfocadas
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-2">
+            Un tema. A fondo.
+          </h2>
+          <p class="text-slate-600 max-w-2xl mx-auto">
+            Cursos cortos enfocados en lo que congela a los profesionales mexicanos — incluso después de años de estudio. Toma uno en una tarde.
+          </p>
+        </div>
+
+        <a
+          href="/es/curso/tiempos-del-pasado/"
+          class="group block bg-gradient-to-br from-slate-900 via-emerald-950 to-slate-900 rounded-2xl border border-emerald-700/40 overflow-hidden hover:shadow-2xl hover:border-emerald-500 transition-all duration-200"
+        >
+          <div class="grid md:grid-cols-5 gap-0">
+            <div class="md:col-span-3 p-8 md:p-10 text-white">
+              <div class="flex items-center gap-2 text-emerald-300 text-xs font-bold uppercase tracking-wider mb-3">
+                <Sparkles class="w-3.5 h-3.5" />
+                Clase Magistral · Nivel B1–C1
+              </div>
+              <h3 class="text-2xl md:text-3xl font-bold mb-3" style="font-family: 'Noto Sans KR', sans-serif;">
+                Domina los Tiempos del Pasado en Inglés
+              </h3>
+              <p class="text-emerald-100 text-base leading-relaxed mb-5">
+                Conoces las reglas. Las puedes recitar. Pero en una junta real te congelas — y dices <em class="not-italic text-white">"I did the report"</em> cuando la situación pide <em class="not-italic text-white">"I have done the report."</em> Esta clase magistral te recablea la elección de tiempo pasado mediante la visualización, no la memorización de reglas.
+              </p>
+              <div class="flex flex-wrap gap-x-6 gap-y-2 text-sm text-emerald-100 mb-6">
+                <span class="inline-flex items-center gap-1.5"><CheckCircle2 class="w-4 h-4 text-emerald-400" /> 5 lecciones enfocadas</span>
+                <span class="inline-flex items-center gap-1.5"><CheckCircle2 class="w-4 h-4 text-emerald-400" /> El método de los 4 tiempos</span>
+                <span class="inline-flex items-center gap-1.5"><CheckCircle2 class="w-4 h-4 text-emerald-400" /> Hecho para mexicanos</span>
+              </div>
+              <span class="inline-flex items-center gap-1 text-amber-400 font-semibold text-sm group-hover:gap-2 transition-all">
+                Empezar la clase magistral
+                <ArrowRight class="w-4 h-4" />
+              </span>
+            </div>
+            <div class="md:col-span-2 bg-emerald-950/40 p-8 md:p-10 border-t md:border-t-0 md:border-l border-emerald-700/30">
+              <p class="text-xs font-bold uppercase tracking-wider text-emerald-300 mb-4">Qué vas a aprender</p>
+              <ul class="space-y-3 text-emerald-50 text-sm">
+                <li class="flex items-start gap-3">
+                  <Clock class="w-4 h-4 text-emerald-400 shrink-0 mt-0.5" />
+                  <span><strong class="text-white">Pasado Simple</strong> — momentos cerrados, tiempo terminado</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <Film class="w-4 h-4 text-emerald-400 shrink-0 mt-0.5" />
+                  <span><strong class="text-white">Pasado Continuo</strong> — escenas de fondo, interrupciones</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <LinkIcon class="w-4 h-4 text-emerald-400 shrink-0 mt-0.5" />
+                  <span><strong class="text-white">Presente Perfecto</strong> — pasado con un hilo al ahora</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <Layers class="w-4 h-4 text-emerald-400 shrink-0 mt-0.5" />
+                  <span><strong class="text-white">Pasado Perfecto</strong> — la capa debajo de otro pasado</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <Map class="w-4 h-4 text-emerald-400 shrink-0 mt-0.5" />
+                  <span><strong class="text-white">Mapa del Flujo</strong> — elige tiempos en tiempo real</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </a>
+      </div>
+
       <div class="max-w-3xl mx-auto mt-16 text-center">
         <h3 class="text-2xl font-bold text-slate-900 mb-3">¿No sabes con cuál empezar?</h3>
         <p class="text-slate-600 mb-6">
@@ -378,6 +454,15 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
         "@type": "Course",
         "name": "Curso Ejecutivo de Ingles (C1-C2)",
         "url": "https://www.nyenglishteacher.com/es/curso/ejecutivo/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 6,
+      "item": {
+        "@type": "Course",
+        "name": "Domina los Tiempos del Pasado en Ingles (Clase Magistral Gratis)",
+        "url": "https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/"
       }
     }
   ]


### PR DESCRIPTION
## Summary

The Past Tenses master class shipped to production with all 5 lessons (PRs #164–#169) but was orphaned — no links from /en/courses/, /es/cursos/, or any sibling course page. This PR makes it discoverable and ships the first bonus resource.

**Navigation / promotion**
- Adds a "Targeted Master Classes" section to `/en/courses/` and `/es/cursos/` with a wide featured card for Past Tenses (keeps the 5-level grid intact instead of cramming a 6th level into it).
- Cross-link callout on the intermediate (B1-B2) and advanced (B2-C1) course landings, EN + ES — past-tense choice is the #1 freeze point at those levels.
- Adds the master class to the `ItemList` JSON-LD on both `/courses/` pages.

**Bonus 1 — One-Page Cheat Sheet (EN + ES)**
- `/en/course/past-tenses/cheat-sheet/`
- `/es/curso/tiempos-del-pasado/guia-rapida/` — Mexican Professional Spanish (audited for Iberian markers, none present)
- Four-tense compact reference, Story Flow decision tree, trigger-word table, three Spanish-mirror verb pairs.
- Print button + `@media print` rules + `break-inside-avoid` on every card so it actually prints clean on one or two pages.
- `LearningResource` JSON-LD scoped to the parent Course.
- Flips bonus 1's `available` flag and makes the bonus cards clickable on both course landings (from previously stashed scaffolding).

**Not in this PR**
- Bonuses 2–5 (Top 10 Verb Pairs, Knew vs Found Out, Story Openers, There Was vs Has Been) are still `available: false` on the landing. Separate PRs.
- Header nav is unchanged — the master class is reachable via the Courses index, which is the intended discovery path.

## Test plan

- [ ] Preview EN landing — Master Classes section renders below the 5-level grid: https://ny-eng-git-feat-past-tenses-promo-and-cheat-sheet-rcushmaniii-projects.vercel.app/en/courses/
- [ ] Preview ES landing — same: https://ny-eng-git-feat-past-tenses-promo-and-cheat-sheet-rcushmaniii-projects.vercel.app/es/cursos/
- [ ] EN cheat sheet renders and prints clean: https://ny-eng-git-feat-past-tenses-promo-and-cheat-sheet-rcushmaniii-projects.vercel.app/en/course/past-tenses/cheat-sheet/
- [ ] ES cheat sheet (`guía rápida`) renders and prints clean: https://ny-eng-git-feat-past-tenses-promo-and-cheat-sheet-rcushmaniii-projects.vercel.app/es/curso/tiempos-del-pasado/guia-rapida/
- [ ] Cross-link callout visible at the bottom of the intermediate and advanced course landings (EN + ES)
- [ ] Mexican Spanish — no `vosotros`, `vale`, `coger`, `ordenador`, `móvil` (as phone noun), etc. in the ES page

Pre-existing 18 `ts(2322)` typecheck errors on `elementary/unit-N.astro` `Connector` shape are unrelated to this PR and don't block `npm run build` (which CI uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)