### PR TITLE
fix(seo): shorten lesson-2 titles + wire validate:seo into build pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "validate:performance": "node scripts/validate-performance.mjs",
     "validate:urls": "node scripts/validate-url-structure.mjs",
     "validate:seo": "node scripts/pre-deploy/audits/seo-validator.js",
-    "validate:all": "npm run validate:404 && npm run validate:canonical && npm run validate:links && npm run validate:performance && npm run validate:urls",
+    "validate:all": "npm run validate:404 && npm run validate:canonical && npm run validate:links && npm run validate:performance && npm run validate:urls && npm run validate:seo",
     "generate:pdfs": "python scripts/generate-all-pdfs.py",
     "pdf:metadata": "node scripts/apply-pdf-metadata.mjs",
     "pdf:metadata:dry-run": "node scripts/apply-pdf-metadata.mjs --dry-run --verbose",

--- a/scripts/pre-deploy/CRITICAL-URLS.txt
+++ b/scripts/pre-deploy/CRITICAL-URLS.txt
@@ -1,5 +1,5 @@
 # Critical URLs Whitelist - New York English Teacher
-# Last Updated: 2024-11-30
+# Last Updated: 2026-05-16
 # 
 # This is the baseline truth for what MUST be in sitemap.xml
 # Organized by: Language > Page Type
@@ -62,6 +62,80 @@ LEGAL
 https://www.nyenglishteacher.com/en/legal/privacy-policy/
 https://www.nyenglishteacher.com/en/legal/terms-of-service/
 
+COURSES
+-------
+https://www.nyenglishteacher.com/en/course/past-tenses/
+https://www.nyenglishteacher.com/en/course/past-tenses/lesson-1/
+https://www.nyenglishteacher.com/en/course/past-tenses/lesson-2/
+https://www.nyenglishteacher.com/en/course/past-tenses/lesson-3/
+https://www.nyenglishteacher.com/en/course/past-tenses/lesson-4/
+https://www.nyenglishteacher.com/en/course/past-tenses/lesson-5/
+https://www.nyenglishteacher.com/en/course/past-tenses/cheat-sheet/
+https://www.nyenglishteacher.com/en/course/past-tenses/knew-vs-found-out/
+https://www.nyenglishteacher.com/en/course/past-tenses/story-openers/
+https://www.nyenglishteacher.com/en/course/past-tenses/there-was-vs-there-has-been/
+https://www.nyenglishteacher.com/en/course/past-tenses/top-10-confused-pairs/
+https://www.nyenglishteacher.com/en/course/beginners/
+https://www.nyenglishteacher.com/en/course/beginners/unit-1/
+https://www.nyenglishteacher.com/en/course/beginners/unit-2/
+https://www.nyenglishteacher.com/en/course/beginners/unit-3/
+https://www.nyenglishteacher.com/en/course/beginners/unit-4/
+https://www.nyenglishteacher.com/en/course/beginners/unit-5/
+https://www.nyenglishteacher.com/en/course/beginners/unit-6/
+https://www.nyenglishteacher.com/en/course/beginners/unit-7/
+https://www.nyenglishteacher.com/en/course/beginners/unit-8/
+https://www.nyenglishteacher.com/en/course/beginners/unit-9/
+https://www.nyenglishteacher.com/en/course/beginners/unit-10/
+https://www.nyenglishteacher.com/en/course/beginners/exam/
+https://www.nyenglishteacher.com/en/course/elementary/
+https://www.nyenglishteacher.com/en/course/elementary/unit-1/
+https://www.nyenglishteacher.com/en/course/elementary/unit-2/
+https://www.nyenglishteacher.com/en/course/elementary/unit-3/
+https://www.nyenglishteacher.com/en/course/elementary/unit-4/
+https://www.nyenglishteacher.com/en/course/elementary/unit-5/
+https://www.nyenglishteacher.com/en/course/elementary/unit-6/
+https://www.nyenglishteacher.com/en/course/elementary/unit-7/
+https://www.nyenglishteacher.com/en/course/elementary/unit-8/
+https://www.nyenglishteacher.com/en/course/elementary/unit-9/
+https://www.nyenglishteacher.com/en/course/elementary/unit-10/
+https://www.nyenglishteacher.com/en/course/elementary/exam/
+https://www.nyenglishteacher.com/en/course/intermediate/
+https://www.nyenglishteacher.com/en/course/intermediate/unit-1/
+https://www.nyenglishteacher.com/en/course/intermediate/unit-2/
+https://www.nyenglishteacher.com/en/course/intermediate/unit-3/
+https://www.nyenglishteacher.com/en/course/intermediate/unit-4/
+https://www.nyenglishteacher.com/en/course/intermediate/unit-5/
+https://www.nyenglishteacher.com/en/course/intermediate/unit-6/
+https://www.nyenglishteacher.com/en/course/intermediate/unit-7/
+https://www.nyenglishteacher.com/en/course/intermediate/unit-8/
+https://www.nyenglishteacher.com/en/course/intermediate/unit-9/
+https://www.nyenglishteacher.com/en/course/intermediate/unit-10/
+https://www.nyenglishteacher.com/en/course/intermediate/exam/
+https://www.nyenglishteacher.com/en/course/advanced/
+https://www.nyenglishteacher.com/en/course/advanced/unit-1/
+https://www.nyenglishteacher.com/en/course/advanced/unit-2/
+https://www.nyenglishteacher.com/en/course/advanced/unit-3/
+https://www.nyenglishteacher.com/en/course/advanced/unit-4/
+https://www.nyenglishteacher.com/en/course/advanced/unit-5/
+https://www.nyenglishteacher.com/en/course/advanced/unit-6/
+https://www.nyenglishteacher.com/en/course/advanced/unit-7/
+https://www.nyenglishteacher.com/en/course/advanced/unit-8/
+https://www.nyenglishteacher.com/en/course/advanced/unit-9/
+https://www.nyenglishteacher.com/en/course/advanced/unit-10/
+https://www.nyenglishteacher.com/en/course/advanced/exam/
+https://www.nyenglishteacher.com/en/course/executive/
+https://www.nyenglishteacher.com/en/course/executive/unit-1/
+https://www.nyenglishteacher.com/en/course/executive/unit-2/
+https://www.nyenglishteacher.com/en/course/executive/unit-3/
+https://www.nyenglishteacher.com/en/course/executive/unit-4/
+https://www.nyenglishteacher.com/en/course/executive/unit-5/
+https://www.nyenglishteacher.com/en/course/executive/unit-6/
+https://www.nyenglishteacher.com/en/course/executive/unit-7/
+https://www.nyenglishteacher.com/en/course/executive/unit-8/
+https://www.nyenglishteacher.com/en/course/executive/unit-9/
+https://www.nyenglishteacher.com/en/course/executive/unit-10/
+https://www.nyenglishteacher.com/en/course/executive/capstone/
+
 
 ================================================================================
 SPANISH PAGES
