### PR TITLE
fix(schema): resolve schema.org validation errors on 202 pages

### DIFF
--- a/src/components/seo/BlogPostSchema.astro
+++ b/src/components/seo/BlogPostSchema.astro
@@ -73,10 +73,13 @@ const article = {
   },
   "publisher": {
     "@type": "Organization",
+    "@id": `${cleanSiteUrl}/#org`,
     "name": siteConfig.companyName,
     "logo": {
       "@type": "ImageObject",
-      "url": `${cleanSiteUrl}/images/logos/new-york-english-og.jpg`
+      "url": `${cleanSiteUrl}/images/logos/logo-512.png`,
+      "width": 512,
+      "height": 512
     }
   },
   "mainEntityOfPage": {

--- a/src/components/seo/OrgSchema.astro
+++ b/src/components/seo/OrgSchema.astro
@@ -15,12 +15,7 @@ const org = {
     "@type": "ContactPoint",
     "url": "https://wa.link/pk4f97",
     "email": "info@nyenglishteacher.com",
-    "contactType": "Customer Service",
-    "areaServed": [
-      { "@type": "Country", "name": "Mexico" },
-      { "@type": "Country", "name": "United States" },
-      { "@type": "Country", "name": "Canada" }
-    ],
+    "contactType": "customer support",
     "availableLanguage": ["English","Spanish"]
   }
 };

