### PR TITLE
fix(course): clarify two misleading CTAs on past-tenses bonus pages

### DIFF
--- a/src/pages/en/course/past-tenses/practice-plan.astro
+++ b/src/pages/en/course/past-tenses/practice-plan.astro
@@ -389,14 +389,14 @@ const tkey = "course/past-tenses/practice-plan" as const;
             href="/en/course/past-tenses/cheat-sheet/"
             class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold transition-colors"
           >
-            Save the cheat sheet
+            Open the cheat sheet
             <ArrowRight class="w-5 h-5" />
           </a>
           <a
-            href="/en/services/"
+            href="/en/book/"
             class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-white/10 hover:bg-white/20 text-white font-semibold transition-colors"
           >
-            Work 1-on-1 with Robert
+            Book a session with Robert
             <ArrowRight class="w-5 h-5" />
           </a>
         </div>

--- a/src/pages/en/course/past-tenses/there-was-vs-there-has-been.astro
+++ b/src/pages/en/course/past-tenses/there-was-vs-there-has-been.astro
@@ -219,14 +219,14 @@ const tkey = "course/past-tenses/there-was-vs-there-has-been" as const;
             href="/en/course/past-tenses/cheat-sheet/"
             class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold transition-colors"
           >
-            Save the cheat sheet
+            Open the cheat sheet
             <ArrowRight class="w-5 h-5" />
           </a>
           <a
-            href="/en/services/"
+            href="/en/book/"
             class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-white/10 hover:bg-white/20 text-white font-semibold transition-colors"
           >
-            Work 1-on-1 with Robert
+            Book a session with Robert
             <ArrowRight class="w-5 h-5" />
           </a>
         </div>

--- a/src/pages/es/curso/tiempos-del-pasado/plan-de-practica.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/plan-de-practica.astro
@@ -389,14 +389,14 @@ const tkey = "course/past-tenses/practice-plan" as const;
             href="/es/curso/tiempos-del-pasado/guia-rapida/"
             class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold transition-colors"
           >
-            Guarda la guía rápida
+            Abrir la guía rápida
             <ArrowRight class="w-5 h-5" />
           </a>
           <a
-            href="/es/servicios/"
+            href="/es/reservar/"
             class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-white/10 hover:bg-white/20 text-white font-semibold transition-colors"
           >
-            Trabaja 1-a-1 con Robert
+            Reserva una sesión con Robert
             <ArrowRight class="w-5 h-5" />
           </a>
         </div>

--- a/src/pages/es/curso/tiempos-del-pasado/there-was-vs-there-has-been.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/there-was-vs-there-has-been.astro
@@ -219,14 +219,14 @@ const tkey = "course/past-tenses/there-was-vs-there-has-been" as const;
             href="/es/curso/tiempos-del-pasado/guia-rapida/"
             class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold transition-colors"
           >
-            Guarda la guía rápida
+            Abrir la guía rápida
             <ArrowRight class="w-5 h-5" />
           </a>
           <a
-            href="/es/servicios/"
+            href="/es/reservar/"
             class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-white/10 hover:bg-white/20 text-white font-semibold transition-colors"
           >
-            Trabaja 1-a-1 con Robert
+            Reserva una sesión con Robert
             <ArrowRight class="w-5 h-5" />
           </a>
         </div>


### PR DESCRIPTION
## Summary

Two CTA buttons on the past-tenses bonus pages were misleading — verb didn't match destination. Flagged on https://www.nyenglishteacher.com/en/course/past-tenses/practice-plan/, same pattern on Bonus 5 (there-was-vs-there-has-been).

**Before:**
- "Save the cheat sheet" → `/en/course/past-tenses/cheat-sheet/` — but clicking just navigated, didn't save anything
- "Work 1-on-1 with Robert" → `/en/services/` — but "Work" implies action; the services index is a browse-and-choose directory

**After:**
- "Open the cheat sheet" → `/en/course/past-tenses/cheat-sheet/` — verb matches what actually happens
- "Book a session with Robert" → `/en/book/` — verb now aligned with the destination; sends course finishers straight to the booking funnel

ES mirrors updated with the same logic: "Abrir la guía rápida" + "Reserva una sesión con Robert" → `/es/reservar/`.

4 files touched (2 EN + 2 ES). 12 lines changed.

## Test plan

- [ ] EN practice plan CTA: https://ny-eng-git-fix-practice-plan-cta-buttons-rcushmaniii-projects.vercel.app/en/course/past-tenses/practice-plan/
- [ ] ES practice plan CTA: https://ny-eng-git-fix-practice-plan-cta-buttons-rcushmaniii-projects.vercel.app/es/curso/tiempos-del-pasado/plan-de-practica/
- [ ] EN bonus 5 CTA: https://ny-eng-git-fix-practice-plan-cta-buttons-rcushmaniii-projects.vercel.app/en/course/past-tenses/there-was-vs-there-has-been/
- [ ] ES bonus 5 CTA: https://ny-eng-git-fix-practice-plan-cta-buttons-rcushmaniii-projects.vercel.app/es/curso/tiempos-del-pasado/there-was-vs-there-has-been/

🤖 Generated with [Claude Code](https://claude.com/claude-code)