@@ -113,13 +187,87 @@ LEGAL
 https://www.nyenglishteacher.com/es/legal/privacy-policy/
 https://www.nyenglishteacher.com/es/legal/terms-of-service/
 
+COURSES
+-------
+https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/
+https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/leccion-1/
+https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/leccion-2/
+https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/leccion-3/
+https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/leccion-4/
+https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/leccion-5/
+https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/guia-rapida/
+https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/frases-iniciales/
+https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/knew-vs-found-out/
+https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/there-was-vs-there-has-been/
+https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/top-10-pares-confundidos/
+https://www.nyenglishteacher.com/es/curso/principiantes/
+https://www.nyenglishteacher.com/es/curso/principiantes/unidad-1/
+https://www.nyenglishteacher.com/es/curso/principiantes/unidad-2/
+https://www.nyenglishteacher.com/es/curso/principiantes/unidad-3/
+https://www.nyenglishteacher.com/es/curso/principiantes/unidad-4/
+https://www.nyenglishteacher.com/es/curso/principiantes/unidad-5/
+https://www.nyenglishteacher.com/es/curso/principiantes/unidad-6/
+https://www.nyenglishteacher.com/es/curso/principiantes/unidad-7/
+https://www.nyenglishteacher.com/es/curso/principiantes/unidad-8/
+https://www.nyenglishteacher.com/es/curso/principiantes/unidad-9/
+https://www.nyenglishteacher.com/es/curso/principiantes/unidad-10/
+https://www.nyenglishteacher.com/es/curso/principiantes/examen/
+https://www.nyenglishteacher.com/es/curso/elemental/
+https://www.nyenglishteacher.com/es/curso/elemental/unidad-1/
+https://www.nyenglishteacher.com/es/curso/elemental/unidad-2/
+https://www.nyenglishteacher.com/es/curso/elemental/unidad-3/
+https://www.nyenglishteacher.com/es/curso/elemental/unidad-4/
+https://www.nyenglishteacher.com/es/curso/elemental/unidad-5/
+https://www.nyenglishteacher.com/es/curso/elemental/unidad-6/
+https://www.nyenglishteacher.com/es/curso/elemental/unidad-7/
+https://www.nyenglishteacher.com/es/curso/elemental/unidad-8/
+https://www.nyenglishteacher.com/es/curso/elemental/unidad-9/
+https://www.nyenglishteacher.com/es/curso/elemental/unidad-10/
+https://www.nyenglishteacher.com/es/curso/elemental/examen/
+https://www.nyenglishteacher.com/es/curso/intermedio/
+https://www.nyenglishteacher.com/es/curso/intermedio/unidad-1/
+https://www.nyenglishteacher.com/es/curso/intermedio/unidad-2/
+https://www.nyenglishteacher.com/es/curso/intermedio/unidad-3/
+https://www.nyenglishteacher.com/es/curso/intermedio/unidad-4/
+https://www.nyenglishteacher.com/es/curso/intermedio/unidad-5/
+https://www.nyenglishteacher.com/es/curso/intermedio/unidad-6/
+https://www.nyenglishteacher.com/es/curso/intermedio/unidad-7/
+https://www.nyenglishteacher.com/es/curso/intermedio/unidad-8/
+https://www.nyenglishteacher.com/es/curso/intermedio/unidad-9/
+https://www.nyenglishteacher.com/es/curso/intermedio/unidad-10/
+https://www.nyenglishteacher.com/es/curso/intermedio/examen/
+https://www.nyenglishteacher.com/es/curso/avanzado/
+https://www.nyenglishteacher.com/es/curso/avanzado/unidad-1/
+https://www.nyenglishteacher.com/es/curso/avanzado/unidad-2/
+https://www.nyenglishteacher.com/es/curso/avanzado/unidad-3/
+https://www.nyenglishteacher.com/es/curso/avanzado/unidad-4/
+https://www.nyenglishteacher.com/es/curso/avanzado/unidad-5/
+https://www.nyenglishteacher.com/es/curso/avanzado/unidad-6/
+https://www.nyenglishteacher.com/es/curso/avanzado/unidad-7/
+https://www.nyenglishteacher.com/es/curso/avanzado/unidad-8/
+https://www.nyenglishteacher.com/es/curso/avanzado/unidad-9/
+https://www.nyenglishteacher.com/es/curso/avanzado/unidad-10/
+https://www.nyenglishteacher.com/es/curso/avanzado/examen/
+https://www.nyenglishteacher.com/es/curso/ejecutivo/
+https://www.nyenglishteacher.com/es/curso/ejecutivo/unidad-1/
+https://www.nyenglishteacher.com/es/curso/ejecutivo/unidad-2/
+https://www.nyenglishteacher.com/es/curso/ejecutivo/unidad-3/
+https://www.nyenglishteacher.com/es/curso/ejecutivo/unidad-4/
+https://www.nyenglishteacher.com/es/curso/ejecutivo/unidad-5/
+https://www.nyenglishteacher.com/es/curso/ejecutivo/unidad-6/
+https://www.nyenglishteacher.com/es/curso/ejecutivo/unidad-7/
+https://www.nyenglishteacher.com/es/curso/ejecutivo/unidad-8/
+https://www.nyenglishteacher.com/es/curso/ejecutivo/unidad-9/
+https://www.nyenglishteacher.com/es/curso/ejecutivo/unidad-10/
+https://www.nyenglishteacher.com/es/curso/ejecutivo/reto-final/
+
 
 ================================================================================
 SUMMARY
 ================================================================================