--- a/src/components/seo/ProfessionalServiceSchema.astro
+++ b/src/components/seo/ProfessionalServiceSchema.astro
@@ -97,7 +97,7 @@ const professionalService = {
     "@type": "ContactPoint",
     "url": "https://wa.link/pk4f97",
     "email": "info@nyenglishteacher.com",
-    "contactType": "Customer Service",
+    "contactType": "customer support",
     "availableLanguage": ["English", "Spanish"]
   },
   "sameAs": [

--- a/src/pages/en/course/advanced/index.astro
+++ b/src/pages/en/course/advanced/index.astro
@@ -1,4 +1,4 @@
----
+﻿---
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
@@ -274,7 +274,7 @@ const iconMap: Record<string, any> = {
     "@type": "Course",
     "name": "Free Advanced English Course (B2-C1)",
     "description": "A free 10-unit advanced English course for B2-C1 Spanish speakers. Fix weak phrasing, word traps, articles, and pronunciation tells. No fluff — just precision.",
-    "provider": { "@type": "Person", "name": "Robert Cushman", "url": "https://www.nyenglishteacher.com/en/about/" },
+    "provider": { "@type": "Organization", "name": "New York English Teacher", "url": "https://www.nyenglishteacher.com/" },
     "educationalLevel": "Advanced (B2-C1)",
     "inLanguage": "en",
     "url": "https://www.nyenglishteacher.com/en/course/advanced/",

--- a/src/pages/en/course/beginners/index.astro
+++ b/src/pages/en/course/beginners/index.astro
@@ -1,4 +1,4 @@
----
+﻿---
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
@@ -266,11 +266,7 @@ const iconMap: Record<string, any> = {
   "@type": "Course",
   "name": "Free English Course for Spanish Speakers (Beginner)",
   "description": "A free 10-unit English course for Spanish speakers. Start from words you already know. Interactive lessons with audio. No textbooks — just real sentences.",
-  "provider": {
-    "@type": "Person",
-    "name": "Robert Cushman",
-    "url": "https://www.nyenglishteacher.com/en/about/"
-  },
+  "provider": { "@type": "Organization", "name": "New York English Teacher", "url": "https://www.nyenglishteacher.com/" },
   "educationalLevel": "Beginner (A1-A2)",
   "inLanguage": "en",
   "url": "https://www.nyenglishteacher.com/en/course/beginners/",

--- a/src/pages/en/course/elementary/index.astro
+++ b/src/pages/en/course/elementary/index.astro
@@ -1,4 +1,4 @@
----
+﻿---
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
@@ -286,11 +286,7 @@ const firstUnitLabel = firstAvailableUnit
   "@type": "Course",
   "name": "Free Elementary English Course (A2)",
   "description": "A free 10-unit elementary English course for A2 Spanish speakers. Past simple, future plans, comparatives, and Wh-questions — tell your story.",
-  "provider": {
-    "@type": "Person",
-    "name": "Robert Cushman",
-    "url": "https://www.nyenglishteacher.com/en/about/"
-  },
+  "provider": { "@type": "Organization", "name": "New York English Teacher", "url": "https://www.nyenglishteacher.com/" },
   "educationalLevel": "Elementary (A2)",
   "inLanguage": "en",
   "url": "https://www.nyenglishteacher.com/en/course/elementary/",

--- a/src/pages/en/course/executive/index.astro
+++ b/src/pages/en/course/executive/index.astro
@@ -1,4 +1,4 @@
----
+﻿---
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
@@ -274,11 +274,7 @@ const iconMap: Record<string, any> = {
   "@type": "Course",
   "name": "Executive English Course (C1-C2)",
   "description": "Free C1-C2 executive English course. Ten drill-based units that replace vague language with precision, structure, and calm authority.",
-  "provider": {
-    "@type": "Person",
-    "name": "Robert Cushman",
-    "url": "https://www.nyenglishteacher.com/en/about/"
-  },
+  "provider": { "@type": "Organization", "name": "New York English Teacher", "url": "https://www.nyenglishteacher.com/" },
   "educationalLevel": "Executive (C1-C2)",
   "inLanguage": "en",
   "url": "https://www.nyenglishteacher.com/en/course/executive/",

--- a/src/pages/en/course/intermediate/index.astro
+++ b/src/pages/en/course/intermediate/index.astro
@@ -1,4 +1,4 @@
----
+﻿---
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
@@ -308,11 +308,7 @@ const iconMap: Record<string, any> = {
   "@type": "Course",
   "name": "Free Intermediate English Course (B1-B2)",
   "description": "A free 10-unit intermediate English course for B1-B2 Spanish speakers. Master phrasal verbs, complex tenses, and natural speech through real-world dialogues.",
-  "provider": {
-    "@type": "Person",
-    "name": "Robert Cushman",
-    "url": "https://www.nyenglishteacher.com/en/about/"
-  },
+  "provider": { "@type": "Organization", "name": "New York English Teacher", "url": "https://www.nyenglishteacher.com/" },
   "educationalLevel": "Intermediate (B1-B2)",
   "inLanguage": "en",
   "url": "https://www.nyenglishteacher.com/en/course/intermediate/",

--- a/src/pages/en/course/past-tenses/index.astro
+++ b/src/pages/en/course/past-tenses/index.astro
@@ -1,4 +1,4 @@
----
+﻿---
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
@@ -324,11 +324,7 @@ const iconMap: Record<string, any> = {
     "@type": "Course",
     "name": "Master English Past Tenses — Free Master Class",
     "description": "A focused 5-lesson master class teaching English past tenses through visualization rather than rule-memorization. Built for Mexican professionals who freeze in conversation despite knowing the rules.",
-    "provider": {
-      "@type": "Person",
-      "name": "Robert Cushman",
-      "url": "https://www.nyenglishteacher.com/en/about/"
-    },
+    "provider": { "@type": "Organization", "name": "New York English Teacher", "url": "https://www.nyenglishteacher.com/" },
     "educationalLevel": "Intermediate to Advanced",
     "inLanguage": "en",
     "url": "https://www.nyenglishteacher.com/en/course/past-tenses/",

--- a/src/pages/en/services/corporate-package.astro
+++ b/src/pages/en/services/corporate-package.astro
@@ -328,10 +328,9 @@ const faqs = serviceFaqs["corporate-package"]?.en || [];
     "alternateName": ["Corporate English Training for Leadership Teams", "Executive English Coaching", "Courage While Leading in English"],
     "description": "Business English coaching 1-on-1 online for leadership teams in Mexico. A 12-week structured program that combines individual preparation, peer-pressure group presentations, and a final assessment — designed to close the gap between private fluency and public performance.",
     "provider": {
-      "@type": "Person",
-      "name": "Robert Cushman",
-      "jobTitle": "English Coach",
-      "url": "https://www.nyenglishteacher.com/en/about/"
+      "@type": "Organization",
+      "name": "New York English Teacher",
+      "url": "https://www.nyenglishteacher.com/"
     },
     "serviceType": "Business English Coaching",
     "areaServed": {

--- a/src/pages/es/curso/avanzado/index.astro
+++ b/src/pages/es/curso/avanzado/index.astro
@@ -1,4 +1,4 @@
----
+﻿---
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
@@ -264,11 +264,7 @@ const iconMap: Record<string, any> = {
   "@type": "Course",
   "name": "Curso Avanzado de Ingles Gratis (B2-C1)",
   "description": "Curso avanzado gratis de 10 unidades para hispanohablantes B2-C1. Corrige frases debiles, trampas de palabras, articulos y pronunciacion. Solo precision.",
-  "provider": {
-    "@type": "Person",
-    "name": "Robert Cushman",
-    "url": "https://www.nyenglishteacher.com/es/about/"
-  },
+  "provider": { "@type": "Organization", "name": "New York English Teacher", "url": "https://www.nyenglishteacher.com/" },
   "educationalLevel": "Avanzado (B2-C1)",
   "inLanguage": "es",
   "url": "https://www.nyenglishteacher.com/es/curso/avanzado/",

--- a/src/pages/es/curso/ejecutivo/index.astro
+++ b/src/pages/es/curso/ejecutivo/index.astro
@@ -1,4 +1,4 @@
----
+﻿---
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
@@ -268,11 +268,7 @@ const iconMap: Record<string, any> = {
   "@type": "Course",
   "name": "Curso Ejecutivo de Ingles (C1-C2)",
   "description": "Curso gratuito de ingles ejecutivo C1-C2. Diez unidades basadas en drills que reemplazan el lenguaje vago con precision, estructura y autoridad.",
-  "provider": {
-    "@type": "Person",
-    "name": "Robert Cushman",
-    "url": "https://www.nyenglishteacher.com/es/about/"
-  },
+  "provider": { "@type": "Organization", "name": "New York English Teacher", "url": "https://www.nyenglishteacher.com/" },
   "educationalLevel": "Ejecutivo (C1-C2)",
   "inLanguage": "es",
   "url": "https://www.nyenglishteacher.com/es/curso/ejecutivo/",

--- a/src/pages/es/curso/elemental/index.astro
+++ b/src/pages/es/curso/elemental/index.astro
@@ -1,4 +1,4 @@
----
+﻿---
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
@@ -286,11 +286,7 @@ const firstUnitLabel = firstAvailableUnit
   "@type": "Course",
   "name": "Curso Elemental de Ingles Gratis (A2)",
   "description": "Curso elemental de ingles gratuito de 10 unidades para hispanohablantes A2. Pasado simple, planes futuros, comparativos y preguntas Wh - cuenta tu historia.",
-  "provider": {
-    "@type": "Person",
-    "name": "Robert Cushman",
-    "url": "https://www.nyenglishteacher.com/es/about/"
-  },
+  "provider": { "@type": "Organization", "name": "New York English Teacher", "url": "https://www.nyenglishteacher.com/" },
   "educationalLevel": "Elementary (A2)",
   "inLanguage": "es",
   "url": "https://www.nyenglishteacher.com/es/curso/elemental/",

--- a/src/pages/es/curso/intermedio/index.astro
+++ b/src/pages/es/curso/intermedio/index.astro
@@ -1,4 +1,4 @@
----
+﻿---
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
@@ -308,11 +308,7 @@ const iconMap: Record<string, any> = {
   "@type": "Course",
   "name": "Curso Gratis de Ingles Intermedio (B1-B2)",
   "description": "Curso gratuito de 10 unidades de ingles intermedio para hispanohablantes B1-B2. Domina los phrasal verbs, tiempos complejos y el habla natural.",
-  "provider": {
-    "@type": "Person",
-    "name": "Robert Cushman",
-    "url": "https://www.nyenglishteacher.com/es/about/"
-  },
+  "provider": { "@type": "Organization", "name": "New York English Teacher", "url": "https://www.nyenglishteacher.com/" },
   "educationalLevel": "Intermedio (B1-B2)",
   "inLanguage": "es",
   "url": "https://www.nyenglishteacher.com/es/curso/intermedio/",

--- a/src/pages/es/curso/principiantes/index.astro
+++ b/src/pages/es/curso/principiantes/index.astro
@@ -1,4 +1,4 @@
----
+﻿---
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
@@ -266,11 +266,7 @@ const iconMap: Record<string, any> = {
   "@type": "Course",
   "name": "Curso Gratis de Ingles para Hispanohablantes (Principiante)",
   "description": "Curso gratuito de 10 unidades de ingles para hispanohablantes. Empieza con palabras que ya conoces. Lecciones interactivas con audio. Sin libros de texto.",
-  "provider": {
-    "@type": "Person",
-    "name": "Robert Cushman",
-    "url": "https://www.nyenglishteacher.com/es/about/"
-  },
+  "provider": { "@type": "Organization", "name": "New York English Teacher", "url": "https://www.nyenglishteacher.com/" },
   "educationalLevel": "Principiante (A1-A2)",
   "inLanguage": "es",
   "url": "https://www.nyenglishteacher.com/es/curso/principiantes/",

--- a/src/pages/es/curso/tiempos-del-pasado/index.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/index.astro
@@ -1,4 +1,4 @@
----
+﻿---
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
@@ -324,11 +324,7 @@ const iconMap: Record<string, any> = {
     "@type": "Course",
     "name": "Domina los Tiempos del Pasado en Inglés — Clase Magistral Gratuita",
     "description": "Una clase magistral de 5 lecciones enfocada en los tiempos del pasado en inglés a través de la visualización en lugar de memorizar reglas. Diseñada para profesionales mexicanos que se congelan al hablar a pesar de conocer las reglas.",
-    "provider": {
-      "@type": "Person",
-      "name": "Robert Cushman",
-      "url": "https://www.nyenglishteacher.com/es/about/"
-    },
+    "provider": { "@type": "Organization", "name": "New York English Teacher", "url": "https://www.nyenglishteacher.com/" },
     "educationalLevel": "Intermedio a Avanzado",
     "inLanguage": "es",
     "url": "https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/",


### PR DESCRIPTION
## Summary
Fixes four distinct schema.org validation issues that Ahrefs flagged across 202 pages in the May 16 crawl. Despite the logo fix from the previous session (PR #172), these errors persisted — this PR addresses the remaining issues.

- **`ContactPoint.contactType` invalid value** — `"Customer Service"` is not a recognized schema.org enum; changed to `"customer support"` (lowercase, the spec-defined value). Affected `OrgSchema.astro` and `ProfessionalServiceSchema.astro` — injected on every page, hence ~202 affected.
- **`ContactPoint.areaServed` invalid property** — `areaServed` is not a property of `ContactPoint` per schema.org spec. Removed from `OrgSchema.astro`.
- **`Course.provider @type "Person"`** — Google requires `@type "Organization"` for Course rich results. Fixed across all 12 course landing pages (6 EN + 6 ES) and `corporate-package.astro`.
- **Article `publisher.logo` wrong image** — `BlogPostSchema.astro` was using the 1200×630 OG social card image as the publisher logo. Switched to `logo-512.png` (square logo) with dimensions.

## Test plan
- [ ] After deploy, validate any page via Google Rich Results Test — expect no schema errors for Organization / ProfessionalService / WebSite
- [ ] Check a course page (e.g. `/en/course/beginners/`) — Course provider should show `Organization` not `Person`
- [ ] Check a blog post — Article publisher logo should resolve to `logo-512.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)