### PR TITLE
feat(course): Past Tenses Bonuses 2-5 — master class complete

### DIFF
--- a/src/data/past-tenses/lessons.ts
+++ b/src/data/past-tenses/lessons.ts
@@ -131,7 +131,7 @@ export const pastTenseBonuses: PastTenseBonus[] = [
     description: "say/tell, do/make, lay/lie, rise/raise, and the seven others that trip up intermediate Mexican speakers.",
     descriptionEs: "say/tell, do/make, lay/lie, rise/raise y los otros siete que confunden a hispanohablantes intermedios.",
     icon: "AlertCircle",
-    available: false,
+    available: true,
   },
   {
     id: 3,
@@ -142,7 +142,7 @@ export const pastTenseBonuses: PastTenseBonus[] = [
     description: "The English equivalent of sabía vs supe. Same trap, same solution.",
     descriptionEs: 'El equivalente en inglés de "sabía vs supe". La misma trampa, la misma solución.',
     icon: "Lightbulb",
-    available: false,
+    available: true,
   },
   {
     id: 4,
@@ -153,7 +153,7 @@ export const pastTenseBonuses: PastTenseBonus[] = [
     description: '"Back when I was at…", "I remember when…", "The other day…" — ready-made launchpads native speakers actually use.',
     descriptionEs: '"Back when I was at…", "I remember when…", "The other day…" — frases iniciales reales que usan los nativos.',
     icon: "Mic",
-    available: false,
+    available: true,
   },
   {
     id: 5,
@@ -164,6 +164,6 @@ export const pastTenseBonuses: PastTenseBonus[] = [
     description: "The English equivalent of hubo vs había. Why one closes the story and the other keeps it open.",
     descriptionEs: 'El equivalente en inglés de "hubo vs había". Por qué uno cierra la historia y el otro la deja abierta.',
     icon: "MessageSquare",
-    available: false,
+    available: true,
   },
 ];

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -145,6 +145,10 @@ export type TKey =
   | "course/past-tenses/lesson-4"
   | "course/past-tenses/lesson-5"
   | "course/past-tenses/cheat-sheet"
+  | "course/past-tenses/top-10-confused-pairs"
+  | "course/past-tenses/knew-vs-found-out"
+  | "course/past-tenses/story-openers"
+  | "course/past-tenses/there-was-vs-there-has-been"
   | "corporate/for-hr"
   | "meme-portfolio"
   | "site-index";
@@ -305,6 +309,13 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/past-tenses/lesson-4": "/en/course/past-tenses/lesson-4/",
     "course/past-tenses/lesson-5": "/en/course/past-tenses/lesson-5/",
     "course/past-tenses/cheat-sheet": "/en/course/past-tenses/cheat-sheet/",
+    "course/past-tenses/top-10-confused-pairs":
+      "/en/course/past-tenses/top-10-confused-pairs/",
+    "course/past-tenses/knew-vs-found-out":
+      "/en/course/past-tenses/knew-vs-found-out/",
+    "course/past-tenses/story-openers": "/en/course/past-tenses/story-openers/",
+    "course/past-tenses/there-was-vs-there-has-been":
+      "/en/course/past-tenses/there-was-vs-there-has-been/",
     "corporate/for-hr": "/en/for-hr-managers/",
     "meme-portfolio": "/en/meme-portfolio/all/",
     "site-index": "/en/site-index/",
@@ -469,6 +480,14 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/past-tenses/lesson-4": "/es/curso/tiempos-del-pasado/leccion-4/",
     "course/past-tenses/lesson-5": "/es/curso/tiempos-del-pasado/leccion-5/",
     "course/past-tenses/cheat-sheet": "/es/curso/tiempos-del-pasado/guia-rapida/",
+    "course/past-tenses/top-10-confused-pairs":
+      "/es/curso/tiempos-del-pasado/top-10-pares-confundidos/",
+    "course/past-tenses/knew-vs-found-out":
+      "/es/curso/tiempos-del-pasado/knew-vs-found-out/",
+    "course/past-tenses/story-openers":
+      "/es/curso/tiempos-del-pasado/frases-iniciales/",
+    "course/past-tenses/there-was-vs-there-has-been":
+      "/es/curso/tiempos-del-pasado/there-was-vs-there-has-been/",
     "corporate/for-hr": "/es/para-rh/",
     "meme-portfolio": "/es/meme-portfolio/all/",
     "site-index": "/es/indice-del-sitio/",
@@ -562,6 +581,10 @@ export function getAllTKeys(): TKey[] {
     "course/past-tenses/lesson-4",
     "course/past-tenses/lesson-5",
     "course/past-tenses/cheat-sheet",
+    "course/past-tenses/top-10-confused-pairs",
+    "course/past-tenses/knew-vs-found-out",
+    "course/past-tenses/story-openers",
+    "course/past-tenses/there-was-vs-there-has-been",
     "category/startup-founders",
     "category/tech-english",
     "category/logistics-english",

--- a/src/pages/en/course/past-tenses/knew-vs-found-out.astro
+++ b/src/pages/en/course/past-tenses/knew-vs-found-out.astro
@@ -1,0 +1,267 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import {
+  ArrowRight,
+  ArrowLeft,
+  Lightbulb,
+  CheckCircle2,
+  XCircle,
+  Eye,
+  Brain,
+  Printer,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/past-tenses/knew-vs-found-out" as const;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="&quot;Knew&quot; vs &quot;Found Out&quot; in English | NY English Teacher"
+  description="The English equivalent of sabía vs supe. Why one is a state and one is a moment — and the drill that fixes it for Mexican speakers in 30 seconds."
+>
+  <!-- Hero -->
+  <section class="bg-gradient-to-b from-slate-900 to-emerald-950 pt-28 pb-12 md:pt-32 md:pb-16 print:hidden">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-emerald-400 text-sm font-semibold mb-3">
+          <Lightbulb class="w-4 h-4" />
+          Bonus 3 · The Spanish Mirror
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          "Knew" vs "Found Out"
+        </h1>
+        <p class="text-2xl text-emerald-300 italic font-light mb-4">The English equivalent of <em>sabía</em> vs <em>supe</em>.</p>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed mb-6">
+          Same trap. Same solution. If you can feel the difference in Spanish, you can feel it in English —
+          but English uses two different verbs instead of one verb in two tenses.
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <button
+            onclick="window.print()"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold text-sm transition-colors"
+          >
+            <Printer class="w-4 h-4" />
+            Print this page
+          </button>
+          <a
+            href="/en/course/past-tenses/"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            <ArrowLeft class="w-4 h-4" />
+            Back to the master class
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- The split -->
+  <section class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="text-center mb-10">
+          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-3">The Spanish Split</h2>
+          <p class="text-lg text-slate-600 max-w-2xl mx-auto">
+            In Spanish, <em>saber</em> changes meaning between imperfect and preterite. In English, it splits into <strong>two different verbs</strong>.
+          </p>
+        </div>
+
+        <div class="grid md:grid-cols-2 gap-6">
+          <div class="rounded-2xl border-2 border-emerald-300 bg-emerald-50/60 p-7">
+            <div class="flex items-center gap-3 mb-3">
+              <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-emerald-500 text-white">
+                <Brain class="w-5 h-5" />
+              </div>
+              <h3 class="text-2xl font-bold text-slate-900">knew</h3>
+            </div>
+            <p class="text-sm font-mono text-emerald-700 mb-3"><em>sabía</em> — imperfect</p>
+            <p class="text-slate-700 mb-3">
+              A <strong>state</strong> of knowing. You already had the information. The knowledge was sitting in your head, possibly for years.
+            </p>
+            <div class="bg-white rounded-lg p-3 border border-emerald-200 text-sm space-y-1.5">
+              <p>"I <strong>knew</strong> she was leaving." (the whole time)</p>
+              <p>"He <strong>knew</strong> the answer." (already had it)</p>
+              <p>"We <strong>knew</strong> each other from college."</p>
+            </div>
+          </div>
+
+          <div class="rounded-2xl border-2 border-amber-400 bg-amber-50/60 p-7">
+            <div class="flex items-center gap-3 mb-3">
+              <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-amber-500 text-white">
+                <Eye class="w-5 h-5" />
+              </div>
+              <h3 class="text-2xl font-bold text-slate-900">found out</h3>
+            </div>
+            <p class="text-sm font-mono text-amber-700 mb-3"><em>supe</em> — preterite</p>
+            <p class="text-slate-700 mb-3">
+              The <strong>moment</strong> of discovering. A single point in time when the knowledge entered your head.
+            </p>
+            <div class="bg-white rounded-lg p-3 border border-amber-200 text-sm space-y-1.5">
+              <p>"I <strong>found out</strong> she was leaving." (one moment — maybe yesterday)</p>
+              <p>"He <strong>found out</strong> the answer at 5pm."</p>
+              <p>"We <strong>found out</strong> about it on Monday."</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- The mental picture -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">The Mental Picture</h2>
+        <div class="bg-white rounded-2xl border-2 border-slate-200 p-7">
+          <p class="text-slate-700 leading-relaxed mb-4">
+            Picture a <strong>line</strong> stretching across time. Now picture a <strong>dot</strong> on that line.
+          </p>
+          <ul class="space-y-3 text-slate-700">
+            <li class="flex gap-3">
+              <span class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-emerald-500 text-white text-sm font-bold shrink-0">━</span>
+              <span><strong class="text-slate-900">The line is "knew."</strong> The knowledge was there the whole time. It has duration. It's a state.</span>
+            </li>
+            <li class="flex gap-3">
+              <span class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-amber-500 text-white text-sm font-bold shrink-0">●</span>
+              <span><strong class="text-slate-900">The dot is "found out."</strong> A specific moment when the knowledge entered. It's an event.</span>
+            </li>
+          </ul>
+          <p class="text-slate-700 leading-relaxed mt-4">
+            If you can put a <em>when</em> on it ("yesterday", "at 3pm", "this morning"), you almost always need <strong>found out</strong>.
+            If the knowledge has been sitting there for an indefinite period, you need <strong>knew</strong>.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 30-second drill -->
+  <section class="py-12 md:py-16 bg-white print:py-3 print:break-inside-avoid">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="text-center mb-8">
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-2">The 30-Second Drill</h2>
+          <p class="text-slate-600">Pick the right verb. Cover the right side. Don't think — feel.</p>
+        </div>
+
+        <div class="bg-emerald-50 rounded-2xl border-2 border-emerald-300 p-6 md:p-8 print:p-3 print:rounded-md">
+          <div class="space-y-4 print:space-y-2">
+            <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">"___ you ___ that he had quit?"</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>Did you know</strong> (state) <span class="text-slate-400">or</span> <strong>Did you find out</strong> (moment) — both work, depending on intent</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">"I ___ about the meeting at 4pm."</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>found out</strong> — "at 4pm" is a moment</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">"She ___ him for years before they dated."</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>knew</strong> — "for years" is a state</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">"How did you ___ that the company was sold?"</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>find out</strong> — "How" asks about the moment of discovery</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">"He ___ the answer the whole time."</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>knew</strong> — "the whole time" is duration</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-center">
+              <p class="text-slate-700">"We ___ about the layoffs yesterday."</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>found out</strong> — "yesterday" + new information = moment</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Common errors -->
+  <section class="py-12 md:py-16 bg-slate-50 print:bg-white print:py-3 print:break-inside-avoid">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">The Mexican Trap</h2>
+        <div class="space-y-4">
+          <div class="bg-white rounded-xl border-2 border-red-200 p-5">
+            <p class="flex items-start gap-2 text-slate-700">
+              <XCircle class="w-5 h-5 text-red-600 shrink-0 mt-0.5" />
+              <span>"I <strong>knew</strong> it yesterday."</span>
+            </p>
+            <p class="text-sm text-slate-500 mt-2 ml-7">"Yesterday" is a moment. You can't <em>know</em> something only on one day. You <strong>found out</strong>.</p>
+          </div>
+          <div class="bg-white rounded-xl border-2 border-red-200 p-5">
+            <p class="flex items-start gap-2 text-slate-700">
+              <XCircle class="w-5 h-5 text-red-600 shrink-0 mt-0.5" />
+              <span>"How did you <strong>know</strong> about it?"</span>
+            </p>
+            <p class="text-sm text-slate-500 mt-2 ml-7">Possible — but you're usually asking <em>how the discovery happened</em>. Native speakers say "How did you <strong>find out</strong> about it?"</p>
+          </div>
+          <div class="bg-white rounded-xl border-2 border-emerald-300 p-5">
+            <p class="flex items-start gap-2 text-slate-700">
+              <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+              <span><strong>Native ear test:</strong> if you can replace it with <em>realized</em> or <em>learned</em>, you want <strong>found out</strong>.</span>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="py-12 md:py-16 bg-emerald-950 text-white print:hidden">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-2xl md:text-3xl font-bold mb-3" style="font-family: 'Noto Sans KR', sans-serif;">Keep Going</h2>
+        <p class="text-emerald-100 mb-6">
+          The "knew vs. found out" pattern is one of three Spanish mirrors. The other two — <em>there was vs. has been</em> and <em>did vs. have done</em> — follow the same logic.
+        </p>
+        <div class="flex flex-wrap gap-3 justify-center">
+          <a
+            href="/en/course/past-tenses/there-was-vs-there-has-been/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold transition-colors"
+          >
+            Next: "There Was" vs "There Has Been"
+            <ArrowRight class="w-5 h-5" />
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <style is:global>
+    @media print {
+      header, footer, nav { display: none !important; }
+      body { background: white !important; color: black !important; }
+      a { text-decoration: none !important; color: #064e3b !important; }
+    }
+  </style>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    "name": "Knew vs Found Out in English",
+    "description": "Focused reference on the English equivalent of Spanish sabia vs supe: knew (state) vs found out (moment). Includes mental picture, 30-second drill, and Mexican-speaker traps.",
+    "learningResourceType": "Reference",
+    "educationalLevel": "Intermediate to Advanced",
+    "inLanguage": "en",
+    "isAccessibleForFree": true,
+    "url": "https://www.nyenglishteacher.com/en/course/past-tenses/knew-vs-found-out/",
+    "isPartOf": {
+      "@type": "Course",
+      "name": "Master English Past Tenses — Free Master Class",
+      "url": "https://www.nyenglishteacher.com/en/course/past-tenses/"
+    },
+    "author": {
+      "@type": "Person",
+      "name": "Robert Cushman",
+      "url": "https://www.nyenglishteacher.com/en/about/"
+    }
+  })} />
+</Base>

--- a/src/pages/en/course/past-tenses/story-openers.astro
+++ b/src/pages/en/course/past-tenses/story-openers.astro
@@ -1,0 +1,244 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import {
+  ArrowRight,
+  ArrowLeft,
+  Mic,
+  Coffee,
+  Briefcase,
+  GitBranch,
+  Printer,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/past-tenses/story-openers" as const;
+
+const groups = [
+  {
+    icon: "Coffee",
+    title: "Casual — coffee, lunch, after-work",
+    description: "When you're swapping stories with peers or telling something you saw on the way to work.",
+    color: "emerald",
+    openers: [
+      { en: "The other day…", note: "Recent but vague timing. Past Simple follows." },
+      { en: "I remember when…", note: "Signals a true story you're recalling." },
+      { en: "Funny story —", note: "Sets up something light or surprising." },
+      { en: "So get this…", note: "Energetic; warns the listener something good is coming." },
+      { en: "You know what's weird?", note: "Hooks with curiosity before the story lands." },
+      { en: "Speaking of [X]…", note: "Bridges from the current topic — natives use this constantly." },
+      { en: "That reminds me of the time…", note: "Triggered by something the other person said." },
+      { en: "Back when I was a kid…", note: "Long-ago casual. Past Simple + Past Continuous mix." },
+      { en: "There was this one time…", note: "The classic story opener. Singular, vivid, specific." },
+      { en: "Picture this:", note: "Cinematic. Forces the listener to visualize the scene." },
+    ],
+  },
+  {
+    icon: "Briefcase",
+    title: "Professional — meetings, interviews, presentations",
+    description: "When credibility matters. These signal experience without bragging.",
+    color: "amber",
+    openers: [
+      { en: "Back when I was at [Company]…", note: "Establishes context + tenure in one phrase." },
+      { en: "A few years ago, I…", note: "Slightly distancing — lets you tell a learning story." },
+      { en: "In my last role, we…", note: "Pivot from past job to current relevance." },
+      { en: "We had a situation where…", note: "Pre-loads the listener for a problem-solution arc." },
+      { en: "I'll never forget the time…", note: "Emotional weight — use for high-stakes stories." },
+      { en: "Let me give you some background:", note: "Buys you 60 seconds for context. Perfect for interviews." },
+      { en: "To put it in context, …", note: "Same as above but tighter, more executive." },
+      { en: "Earlier this year, we…", note: "Recent, professional, and still relevant." },
+      { en: "Walking into that meeting, I had no idea that…", note: "Past Continuous opener + Past Perfect twist." },
+      { en: "The lesson I learned the hard way was…", note: "Sets up a story whose payoff is wisdom." },
+    ],
+  },
+  {
+    icon: "GitBranch",
+    title: "Bridges — keeping the story moving",
+    description: "Use these mid-story to advance, twist, or land the point.",
+    color: "violet",
+    openers: [
+      { en: "Which brings me to…", note: "Connects the story to your current point." },
+      { en: "And that's how I ended up…", note: "Resolves into an unexpected outcome." },
+      { en: "Long story short, …", note: "Skips the middle. Use when time is short." },
+      { en: "What happened next was…", note: "Builds suspense; signals a turn." },
+      { en: "So I ended up …ing…", note: "Casual resolution — \"So I ended up calling her.\"" },
+      { en: "It turned out that…", note: "Reveals a twist or hidden information." },
+      { en: "Looking back, I realize…", note: "Reflective register — natural in C1+ speech." },
+      { en: "By the time we got there, …", note: "Past Perfect trigger — \"By the time we got there, she had left.\"" },
+      { en: "That was the moment when…", note: "Marks the pivotal event of the story." },
+      { en: "And the punchline is…", note: "Native idiom for setting up the payoff." },
+    ],
+  },
+];
+
+const colorClasses = {
+  emerald: { ring: "border-emerald-300", icon: "bg-emerald-500", chip: "text-emerald-700" },
+  amber: { ring: "border-amber-300", icon: "bg-amber-500", chip: "text-amber-700" },
+  violet: { ring: "border-violet-300", icon: "bg-violet-500", chip: "text-violet-700" },
+};
+
+const iconMap: Record<string, any> = { Coffee, Briefcase, GitBranch };
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="30 English Story Openers Native Speakers Actually Use | NY English Teacher"
+  description="Thirty ready-made launchpads for telling stories in English — casual, professional, and bridges. The phrases native speakers actually reach for."
+>
+  <!-- Hero -->
+  <section class="bg-gradient-to-b from-slate-900 to-emerald-950 pt-28 pb-12 md:pt-32 md:pb-16 print:hidden">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-emerald-400 text-sm font-semibold mb-3">
+          <Mic class="w-4 h-4" />
+          Bonus 4 · Master Class Reference
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          30 Story Openers in English
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed mb-6">
+          Mexican professionals freeze at the start of a story — not the middle. The opening line is the hardest.
+          Memorize three from this list and you have a launchpad for every situation.
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <button
+            onclick="window.print()"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold text-sm transition-colors"
+          >
+            <Printer class="w-4 h-4" />
+            Print this page
+          </button>
+          <a
+            href="/en/course/past-tenses/"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            <ArrowLeft class="w-4 h-4" />
+            Back to the master class
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Print header -->
+  <div class="hidden print:block py-4 border-b-2 border-slate-300">
+    <h1 class="text-2xl font-bold text-slate-900">30 English Story Openers — Native-Speaker Reference</h1>
+    <p class="text-sm text-slate-600">nyenglishteacher.com — free for Mexican professionals</p>
+  </div>
+
+  <!-- Groups -->
+  <section class="py-12 md:py-16 bg-white print:py-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto space-y-10 print:space-y-4">
+        {groups.map((g) => {
+          const Icon = iconMap[g.icon];
+          const c = colorClasses[g.color as keyof typeof colorClasses];
+          return (
+            <div class="print:break-inside-avoid">
+              <div class="flex items-center gap-3 mb-4 print:mb-2">
+                <div class:list={["flex items-center justify-center w-10 h-10 rounded-lg text-white shrink-0", c.icon]}>
+                  {Icon && <Icon class="w-5 h-5" />}
+                </div>
+                <div>
+                  <h2 class="text-xl md:text-2xl font-bold text-slate-900 print:text-base">{g.title}</h2>
+                  <p class="text-sm text-slate-500 print:hidden">{g.description}</p>
+                </div>
+              </div>
+
+              <div class:list={["rounded-2xl border-2 bg-white p-6 print:p-2 print:rounded-md", c.ring]}>
+                <ol class="space-y-3 print:space-y-1">
+                  {g.openers.map((o, i) => (
+                    <li class="flex gap-3 pb-3 last:pb-0 last:border-0 border-b border-slate-100 print:pb-1">
+                      <span class:list={["font-mono text-xs font-bold shrink-0 w-6 text-right", c.chip]}>{i + 1}.</span>
+                      <div class="flex-1">
+                        <p class="font-semibold text-slate-900 text-base print:text-sm">"{o.en}"</p>
+                        <p class="text-xs text-slate-500 mt-0.5 print:hidden">{o.note}</p>
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <!-- How to drill -->
+  <section class="py-12 md:py-16 bg-slate-50 print:hidden">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">How to Drill This</h2>
+        <ol class="space-y-4 text-slate-700">
+          <li class="flex gap-4">
+            <span class="flex items-center justify-center w-8 h-8 rounded-full bg-emerald-500 text-white text-sm font-bold shrink-0">1</span>
+            <p><strong>Pick three.</strong> One casual, one professional, one bridge. Don't try to memorize all thirty.</p>
+          </li>
+          <li class="flex gap-4">
+            <span class="flex items-center justify-center w-8 h-8 rounded-full bg-emerald-500 text-white text-sm font-bold shrink-0">2</span>
+            <p><strong>Tell the same story three times</strong> — once with each opener. Notice how the opener changes the tone, the tense pattern, the listener's expectation.</p>
+          </li>
+          <li class="flex gap-4">
+            <span class="flex items-center justify-center w-8 h-8 rounded-full bg-emerald-500 text-white text-sm font-bold shrink-0">3</span>
+            <p><strong>Use one in real conversation this week.</strong> Don't wait for the perfect moment. Force one in. The fluency comes from <em>using</em>, not <em>knowing</em>.</p>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="py-12 md:py-16 bg-emerald-950 text-white print:hidden">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-2xl md:text-3xl font-bold mb-3" style="font-family: 'Noto Sans KR', sans-serif;">One Bonus Left</h2>
+        <p class="text-emerald-100 mb-6">
+          You've got the openers. Now the closing trap: <em>there was</em> vs <em>there has been</em> — the difference that decides whether your story sounds <em>finished</em> or <em>still mine to fix</em>.
+        </p>
+        <a
+          href="/en/course/past-tenses/there-was-vs-there-has-been/"
+          class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold transition-colors"
+        >
+          "There Was" vs "There Has Been"
+          <ArrowRight class="w-5 h-5" />
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <style is:global>
+    @media print {
+      header, footer, nav { display: none !important; }
+      body { background: white !important; color: black !important; }
+      a { text-decoration: none !important; color: #064e3b !important; }
+    }
+  </style>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    "name": "30 English Story Openers Native Speakers Actually Use",
+    "description": "Thirty ready-made launchpads for telling stories in English, grouped by register: casual, professional, and bridges. The exact phrases native speakers reach for, with notes on tense patterns.",
+    "learningResourceType": "Reference",
+    "educationalLevel": "Intermediate to Advanced",
+    "inLanguage": "en",
+    "isAccessibleForFree": true,
+    "url": "https://www.nyenglishteacher.com/en/course/past-tenses/story-openers/",
+    "isPartOf": {
+      "@type": "Course",
+      "name": "Master English Past Tenses — Free Master Class",
+      "url": "https://www.nyenglishteacher.com/en/course/past-tenses/"
+    },
+    "author": {
+      "@type": "Person",
+      "name": "Robert Cushman",
+      "url": "https://www.nyenglishteacher.com/en/about/"
+    }
+  })} />
+</Base>

--- a/src/pages/en/course/past-tenses/there-was-vs-there-has-been.astro
+++ b/src/pages/en/course/past-tenses/there-was-vs-there-has-been.astro
@@ -1,0 +1,266 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import {
+  ArrowRight,
+  ArrowLeft,
+  MessageSquare,
+  CheckCircle2,
+  XCircle,
+  Lock,
+  Link as LinkIcon,
+  Printer,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/past-tenses/there-was-vs-there-has-been" as const;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="&quot;There Was&quot; vs &quot;There Has Been&quot; in English | NY English Teacher"
+  description="The English equivalent of Spanish hubo vs ha habido. Why one closes the story and the other keeps it open — and how to feel the difference instantly."
+>
+  <!-- Hero -->
+  <section class="bg-gradient-to-b from-slate-900 to-emerald-950 pt-28 pb-12 md:pt-32 md:pb-16 print:hidden">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-emerald-400 text-sm font-semibold mb-3">
+          <MessageSquare class="w-4 h-4" />
+          Bonus 5 · The Closing Trap
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          "There Was" vs "There Has Been"
+        </h1>
+        <p class="text-2xl text-emerald-300 italic font-light mb-4">The English equivalent of <em>hubo</em> vs <em>ha habido</em>.</p>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed mb-6">
+          One closes the story. The other keeps it open. In a status update, in a meeting, in a Slack reply — choosing wrong
+          sends a different message than you intended.
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <button
+            onclick="window.print()"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold text-sm transition-colors"
+          >
+            <Printer class="w-4 h-4" />
+            Print this page
+          </button>
+          <a
+            href="/en/course/past-tenses/"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            <ArrowLeft class="w-4 h-4" />
+            Back to the master class
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- The split -->
+  <section class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="text-center mb-10">
+          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-3">Closed Story vs. Open Story</h2>
+          <p class="text-lg text-slate-600 max-w-2xl mx-auto">
+            Same situation. Different relationship to <em>now</em>. The verb you choose tells your listener whether the matter is done or still on your plate.
+          </p>
+        </div>
+
+        <div class="grid md:grid-cols-2 gap-6">
+          <div class="rounded-2xl border-2 border-emerald-300 bg-emerald-50/60 p-7">
+            <div class="flex items-center gap-3 mb-3">
+              <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-emerald-500 text-white">
+                <Lock class="w-5 h-5" />
+              </div>
+              <h3 class="text-2xl font-bold text-slate-900">there was</h3>
+            </div>
+            <p class="text-sm font-mono text-emerald-700 mb-3"><em>hubo</em> — Past Simple</p>
+            <p class="text-slate-700 mb-3">
+              The situation existed in <strong>closed past time</strong>. It's done. It's filed. It's a fact you're reporting from a sealed past.
+            </p>
+            <div class="bg-white rounded-lg p-3 border border-emerald-200 text-sm space-y-1.5">
+              <p>"<strong>There was</strong> a fire in 2018."</p>
+              <p>"<strong>There was</strong> an issue last week — we fixed it."</p>
+              <p>"<strong>There was</strong> a problem during the demo." (the demo is over)</p>
+            </div>
+          </div>
+
+          <div class="rounded-2xl border-2 border-amber-400 bg-amber-50/60 p-7">
+            <div class="flex items-center gap-3 mb-3">
+              <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-amber-500 text-white">
+                <LinkIcon class="w-5 h-5" />
+              </div>
+              <h3 class="text-2xl font-bold text-slate-900">there has been</h3>
+            </div>
+            <p class="text-sm font-mono text-amber-700 mb-3"><em>ha habido</em> — Present Perfect</p>
+            <p class="text-slate-700 mb-3">
+              The situation is <strong>still relevant</strong>. It started in the past and the consequence is still here, still mine to deal with.
+            </p>
+            <div class="bg-white rounded-lg p-3 border border-amber-200 text-sm space-y-1.5">
+              <p>"<strong>There has been</strong> a problem this morning." (still today, still happening)</p>
+              <p>"<strong>There have been</strong> delays — we're working on it." (currently)</p>
+              <p>"<strong>There has been</strong> an update since we last spoke."</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- The business impact -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3 text-center">Why This Matters in Business English</h2>
+        <p class="text-slate-600 mb-8 text-center">The same news lands two completely different ways depending on which one you pick.</p>
+
+        <div class="space-y-4">
+          <div class="bg-white rounded-2xl border-2 border-slate-200 p-6">
+            <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-2">Closed — "Don't worry about it"</p>
+            <p class="text-slate-800 text-lg italic">"There was an issue with the deployment last night."</p>
+            <p class="text-sm text-slate-500 mt-2">→ The listener hears: "I'm reporting history. It's fixed. Moving on."</p>
+          </div>
+          <div class="bg-white rounded-2xl border-2 border-amber-300 p-6">
+            <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">Open — "I need your attention"</p>
+            <p class="text-slate-800 text-lg italic">"There has been an issue with the deployment."</p>
+            <p class="text-sm text-slate-500 mt-2">→ The listener hears: "This is still happening. Drop what you're doing."</p>
+          </div>
+        </div>
+
+        <p class="text-center text-slate-600 mt-8 text-sm italic">
+          A Mexican speaker who defaults to "there was" for everything sounds like they're <em>always reporting closed events</em> — even when the problem is on fire right now.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Drill -->
+  <section class="py-12 md:py-16 bg-white print:py-3 print:break-inside-avoid">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="text-center mb-8">
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-2">The Choose-It Drill</h2>
+          <p class="text-slate-600">Read the situation. Pick "there was" or "there has been."</p>
+        </div>
+
+        <div class="bg-emerald-50 rounded-2xl border-2 border-emerald-300 p-6 md:p-8 print:p-3 print:rounded-md">
+          <div class="space-y-4 print:space-y-2">
+            <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">A fire happened in 2018. Now it's 2026.</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> a fire — closed time.</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">Three Slack messages came in this morning. It's still morning.</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There have been</strong> three messages — period still open.</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">You're explaining a closed Q1 result to the board in Q3.</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> a 12% dip in Q1 — Q1 is sealed.</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">Customer complaints have been arriving all week. It's Thursday.</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There have been</strong> complaints this week — the week isn't over.</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-start">
+              <p class="text-slate-700">Server outage happened yesterday. Already resolved.</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> an outage yesterday — fixed, closed.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Quick test -->
+  <section class="py-12 md:py-16 bg-slate-50 print:bg-white print:py-3 print:break-inside-avoid">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">The Two-Second Test</h2>
+        <div class="bg-white rounded-2xl border-2 border-emerald-300 p-7">
+          <p class="text-slate-700 leading-relaxed mb-4">
+            Ask yourself: <strong>"Is this period of time still going?"</strong>
+          </p>
+          <ul class="space-y-3 text-slate-700">
+            <li class="flex gap-3">
+              <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+              <span>If yes (this week, today, this year, since Monday) → <strong>there has been</strong></span>
+            </li>
+            <li class="flex gap-3">
+              <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+              <span>If no (yesterday, last week, in 2019, at 3pm yesterday) → <strong>there was</strong></span>
+            </li>
+            <li class="flex gap-3">
+              <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+              <span>If the consequence is still on your plate <em>regardless</em> of when it started → <strong>there has been</strong></span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="py-12 md:py-16 bg-emerald-950 text-white print:hidden">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-2xl md:text-3xl font-bold mb-3" style="font-family: 'Noto Sans KR', sans-serif;">You've Completed the Master Class</h2>
+        <p class="text-emerald-100 mb-6">
+          5 lessons. 5 bonuses. The 4-tense method. You have everything the Mexican professional needs to stop freezing on past tense — in a real meeting, in real time.
+        </p>
+        <div class="flex flex-wrap gap-3 justify-center">
+          <a
+            href="/en/course/past-tenses/cheat-sheet/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold transition-colors"
+          >
+            Save the cheat sheet
+            <ArrowRight class="w-5 h-5" />
+          </a>
+          <a
+            href="/en/services/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-white/10 hover:bg-white/20 text-white font-semibold transition-colors"
+          >
+            Work 1-on-1 with Robert
+            <ArrowRight class="w-5 h-5" />
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <style is:global>
+    @media print {
+      header, footer, nav { display: none !important; }
+      body { background: white !important; color: black !important; }
+      a { text-decoration: none !important; color: #064e3b !important; }
+    }
+  </style>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    "name": "There Was vs There Has Been in English",
+    "description": "Focused reference on the English equivalent of Spanish hubo vs ha habido. Why one closes the story and the other keeps it open — with business-context examples and a two-second decision test.",
+    "learningResourceType": "Reference",
+    "educationalLevel": "Intermediate to Advanced",
+    "inLanguage": "en",
+    "isAccessibleForFree": true,
+    "url": "https://www.nyenglishteacher.com/en/course/past-tenses/there-was-vs-there-has-been/",
+    "isPartOf": {
+      "@type": "Course",
+      "name": "Master English Past Tenses — Free Master Class",
+      "url": "https://www.nyenglishteacher.com/en/course/past-tenses/"
+    },
+    "author": {
+      "@type": "Person",
+      "name": "Robert Cushman",
+      "url": "https://www.nyenglishteacher.com/en/about/"
+    }
+  })} />
+</Base>

--- a/src/pages/en/course/past-tenses/top-10-confused-pairs.astro
+++ b/src/pages/en/course/past-tenses/top-10-confused-pairs.astro
@@ -1,0 +1,251 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import {
+  ArrowRight,
+  ArrowLeft,
+  AlertCircle,
+  CheckCircle2,
+  XCircle,
+  Printer,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/past-tenses/top-10-confused-pairs" as const;
+
+const pairs = [
+  {
+    n: 1,
+    a: "say",
+    b: "tell",
+    spanish: "Both come from <em>decir</em> in Spanish.",
+    rule: "<strong>Say</strong> the words. <strong>Tell</strong> a person.",
+    good: "She <strong>told me</strong> the news. / She <strong>said</strong> the news was bad.",
+    trap: "\"She told that…\" — wrong. You tell <em>someone</em>. \"She told <strong>me</strong> that…\"",
+  },
+  {
+    n: 2,
+    a: "do",
+    b: "make",
+    spanish: "Both come from <em>hacer</em>.",
+    rule: "<strong>Do</strong> a task or activity. <strong>Make</strong> a thing or a result.",
+    good: "I <strong>did</strong> the report. / I <strong>made</strong> a decision.",
+    trap: "\"I made the homework\" — wrong. Homework is an activity → <strong>did</strong> the homework.",
+  },
+  {
+    n: 3,
+    a: "lay",
+    b: "lie",
+    spanish: "Both feel like <em>acostar(se)</em>.",
+    rule: "<strong>Lay</strong> takes an object. <strong>Lie</strong> doesn't.",
+    good: "I <strong>laid</strong> the report on his desk. / I <strong>lay</strong> on the sofa for an hour.",
+    trap: "Past of <em>lie</em> is <em>lay</em>. Past of <em>lay</em> is <em>laid</em>. \"I <strong>lay</strong> down yesterday\" = past of <em>lie</em>, no object.",
+  },
+  {
+    n: 4,
+    a: "rise",
+    b: "raise",
+    spanish: "<em>Subir / levantar(se)</em> overlap.",
+    rule: "<strong>Rise</strong> goes up by itself. <strong>Raise</strong> takes an object.",
+    good: "Prices <strong>rose</strong> last quarter. / The CEO <strong>raised</strong> prices last quarter.",
+    trap: "\"They raised\" without an object = wrong. Use <em>rose</em>.",
+  },
+  {
+    n: 5,
+    a: "win",
+    b: "beat",
+    spanish: "Both feel like <em>ganar</em>.",
+    rule: "<strong>Win</strong> a thing (a game, a prize, an argument). <strong>Beat</strong> a person or team.",
+    good: "We <strong>won</strong> the contract. / We <strong>beat</strong> their team.",
+    trap: "\"We won them\" — wrong. \"We <strong>beat</strong> them\" or \"we won <strong>against</strong> them.\"",
+  },
+  {
+    n: 6,
+    a: "borrow",
+    b: "lend",
+    spanish: "<em>Prestar</em> goes both directions in Spanish.",
+    rule: "<strong>Borrow</strong> = take from someone. <strong>Lend</strong> = give to someone.",
+    good: "Can I <strong>borrow</strong> your charger? / Can you <strong>lend</strong> me your charger?",
+    trap: "\"Can you borrow me…\" — wrong. You'd be taking from yourself.",
+  },
+  {
+    n: 7,
+    a: "bring",
+    b: "take",
+    spanish: "<em>Traer / llevar</em> — but the English perspective flips.",
+    rule: "<strong>Bring</strong> toward the speaker. <strong>Take</strong> away from the speaker.",
+    good: "<strong>Bring</strong> the report <em>here</em>. / <strong>Take</strong> the report <em>there</em>.",
+    trap: "\"I'll bring it to the meeting\" (you're <em>going to</em> the meeting) — usually <em>take</em>. Use <em>bring</em> only if the listener is <em>at</em> the meeting.",
+  },
+  {
+    n: 8,
+    a: "remember",
+    b: "remind",
+    spanish: "Both can land as <em>recordar</em>.",
+    rule: "<strong>Remember</strong> = recall on your own. <strong>Remind</strong> = make someone else recall.",
+    good: "I <strong>remember</strong> the meeting. / Can you <strong>remind</strong> me about the meeting?",
+    trap: "\"Remember me to call her\" — wrong. \"<strong>Remind</strong> me to call her.\"",
+  },
+  {
+    n: 9,
+    a: "miss",
+    b: "lose",
+    spanish: "<em>Perder</em> covers both in Spanish.",
+    rule: "<strong>Miss</strong> a deadline, a flight, a chance. <strong>Lose</strong> a thing or a competition.",
+    good: "I <strong>missed</strong> the flight. / I <strong>lost</strong> my keys.",
+    trap: "\"I lost the bus\" — wrong. You <strong>missed</strong> the bus. You only <em>lose</em> things you possess.",
+  },
+  {
+    n: 10,
+    a: "listen",
+    b: "hear",
+    spanish: "<em>Escuchar / oír</em> — but distribution differs.",
+    rule: "<strong>Listen</strong> is active (intention). <strong>Hear</strong> is passive (just the sound).",
+    good: "I <strong>listened</strong> to the call carefully. / I <strong>heard</strong> a noise outside.",
+    trap: "\"I'm hearing music\" — usually wrong. If you put it on intentionally, you're <strong>listening to</strong> music.",
+  },
+];
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Top 10 Most Confused English Verb Pairs | NY English Teacher"
+  description="The ten verb pairs that trip up intermediate Mexican speakers most — say/tell, do/make, lay/lie, rise/raise, and six others. Each pair: rule, trap, example."
+>
+  <!-- Hero -->
+  <section class="bg-gradient-to-b from-slate-900 to-emerald-950 pt-28 pb-12 md:pt-32 md:pb-16 print:hidden">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-emerald-400 text-sm font-semibold mb-3">
+          <AlertCircle class="w-4 h-4" />
+          Bonus 2 · Master Class Reference
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Top 10 Most Confused Verb Pairs
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed mb-6">
+          One Spanish verb often splits into two English verbs. These ten pairs cause more mistakes
+          than any other source for intermediate Mexican speakers. Memorize the trap, not the rule.
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <button
+            onclick="window.print()"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold text-sm transition-colors"
+          >
+            <Printer class="w-4 h-4" />
+            Print this page
+          </button>
+          <a
+            href="/en/course/past-tenses/"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            <ArrowLeft class="w-4 h-4" />
+            Back to the master class
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Print header -->
+  <div class="hidden print:block py-4 border-b-2 border-slate-300">
+    <h1 class="text-2xl font-bold text-slate-900">Top 10 Confused English Verb Pairs</h1>
+    <p class="text-sm text-slate-600">nyenglishteacher.com — free for Mexican professionals</p>
+  </div>
+
+  <!-- The 10 pairs -->
+  <section class="py-12 md:py-16 bg-white print:py-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-5xl mx-auto">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-5 print:gap-2">
+          {pairs.map((p) => (
+            <div class="rounded-2xl border-2 border-emerald-300 bg-white p-5 print:p-3 print:rounded-md print:break-inside-avoid">
+              <div class="flex items-baseline gap-2 mb-2">
+                <span class="text-xs font-bold uppercase tracking-wider text-emerald-700">#{p.n}</span>
+                <h3 class="text-xl font-bold text-slate-900 print:text-base">
+                  <span class="text-emerald-700">{p.a}</span> <span class="text-slate-400 font-normal">vs.</span> <span class="text-emerald-700">{p.b}</span>
+                </h3>
+              </div>
+              <p class="text-xs text-slate-500 italic mb-3 print:text-xs" set:html={p.spanish} />
+              <div class="space-y-2.5 text-sm text-slate-700 print:text-xs">
+                <p set:html={`<strong class="text-slate-900">Rule:</strong> ${p.rule}`} />
+                <div class="bg-emerald-50 rounded p-2.5 border border-emerald-200 flex gap-2">
+                  <CheckCircle2 class="w-4 h-4 text-emerald-600 shrink-0 mt-0.5" />
+                  <p set:html={p.good} />
+                </div>
+                <div class="bg-red-50 rounded p-2.5 border border-red-200 flex gap-2">
+                  <XCircle class="w-4 h-4 text-red-600 shrink-0 mt-0.5" />
+                  <p class="text-slate-700" set:html={`<strong class="text-red-700">Trap:</strong> ${p.trap}`} />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="py-12 md:py-16 bg-emerald-950 text-white print:hidden">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-2xl md:text-3xl font-bold mb-3" style="font-family: 'Noto Sans KR', sans-serif;">Next: The Tense Traps</h2>
+        <p class="text-emerald-100 mb-6 max-w-2xl mx-auto">
+          Wrong verb is one mistake. Wrong tense is another. The two bonus pairs below drill the exact
+          tense choices that decide whether you sound fluent or like you're translating.
+        </p>
+        <div class="flex flex-wrap gap-3 justify-center">
+          <a
+            href="/en/course/past-tenses/knew-vs-found-out/"
+            class="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-white/10 hover:bg-white/20 text-white font-semibold transition-colors"
+          >
+            "Knew" vs "Found Out"
+            <ArrowRight class="w-4 h-4" />
+          </a>
+          <a
+            href="/en/course/past-tenses/there-was-vs-there-has-been/"
+            class="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-white/10 hover:bg-white/20 text-white font-semibold transition-colors"
+          >
+            "There Was" vs "There Has Been"
+            <ArrowRight class="w-4 h-4" />
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <style is:global>
+    @media print {
+      header, footer, nav { display: none !important; }
+      body { background: white !important; color: black !important; }
+      a { text-decoration: none !important; color: #064e3b !important; }
+    }
+  </style>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    "name": "Top 10 Most Confused English Verb Pairs",
+    "description": "Compact reference covering the ten English verb pairs that trip up intermediate Spanish speakers most: say/tell, do/make, lay/lie, rise/raise, win/beat, borrow/lend, bring/take, remember/remind, miss/lose, listen/hear.",
+    "learningResourceType": "Reference",
+    "educationalLevel": "Intermediate to Advanced",
+    "inLanguage": "en",
+    "isAccessibleForFree": true,
+    "url": "https://www.nyenglishteacher.com/en/course/past-tenses/top-10-confused-pairs/",
+    "isPartOf": {
+      "@type": "Course",
+      "name": "Master English Past Tenses — Free Master Class",
+      "url": "https://www.nyenglishteacher.com/en/course/past-tenses/"
+    },
+    "author": {
+      "@type": "Person",
+      "name": "Robert Cushman",
+      "url": "https://www.nyenglishteacher.com/en/about/"
+    }
+  })} />
+</Base>

--- a/src/pages/es/curso/tiempos-del-pasado/frases-iniciales.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/frases-iniciales.astro
@@ -1,0 +1,244 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import {
+  ArrowRight,
+  ArrowLeft,
+  Mic,
+  Coffee,
+  Briefcase,
+  GitBranch,
+  Printer,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/past-tenses/story-openers" as const;
+
+const groups = [
+  {
+    icon: "Coffee",
+    title: "Casual — café, comida, after-work",
+    description: "Cuando intercambias historias con compañeros o cuentas algo que viste en el camino al trabajo.",
+    color: "emerald",
+    openers: [
+      { en: "The other day…", note: "Tiempo reciente pero vago. Sigue Past Simple." },
+      { en: "I remember when…", note: "Señala una historia real que estás recordando." },
+      { en: "Funny story —", note: "Prepara algo ligero o sorprendente." },
+      { en: "So get this…", note: "Enérgico; avisa al que escucha que viene algo bueno." },
+      { en: "You know what's weird?", note: "Engancha con curiosidad antes de soltar la historia." },
+      { en: "Speaking of [X]…", note: "Puente desde el tema actual — los nativos lo usan constantemente." },
+      { en: "That reminds me of the time…", note: "Disparado por algo que dijo la otra persona." },
+      { en: "Back when I was a kid…", note: "Casual de hace mucho. Mezcla Past Simple + Past Continuous." },
+      { en: "There was this one time…", note: "El abridor clásico de historias. Singular, vívido, específico." },
+      { en: "Picture this:", note: "Cinematográfico. Obliga a quien escucha a visualizar la escena." },
+    ],
+  },
+  {
+    icon: "Briefcase",
+    title: "Profesional — juntas, entrevistas, presentaciones",
+    description: "Cuando importa la credibilidad. Señalan experiencia sin presumir.",
+    color: "amber",
+    openers: [
+      { en: "Back when I was at [Company]…", note: "Establece contexto + antigüedad en una frase." },
+      { en: "A few years ago, I…", note: "Distancia ligeramente — te permite contar una historia de aprendizaje." },
+      { en: "In my last role, we…", note: "Pivote del trabajo pasado a la relevancia actual." },
+      { en: "We had a situation where…", note: "Prepara a quien escucha para un arco problema-solución." },
+      { en: "I'll never forget the time…", note: "Peso emocional — úsalo para historias de alto impacto." },
+      { en: "Let me give you some background:", note: "Te compra 60 segundos para contexto. Ideal para entrevistas." },
+      { en: "To put it in context, …", note: "Lo mismo pero más conciso y ejecutivo." },
+      { en: "Earlier this year, we…", note: "Reciente, profesional y todavía relevante." },
+      { en: "Walking into that meeting, I had no idea that…", note: "Past Continuous + giro con Past Perfect." },
+      { en: "The lesson I learned the hard way was…", note: "Prepara una historia cuya recompensa es sabiduría." },
+    ],
+  },
+  {
+    icon: "GitBranch",
+    title: "Puentes — para que la historia avance",
+    description: "Úsalos a mitad de la historia para avanzar, dar giros, o aterrizar el punto.",
+    color: "violet",
+    openers: [
+      { en: "Which brings me to…", note: "Conecta la historia con tu punto actual." },
+      { en: "And that's how I ended up…", note: "Resuelve en un resultado inesperado." },
+      { en: "Long story short, …", note: "Salta el medio. Úsalo cuando hay poco tiempo." },
+      { en: "What happened next was…", note: "Construye suspenso; señala un giro." },
+      { en: "So I ended up …ing…", note: "Resolución casual — \"So I ended up calling her.\"" },
+      { en: "It turned out that…", note: "Revela un giro o información oculta." },
+      { en: "Looking back, I realize…", note: "Registro reflexivo — natural en C1+." },
+      { en: "By the time we got there, …", note: "Disparador de Past Perfect — \"By the time we got there, she had left.\"" },
+      { en: "That was the moment when…", note: "Marca el evento pivote de la historia." },
+      { en: "And the punchline is…", note: "Modismo nativo para preparar el remate." },
+    ],
+  },
+];
+
+const colorClasses = {
+  emerald: { ring: "border-emerald-300", icon: "bg-emerald-500", chip: "text-emerald-700" },
+  amber: { ring: "border-amber-300", icon: "bg-amber-500", chip: "text-amber-700" },
+  violet: { ring: "border-violet-300", icon: "bg-violet-500", chip: "text-violet-700" },
+};
+
+const iconMap: Record<string, any> = { Coffee, Briefcase, GitBranch };
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="30 Frases para Empezar una Historia en Inglés | NY English Teacher"
+  description="Treinta lanzaderas para contar historias en inglés — casuales, profesionales y puentes. Las frases exactas que usan los nativos, no rellenos."
+>
+  <!-- Hero -->
+  <section class="bg-gradient-to-b from-slate-900 to-emerald-950 pt-28 pb-12 md:pt-32 md:pb-16 print:hidden">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-emerald-400 text-sm font-semibold mb-3">
+          <Mic class="w-4 h-4" />
+          Bono 4 · Referencia de la Clase Magistral
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          30 Frases para Empezar una Historia en Inglés
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed mb-6">
+          Los profesionales mexicanos se congelan al empezar una historia — no a mitad. La frase de apertura es la más difícil.
+          Memoriza tres de esta lista y tienes una lanzadera para cada situación.
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <button
+            onclick="window.print()"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold text-sm transition-colors"
+          >
+            <Printer class="w-4 h-4" />
+            Imprimir esta página
+          </button>
+          <a
+            href="/es/curso/tiempos-del-pasado/"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            <ArrowLeft class="w-4 h-4" />
+            Volver a la clase magistral
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Print header -->
+  <div class="hidden print:block py-4 border-b-2 border-slate-300">
+    <h1 class="text-2xl font-bold text-slate-900">30 Frases para Empezar una Historia en Inglés — Referencia Nativa</h1>
+    <p class="text-sm text-slate-600">nyenglishteacher.com — gratis para profesionales mexicanos</p>
+  </div>
+
+  <!-- Groups -->
+  <section class="py-12 md:py-16 bg-white print:py-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto space-y-10 print:space-y-4">
+        {groups.map((g) => {
+          const Icon = iconMap[g.icon];
+          const c = colorClasses[g.color as keyof typeof colorClasses];
+          return (
+            <div class="print:break-inside-avoid">
+              <div class="flex items-center gap-3 mb-4 print:mb-2">
+                <div class:list={["flex items-center justify-center w-10 h-10 rounded-lg text-white shrink-0", c.icon]}>
+                  {Icon && <Icon class="w-5 h-5" />}
+                </div>
+                <div>
+                  <h2 class="text-xl md:text-2xl font-bold text-slate-900 print:text-base">{g.title}</h2>
+                  <p class="text-sm text-slate-500 print:hidden">{g.description}</p>
+                </div>
+              </div>
+
+              <div class:list={["rounded-2xl border-2 bg-white p-6 print:p-2 print:rounded-md", c.ring]}>
+                <ol class="space-y-3 print:space-y-1">
+                  {g.openers.map((o, i) => (
+                    <li class="flex gap-3 pb-3 last:pb-0 last:border-0 border-b border-slate-100 print:pb-1">
+                      <span class:list={["font-mono text-xs font-bold shrink-0 w-6 text-right", c.chip]}>{i + 1}.</span>
+                      <div class="flex-1">
+                        <p class="font-semibold text-slate-900 text-base print:text-sm">"{o.en}"</p>
+                        <p class="text-xs text-slate-500 mt-0.5 print:hidden">{o.note}</p>
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <!-- How to drill -->
+  <section class="py-12 md:py-16 bg-slate-50 print:hidden">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">Cómo Practicarlo</h2>
+        <ol class="space-y-4 text-slate-700">
+          <li class="flex gap-4">
+            <span class="flex items-center justify-center w-8 h-8 rounded-full bg-emerald-500 text-white text-sm font-bold shrink-0">1</span>
+            <p><strong>Elige tres.</strong> Una casual, una profesional, una puente. No intentes memorizar las treinta.</p>
+          </li>
+          <li class="flex gap-4">
+            <span class="flex items-center justify-center w-8 h-8 rounded-full bg-emerald-500 text-white text-sm font-bold shrink-0">2</span>
+            <p><strong>Cuenta la misma historia tres veces</strong> — una con cada abridor. Nota cómo el abridor cambia el tono, el patrón de tiempos, y la expectativa de quien escucha.</p>
+          </li>
+          <li class="flex gap-4">
+            <span class="flex items-center justify-center w-8 h-8 rounded-full bg-emerald-500 text-white text-sm font-bold shrink-0">3</span>
+            <p><strong>Usa una en conversación real esta semana.</strong> No esperes el momento perfecto. Fuerza uno. La fluidez viene de <em>usar</em>, no de <em>saber</em>.</p>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="py-12 md:py-16 bg-emerald-950 text-white print:hidden">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-2xl md:text-3xl font-bold mb-3" style="font-family: 'Noto Sans KR', sans-serif;">Queda Un Bono</h2>
+        <p class="text-emerald-100 mb-6">
+          Ya tienes los abridores. Ahora la trampa del cierre: <em>there was</em> vs <em>there has been</em> — la diferencia que decide si tu historia suena <em>terminada</em> o <em>todavía me toca resolverla</em>.
+        </p>
+        <a
+          href="/es/curso/tiempos-del-pasado/there-was-vs-there-has-been/"
+          class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold transition-colors"
+        >
+          "There Was" vs "There Has Been"
+          <ArrowRight class="w-5 h-5" />
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <style is:global>
+    @media print {
+      header, footer, nav { display: none !important; }
+      body { background: white !important; color: black !important; }
+      a { text-decoration: none !important; color: #064e3b !important; }
+    }
+  </style>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    "name": "30 Frases Iniciales en Ingles que Usan los Nativos",
+    "description": "Treinta lanzaderas para contar historias en ingles, agrupadas por registro: casual, profesional y puentes. Las frases exactas que usan los nativos, con notas sobre patrones de tiempo verbal.",
+    "learningResourceType": "Reference",
+    "educationalLevel": "Intermedio a Avanzado",
+    "inLanguage": "es",
+    "isAccessibleForFree": true,
+    "url": "https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/frases-iniciales/",
+    "isPartOf": {
+      "@type": "Course",
+      "name": "Domina los Tiempos del Pasado en Ingles — Clase Magistral Gratis",
+      "url": "https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/"
+    },
+    "author": {
+      "@type": "Person",
+      "name": "Robert Cushman",
+      "url": "https://www.nyenglishteacher.com/es/about/"
+    }
+  })} />
+</Base>

--- a/src/pages/es/curso/tiempos-del-pasado/knew-vs-found-out.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/knew-vs-found-out.astro
@@ -1,0 +1,267 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import {
+  ArrowRight,
+  ArrowLeft,
+  Lightbulb,
+  CheckCircle2,
+  XCircle,
+  Eye,
+  Brain,
+  Printer,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/past-tenses/knew-vs-found-out" as const;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="&quot;Knew&quot; vs &quot;Found Out&quot; en Inglés | NY English Teacher"
+  description="El equivalente en inglés de sabía vs supe. Por qué uno es un estado y el otro un momento — y el drill que lo arregla en 30 segundos."
+>
+  <!-- Hero -->
+  <section class="bg-gradient-to-b from-slate-900 to-emerald-950 pt-28 pb-12 md:pt-32 md:pb-16 print:hidden">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-emerald-400 text-sm font-semibold mb-3">
+          <Lightbulb class="w-4 h-4" />
+          Bono 3 · El Espejo del Español
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          "Knew" vs "Found Out"
+        </h1>
+        <p class="text-2xl text-emerald-300 italic font-light mb-4">El equivalente en inglés de <em>sabía</em> vs <em>supe</em>.</p>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed mb-6">
+          La misma trampa. La misma solución. Si puedes sentir la diferencia en español, la puedes sentir en inglés —
+          pero el inglés usa dos verbos diferentes en lugar de un verbo en dos tiempos.
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <button
+            onclick="window.print()"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold text-sm transition-colors"
+          >
+            <Printer class="w-4 h-4" />
+            Imprimir esta página
+          </button>
+          <a
+            href="/es/curso/tiempos-del-pasado/"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            <ArrowLeft class="w-4 h-4" />
+            Volver a la clase magistral
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- The split -->
+  <section class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="text-center mb-10">
+          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-3">La División del Español</h2>
+          <p class="text-lg text-slate-600 max-w-2xl mx-auto">
+            En español, <em>saber</em> cambia de significado entre imperfecto y pretérito. En inglés, se parte en <strong>dos verbos diferentes</strong>.
+          </p>
+        </div>
+
+        <div class="grid md:grid-cols-2 gap-6">
+          <div class="rounded-2xl border-2 border-emerald-300 bg-emerald-50/60 p-7">
+            <div class="flex items-center gap-3 mb-3">
+              <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-emerald-500 text-white">
+                <Brain class="w-5 h-5" />
+              </div>
+              <h3 class="text-2xl font-bold text-slate-900">knew</h3>
+            </div>
+            <p class="text-sm font-mono text-emerald-700 mb-3"><em>sabía</em> — imperfecto</p>
+            <p class="text-slate-700 mb-3">
+              Un <strong>estado</strong> de saber. Ya tenías la información. El conocimiento estaba en tu cabeza, posiblemente desde hace años.
+            </p>
+            <div class="bg-white rounded-lg p-3 border border-emerald-200 text-sm space-y-1.5">
+              <p>"I <strong>knew</strong> she was leaving." (todo el tiempo)</p>
+              <p>"He <strong>knew</strong> the answer." (ya la tenía)</p>
+              <p>"We <strong>knew</strong> each other from college."</p>
+            </div>
+          </div>
+
+          <div class="rounded-2xl border-2 border-amber-400 bg-amber-50/60 p-7">
+            <div class="flex items-center gap-3 mb-3">
+              <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-amber-500 text-white">
+                <Eye class="w-5 h-5" />
+              </div>
+              <h3 class="text-2xl font-bold text-slate-900">found out</h3>
+            </div>
+            <p class="text-sm font-mono text-amber-700 mb-3"><em>supe</em> — pretérito</p>
+            <p class="text-slate-700 mb-3">
+              El <strong>momento</strong> de descubrir. Un punto único en el tiempo cuando el conocimiento entró a tu cabeza.
+            </p>
+            <div class="bg-white rounded-lg p-3 border border-amber-200 text-sm space-y-1.5">
+              <p>"I <strong>found out</strong> she was leaving." (un momento — quizás ayer)</p>
+              <p>"He <strong>found out</strong> the answer at 5pm."</p>
+              <p>"We <strong>found out</strong> about it on Monday."</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Mental picture -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">La Imagen Mental</h2>
+        <div class="bg-white rounded-2xl border-2 border-slate-200 p-7">
+          <p class="text-slate-700 leading-relaxed mb-4">
+            Imagina una <strong>línea</strong> que cruza el tiempo. Ahora imagina un <strong>punto</strong> sobre esa línea.
+          </p>
+          <ul class="space-y-3 text-slate-700">
+            <li class="flex gap-3">
+              <span class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-emerald-500 text-white text-sm font-bold shrink-0">━</span>
+              <span><strong class="text-slate-900">La línea es "knew."</strong> El conocimiento estuvo ahí todo el tiempo. Tiene duración. Es un estado.</span>
+            </li>
+            <li class="flex gap-3">
+              <span class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-amber-500 text-white text-sm font-bold shrink-0">●</span>
+              <span><strong class="text-slate-900">El punto es "found out."</strong> Un momento específico cuando entró el conocimiento. Es un evento.</span>
+            </li>
+          </ul>
+          <p class="text-slate-700 leading-relaxed mt-4">
+            Si puedes poner un <em>cuándo</em> ("ayer", "a las 3pm", "esta mañana"), casi siempre necesitas <strong>found out</strong>.
+            Si el conocimiento ha estado ahí por un período indefinido, necesitas <strong>knew</strong>.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Drill -->
+  <section class="py-12 md:py-16 bg-white print:py-3 print:break-inside-avoid">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="text-center mb-8">
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-2">El Drill de 30 Segundos</h2>
+          <p class="text-slate-600">Elige el verbo correcto. Cubre el lado derecho. No pienses — siente.</p>
+        </div>
+
+        <div class="bg-emerald-50 rounded-2xl border-2 border-emerald-300 p-6 md:p-8 print:p-3 print:rounded-md">
+          <div class="space-y-4 print:space-y-2">
+            <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">"___ you ___ that he had quit?"</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>Did you know</strong> (estado) <span class="text-slate-400">o</span> <strong>Did you find out</strong> (momento) — ambos sirven, depende de la intención</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">"I ___ about the meeting at 4pm."</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>found out</strong> — "at 4pm" es un momento</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">"She ___ him for years before they dated."</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>knew</strong> — "for years" es estado</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">"How did you ___ that the company was sold?"</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>find out</strong> — "How" pregunta por el momento del descubrimiento</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">"He ___ the answer the whole time."</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>knew</strong> — "the whole time" es duración</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-center">
+              <p class="text-slate-700">"We ___ about the layoffs yesterday."</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>found out</strong> — "yesterday" + información nueva = momento</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Traps -->
+  <section class="py-12 md:py-16 bg-slate-50 print:bg-white print:py-3 print:break-inside-avoid">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">La Trampa Mexicana</h2>
+        <div class="space-y-4">
+          <div class="bg-white rounded-xl border-2 border-red-200 p-5">
+            <p class="flex items-start gap-2 text-slate-700">
+              <XCircle class="w-5 h-5 text-red-600 shrink-0 mt-0.5" />
+              <span>"I <strong>knew</strong> it yesterday."</span>
+            </p>
+            <p class="text-sm text-slate-500 mt-2 ml-7">"Yesterday" es un momento. No puedes <em>saber</em> algo solo un día. Lo <strong>found out</strong>.</p>
+          </div>
+          <div class="bg-white rounded-xl border-2 border-red-200 p-5">
+            <p class="flex items-start gap-2 text-slate-700">
+              <XCircle class="w-5 h-5 text-red-600 shrink-0 mt-0.5" />
+              <span>"How did you <strong>know</strong> about it?"</span>
+            </p>
+            <p class="text-sm text-slate-500 mt-2 ml-7">Posible — pero usualmente preguntas <em>cómo sucedió el descubrimiento</em>. Los nativos dicen "How did you <strong>find out</strong> about it?"</p>
+          </div>
+          <div class="bg-white rounded-xl border-2 border-emerald-300 p-5">
+            <p class="flex items-start gap-2 text-slate-700">
+              <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+              <span><strong>Prueba del oído nativo:</strong> si lo puedes reemplazar con <em>realized</em> o <em>learned</em>, quieres <strong>found out</strong>.</span>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="py-12 md:py-16 bg-emerald-950 text-white print:hidden">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-2xl md:text-3xl font-bold mb-3" style="font-family: 'Noto Sans KR', sans-serif;">Sigue</h2>
+        <p class="text-emerald-100 mb-6">
+          El patrón "knew vs. found out" es uno de tres espejos del español. Los otros dos — <em>there was vs. has been</em> y <em>did vs. have done</em> — siguen la misma lógica.
+        </p>
+        <div class="flex flex-wrap gap-3 justify-center">
+          <a
+            href="/es/curso/tiempos-del-pasado/there-was-vs-there-has-been/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold transition-colors"
+          >
+            Siguiente: "There Was" vs "There Has Been"
+            <ArrowRight class="w-5 h-5" />
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <style is:global>
+    @media print {
+      header, footer, nav { display: none !important; }
+      body { background: white !important; color: black !important; }
+      a { text-decoration: none !important; color: #064e3b !important; }
+    }
+  </style>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    "name": "Knew vs Found Out en Ingles",
+    "description": "Referencia enfocada en el equivalente en ingles del espanol sabia vs supe: knew (estado) vs found out (momento). Incluye imagen mental, drill de 30 segundos y trampas para hispanohablantes.",
+    "learningResourceType": "Reference",
+    "educationalLevel": "Intermedio a Avanzado",
+    "inLanguage": "es",
+    "isAccessibleForFree": true,
+    "url": "https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/knew-vs-found-out/",
+    "isPartOf": {
+      "@type": "Course",
+      "name": "Domina los Tiempos del Pasado en Ingles — Clase Magistral Gratis",
+      "url": "https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/"
+    },
+    "author": {
+      "@type": "Person",
+      "name": "Robert Cushman",
+      "url": "https://www.nyenglishteacher.com/es/about/"
+    }
+  })} />
+</Base>

--- a/src/pages/es/curso/tiempos-del-pasado/there-was-vs-there-has-been.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/there-was-vs-there-has-been.astro
@@ -1,0 +1,266 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import {
+  ArrowRight,
+  ArrowLeft,
+  MessageSquare,
+  CheckCircle2,
+  XCircle,
+  Lock,
+  Link as LinkIcon,
+  Printer,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/past-tenses/there-was-vs-there-has-been" as const;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="&quot;There Was&quot; vs &quot;There Has Been&quot; en Inglés | NY English Teacher"
+  description="El equivalente en inglés de hubo vs ha habido. Por qué uno cierra la historia y el otro la deja abierta — y cómo sentir la diferencia al instante."
+>
+  <!-- Hero -->
+  <section class="bg-gradient-to-b from-slate-900 to-emerald-950 pt-28 pb-12 md:pt-32 md:pb-16 print:hidden">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-emerald-400 text-sm font-semibold mb-3">
+          <MessageSquare class="w-4 h-4" />
+          Bono 5 · La Trampa del Cierre
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          "There Was" vs "There Has Been"
+        </h1>
+        <p class="text-2xl text-emerald-300 italic font-light mb-4">El equivalente en inglés de <em>hubo</em> vs <em>ha habido</em>.</p>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed mb-6">
+          Uno cierra la historia. El otro la deja abierta. En un status update, en una junta, en una respuesta de Slack —
+          elegir mal manda un mensaje diferente del que querías.
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <button
+            onclick="window.print()"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold text-sm transition-colors"
+          >
+            <Printer class="w-4 h-4" />
+            Imprimir esta página
+          </button>
+          <a
+            href="/es/curso/tiempos-del-pasado/"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            <ArrowLeft class="w-4 h-4" />
+            Volver a la clase magistral
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- The split -->
+  <section class="py-12 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="text-center mb-10">
+          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-3">Historia Cerrada vs. Historia Abierta</h2>
+          <p class="text-lg text-slate-600 max-w-2xl mx-auto">
+            La misma situación. Relación diferente con el <em>ahora</em>. El verbo que elijas le dice a quien escucha si el asunto está terminado o si todavía te toca atenderlo.
+          </p>
+        </div>
+
+        <div class="grid md:grid-cols-2 gap-6">
+          <div class="rounded-2xl border-2 border-emerald-300 bg-emerald-50/60 p-7">
+            <div class="flex items-center gap-3 mb-3">
+              <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-emerald-500 text-white">
+                <Lock class="w-5 h-5" />
+              </div>
+              <h3 class="text-2xl font-bold text-slate-900">there was</h3>
+            </div>
+            <p class="text-sm font-mono text-emerald-700 mb-3"><em>hubo</em> — Past Simple</p>
+            <p class="text-slate-700 mb-3">
+              La situación existió en <strong>tiempo pasado cerrado</strong>. Está hecho. Está archivado. Es un hecho que reportas desde un pasado sellado.
+            </p>
+            <div class="bg-white rounded-lg p-3 border border-emerald-200 text-sm space-y-1.5">
+              <p>"<strong>There was</strong> a fire in 2018."</p>
+              <p>"<strong>There was</strong> an issue last week — we fixed it."</p>
+              <p>"<strong>There was</strong> a problem during the demo." (la demo ya terminó)</p>
+            </div>
+          </div>
+
+          <div class="rounded-2xl border-2 border-amber-400 bg-amber-50/60 p-7">
+            <div class="flex items-center gap-3 mb-3">
+              <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-amber-500 text-white">
+                <LinkIcon class="w-5 h-5" />
+              </div>
+              <h3 class="text-2xl font-bold text-slate-900">there has been</h3>
+            </div>
+            <p class="text-sm font-mono text-amber-700 mb-3"><em>ha habido</em> — Present Perfect</p>
+            <p class="text-slate-700 mb-3">
+              La situación <strong>todavía es relevante</strong>. Empezó en el pasado y la consecuencia sigue aquí, todavía me toca atenderla.
+            </p>
+            <div class="bg-white rounded-lg p-3 border border-amber-200 text-sm space-y-1.5">
+              <p>"<strong>There has been</strong> a problem this morning." (todavía hoy, todavía pasando)</p>
+              <p>"<strong>There have been</strong> delays — we're working on it." (actualmente)</p>
+              <p>"<strong>There has been</strong> an update since we last spoke."</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Business impact -->
+  <section class="py-12 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-3 text-center">Por Qué Importa en Inglés de Negocios</h2>
+        <p class="text-slate-600 mb-8 text-center">La misma noticia aterriza de dos formas completamente diferentes según cuál elijas.</p>
+
+        <div class="space-y-4">
+          <div class="bg-white rounded-2xl border-2 border-slate-200 p-6">
+            <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-2">Cerrado — "No te preocupes"</p>
+            <p class="text-slate-800 text-lg italic">"There was an issue with the deployment last night."</p>
+            <p class="text-sm text-slate-500 mt-2">→ Quien escucha entiende: "Estoy reportando historia. Está arreglado. Seguimos."</p>
+          </div>
+          <div class="bg-white rounded-2xl border-2 border-amber-300 p-6">
+            <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">Abierto — "Necesito tu atención"</p>
+            <p class="text-slate-800 text-lg italic">"There has been an issue with the deployment."</p>
+            <p class="text-sm text-slate-500 mt-2">→ Quien escucha entiende: "Esto sigue pasando. Deja lo que estés haciendo."</p>
+          </div>
+        </div>
+
+        <p class="text-center text-slate-600 mt-8 text-sm italic">
+          Un hispanohablante que usa "there was" para todo suena como si <em>siempre reportara eventos cerrados</em> — incluso cuando el problema está encendido ahora mismo.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Drill -->
+  <section class="py-12 md:py-16 bg-white print:py-3 print:break-inside-avoid">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="text-center mb-8">
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-2">El Drill de Elegir</h2>
+          <p class="text-slate-600">Lee la situación. Elige "there was" o "there has been."</p>
+        </div>
+
+        <div class="bg-emerald-50 rounded-2xl border-2 border-emerald-300 p-6 md:p-8 print:p-3 print:rounded-md">
+          <div class="space-y-4 print:space-y-2">
+            <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">Hubo un incendio en 2018. Ahora es 2026.</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> a fire — tiempo cerrado.</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">Llegaron tres mensajes de Slack esta mañana. Todavía es la mañana.</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There have been</strong> three messages — el periodo sigue abierto.</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">Estás explicando un resultado cerrado del Q1 a la junta directiva en el Q3.</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> a 12% dip in Q1 — el Q1 está sellado.</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
+              <p class="text-slate-700">Han llegado quejas de clientes toda la semana. Es jueves.</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There have been</strong> complaints this week — la semana no termina.</p>
+            </div>
+            <div class="grid md:grid-cols-2 gap-3 items-start">
+              <p class="text-slate-700">Hubo una caída del servidor ayer. Ya está resuelto.</p>
+              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> an outage yesterday — arreglado, cerrado.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Quick test -->
+  <section class="py-12 md:py-16 bg-slate-50 print:bg-white print:py-3 print:break-inside-avoid">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">La Prueba de Dos Segundos</h2>
+        <div class="bg-white rounded-2xl border-2 border-emerald-300 p-7">
+          <p class="text-slate-700 leading-relaxed mb-4">
+            Pregúntate: <strong>"¿Este periodo de tiempo sigue corriendo?"</strong>
+          </p>
+          <ul class="space-y-3 text-slate-700">
+            <li class="flex gap-3">
+              <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+              <span>Si sí (esta semana, hoy, este año, desde el lunes) → <strong>there has been</strong></span>
+            </li>
+            <li class="flex gap-3">
+              <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+              <span>Si no (ayer, la semana pasada, en 2019, a las 3pm de ayer) → <strong>there was</strong></span>
+            </li>
+            <li class="flex gap-3">
+              <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+              <span>Si la consecuencia todavía te toca <em>sin importar</em> cuándo empezó → <strong>there has been</strong></span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="py-12 md:py-16 bg-emerald-950 text-white print:hidden">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-2xl md:text-3xl font-bold mb-3" style="font-family: 'Noto Sans KR', sans-serif;">Terminaste la Clase Magistral</h2>
+        <p class="text-emerald-100 mb-6">
+          5 lecciones. 5 bonos. El método de los 4 tiempos. Tienes todo lo que un profesional mexicano necesita para dejar de congelarse en tiempo pasado — en una junta real, en tiempo real.
+        </p>
+        <div class="flex flex-wrap gap-3 justify-center">
+          <a
+            href="/es/curso/tiempos-del-pasado/guia-rapida/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold transition-colors"
+          >
+            Guarda la guía rápida
+            <ArrowRight class="w-5 h-5" />
+          </a>
+          <a
+            href="/es/servicios/"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-white/10 hover:bg-white/20 text-white font-semibold transition-colors"
+          >
+            Trabaja 1-a-1 con Robert
+            <ArrowRight class="w-5 h-5" />
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <style is:global>
+    @media print {
+      header, footer, nav { display: none !important; }
+      body { background: white !important; color: black !important; }
+      a { text-decoration: none !important; color: #064e3b !important; }
+    }
+  </style>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    "name": "There Was vs There Has Been en Ingles",
+    "description": "Referencia enfocada en el equivalente en ingles del espanol hubo vs ha habido. Por que uno cierra la historia y el otro la deja abierta — con ejemplos de contexto de negocios y una prueba de decision de dos segundos.",
+    "learningResourceType": "Reference",
+    "educationalLevel": "Intermedio a Avanzado",
+    "inLanguage": "es",
+    "isAccessibleForFree": true,
+    "url": "https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/there-was-vs-there-has-been/",
+    "isPartOf": {
+      "@type": "Course",
+      "name": "Domina los Tiempos del Pasado en Ingles — Clase Magistral Gratis",
+      "url": "https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/"
+    },
+    "author": {
+      "@type": "Person",
+      "name": "Robert Cushman",
+      "url": "https://www.nyenglishteacher.com/es/about/"
+    }
+  })} />
+</Base>

--- a/src/pages/es/curso/tiempos-del-pasado/top-10-pares-confundidos.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/top-10-pares-confundidos.astro
@@ -1,0 +1,251 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import {
+  ArrowRight,
+  ArrowLeft,
+  AlertCircle,
+  CheckCircle2,
+  XCircle,
+  Printer,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/past-tenses/top-10-confused-pairs" as const;
+
+const pairs = [
+  {
+    n: 1,
+    a: "say",
+    b: "tell",
+    spanish: "Ambos vienen de <em>decir</em>.",
+    rule: "<strong>Say</strong> las palabras. <strong>Tell</strong> a una persona.",
+    good: "She <strong>told me</strong> the news. / She <strong>said</strong> the news was bad.",
+    trap: "\"She told that…\" — mal. Le dices <em>a alguien</em>. \"She told <strong>me</strong> that…\"",
+  },
+  {
+    n: 2,
+    a: "do",
+    b: "make",
+    spanish: "Ambos vienen de <em>hacer</em>.",
+    rule: "<strong>Do</strong> una tarea o actividad. <strong>Make</strong> una cosa o un resultado.",
+    good: "I <strong>did</strong> the report. / I <strong>made</strong> a decision.",
+    trap: "\"I made the homework\" — mal. Tarea es actividad → <strong>did</strong> the homework.",
+  },
+  {
+    n: 3,
+    a: "lay",
+    b: "lie",
+    spanish: "Ambos se sienten como <em>acostar(se)</em>.",
+    rule: "<strong>Lay</strong> lleva objeto. <strong>Lie</strong> no.",
+    good: "I <strong>laid</strong> the report on his desk. / I <strong>lay</strong> on the sofa for an hour.",
+    trap: "Pasado de <em>lie</em> es <em>lay</em>. Pasado de <em>lay</em> es <em>laid</em>. \"I <strong>lay</strong> down yesterday\" = pasado de <em>lie</em>, sin objeto.",
+  },
+  {
+    n: 4,
+    a: "rise",
+    b: "raise",
+    spanish: "<em>Subir / levantar(se)</em> se traslapan.",
+    rule: "<strong>Rise</strong> sube por sí solo. <strong>Raise</strong> lleva objeto.",
+    good: "Prices <strong>rose</strong> last quarter. / The CEO <strong>raised</strong> prices last quarter.",
+    trap: "\"They raised\" sin objeto = mal. Usa <em>rose</em>.",
+  },
+  {
+    n: 5,
+    a: "win",
+    b: "beat",
+    spanish: "Ambos se sienten como <em>ganar</em>.",
+    rule: "<strong>Win</strong> una cosa (un juego, un premio, una discusión). <strong>Beat</strong> a una persona o equipo.",
+    good: "We <strong>won</strong> the contract. / We <strong>beat</strong> their team.",
+    trap: "\"We won them\" — mal. \"We <strong>beat</strong> them\" o \"we won <strong>against</strong> them.\"",
+  },
+  {
+    n: 6,
+    a: "borrow",
+    b: "lend",
+    spanish: "<em>Prestar</em> va en ambas direcciones en español.",
+    rule: "<strong>Borrow</strong> = tomar prestado de alguien. <strong>Lend</strong> = prestar a alguien.",
+    good: "Can I <strong>borrow</strong> your charger? / Can you <strong>lend</strong> me your charger?",
+    trap: "\"Can you borrow me…\" — mal. Estarías tomando prestado de ti mismo.",
+  },
+  {
+    n: 7,
+    a: "bring",
+    b: "take",
+    spanish: "<em>Traer / llevar</em> — pero la perspectiva en inglés cambia.",
+    rule: "<strong>Bring</strong> hacia quien habla. <strong>Take</strong> lejos de quien habla.",
+    good: "<strong>Bring</strong> the report <em>here</em>. / <strong>Take</strong> the report <em>there</em>.",
+    trap: "\"I'll bring it to the meeting\" (vas <em>a</em> la junta) — usualmente <em>take</em>. Usa <em>bring</em> solo si quien escucha <em>está</em> en la junta.",
+  },
+  {
+    n: 8,
+    a: "remember",
+    b: "remind",
+    spanish: "Ambos pueden caer como <em>recordar</em>.",
+    rule: "<strong>Remember</strong> = recordar tú solo. <strong>Remind</strong> = hacer que alguien más recuerde.",
+    good: "I <strong>remember</strong> the meeting. / Can you <strong>remind</strong> me about the meeting?",
+    trap: "\"Remember me to call her\" — mal. \"<strong>Remind</strong> me to call her.\"",
+  },
+  {
+    n: 9,
+    a: "miss",
+    b: "lose",
+    spanish: "<em>Perder</em> cubre ambos en español.",
+    rule: "<strong>Miss</strong> una fecha límite, un vuelo, una oportunidad. <strong>Lose</strong> una cosa o una competencia.",
+    good: "I <strong>missed</strong> the flight. / I <strong>lost</strong> my keys.",
+    trap: "\"I lost the bus\" — mal. Lo <strong>missed</strong>. Solo <em>lose</em> cosas que posees.",
+  },
+  {
+    n: 10,
+    a: "listen",
+    b: "hear",
+    spanish: "<em>Escuchar / oír</em> — pero el reparto cambia.",
+    rule: "<strong>Listen</strong> es activo (intención). <strong>Hear</strong> es pasivo (solo el sonido).",
+    good: "I <strong>listened</strong> to the call carefully. / I <strong>heard</strong> a noise outside.",
+    trap: "\"I'm hearing music\" — usualmente mal. Si la pusiste con intención, estás <strong>listening to</strong> music.",
+  },
+];
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Top 10 Pares de Verbos Confundidos en Inglés | NY English Teacher"
+  description="Los diez pares de verbos que más confunden a hispanohablantes intermedios — say/tell, do/make, lay/lie y siete más. Cada par: regla, trampa y ejemplo."
+>
+  <!-- Hero -->
+  <section class="bg-gradient-to-b from-slate-900 to-emerald-950 pt-28 pb-12 md:pt-32 md:pb-16 print:hidden">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-emerald-400 text-sm font-semibold mb-3">
+          <AlertCircle class="w-4 h-4" />
+          Bono 2 · Referencia de la Clase Magistral
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Top 10 Pares de Verbos Más Confundidos
+        </h1>
+        <p class="text-lg text-slate-300 max-w-2xl leading-relaxed mb-6">
+          Un solo verbo en español a menudo se parte en dos verbos en inglés. Estos diez pares causan
+          más errores que cualquier otra fuente para hispanohablantes intermedios. Memoriza la trampa, no la regla.
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <button
+            onclick="window.print()"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold text-sm transition-colors"
+          >
+            <Printer class="w-4 h-4" />
+            Imprimir esta página
+          </button>
+          <a
+            href="/es/curso/tiempos-del-pasado/"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            <ArrowLeft class="w-4 h-4" />
+            Volver a la clase magistral
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Print header -->
+  <div class="hidden print:block py-4 border-b-2 border-slate-300">
+    <h1 class="text-2xl font-bold text-slate-900">Top 10 Pares de Verbos Confundidos en Inglés</h1>
+    <p class="text-sm text-slate-600">nyenglishteacher.com — gratis para profesionales mexicanos</p>
+  </div>
+
+  <!-- The 10 pairs -->
+  <section class="py-12 md:py-16 bg-white print:py-2">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-5xl mx-auto">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-5 print:gap-2">
+          {pairs.map((p) => (
+            <div class="rounded-2xl border-2 border-emerald-300 bg-white p-5 print:p-3 print:rounded-md print:break-inside-avoid">
+              <div class="flex items-baseline gap-2 mb-2">
+                <span class="text-xs font-bold uppercase tracking-wider text-emerald-700">#{p.n}</span>
+                <h3 class="text-xl font-bold text-slate-900 print:text-base">
+                  <span class="text-emerald-700">{p.a}</span> <span class="text-slate-400 font-normal">vs.</span> <span class="text-emerald-700">{p.b}</span>
+                </h3>
+              </div>
+              <p class="text-xs text-slate-500 italic mb-3 print:text-xs" set:html={p.spanish} />
+              <div class="space-y-2.5 text-sm text-slate-700 print:text-xs">
+                <p set:html={`<strong class="text-slate-900">Regla:</strong> ${p.rule}`} />
+                <div class="bg-emerald-50 rounded p-2.5 border border-emerald-200 flex gap-2">
+                  <CheckCircle2 class="w-4 h-4 text-emerald-600 shrink-0 mt-0.5" />
+                  <p set:html={p.good} />
+                </div>
+                <div class="bg-red-50 rounded p-2.5 border border-red-200 flex gap-2">
+                  <XCircle class="w-4 h-4 text-red-600 shrink-0 mt-0.5" />
+                  <p class="text-slate-700" set:html={`<strong class="text-red-700">Trampa:</strong> ${p.trap}`} />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="py-12 md:py-16 bg-emerald-950 text-white print:hidden">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-2xl md:text-3xl font-bold mb-3" style="font-family: 'Noto Sans KR', sans-serif;">Siguiente: Las Trampas de Tiempo</h2>
+        <p class="text-emerald-100 mb-6 max-w-2xl mx-auto">
+          El verbo equivocado es un error. El tiempo equivocado es otro. Estos dos bonos extra trabajan
+          las decisiones exactas de tiempo que deciden si suenas fluido o si suenas traduciendo.
+        </p>
+        <div class="flex flex-wrap gap-3 justify-center">
+          <a
+            href="/es/curso/tiempos-del-pasado/knew-vs-found-out/"
+            class="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-white/10 hover:bg-white/20 text-white font-semibold transition-colors"
+          >
+            "Knew" vs "Found Out"
+            <ArrowRight class="w-4 h-4" />
+          </a>
+          <a
+            href="/es/curso/tiempos-del-pasado/there-was-vs-there-has-been/"
+            class="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-white/10 hover:bg-white/20 text-white font-semibold transition-colors"
+          >
+            "There Was" vs "There Has Been"
+            <ArrowRight class="w-4 h-4" />
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <style is:global>
+    @media print {
+      header, footer, nav { display: none !important; }
+      body { background: white !important; color: black !important; }
+      a { text-decoration: none !important; color: #064e3b !important; }
+    }
+  </style>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    "name": "Top 10 Pares de Verbos Mas Confundidos en Ingles",
+    "description": "Referencia compacta de los diez pares de verbos en ingles que mas confunden a hispanohablantes intermedios: say/tell, do/make, lay/lie, rise/raise, win/beat, borrow/lend, bring/take, remember/remind, miss/lose, listen/hear.",
+    "learningResourceType": "Reference",
+    "educationalLevel": "Intermedio a Avanzado",
+    "inLanguage": "es",
+    "isAccessibleForFree": true,
+    "url": "https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/top-10-pares-confundidos/",
+    "isPartOf": {
+      "@type": "Course",
+      "name": "Domina los Tiempos del Pasado en Ingles — Clase Magistral Gratis",
+      "url": "https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/"
+    },
+    "author": {
+      "@type": "Person",
+      "name": "Robert Cushman",
+      "url": "https://www.nyenglishteacher.com/es/about/"
+    }
+  })} />
+</Base>


### PR DESCRIPTION
## Summary

Finishes the Past Tenses master class. With this merged, all 5 lessons + all 5 bonuses are live, the bonus cards on the course landing all become clickable, and there's nothing else marked "Coming soon."

**Bonus 2 — Top 10 Most Confused Verb Pairs**
say/tell, do/make, lay/lie, rise/raise, win/beat, borrow/lend, bring/take, remember/remind, miss/lose, listen/hear. Each pair gets the underlying Spanish (one verb → two English verbs), the rule, a good example, and the specific Mexican-speaker trap.

**Bonus 3 — "Knew" vs "Found Out"**
`sabía` vs `supe` in English form. Mental picture (line vs dot), 6-item drill, and the native-ear test ("if replaceable by *realized* or *learned*, you want *found out*").

**Bonus 4 — 30 Story Openers**
Grouped by register — casual (10), professional (10), bridges (10). Each opener carries a one-line note on the tense pattern that naturally follows.

**Bonus 5 — "There Was" vs "There Has Been"**
`hubo` vs `ha habido` / closed vs open story. Framed around business impact ("don't worry about it" vs "I need your attention") with a 5-item drill and a two-second decision test.

**Wiring**
- All four bonuses flipped to `available: true` in `src/data/past-tenses/lessons.ts`. The previously-greyed bonus cards on `/en/course/past-tenses/` and `/es/curso/tiempos-del-pasado/` become clickable automatically.
- 4 new tkeys registered in `src/lib/i18n.ts` for hreflang.
- All pages have `LearningResource` JSON-LD scoped to the parent `Course`.
- Print-friendly (`window.print`, `@media print` rules, `break-inside-avoid` on every card).

**Caught while shipping** — Astro JSX attributes don't honor `\"` backslash-escape (parsed as HTML, not JS). Use `&quot;` for embedded quotes. Documented in commit message for future reference.

## Test plan

- [ ] EN bonus pages render and print clean:
  - https://ny-eng-git-feat-past-tenses-bonuses-2-5-rcushmaniii-projects.vercel.app/en/course/past-tenses/top-10-confused-pairs/
  - https://ny-eng-git-feat-past-tenses-bonuses-2-5-rcushmaniii-projects.vercel.app/en/course/past-tenses/knew-vs-found-out/
  - https://ny-eng-git-feat-past-tenses-bonuses-2-5-rcushmaniii-projects.vercel.app/en/course/past-tenses/story-openers/
  - https://ny-eng-git-feat-past-tenses-bonuses-2-5-rcushmaniii-projects.vercel.app/en/course/past-tenses/there-was-vs-there-has-been/
- [ ] ES bonus pages render and print clean (Mexican Spanish — no Iberian markers, audited):
  - https://ny-eng-git-feat-past-tenses-bonuses-2-5-rcushmaniii-projects.vercel.app/es/curso/tiempos-del-pasado/top-10-pares-confundidos/
  - https://ny-eng-git-feat-past-tenses-bonuses-2-5-rcushmaniii-projects.vercel.app/es/curso/tiempos-del-pasado/knew-vs-found-out/
  - https://ny-eng-git-feat-past-tenses-bonuses-2-5-rcushmaniii-projects.vercel.app/es/curso/tiempos-del-pasado/frases-iniciales/
  - https://ny-eng-git-feat-past-tenses-bonuses-2-5-rcushmaniii-projects.vercel.app/es/curso/tiempos-del-pasado/there-was-vs-there-has-been/
- [ ] Bonus cards on the EN + ES course landing are all clickable (no more "Coming soon"):
  - https://ny-eng-git-feat-past-tenses-bonuses-2-5-rcushmaniii-projects.vercel.app/en/course/past-tenses/
  - https://ny-eng-git-feat-past-tenses-bonuses-2-5-rcushmaniii-projects.vercel.app/es/curso/tiempos-del-pasado/

🤖 Generated with [Claude Code](https://claude.com/claude-code)