-English Pages: 40 (10 blog posts + 30 other pages)
-Spanish Pages: 40 (10 blog posts + 30 other pages)
-Total: 80 critical URLs
+English Pages: 111 (10 blog posts + 30 other pages + 71 course pages)
+Spanish Pages: 111 (10 blog posts + 30 other pages + 71 course pages)
+Total: 222 critical URLs
 
 EXCLUDED FROM SITEMAP (by design):
 - Quiz question pages (/quiz/question/1/, etc.) - thin content, no SEO value

--- a/src/pages/en/course/past-tenses/lesson-2.astro
+++ b/src/pages/en/course/past-tenses/lesson-2.astro
@@ -22,7 +22,7 @@ const tkey = "course/past-tenses/lesson-2" as const;
 <Base
   lang={lang}
   tkey={tkey}
-  title="Lesson 2: Past Continuous — The Background Scene | NY English Teacher"
+  title="Past Continuous — The Background Scene | NY English Teacher"
   description="The second lesson in the Master Past Tenses course. Learn to feel the background scene — and stop sounding choppy when you describe what was happening."
 >
   <!-- Lesson hero -->

--- a/src/pages/es/curso/tiempos-del-pasado/leccion-2.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/leccion-2.astro
@@ -22,7 +22,7 @@ const tkey = "course/past-tenses/lesson-2" as const;
 <Base
   lang={lang}
   tkey={tkey}
-  title="Lección 2: Past Continuous — La Escena de Fondo | NY English Teacher"
+  title="Past Continuous — La Escena de Fondo | NY English Teacher"
   description="Segunda lección del curso de tiempos del pasado en inglés. Aprende a sentir la escena de fondo — y deja de sonar cortado al narrar lo que pasaba."
 >
   <!-- Hero de la lección -->


### PR DESCRIPTION
## Summary
- Lesson-2 titles trimmed to ≤60 chars (EN: 59, ES: 57) — previous attempt left them at 69/68
- `validate:seo` added to `validate:all` so title violations now **fail the build** instead of going undetected
- `CRITICAL-URLS.txt` expanded from 80 → 222 URLs, covering all 142 course pages (was zero) — without course page coverage the validator couldn't catch violations on lesson pages

## Root-cause explanation
The recurring lesson-2 title issue happened because:
1. `validate:seo` was a standalone command never called by `validate:all` or the build
2. `CRITICAL-URLS.txt` had no course pages, so even if `validate:seo` ran it would miss them
3. The previous fix shortened the title from 71 → 69 chars — still over the 60-char limit

## Test plan
- [ ] PR CI passes
- [ ] After merge: run `npm run validate:seo` locally — lesson-2 must pass (59 / 57 chars)
- [ ] Verify `npm run validate:all` now includes title validation in its output

🤖 Generated with [Claude Code](https://claude.com/claude-code)