### PR TITLE
feat(course): complete AudioButton coverage across all 14 Past Tenses pages EN+ES

### DIFF
--- a/src/components/blog/BlogImageLightbox.tsx
+++ b/src/components/blog/BlogImageLightbox.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from "react";
+
+interface BlogImageLightboxProps {
+  src: string;
+  alt: string;
+  children?: React.ReactNode;
+}
+
+export default function BlogImageLightbox({ src, alt, children }: BlogImageLightboxProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleClose = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      setIsOpen(false);
+    }
+  };
+
+  React.useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleEscape);
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      document.body.style.overflow = "auto";
+    };
+  }, [isOpen]);
+
+  return (
+    <>
+      <div
+        className="relative group cursor-pointer"
+        onClick={() => setIsOpen(true)}
+        style={{ overflow: "hidden" }}
+      >
+        {children}
+        <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors duration-300 flex items-center justify-center">
+          <div className="opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+            <svg
+              className="w-12 h-12 text-white drop-shadow-lg"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" />
+            </svg>
+          </div>
+        </div>
+      </div>
+
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 p-4"
+          onClick={handleClose}
+        >
+          <div className="relative max-w-5xl max-h-[90vh] flex items-center justify-center">
+            <img src={src} alt={alt} className="max-w-full max-h-[90vh] object-contain" />
+            <button
+              onClick={() => setIsOpen(false)}
+              className="absolute top-4 right-4 text-white hover:text-gray-300 transition-colors z-10"
+              aria-label="Close lightbox"
+            >
+              <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/pages/en/blog/[slug].astro
+++ b/src/pages/en/blog/[slug].astro
@@ -9,6 +9,7 @@ import CategoryPill from '@components/ui/CategoryPill.astro';
 import DateComponent from '@components/ui/Date.astro';
 import { Image } from 'astro:assets';
 import VideoHero from '@components/blog/VideoHero.tsx';
+import BlogImageLightbox from '@components/blog/BlogImageLightbox.tsx';
 import SpeakEnglish from '@components/blog/SpeakEnglish.astro';
 import { siteConfig } from '@data/config';
 import { normalizeBlogSlug, buildPostUrl, assertNoDoubleLang, stripLangPrefix } from '@utils/i18nRoutes';
@@ -215,31 +216,37 @@ const customHreflangs = [
           />
         </div>
       ) : (featuredObj || featuredUrl) && (
-        <div class="relative mb-12 rounded-lg shadow-lg" style="overflow: hidden;">
-          {featuredObj ? (
-            <Image
-              src={featuredObj}
-              alt={post.data.imageAlt || post.data.title}
-              width={1200}
-              height={675}
-              class="w-full object-cover h-[300px] md:h-[450px] lg:h-[675px] rounded-lg"
-              quality={80}
-              format="webp"
-              style="display: block; margin: 0; padding: 0;"
-            />
-          ) : (
-            <img
-              src={featuredUrl!}
-              alt={post.data.imageAlt || post.data.title}
-              class="w-full object-cover h-[300px] md:h-[450px] lg:h-[675px] rounded-lg"
-              loading="eager"
-              width="1200"
-              height="675"
-              style="display: block; margin: 0; padding: 0;"
-            />
-          )}
-          <div class="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-black/50 to-transparent rounded-b-lg"></div>
-        </div>
+        <BlogImageLightbox
+          client:load
+          src={featuredUrl || (featuredObj?.src as string)}
+          alt={post.data.imageAlt || post.data.title}
+        >
+          <div class="relative mb-12 rounded-lg shadow-lg" style="overflow: hidden;">
+            {featuredObj ? (
+              <Image
+                src={featuredObj}
+                alt={post.data.imageAlt || post.data.title}
+                width={1200}
+                height={675}
+                class="w-full object-cover h-[300px] md:h-[450px] lg:h-[675px] rounded-lg"
+                quality={80}
+                format="webp"
+                style="display: block; margin: 0; padding: 0;"
+              />
+            ) : (
+              <img
+                src={featuredUrl!}
+                alt={post.data.imageAlt || post.data.title}
+                class="w-full object-cover h-[300px] md:h-[450px] lg:h-[675px] rounded-lg"
+                loading="eager"
+                width="1200"
+                height="675"
+                style="display: block; margin: 0; padding: 0;"
+              />
+            )}
+            <div class="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-black/50 to-transparent rounded-b-lg"></div>
+          </div>
+        </BlogImageLightbox>
       )}
       
       <Content />
@@ -367,21 +374,24 @@ const customHreflangs = [
             {relatedPosts.map((related: CollectionEntry<'blog'>) => (
                 <a
                   href={cleanBlogUrl(buildPostUrl('en', stripLangPrefix(related.slug)))}
-                  class="group block bg-white rounded-lg shadow-md hover:shadow-xl transition-shadow duration-300 no-underline"
+                  class="group block bg-white rounded-lg shadow-md hover:shadow-xl transition-all duration-300 no-underline flex flex-col h-full"
                   style="overflow: hidden; padding: 0; margin: 0;"
                 >
                   {(() => {
                     const relObj = related?.data?.featuredImage;
                     const relUrl = (typeof relObj === 'object' && relObj?.src) ? relObj.src : (related?.data?.seo?.image ?? related?.data?.heroVideoPoster ?? null);
                     return relUrl ? (
-                      <div class="w-full h-36 bg-gray-100" style="margin: 0; padding: 0; display: block;">
+                      <div class="w-full h-36 bg-gray-100 overflow-hidden" style="margin: 0; padding: 0; display: block;">
                         <img src={relUrl} alt={related.data.imageAlt || related.data.title} class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300" loading="lazy" style="display: block; margin: 0; padding: 0;" />
                       </div>
                     ) : null;
                   })()}
-                  <div class="p-4">
+                  <div class="p-4 flex flex-col flex-grow">
                     <h3 class="font-bold text-sm mb-2 text-gray-900 group-hover:text-primary transition-colors line-clamp-2">{related.data.title}</h3>
-                    <p class="text-xs text-gray-600 line-clamp-2">{related.data.excerpt}</p>
+                    <p class="text-xs text-gray-600 line-clamp-2 flex-grow">{related.data.excerpt}</p>
+                    <div class="mt-3 inline-block text-primary font-semibold text-xs uppercase tracking-wide opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                      Read More →
+                    </div>
                   </div>
                 </a>
             ))}

--- a/src/pages/en/course/past-tenses/cheat-sheet.astro
+++ b/src/pages/en/course/past-tenses/cheat-sheet.astro
@@ -2,6 +2,7 @@
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
+import AudioButton from "@components/course/AudioButton";
 import {
   ArrowRight,
   ArrowLeft,
@@ -101,8 +102,14 @@ const tkey = "course/past-tenses/cheat-sheet" as const;
               <p><strong class="text-slate-900">Triggers:</strong> yesterday · last week · in 2019 · when I was 20 · ago</p>
               <div class="bg-white rounded p-2.5 border border-emerald-200">
                 <p class="text-xs text-emerald-700 font-semibold mb-1">EXAMPLES</p>
-                <p>"I <strong>worked</strong> at Telmex for eight years."</p>
-                <p>"She <strong>quit</strong> last Friday."</p>
+                <div class="flex items-center gap-2">
+                  <p class="flex-1">"I <strong>worked</strong> at Telmex for eight years."</p>
+                  <AudioButton client:load text="I worked at Telmex for eight years." lang="en-US" size="sm" />
+                </div>
+                <div class="flex items-center gap-2">
+                  <p class="flex-1">"She <strong>quit</strong> last Friday."</p>
+                  <AudioButton client:load text="She quit last Friday." lang="en-US" size="sm" />
+                </div>
               </div>
               <div class="bg-red-50 rounded p-2.5 border border-red-200">
                 <p class="text-xs text-red-700 font-semibold mb-1 flex items-center gap-1"><AlertTriangle class="w-3 h-3" /> MEXICAN TRAP</p>
@@ -131,8 +138,14 @@ const tkey = "course/past-tenses/cheat-sheet" as const;
               <p><strong class="text-slate-900">Triggers:</strong> when… · while… · as… · at 3pm yesterday · all morning</p>
               <div class="bg-white rounded p-2.5 border border-emerald-200">
                 <p class="text-xs text-emerald-700 font-semibold mb-1">EXAMPLES</p>
-                <p>"I <strong>was driving</strong> home when she <strong>called</strong>."</p>
-                <p>"We <strong>were having</strong> dinner at 8."</p>
+                <div class="flex items-center gap-2">
+                  <p class="flex-1">"I <strong>was driving</strong> home when she <strong>called</strong>."</p>
+                  <AudioButton client:load text="I was driving home when she called." lang="en-US" size="sm" />
+                </div>
+                <div class="flex items-center gap-2">
+                  <p class="flex-1">"We <strong>were having</strong> dinner at 8."</p>
+                  <AudioButton client:load text="We were having dinner at 8." lang="en-US" size="sm" />
+                </div>
               </div>
               <div class="bg-red-50 rounded p-2.5 border border-red-200">
                 <p class="text-xs text-red-700 font-semibold mb-1 flex items-center gap-1"><AlertTriangle class="w-3 h-3" /> MEXICAN TRAP</p>
@@ -161,9 +174,18 @@ const tkey = "course/past-tenses/cheat-sheet" as const;
               <p><strong class="text-slate-900">Triggers:</strong> already · yet · ever · never · just · since · for · this week (still going) · so far</p>
               <div class="bg-white rounded p-2.5 border border-emerald-300">
                 <p class="text-xs text-emerald-700 font-semibold mb-1">EXAMPLES</p>
-                <p>"I <strong>have done</strong> the report." (it's ready <em>now</em>)</p>
-                <p>"She <strong>has lived</strong> here since 2018." (still does)</p>
-                <p>"<strong>Have</strong> you <strong>seen</strong> the email?" (any time up to now)</p>
+                <div class="flex items-center gap-2">
+                  <p class="flex-1">"I <strong>have done</strong> the report." (it's ready <em>now</em>)</p>
+                  <AudioButton client:load text="I have done the report." lang="en-US" size="sm" />
+                </div>
+                <div class="flex items-center gap-2">
+                  <p class="flex-1">"She <strong>has lived</strong> here since 2018." (still does)</p>
+                  <AudioButton client:load text="She has lived here since 2018." lang="en-US" size="sm" />
+                </div>
+                <div class="flex items-center gap-2">
+                  <p class="flex-1">"<strong>Have</strong> you <strong>seen</strong> the email?" (any time up to now)</p>
+                  <AudioButton client:load text="Have you seen the email?" lang="en-US" size="sm" />
+                </div>
               </div>
               <div class="bg-red-50 rounded p-2.5 border border-red-200">
                 <p class="text-xs text-red-700 font-semibold mb-1 flex items-center gap-1"><AlertTriangle class="w-3 h-3" /> MEXICAN TRAP</p>
@@ -192,8 +214,14 @@ const tkey = "course/past-tenses/cheat-sheet" as const;
               <p><strong class="text-slate-900">Triggers:</strong> by the time… · before… · after… · already had… · when she arrived, I had already…</p>
               <div class="bg-white rounded p-2.5 border border-emerald-200">
                 <p class="text-xs text-emerald-700 font-semibold mb-1">EXAMPLES</p>
-                <p>"When I got there, the meeting <strong>had started</strong>."</p>
-                <p>"She <strong>had finished</strong> before I asked."</p>
+                <div class="flex items-center gap-2">
+                  <p class="flex-1">"When I got there, the meeting <strong>had started</strong>."</p>
+                  <AudioButton client:load text="When I got there, the meeting had started." lang="en-US" size="sm" />
+                </div>
+                <div class="flex items-center gap-2">
+                  <p class="flex-1">"She <strong>had finished</strong> before I asked."</p>
+                  <AudioButton client:load text="She had finished before I asked." lang="en-US" size="sm" />
+                </div>
               </div>
               <div class="bg-red-50 rounded p-2.5 border border-red-200">
                 <p class="text-xs text-red-700 font-semibold mb-1 flex items-center gap-1"><AlertTriangle class="w-3 h-3" /> MEXICAN TRAP</p>
@@ -311,17 +339,38 @@ const tkey = "course/past-tenses/cheat-sheet" as const;
           <div class="bg-white rounded-xl border border-slate-200 p-5 print:p-2 print:rounded-md print:break-inside-avoid">
             <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">Knew vs. Found out</p>
             <p class="text-sm text-slate-700 mb-2"><strong>Spanish:</strong> <em>sabía</em> (state) vs. <em>supe</em> (moment of discovery)</p>
-            <p class="text-sm text-slate-700"><strong>English:</strong> "I <strong>knew</strong> she was leaving" (ongoing state). "I <strong>found out</strong> she was leaving" (one moment of discovery — never "I knew it yesterday").</p>
+            <div class="flex items-center gap-2 text-sm text-slate-700 mb-1">
+              <p class="flex-1">"I <strong>knew</strong> she was leaving" (ongoing state).</p>
+              <AudioButton client:load text="I knew she was leaving." lang="en-US" size="sm" />
+            </div>
+            <div class="flex items-center gap-2 text-sm text-slate-700">
+              <p class="flex-1">"I <strong>found out</strong> she was leaving" (one moment of discovery).</p>
+              <AudioButton client:load text="I found out she was leaving." lang="en-US" size="sm" />
+            </div>
           </div>
           <div class="bg-white rounded-xl border border-slate-200 p-5 print:p-2 print:rounded-md print:break-inside-avoid">
             <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">There was vs. There has been</p>
             <p class="text-sm text-slate-700 mb-2"><strong>Spanish:</strong> <em>hubo</em> (closed) vs. <em>ha habido</em> (still relevant)</p>
-            <p class="text-sm text-slate-700"><strong>English:</strong> "There <strong>was</strong> a problem last week" (closed). "There <strong>has been</strong> a problem this morning" (still here, still mine to fix).</p>
+            <div class="flex items-center gap-2 text-sm text-slate-700 mb-1">
+              <p class="flex-1">"There <strong>was</strong> a problem last week" (closed).</p>
+              <AudioButton client:load text="There was a problem last week." lang="en-US" size="sm" />
+            </div>
+            <div class="flex items-center gap-2 text-sm text-slate-700">
+              <p class="flex-1">"There <strong>has been</strong> a problem this morning" (still here, still mine to fix).</p>
+              <AudioButton client:load text="There has been a problem this morning." lang="en-US" size="sm" />
+            </div>
           </div>
           <div class="bg-white rounded-xl border border-slate-200 p-5 print:p-2 print:rounded-md print:break-inside-avoid">
             <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">Did vs. Have done</p>
             <p class="text-sm text-slate-700 mb-2"><strong>Spanish:</strong> <em>hice</em> vs. <em>he hecho</em> — the same instinct works.</p>
-            <p class="text-sm text-slate-700"><strong>English:</strong> "I <strong>did</strong> the report yesterday" (closed). "I <strong>have done</strong> the report" (it's on your desk now — relevant).</p>
+            <div class="flex items-center gap-2 text-sm text-slate-700 mb-1">
+              <p class="flex-1">"I <strong>did</strong> the report yesterday" (closed).</p>
+              <AudioButton client:load text="I did the report yesterday." lang="en-US" size="sm" />
+            </div>
+            <div class="flex items-center gap-2 text-sm text-slate-700">
+              <p class="flex-1">"I <strong>have done</strong> the report" (it's on your desk now — relevant).</p>
+              <AudioButton client:load text="I have done the report." lang="en-US" size="sm" />
+            </div>
           </div>
         </div>
       </div>

--- a/src/pages/en/course/past-tenses/knew-vs-found-out.astro
+++ b/src/pages/en/course/past-tenses/knew-vs-found-out.astro
@@ -2,6 +2,7 @@
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
+import AudioButton from "@components/course/AudioButton";
 import {
   ArrowRight,
   ArrowLeft,
@@ -86,9 +87,18 @@ const tkey = "course/past-tenses/knew-vs-found-out" as const;
               A <strong>state</strong> of knowing. You already had the information. The knowledge was sitting in your head, possibly for years.
             </p>
             <div class="bg-white rounded-lg p-3 border border-emerald-200 text-sm space-y-1.5">
-              <p>"I <strong>knew</strong> she was leaving." (the whole time)</p>
-              <p>"He <strong>knew</strong> the answer." (already had it)</p>
-              <p>"We <strong>knew</strong> each other from college."</p>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"I <strong>knew</strong> she was leaving." (the whole time)</p>
+                <AudioButton client:load text="I knew she was leaving." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"He <strong>knew</strong> the answer." (already had it)</p>
+                <AudioButton client:load text="He knew the answer." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"We <strong>knew</strong> each other from college."</p>
+                <AudioButton client:load text="We knew each other from college." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
 
@@ -104,9 +114,18 @@ const tkey = "course/past-tenses/knew-vs-found-out" as const;
               The <strong>moment</strong> of discovering. A single point in time when the knowledge entered your head.
             </p>
             <div class="bg-white rounded-lg p-3 border border-amber-200 text-sm space-y-1.5">
-              <p>"I <strong>found out</strong> she was leaving." (one moment — maybe yesterday)</p>
-              <p>"He <strong>found out</strong> the answer at 5pm."</p>
-              <p>"We <strong>found out</strong> about it on Monday."</p>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"I <strong>found out</strong> she was leaving." (one moment — maybe yesterday)</p>
+                <AudioButton client:load text="I found out she was leaving." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"He <strong>found out</strong> the answer at 5pm."</p>
+                <AudioButton client:load text="He found out the answer at 5pm." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"We <strong>found out</strong> about it on Monday."</p>
+                <AudioButton client:load text="We found out about it on Monday." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
         </div>
@@ -155,27 +174,48 @@ const tkey = "course/past-tenses/knew-vs-found-out" as const;
           <div class="space-y-4 print:space-y-2">
             <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"___ you ___ that he had quit?"</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>Did you know</strong> (state) <span class="text-slate-400">or</span> <strong>Did you find out</strong> (moment) — both work, depending on intent</p>
+              <div class="flex items-start gap-2 text-sm">
+                <div class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>Did you know</strong> (state) <span class="text-slate-400">or</span> <strong>Did you find out</strong> (moment) — both work, depending on intent</div>
+                <div class="flex flex-col gap-1">
+                  <AudioButton client:load text="Did you know that he had quit?" lang="en-US" size="sm" />
+                  <AudioButton client:load text="Did you find out that he had quit?" lang="en-US" size="sm" />
+                </div>
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"I ___ about the meeting at 4pm."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>found out</strong> — "at 4pm" is a moment</p>
+              <div class="flex items-start gap-2 text-sm">
+                <div class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>found out</strong> — "at 4pm" is a moment</div>
+                <AudioButton client:load text="I found out about the meeting at 4pm." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"She ___ him for years before they dated."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>knew</strong> — "for years" is a state</p>
+              <div class="flex items-start gap-2 text-sm">
+                <div class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>knew</strong> — "for years" is a state</div>
+                <AudioButton client:load text="She knew him for years before they dated." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"How did you ___ that the company was sold?"</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>find out</strong> — "How" asks about the moment of discovery</p>
+              <div class="flex items-start gap-2 text-sm">
+                <div class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>find out</strong> — "How" asks about the moment of discovery</div>
+                <AudioButton client:load text="How did you find out that the company was sold?" lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"He ___ the answer the whole time."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>knew</strong> — "the whole time" is duration</p>
+              <div class="flex items-start gap-2 text-sm">
+                <div class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>knew</strong> — "the whole time" is duration</div>
+                <AudioButton client:load text="He knew the answer the whole time." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-center">
               <p class="text-slate-700">"We ___ about the layoffs yesterday."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>found out</strong> — "yesterday" + new information = moment</p>
+              <div class="flex items-start gap-2 text-sm">
+                <div class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>found out</strong> — "yesterday" + new information = moment</div>
+                <AudioButton client:load text="We found out about the layoffs yesterday." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/en/course/past-tenses/lesson-5.astro
+++ b/src/pages/en/course/past-tenses/lesson-5.astro
@@ -110,9 +110,18 @@ const tkey = "course/past-tenses/lesson-5" as const;
             <p class="text-sm text-emerald-700 font-mono mb-3">Works for actions AND states.</p>
             <p class="text-slate-700 text-sm mb-4">The flexible one. Covers anything that was repeatedly true or repeatedly done in the past.</p>
             <div class="bg-emerald-50 rounded-lg p-3 border border-emerald-200 text-sm space-y-2">
-              <p><strong>State:</strong> "I <strong>used to live</strong> in Guadalajara." (a situation that persisted)</p>
-              <p><strong>Action:</strong> "I <strong>used to play</strong> soccer every Saturday." (a habit)</p>
-              <p><strong>Feeling:</strong> "She <strong>used to love</strong> chocolate." (an old preference)</p>
+              <div class="flex items-center gap-2">
+                <p class="flex-1"><strong>State:</strong> "I <strong>used to live</strong> in Guadalajara." (a situation that persisted)</p>
+                <AudioButton client:load text="I used to live in Guadalajara." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1"><strong>Action:</strong> "I <strong>used to play</strong> soccer every Saturday." (a habit)</p>
+                <AudioButton client:load text="I used to play soccer every Saturday." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1"><strong>Feeling:</strong> "She <strong>used to love</strong> chocolate." (an old preference)</p>
+                <AudioButton client:load text="She used to love chocolate." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
 
@@ -121,8 +130,14 @@ const tkey = "course/past-tenses/lesson-5" as const;
             <p class="text-sm text-amber-700 font-mono mb-3">Works for repeated ACTIONS only.</p>
             <p class="text-slate-700 text-sm mb-4">The restricted one. Use it for things that <em>happened</em> repeatedly — but never for states like <em>live</em>, <em>have</em>, <em>be</em>, <em>love</em>.</p>
             <div class="bg-amber-50 rounded-lg p-3 border border-amber-200 text-sm space-y-2">
-              <p>✓ "Every Sunday, I <strong>would call</strong> my grandmother."</p>
-              <p>✓ "When we were kids, we <strong>would walk</strong> to school together."</p>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">✓ "Every Sunday, I <strong>would call</strong> my grandmother."</p>
+                <AudioButton client:load text="Every Sunday, I would call my grandmother." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">✓ "When we were kids, we <strong>would walk</strong> to school together."</p>
+                <AudioButton client:load text="When we were kids, we would walk to school together." lang="en-US" size="sm" />
+              </div>
               <p>✗ <span class="text-red-600">"I would live in Guadalajara"</span> — sounds like a conditional. Use <em>used to live</em>.</p>
             </div>
           </div>
@@ -152,16 +167,25 @@ const tkey = "course/past-tenses/lesson-5" as const;
         <div class="space-y-5">
           <div class="rounded-xl border-2 border-emerald-300 bg-emerald-50/60 p-6">
             <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-2">Positive</p>
-            <p class="text-slate-800">"I <strong>used to</strong> drink coffee every morning."</p>
+            <div class="flex items-center gap-2">
+              <p class="text-slate-800 flex-1">"I <strong>used to</strong> drink coffee every morning."</p>
+              <AudioButton client:load text="I used to drink coffee every morning." lang="en-US" size="sm" />
+            </div>
           </div>
           <div class="rounded-xl border-2 border-amber-300 bg-amber-50/60 p-6">
             <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">Negative (notice — no <em>'d'</em> after <em>didn't</em>)</p>
-            <p class="text-slate-800">"I <strong>didn't use to</strong> drink coffee."</p>
+            <div class="flex items-center gap-2">
+              <p class="text-slate-800 flex-1">"I <strong>didn't use to</strong> drink coffee."</p>
+              <AudioButton client:load text="I didn't use to drink coffee." lang="en-US" size="sm" />
+            </div>
             <p class="text-sm text-slate-500 mt-1">Not "didn't <s>used</s> to." The <em>did</em> already carries the past — the verb drops to <em>use</em>.</p>
           </div>
           <div class="rounded-xl border-2 border-amber-300 bg-amber-50/60 p-6">
             <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">Question</p>
-            <p class="text-slate-800">"<strong>Did</strong> you <strong>use to</strong> drink coffee?"</p>
+            <div class="flex items-center gap-2">
+              <p class="text-slate-800 flex-1">"<strong>Did</strong> you <strong>use to</strong> drink coffee?"</p>
+              <AudioButton client:load text="Did you use to drink coffee?" lang="en-US" size="sm" />
+            </div>
             <p class="text-sm text-slate-500 mt-1">Same rule. <em>Did</em> first, then <em>use to</em> (no 'd').</p>
           </div>
         </div>
@@ -248,27 +272,48 @@ const tkey = "course/past-tenses/lesson-5" as const;
           <div class="space-y-4">
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"___ I ___ in Monterrey for three years."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>I lived</strong> — a closed period with a specific duration → Past Simple.</p>
+              <div class="flex items-start gap-2 text-sm">
+                <div class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>I lived</strong> — a closed period with a specific duration → Past Simple.</div>
+                <AudioButton client:load text="I lived in Monterrey for three years." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"___ When I was a kid, I ___ in Monterrey."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>used to live</strong> — describing an old state with no duration ("when I was a kid" → vague past period).</p>
+              <div class="flex items-start gap-2 text-sm">
+                <div class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>used to live</strong> — describing an old state with no duration ("when I was a kid" → vague past period).</div>
+                <AudioButton client:load text="When I was a kid, I used to live in Monterrey." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"Last Sunday, I ___ my grandmother."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>called</strong> — one specific event → Past Simple.</p>
+              <div class="flex items-start gap-2 text-sm">
+                <div class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>called</strong> — one specific event → Past Simple.</div>
+                <AudioButton client:load text="Last Sunday, I called my grandmother." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"Every Sunday, I ___ my grandmother."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>used to call</strong> OR <strong>would call</strong> — the repeated habit. Both work because <em>call</em> is an action.</p>
+              <div class="flex items-start gap-2 text-sm">
+                <div class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>used to call</strong> OR <strong>would call</strong> — the repeated habit. Both work because <em>call</em> is an action.</div>
+                <div class="flex flex-col gap-1">
+                  <AudioButton client:load text="Every Sunday, I used to call my grandmother." lang="en-US" size="sm" />
+                  <AudioButton client:load text="Every Sunday, I would call my grandmother." lang="en-US" size="sm" />
+                </div>
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"She ___ coffee, but now she drinks tea."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>used to drink</strong> — past habit explicitly contrasted with the present → screams for <em>used to</em>.</p>
+              <div class="flex items-start gap-2 text-sm">
+                <div class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>used to drink</strong> — past habit explicitly contrasted with the present → screams for <em>used to</em>.</div>
+                <AudioButton client:load text="She used to drink coffee, but now she drinks tea." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start">
               <p class="text-slate-700">"Back then, we ___ broke."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>used to be</strong> — state. <em>Would be</em> is wrong here (sounds conditional).</p>
+              <div class="flex items-start gap-2 text-sm">
+                <div class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>used to be</strong> — state. <em>Would be</em> is wrong here (sounds conditional).</div>
+                <AudioButton client:load text="Back then, we used to be broke." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/en/course/past-tenses/practice-plan.astro
+++ b/src/pages/en/course/past-tenses/practice-plan.astro
@@ -2,6 +2,7 @@
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
+import AudioButton from "@components/course/AudioButton";
 import {
   ArrowRight,
   ArrowLeft,
@@ -104,9 +105,18 @@ const tkey = "course/past-tenses/practice-plan" as const;
             <h3 class="text-lg font-bold text-slate-900 mb-2">The 3-Sentence Diary</h3>
             <p class="text-sm text-slate-700 mb-3">Write exactly three sentences about yesterday. Use three different past tenses. Don't translate from Spanish.</p>
             <div class="bg-emerald-50 rounded-lg p-3 border border-emerald-200 text-xs space-y-1.5 text-slate-700">
-              <p><strong>Past Simple:</strong> "Yesterday I had a meeting with the new client."</p>
-              <p><strong>Past Continuous:</strong> "While I was preparing, the office WiFi went down."</p>
-              <p><strong>Present Perfect:</strong> "I have already followed up with him this morning."</p>
+              <div class="flex items-center gap-2">
+                <p class="flex-1"><strong>Past Simple:</strong> "Yesterday I had a meeting with the new client."</p>
+                <AudioButton client:load text="Yesterday I had a meeting with the new client." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1"><strong>Past Continuous:</strong> "While I was preparing, the office WiFi went down."</p>
+                <AudioButton client:load text="While I was preparing, the office WiFi went down." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1"><strong>Present Perfect:</strong> "I have already followed up with him this morning."</p>
+                <AudioButton client:load text="I have already followed up with him this morning." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
 

--- a/src/pages/en/course/past-tenses/story-openers.astro
+++ b/src/pages/en/course/past-tenses/story-openers.astro
@@ -2,6 +2,7 @@
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
+import AudioButton from "@components/course/AudioButton";
 import {
   ArrowRight,
   ArrowLeft,
@@ -156,7 +157,12 @@ const iconMap: Record<string, any> = { Coffee, Briefcase, GitBranch };
                     <li class="flex gap-3 pb-3 last:pb-0 last:border-0 border-b border-slate-100 print:pb-1">
                       <span class:list={["font-mono text-xs font-bold shrink-0 w-6 text-right", c.chip]}>{i + 1}.</span>
                       <div class="flex-1">
-                        <p class="font-semibold text-slate-900 text-base print:text-sm">"{o.en}"</p>
+                        <div class="flex items-center gap-2">
+                          <p class="font-semibold text-slate-900 text-base print:text-sm flex-1">"{o.en}"</p>
+                          <div class="print:hidden shrink-0">
+                            <AudioButton client:load text={o.en} lang="en-US" size="sm" />
+                          </div>
+                        </div>
                         <p class="text-xs text-slate-500 mt-0.5 print:hidden">{o.note}</p>
                       </div>
                     </li>

--- a/src/pages/en/course/past-tenses/there-was-vs-there-has-been.astro
+++ b/src/pages/en/course/past-tenses/there-was-vs-there-has-been.astro
@@ -2,6 +2,7 @@
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
+import AudioButton from "@components/course/AudioButton";
 import {
   ArrowRight,
   ArrowLeft,
@@ -86,9 +87,18 @@ const tkey = "course/past-tenses/there-was-vs-there-has-been" as const;
               The situation existed in <strong>closed past time</strong>. It's done. It's filed. It's a fact you're reporting from a sealed past.
             </p>
             <div class="bg-white rounded-lg p-3 border border-emerald-200 text-sm space-y-1.5">
-              <p>"<strong>There was</strong> a fire in 2018."</p>
-              <p>"<strong>There was</strong> an issue last week — we fixed it."</p>
-              <p>"<strong>There was</strong> a problem during the demo." (the demo is over)</p>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"<strong>There was</strong> a fire in 2018."</p>
+                <AudioButton client:load text="There was a fire in 2018." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"<strong>There was</strong> an issue last week — we fixed it."</p>
+                <AudioButton client:load text="There was an issue last week. We fixed it." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"<strong>There was</strong> a problem during the demo." (the demo is over)</p>
+                <AudioButton client:load text="There was a problem during the demo." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
 
@@ -104,9 +114,18 @@ const tkey = "course/past-tenses/there-was-vs-there-has-been" as const;
               The situation is <strong>still relevant</strong>. It started in the past and the consequence is still here, still mine to deal with.
             </p>
             <div class="bg-white rounded-lg p-3 border border-amber-200 text-sm space-y-1.5">
-              <p>"<strong>There has been</strong> a problem this morning." (still today, still happening)</p>
-              <p>"<strong>There have been</strong> delays — we're working on it." (currently)</p>
-              <p>"<strong>There has been</strong> an update since we last spoke."</p>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"<strong>There has been</strong> a problem this morning." (still today, still happening)</p>
+                <AudioButton client:load text="There has been a problem this morning." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"<strong>There have been</strong> delays — we're working on it." (currently)</p>
+                <AudioButton client:load text="There have been delays. We're working on it." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"<strong>There has been</strong> an update since we last spoke."</p>
+                <AudioButton client:load text="There has been an update since we last spoke." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
         </div>
@@ -124,13 +143,19 @@ const tkey = "course/past-tenses/there-was-vs-there-has-been" as const;
         <div class="space-y-4">
           <div class="bg-white rounded-2xl border-2 border-slate-200 p-6">
             <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-2">Closed — "Don't worry about it"</p>
-            <p class="text-slate-800 text-lg italic">"There was an issue with the deployment last night."</p>
-            <p class="text-sm text-slate-500 mt-2">→ The listener hears: "I'm reporting history. It's fixed. Moving on."</p>
+            <div class="flex items-start gap-3 mb-2">
+              <p class="text-slate-800 text-lg italic flex-1">"There was an issue with the deployment last night."</p>
+              <AudioButton client:load text="There was an issue with the deployment last night." lang="en-US" size="sm" />
+            </div>
+            <p class="text-sm text-slate-500">→ The listener hears: "I'm reporting history. It's fixed. Moving on."</p>
           </div>
           <div class="bg-white rounded-2xl border-2 border-amber-300 p-6">
             <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">Open — "I need your attention"</p>
-            <p class="text-slate-800 text-lg italic">"There has been an issue with the deployment."</p>
-            <p class="text-sm text-slate-500 mt-2">→ The listener hears: "This is still happening. Drop what you're doing."</p>
+            <div class="flex items-start gap-3 mb-2">
+              <p class="text-slate-800 text-lg italic flex-1">"There has been an issue with the deployment."</p>
+              <AudioButton client:load text="There has been an issue with the deployment." lang="en-US" size="sm" />
+            </div>
+            <p class="text-sm text-slate-500">→ The listener hears: "This is still happening. Drop what you're doing."</p>
           </div>
         </div>
 
@@ -154,23 +179,38 @@ const tkey = "course/past-tenses/there-was-vs-there-has-been" as const;
           <div class="space-y-4 print:space-y-2">
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">A fire happened in 2018. Now it's 2026.</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> a fire — closed time.</p>
+              <div class="flex items-start gap-2 text-sm">
+                <div class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> a fire — closed time.</div>
+                <AudioButton client:load text="There was a fire in 2018." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">Three Slack messages came in this morning. It's still morning.</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There have been</strong> three messages — period still open.</p>
+              <div class="flex items-start gap-2 text-sm">
+                <div class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There have been</strong> three messages — period still open.</div>
+                <AudioButton client:load text="There have been three messages this morning." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">You're explaining a closed Q1 result to the board in Q3.</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> a 12% dip in Q1 — Q1 is sealed.</p>
+              <div class="flex items-start gap-2 text-sm">
+                <div class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> a 12% dip in Q1 — Q1 is sealed.</div>
+                <AudioButton client:load text="There was a 12% dip in Q1." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">Customer complaints have been arriving all week. It's Thursday.</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There have been</strong> complaints this week — the week isn't over.</p>
+              <div class="flex items-start gap-2 text-sm">
+                <div class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There have been</strong> complaints this week — the week isn't over.</div>
+                <AudioButton client:load text="There have been complaints this week." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start">
               <p class="text-slate-700">Server outage happened yesterday. Already resolved.</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> an outage yesterday — fixed, closed.</p>
+              <div class="flex items-start gap-2 text-sm">
+                <div class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> an outage yesterday — fixed, closed.</div>
+                <AudioButton client:load text="There was an outage yesterday." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/en/course/past-tenses/top-10-confused-pairs.astro
+++ b/src/pages/en/course/past-tenses/top-10-confused-pairs.astro
@@ -2,6 +2,7 @@
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
+import AudioButton from "@components/course/AudioButton";
 import {
   ArrowRight,
   ArrowLeft,
@@ -22,6 +23,7 @@ const pairs = [
     spanish: "Both come from <em>decir</em> in Spanish.",
     rule: "<strong>Say</strong> the words. <strong>Tell</strong> a person.",
     good: "She <strong>told me</strong> the news. / She <strong>said</strong> the news was bad.",
+    audioText: "She told me the news. She said the news was bad.",
     trap: "\"She told that…\" — wrong. You tell <em>someone</em>. \"She told <strong>me</strong> that…\"",
   },
   {
@@ -31,6 +33,7 @@ const pairs = [
     spanish: "Both come from <em>hacer</em>.",
     rule: "<strong>Do</strong> a task or activity. <strong>Make</strong> a thing or a result.",
     good: "I <strong>did</strong> the report. / I <strong>made</strong> a decision.",
+    audioText: "I did the report. I made a decision.",
     trap: "\"I made the homework\" — wrong. Homework is an activity → <strong>did</strong> the homework.",
   },
   {
@@ -40,6 +43,7 @@ const pairs = [
     spanish: "Both feel like <em>acostar(se)</em>.",
     rule: "<strong>Lay</strong> takes an object. <strong>Lie</strong> doesn't.",
     good: "I <strong>laid</strong> the report on his desk. / I <strong>lay</strong> on the sofa for an hour.",
+    audioText: "I laid the report on his desk. I lay on the sofa for an hour.",
     trap: "Past of <em>lie</em> is <em>lay</em>. Past of <em>lay</em> is <em>laid</em>. \"I <strong>lay</strong> down yesterday\" = past of <em>lie</em>, no object.",
   },
   {
@@ -49,6 +53,7 @@ const pairs = [
     spanish: "<em>Subir / levantar(se)</em> overlap.",
     rule: "<strong>Rise</strong> goes up by itself. <strong>Raise</strong> takes an object.",
     good: "Prices <strong>rose</strong> last quarter. / The CEO <strong>raised</strong> prices last quarter.",
+    audioText: "Prices rose last quarter. The CEO raised prices last quarter.",
     trap: "\"They raised\" without an object = wrong. Use <em>rose</em>.",
   },
   {
@@ -58,6 +63,7 @@ const pairs = [
     spanish: "Both feel like <em>ganar</em>.",
     rule: "<strong>Win</strong> a thing (a game, a prize, an argument). <strong>Beat</strong> a person or team.",
     good: "We <strong>won</strong> the contract. / We <strong>beat</strong> their team.",
+    audioText: "We won the contract. We beat their team.",
     trap: "\"We won them\" — wrong. \"We <strong>beat</strong> them\" or \"we won <strong>against</strong> them.\"",
   },
   {
@@ -67,6 +73,7 @@ const pairs = [
     spanish: "<em>Prestar</em> goes both directions in Spanish.",
     rule: "<strong>Borrow</strong> = take from someone. <strong>Lend</strong> = give to someone.",
     good: "Can I <strong>borrow</strong> your charger? / Can you <strong>lend</strong> me your charger?",
+    audioText: "Can I borrow your charger? Can you lend me your charger?",
     trap: "\"Can you borrow me…\" — wrong. You'd be taking from yourself.",
   },
   {
@@ -76,6 +83,7 @@ const pairs = [
     spanish: "<em>Traer / llevar</em> — but the English perspective flips.",
     rule: "<strong>Bring</strong> toward the speaker. <strong>Take</strong> away from the speaker.",
     good: "<strong>Bring</strong> the report <em>here</em>. / <strong>Take</strong> the report <em>there</em>.",
+    audioText: "Bring the report here. Take the report there.",
     trap: "\"I'll bring it to the meeting\" (you're <em>going to</em> the meeting) — usually <em>take</em>. Use <em>bring</em> only if the listener is <em>at</em> the meeting.",
   },
   {
@@ -85,6 +93,7 @@ const pairs = [
     spanish: "Both can land as <em>recordar</em>.",
     rule: "<strong>Remember</strong> = recall on your own. <strong>Remind</strong> = make someone else recall.",
     good: "I <strong>remember</strong> the meeting. / Can you <strong>remind</strong> me about the meeting?",
+    audioText: "I remember the meeting. Can you remind me about the meeting?",
     trap: "\"Remember me to call her\" — wrong. \"<strong>Remind</strong> me to call her.\"",
   },
   {
@@ -94,6 +103,7 @@ const pairs = [
     spanish: "<em>Perder</em> covers both in Spanish.",
     rule: "<strong>Miss</strong> a deadline, a flight, a chance. <strong>Lose</strong> a thing or a competition.",
     good: "I <strong>missed</strong> the flight. / I <strong>lost</strong> my keys.",
+    audioText: "I missed the flight. I lost my keys.",
     trap: "\"I lost the bus\" — wrong. You <strong>missed</strong> the bus. You only <em>lose</em> things you possess.",
   },
   {
@@ -103,6 +113,7 @@ const pairs = [
     spanish: "<em>Escuchar / oír</em> — but distribution differs.",
     rule: "<strong>Listen</strong> is active (intention). <strong>Hear</strong> is passive (just the sound).",
     good: "I <strong>listened</strong> to the call carefully. / I <strong>heard</strong> a noise outside.",
+    audioText: "I listened to the call carefully. I heard a noise outside.",
     trap: "\"I'm hearing music\" — usually wrong. If you put it on intentionally, you're <strong>listening to</strong> music.",
   },
 ];
@@ -174,9 +185,12 @@ const pairs = [
               <p class="text-xs text-slate-500 italic mb-3 print:text-xs" set:html={p.spanish} />
               <div class="space-y-2.5 text-sm text-slate-700 print:text-xs">
                 <p set:html={`<strong class="text-slate-900">Rule:</strong> ${p.rule}`} />
-                <div class="bg-emerald-50 rounded p-2.5 border border-emerald-200 flex gap-2">
+                <div class="bg-emerald-50 rounded p-2.5 border border-emerald-200 flex gap-2 items-start">
                   <CheckCircle2 class="w-4 h-4 text-emerald-600 shrink-0 mt-0.5" />
-                  <p set:html={p.good} />
+                  <p set:html={p.good} class="flex-1" />
+                  <div class="print:hidden shrink-0">
+                    <AudioButton client:load text={p.audioText} lang="en-US" size="sm" />
+                  </div>
                 </div>
                 <div class="bg-red-50 rounded p-2.5 border border-red-200 flex gap-2">
                   <XCircle class="w-4 h-4 text-red-600 shrink-0 mt-0.5" />

--- a/src/pages/es/blog/[slug].astro
+++ b/src/pages/es/blog/[slug].astro
@@ -9,6 +9,7 @@ import CategoryPill from '@components/ui/CategoryPill.astro';
 import DateComponent from '@components/ui/Date.astro';
 import { Image } from 'astro:assets';
 import VideoHero from '@components/blog/VideoHero.tsx';
+import BlogImageLightbox from '@components/blog/BlogImageLightbox.tsx';
 import SpeakEnglish from '@components/blog/SpeakEnglish.astro';
 import { siteConfig } from '@data/config';
 import { normalizeBlogSlug, buildPostUrl, assertNoDoubleLang, stripLangPrefix } from '@utils/i18nRoutes';
@@ -214,31 +215,37 @@ const customHreflangs = [
           />
         </div>
       ) : (featuredObj || featuredUrl) && (
-        <div class="relative mb-12 rounded-lg shadow-lg" style="overflow: hidden;">
-          {featuredObj ? (
-            <Image
-              src={featuredObj}
-              alt={post.data.imageAlt || post.data.title}
-              width={1200}
-              height={675}
-              class="w-full object-cover h-[300px] md:h-[450px] lg:h-[675px] rounded-lg"
-              quality={80}
-              format="webp"
-              style="display: block; margin: 0; padding: 0;"
-            />
-          ) : (
-            <img
-              src={featuredUrl!}
-              alt={post.data.imageAlt || post.data.title}
-              class="w-full object-cover h-[300px] md:h-[450px] lg:h-[675px] rounded-lg"
-              loading="eager"
-              width="1200"
-              height="675"
-              style="display: block; margin: 0; padding: 0;"
-            />
-          )}
-          <div class="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-black/50 to-transparent rounded-b-lg"></div>
-        </div>
+        <BlogImageLightbox
+          client:load
+          src={featuredUrl || (featuredObj?.src as string)}
+          alt={post.data.imageAlt || post.data.title}
+        >
+          <div class="relative mb-12 rounded-lg shadow-lg" style="overflow: hidden;">
+            {featuredObj ? (
+              <Image
+                src={featuredObj}
+                alt={post.data.imageAlt || post.data.title}
+                width={1200}
+                height={675}
+                class="w-full object-cover h-[300px] md:h-[450px] lg:h-[675px] rounded-lg"
+                quality={80}
+                format="webp"
+                style="display: block; margin: 0; padding: 0;"
+              />
+            ) : (
+              <img
+                src={featuredUrl!}
+                alt={post.data.imageAlt || post.data.title}
+                class="w-full object-cover h-[300px] md:h-[450px] lg:h-[675px] rounded-lg"
+                loading="eager"
+                width="1200"
+                height="675"
+                style="display: block; margin: 0; padding: 0;"
+              />
+            )}
+            <div class="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-black/50 to-transparent rounded-b-lg"></div>
+          </div>
+        </BlogImageLightbox>
       )}
       
       <Content />
@@ -366,21 +373,24 @@ const customHreflangs = [
             {relatedPosts.map((related: CollectionEntry<'blog'>) => (
                 <a
                   href={cleanBlogUrl(buildPostUrl('es', stripLangPrefix(related.slug)))}
-                  class="group block bg-white rounded-lg shadow-md hover:shadow-xl transition-shadow duration-300 no-underline"
+                  class="group block bg-white rounded-lg shadow-md hover:shadow-xl transition-all duration-300 no-underline flex flex-col h-full"
                   style="overflow: hidden; padding: 0; margin: 0;"
                 >
                   {(() => {
                     const relObj = related?.data?.featuredImage;
                     const relUrl = (typeof relObj === 'object' && relObj?.src) ? relObj.src : (related?.data?.seo?.image ?? related?.data?.heroVideoPoster ?? null);
                     return relUrl ? (
-                      <div class="w-full h-36 bg-gray-100" style="margin: 0; padding: 0; display: block;">
+                      <div class="w-full h-36 bg-gray-100 overflow-hidden" style="margin: 0; padding: 0; display: block;">
                         <img src={relUrl} alt={related.data.imageAlt || related.data.title} class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300" loading="lazy" style="display: block; margin: 0; padding: 0;" />
                       </div>
                     ) : null;
                   })()}
-                  <div class="p-4">
+                  <div class="p-4 flex flex-col flex-grow">
                     <h3 class="font-bold text-sm mb-2 text-gray-900 group-hover:text-primary transition-colors line-clamp-2">{related.data.title}</h3>
-                    <p class="text-xs text-gray-600 line-clamp-2">{related.data.excerpt}</p>
+                    <p class="text-xs text-gray-600 line-clamp-2 flex-grow">{related.data.excerpt}</p>
+                    <div class="mt-3 inline-block text-primary font-semibold text-xs uppercase tracking-wide opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                      Leer Más →
+                    </div>
                   </div>
                 </a>
             ))}

--- a/src/pages/es/curso/tiempos-del-pasado/frases-iniciales.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/frases-iniciales.astro
@@ -2,6 +2,7 @@
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
+import AudioButton from "@components/course/AudioButton";
 import {
   ArrowRight,
   ArrowLeft,
@@ -156,7 +157,12 @@ const iconMap: Record<string, any> = { Coffee, Briefcase, GitBranch };
                     <li class="flex gap-3 pb-3 last:pb-0 last:border-0 border-b border-slate-100 print:pb-1">
                       <span class:list={["font-mono text-xs font-bold shrink-0 w-6 text-right", c.chip]}>{i + 1}.</span>
                       <div class="flex-1">
-                        <p class="font-semibold text-slate-900 text-base print:text-sm">"{o.en}"</p>
+                        <div class="flex items-center gap-2">
+                          <p class="font-semibold text-slate-900 text-base print:text-sm flex-1">"{o.en}"</p>
+                          <div class="print:hidden shrink-0">
+                            <AudioButton client:load text={o.en} lang="en-US" size="sm" />
+                          </div>
+                        </div>
                         <p class="text-xs text-slate-500 mt-0.5 print:hidden">{o.note}</p>
                       </div>
                     </li>

--- a/src/pages/es/curso/tiempos-del-pasado/guia-rapida.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/guia-rapida.astro
@@ -2,6 +2,7 @@
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
+import AudioButton from "@components/course/AudioButton";
 import {
   ArrowRight,
   ArrowLeft,
@@ -99,8 +100,14 @@ const tkey = "course/past-tenses/cheat-sheet" as const;
               <p><strong class="text-slate-900">Disparadores:</strong> yesterday · last week · in 2019 · when I was 20 · ago</p>
               <div class="bg-white rounded p-2.5 border border-emerald-200">
                 <p class="text-xs text-emerald-700 font-semibold mb-1">EJEMPLOS</p>
-                <p>"I <strong>worked</strong> at Telmex for eight years."</p>
-                <p>"She <strong>quit</strong> last Friday."</p>
+                <div class="flex items-center gap-2 mb-0.5">
+                  <p class="flex-1">"I <strong>worked</strong> at Telmex for eight years."</p>
+                  <AudioButton client:load text="I worked at Telmex for eight years." lang="en-US" size="sm" />
+                </div>
+                <div class="flex items-center gap-2">
+                  <p class="flex-1">"She <strong>quit</strong> last Friday."</p>
+                  <AudioButton client:load text="She quit last Friday." lang="en-US" size="sm" />
+                </div>
               </div>
               <div class="bg-red-50 rounded p-2.5 border border-red-200">
                 <p class="text-xs text-red-700 font-semibold mb-1 flex items-center gap-1"><AlertTriangle class="w-3 h-3" /> TRAMPA MEXICANA</p>
@@ -129,8 +136,14 @@ const tkey = "course/past-tenses/cheat-sheet" as const;
               <p><strong class="text-slate-900">Disparadores:</strong> when… · while… · as… · at 3pm yesterday · all morning</p>
               <div class="bg-white rounded p-2.5 border border-emerald-200">
                 <p class="text-xs text-emerald-700 font-semibold mb-1">EJEMPLOS</p>
-                <p>"I <strong>was driving</strong> home when she <strong>called</strong>."</p>
-                <p>"We <strong>were having</strong> dinner at 8."</p>
+                <div class="flex items-center gap-2 mb-0.5">
+                  <p class="flex-1">"I <strong>was driving</strong> home when she <strong>called</strong>."</p>
+                  <AudioButton client:load text="I was driving home when she called." lang="en-US" size="sm" />
+                </div>
+                <div class="flex items-center gap-2">
+                  <p class="flex-1">"We <strong>were having</strong> dinner at 8."</p>
+                  <AudioButton client:load text="We were having dinner at 8." lang="en-US" size="sm" />
+                </div>
               </div>
               <div class="bg-red-50 rounded p-2.5 border border-red-200">
                 <p class="text-xs text-red-700 font-semibold mb-1 flex items-center gap-1"><AlertTriangle class="w-3 h-3" /> TRAMPA MEXICANA</p>
@@ -159,9 +172,18 @@ const tkey = "course/past-tenses/cheat-sheet" as const;
               <p><strong class="text-slate-900">Disparadores:</strong> already · yet · ever · never · just · since · for · this week (sigue corriendo) · so far</p>
               <div class="bg-white rounded p-2.5 border border-emerald-300">
                 <p class="text-xs text-emerald-700 font-semibold mb-1">EJEMPLOS</p>
-                <p>"I <strong>have done</strong> the report." (está listo <em>ahora</em>)</p>
-                <p>"She <strong>has lived</strong> here since 2018." (todavía vive aquí)</p>
-                <p>"<strong>Have</strong> you <strong>seen</strong> the email?" (en cualquier momento hasta ahora)</p>
+                <div class="flex items-center gap-2 mb-0.5">
+                  <p class="flex-1">"I <strong>have done</strong> the report." (está listo <em>ahora</em>)</p>
+                  <AudioButton client:load text="I have done the report." lang="en-US" size="sm" />
+                </div>
+                <div class="flex items-center gap-2 mb-0.5">
+                  <p class="flex-1">"She <strong>has lived</strong> here since 2018." (todavía vive aquí)</p>
+                  <AudioButton client:load text="She has lived here since 2018." lang="en-US" size="sm" />
+                </div>
+                <div class="flex items-center gap-2">
+                  <p class="flex-1">"<strong>Have</strong> you <strong>seen</strong> the email?" (en cualquier momento hasta ahora)</p>
+                  <AudioButton client:load text="Have you seen the email?" lang="en-US" size="sm" />
+                </div>
               </div>
               <div class="bg-red-50 rounded p-2.5 border border-red-200">
                 <p class="text-xs text-red-700 font-semibold mb-1 flex items-center gap-1"><AlertTriangle class="w-3 h-3" /> TRAMPA MEXICANA</p>
@@ -190,8 +212,14 @@ const tkey = "course/past-tenses/cheat-sheet" as const;
               <p><strong class="text-slate-900">Disparadores:</strong> by the time… · before… · after… · already had… · when she arrived, I had already…</p>
               <div class="bg-white rounded p-2.5 border border-emerald-200">
                 <p class="text-xs text-emerald-700 font-semibold mb-1">EJEMPLOS</p>
-                <p>"When I got there, the meeting <strong>had started</strong>."</p>
-                <p>"She <strong>had finished</strong> before I asked."</p>
+                <div class="flex items-center gap-2 mb-0.5">
+                  <p class="flex-1">"When I got there, the meeting <strong>had started</strong>."</p>
+                  <AudioButton client:load text="When I got there, the meeting had started." lang="en-US" size="sm" />
+                </div>
+                <div class="flex items-center gap-2">
+                  <p class="flex-1">"She <strong>had finished</strong> before I asked."</p>
+                  <AudioButton client:load text="She had finished before I asked." lang="en-US" size="sm" />
+                </div>
               </div>
               <div class="bg-red-50 rounded p-2.5 border border-red-200">
                 <p class="text-xs text-red-700 font-semibold mb-1 flex items-center gap-1"><AlertTriangle class="w-3 h-3" /> TRAMPA MEXICANA</p>
@@ -309,17 +337,38 @@ const tkey = "course/past-tenses/cheat-sheet" as const;
           <div class="bg-white rounded-xl border border-slate-200 p-5 print:p-2 print:rounded-md print:break-inside-avoid">
             <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">Knew vs. Found out</p>
             <p class="text-sm text-slate-700 mb-2"><strong>Español:</strong> <em>sabía</em> (estado) vs. <em>supe</em> (momento de descubrir)</p>
-            <p class="text-sm text-slate-700"><strong>Inglés:</strong> "I <strong>knew</strong> she was leaving" (estado continuo). "I <strong>found out</strong> she was leaving" (un momento de descubrimiento — nunca "I knew it yesterday").</p>
+            <div class="flex items-center gap-2 text-sm text-slate-700 mb-1">
+              <p class="flex-1"><strong>Inglés:</strong> "I <strong>knew</strong> she was leaving" (estado continuo).</p>
+              <AudioButton client:load text="I knew she was leaving." lang="en-US" size="sm" />
+            </div>
+            <div class="flex items-center gap-2 text-sm text-slate-700">
+              <p class="flex-1">"I <strong>found out</strong> she was leaving" (momento de descubrimiento).</p>
+              <AudioButton client:load text="I found out she was leaving." lang="en-US" size="sm" />
+            </div>
           </div>
           <div class="bg-white rounded-xl border border-slate-200 p-5 print:p-2 print:rounded-md print:break-inside-avoid">
             <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">There was vs. There has been</p>
             <p class="text-sm text-slate-700 mb-2"><strong>Español:</strong> <em>hubo</em> (cerrado) vs. <em>ha habido</em> (todavía relevante)</p>
-            <p class="text-sm text-slate-700"><strong>Inglés:</strong> "There <strong>was</strong> a problem last week" (cerrado). "There <strong>has been</strong> a problem this morning" (todavía aquí, todavía me toca resolverlo).</p>
+            <div class="flex items-center gap-2 text-sm text-slate-700 mb-1">
+              <p class="flex-1"><strong>Inglés:</strong> "There <strong>was</strong> a problem last week" (cerrado).</p>
+              <AudioButton client:load text="There was a problem last week." lang="en-US" size="sm" />
+            </div>
+            <div class="flex items-center gap-2 text-sm text-slate-700">
+              <p class="flex-1">"There <strong>has been</strong> a problem this morning" (todavía relevante).</p>
+              <AudioButton client:load text="There has been a problem this morning." lang="en-US" size="sm" />
+            </div>
           </div>
           <div class="bg-white rounded-xl border border-slate-200 p-5 print:p-2 print:rounded-md print:break-inside-avoid">
             <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">Did vs. Have done</p>
             <p class="text-sm text-slate-700 mb-2"><strong>Español:</strong> <em>hice</em> vs. <em>he hecho</em> — el mismo instinto funciona.</p>
-            <p class="text-sm text-slate-700"><strong>Inglés:</strong> "I <strong>did</strong> the report yesterday" (cerrado). "I <strong>have done</strong> the report" (está en tu escritorio ahora — relevante).</p>
+            <div class="flex items-center gap-2 text-sm text-slate-700 mb-1">
+              <p class="flex-1"><strong>Inglés:</strong> "I <strong>did</strong> the report yesterday" (cerrado).</p>
+              <AudioButton client:load text="I did the report yesterday." lang="en-US" size="sm" />
+            </div>
+            <div class="flex items-center gap-2 text-sm text-slate-700">
+              <p class="flex-1">"I <strong>have done</strong> the report" (está en tu escritorio ahora).</p>
+              <AudioButton client:load text="I have done the report." lang="en-US" size="sm" />
+            </div>
           </div>
         </div>
       </div>

--- a/src/pages/es/curso/tiempos-del-pasado/knew-vs-found-out.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/knew-vs-found-out.astro
@@ -2,6 +2,7 @@
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
+import AudioButton from "@components/course/AudioButton";
 import {
   ArrowRight,
   ArrowLeft,
@@ -86,9 +87,18 @@ const tkey = "course/past-tenses/knew-vs-found-out" as const;
               Un <strong>estado</strong> de saber. Ya tenías la información. El conocimiento estaba en tu cabeza, posiblemente desde hace años.
             </p>
             <div class="bg-white rounded-lg p-3 border border-emerald-200 text-sm space-y-1.5">
-              <p>"I <strong>knew</strong> she was leaving." (todo el tiempo)</p>
-              <p>"He <strong>knew</strong> the answer." (ya la tenía)</p>
-              <p>"We <strong>knew</strong> each other from college."</p>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"I <strong>knew</strong> she was leaving." (todo el tiempo)</p>
+                <AudioButton client:load text="I knew she was leaving." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"He <strong>knew</strong> the answer." (ya la tenía)</p>
+                <AudioButton client:load text="He knew the answer." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"We <strong>knew</strong> each other from college."</p>
+                <AudioButton client:load text="We knew each other from college." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
 
@@ -104,9 +114,18 @@ const tkey = "course/past-tenses/knew-vs-found-out" as const;
               El <strong>momento</strong> de descubrir. Un punto único en el tiempo cuando el conocimiento entró a tu cabeza.
             </p>
             <div class="bg-white rounded-lg p-3 border border-amber-200 text-sm space-y-1.5">
-              <p>"I <strong>found out</strong> she was leaving." (un momento — quizás ayer)</p>
-              <p>"He <strong>found out</strong> the answer at 5pm."</p>
-              <p>"We <strong>found out</strong> about it on Monday."</p>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"I <strong>found out</strong> she was leaving." (un momento — quizás ayer)</p>
+                <AudioButton client:load text="I found out she was leaving." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"He <strong>found out</strong> the answer at 5pm."</p>
+                <AudioButton client:load text="He found out the answer at 5pm." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"We <strong>found out</strong> about it on Monday."</p>
+                <AudioButton client:load text="We found out about it on Monday." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
         </div>
@@ -153,29 +172,53 @@ const tkey = "course/past-tenses/knew-vs-found-out" as const;
 
         <div class="bg-emerald-50 rounded-2xl border-2 border-emerald-300 p-6 md:p-8 print:p-3 print:rounded-md">
           <div class="space-y-4 print:space-y-2">
-            <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
+            <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"___ you ___ that he had quit?"</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>Did you know</strong> (estado) <span class="text-slate-400">o</span> <strong>Did you find out</strong> (momento) — ambos sirven, depende de la intención</p>
+              <div class="flex flex-col gap-1 text-sm">
+                <div class="flex items-center gap-2">
+                  <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>Did you know</strong> (estado)</p>
+                  <AudioButton client:load text="Did you know that he had quit?" lang="en-US" size="sm" />
+                </div>
+                <div class="flex items-center gap-2">
+                  <p class="flex-1"><span class="text-slate-400">o</span> <strong>Did you find out</strong> (momento) — ambos sirven</p>
+                  <AudioButton client:load text="Did you find out that he had quit?" lang="en-US" size="sm" />
+                </div>
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"I ___ about the meeting at 4pm."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>found out</strong> — "at 4pm" es un momento</p>
+              <div class="flex items-center gap-2 text-sm">
+                <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>found out</strong> — "at 4pm" es un momento</p>
+                <AudioButton client:load text="I found out about the meeting at 4pm." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"She ___ him for years before they dated."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>knew</strong> — "for years" es estado</p>
+              <div class="flex items-center gap-2 text-sm">
+                <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>knew</strong> — "for years" es estado</p>
+                <AudioButton client:load text="She knew him for years before they dated." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"How did you ___ that the company was sold?"</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>find out</strong> — "How" pregunta por el momento del descubrimiento</p>
+              <div class="flex items-center gap-2 text-sm">
+                <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>find out</strong> — "How" pregunta por el momento del descubrimiento</p>
+                <AudioButton client:load text="How did you find out that the company was sold?" lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-center pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"He ___ the answer the whole time."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>knew</strong> — "the whole time" es duración</p>
+              <div class="flex items-center gap-2 text-sm">
+                <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>knew</strong> — "the whole time" es duración</p>
+                <AudioButton client:load text="He knew the answer the whole time." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-center">
               <p class="text-slate-700">"We ___ about the layoffs yesterday."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>found out</strong> — "yesterday" + información nueva = momento</p>
+              <div class="flex items-center gap-2 text-sm">
+                <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>found out</strong> — "yesterday" + información nueva = momento</p>
+                <AudioButton client:load text="We found out about the layoffs yesterday." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/es/curso/tiempos-del-pasado/leccion-5.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/leccion-5.astro
@@ -110,9 +110,18 @@ const tkey = "course/past-tenses/lesson-5" as const;
             <p class="text-sm text-emerald-700 font-mono mb-3">Funciona para acciones Y estados.</p>
             <p class="text-slate-700 text-sm mb-4">El flexible. Cubre cualquier cosa que era repetidamente verdad o se hacía repetidamente en el pasado.</p>
             <div class="bg-emerald-50 rounded-lg p-3 border border-emerald-200 text-sm space-y-2">
-              <p><strong>Estado:</strong> "I <strong>used to live</strong> in Guadalajara." (una situación que persistía)</p>
-              <p><strong>Acción:</strong> "I <strong>used to play</strong> soccer every Saturday." (un hábito)</p>
-              <p><strong>Sentimiento:</strong> "She <strong>used to love</strong> chocolate." (una preferencia vieja)</p>
+              <div class="flex items-center gap-2">
+                <p class="flex-1"><strong>Estado:</strong> "I <strong>used to live</strong> in Guadalajara." (una situación que persistía)</p>
+                <AudioButton client:load text="I used to live in Guadalajara." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1"><strong>Acción:</strong> "I <strong>used to play</strong> soccer every Saturday." (un hábito)</p>
+                <AudioButton client:load text="I used to play soccer every Saturday." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1"><strong>Sentimiento:</strong> "She <strong>used to love</strong> chocolate." (una preferencia vieja)</p>
+                <AudioButton client:load text="She used to love chocolate." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
 
@@ -121,8 +130,14 @@ const tkey = "course/past-tenses/lesson-5" as const;
             <p class="text-sm text-amber-700 font-mono mb-3">Funciona solo para ACCIONES repetidas.</p>
             <p class="text-slate-700 text-sm mb-4">El restringido. Úsalo para cosas que <em>sucedían</em> repetidamente — pero nunca para estados como <em>live</em>, <em>have</em>, <em>be</em>, <em>love</em>.</p>
             <div class="bg-amber-50 rounded-lg p-3 border border-amber-200 text-sm space-y-2">
-              <p>✓ "Every Sunday, I <strong>would call</strong> my grandmother."</p>
-              <p>✓ "When we were kids, we <strong>would walk</strong> to school together."</p>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">✓ "Every Sunday, I <strong>would call</strong> my grandmother."</p>
+                <AudioButton client:load text="Every Sunday, I would call my grandmother." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">✓ "When we were kids, we <strong>would walk</strong> to school together."</p>
+                <AudioButton client:load text="When we were kids, we would walk to school together." lang="en-US" size="sm" />
+              </div>
               <p>✗ <span class="text-red-600">"I would live in Guadalajara"</span> — suena condicional. Usa <em>used to live</em>.</p>
             </div>
           </div>
@@ -152,17 +167,26 @@ const tkey = "course/past-tenses/lesson-5" as const;
         <div class="space-y-5">
           <div class="rounded-xl border-2 border-emerald-300 bg-emerald-50/60 p-6">
             <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-2">Positivo</p>
-            <p class="text-slate-800">"I <strong>used to</strong> drink coffee every morning."</p>
+            <div class="flex items-center gap-2">
+              <p class="text-slate-800 flex-1">"I <strong>used to</strong> drink coffee every morning."</p>
+              <AudioButton client:load text="I used to drink coffee every morning." lang="en-US" size="sm" />
+            </div>
           </div>
           <div class="rounded-xl border-2 border-amber-300 bg-amber-50/60 p-6">
             <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">Negativo (fíjate — sin <em>'d'</em> después de <em>didn't</em>)</p>
-            <p class="text-slate-800">"I <strong>didn't use to</strong> drink coffee."</p>
-            <p class="text-sm text-slate-500 mt-1">No "didn't <s>used</s> to." El <em>did</em> ya carga el pasado — el verbo se queda en <em>use</em>.</p>
+            <div class="flex items-center gap-2 mb-1">
+              <p class="text-slate-800 flex-1">"I <strong>didn't use to</strong> drink coffee."</p>
+              <AudioButton client:load text="I didn't use to drink coffee." lang="en-US" size="sm" />
+            </div>
+            <p class="text-sm text-slate-500">No "didn't <s>used</s> to." El <em>did</em> ya carga el pasado — el verbo se queda en <em>use</em>.</p>
           </div>
           <div class="rounded-xl border-2 border-amber-300 bg-amber-50/60 p-6">
             <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">Pregunta</p>
-            <p class="text-slate-800">"<strong>Did</strong> you <strong>use to</strong> drink coffee?"</p>
-            <p class="text-sm text-slate-500 mt-1">Misma regla. <em>Did</em> primero, luego <em>use to</em> (sin 'd').</p>
+            <div class="flex items-center gap-2 mb-1">
+              <p class="text-slate-800 flex-1">"<strong>Did</strong> you <strong>use to</strong> drink coffee?"</p>
+              <AudioButton client:load text="Did you use to drink coffee?" lang="en-US" size="sm" />
+            </div>
+            <p class="text-sm text-slate-500">Misma regla. <em>Did</em> primero, luego <em>use to</em> (sin 'd').</p>
           </div>
         </div>
 
@@ -248,27 +272,51 @@ const tkey = "course/past-tenses/lesson-5" as const;
           <div class="space-y-4">
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"___ I ___ in Monterrey for three years."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>I lived</strong> — periodo cerrado con duración específica → Past Simple.</p>
+              <div class="flex items-start gap-2 text-sm">
+                <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>I lived</strong> — periodo cerrado con duración específica → Past Simple.</p>
+                <AudioButton client:load text="I lived in Monterrey for three years." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"When I was a kid, I ___ in Monterrey."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>used to live</strong> — describe un estado viejo sin duración ("when I was a kid" → periodo pasado vago).</p>
+              <div class="flex items-start gap-2 text-sm">
+                <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>used to live</strong> — estado viejo sin duración específica.</p>
+                <AudioButton client:load text="When I was a kid, I used to live in Monterrey." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"Last Sunday, I ___ my grandmother."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>called</strong> — un evento específico → Past Simple.</p>
+              <div class="flex items-start gap-2 text-sm">
+                <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>called</strong> — un evento específico → Past Simple.</p>
+                <AudioButton client:load text="Last Sunday, I called my grandmother." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"Every Sunday, I ___ my grandmother."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>used to call</strong> O <strong>would call</strong> — el hábito repetido. Los dos sirven porque <em>call</em> es acción.</p>
+              <div class="flex flex-col gap-1 text-sm">
+                <div class="flex items-center gap-2">
+                  <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>used to call</strong></p>
+                  <AudioButton client:load text="Every Sunday, I used to call my grandmother." lang="en-US" size="sm" />
+                </div>
+                <div class="flex items-center gap-2">
+                  <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>would call</strong> — ambos sirven para acciones.</p>
+                  <AudioButton client:load text="Every Sunday, I would call my grandmother." lang="en-US" size="sm" />
+                </div>
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">"She ___ coffee, but now she drinks tea."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>used to drink</strong> — hábito pasado contrastado explícitamente con el presente → grita por <em>used to</em>.</p>
+              <div class="flex items-start gap-2 text-sm">
+                <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>used to drink</strong> — hábito pasado contrastado con el presente.</p>
+                <AudioButton client:load text="She used to drink coffee, but now she drinks tea." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start">
               <p class="text-slate-700">"Back then, we ___ broke."</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>used to be</strong> — estado. <em>Would be</em> está mal aquí (suena condicional).</p>
+              <div class="flex items-start gap-2 text-sm">
+                <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>used to be</strong> — estado. <em>Would be</em> suena condicional.</p>
+                <AudioButton client:load text="Back then, we used to be broke." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/es/curso/tiempos-del-pasado/plan-de-practica.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/plan-de-practica.astro
@@ -2,6 +2,7 @@
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
+import AudioButton from "@components/course/AudioButton";
 import {
   ArrowRight,
   ArrowLeft,
@@ -104,9 +105,18 @@ const tkey = "course/past-tenses/practice-plan" as const;
             <h3 class="text-lg font-bold text-slate-900 mb-2">El Diario de 3 Oraciones</h3>
             <p class="text-sm text-slate-700 mb-3">Escribe exactamente tres oraciones sobre ayer. Usa tres tiempos del pasado distintos. No traduzcas del español.</p>
             <div class="bg-emerald-50 rounded-lg p-3 border border-emerald-200 text-xs space-y-1.5 text-slate-700">
-              <p><strong>Past Simple:</strong> "Yesterday I had a meeting with the new client."</p>
-              <p><strong>Past Continuous:</strong> "While I was preparing, the office WiFi went down."</p>
-              <p><strong>Present Perfect:</strong> "I have already followed up with him this morning."</p>
+              <div class="flex items-center gap-2">
+                <p class="flex-1"><strong>Past Simple:</strong> "Yesterday I had a meeting with the new client."</p>
+                <AudioButton client:load text="Yesterday I had a meeting with the new client." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1"><strong>Past Continuous:</strong> "While I was preparing, the office WiFi went down."</p>
+                <AudioButton client:load text="While I was preparing, the office WiFi went down." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1"><strong>Present Perfect:</strong> "I have already followed up with him this morning."</p>
+                <AudioButton client:load text="I have already followed up with him this morning." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
 

--- a/src/pages/es/curso/tiempos-del-pasado/there-was-vs-there-has-been.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/there-was-vs-there-has-been.astro
@@ -2,6 +2,7 @@
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
+import AudioButton from "@components/course/AudioButton";
 import {
   ArrowRight,
   ArrowLeft,
@@ -86,9 +87,18 @@ const tkey = "course/past-tenses/there-was-vs-there-has-been" as const;
               La situación existió en <strong>tiempo pasado cerrado</strong>. Está hecho. Está archivado. Es un hecho que reportas desde un pasado sellado.
             </p>
             <div class="bg-white rounded-lg p-3 border border-emerald-200 text-sm space-y-1.5">
-              <p>"<strong>There was</strong> a fire in 2018."</p>
-              <p>"<strong>There was</strong> an issue last week — we fixed it."</p>
-              <p>"<strong>There was</strong> a problem during the demo." (la demo ya terminó)</p>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"<strong>There was</strong> a fire in 2018."</p>
+                <AudioButton client:load text="There was a fire in 2018." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"<strong>There was</strong> an issue last week — we fixed it."</p>
+                <AudioButton client:load text="There was an issue last week. We fixed it." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"<strong>There was</strong> a problem during the demo." (la demo ya terminó)</p>
+                <AudioButton client:load text="There was a problem during the demo." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
 
@@ -104,9 +114,18 @@ const tkey = "course/past-tenses/there-was-vs-there-has-been" as const;
               La situación <strong>todavía es relevante</strong>. Empezó en el pasado y la consecuencia sigue aquí, todavía me toca atenderla.
             </p>
             <div class="bg-white rounded-lg p-3 border border-amber-200 text-sm space-y-1.5">
-              <p>"<strong>There has been</strong> a problem this morning." (todavía hoy, todavía pasando)</p>
-              <p>"<strong>There have been</strong> delays — we're working on it." (actualmente)</p>
-              <p>"<strong>There has been</strong> an update since we last spoke."</p>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"<strong>There has been</strong> a problem this morning." (todavía hoy, todavía pasando)</p>
+                <AudioButton client:load text="There has been a problem this morning." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"<strong>There have been</strong> delays — we're working on it." (actualmente)</p>
+                <AudioButton client:load text="There have been delays. We're working on it." lang="en-US" size="sm" />
+              </div>
+              <div class="flex items-center gap-2">
+                <p class="flex-1">"<strong>There has been</strong> an update since we last spoke."</p>
+                <AudioButton client:load text="There has been an update since we last spoke." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
         </div>
@@ -124,13 +143,19 @@ const tkey = "course/past-tenses/there-was-vs-there-has-been" as const;
         <div class="space-y-4">
           <div class="bg-white rounded-2xl border-2 border-slate-200 p-6">
             <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-2">Cerrado — "No te preocupes"</p>
-            <p class="text-slate-800 text-lg italic">"There was an issue with the deployment last night."</p>
-            <p class="text-sm text-slate-500 mt-2">→ Quien escucha entiende: "Estoy reportando historia. Está arreglado. Seguimos."</p>
+            <div class="flex items-start gap-3 mb-2">
+              <p class="text-slate-800 text-lg italic flex-1">"There was an issue with the deployment last night."</p>
+              <AudioButton client:load text="There was an issue with the deployment last night." lang="en-US" size="sm" />
+            </div>
+            <p class="text-sm text-slate-500">→ Quien escucha entiende: "Estoy reportando historia. Está arreglado. Seguimos."</p>
           </div>
           <div class="bg-white rounded-2xl border-2 border-amber-300 p-6">
             <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-2">Abierto — "Necesito tu atención"</p>
-            <p class="text-slate-800 text-lg italic">"There has been an issue with the deployment."</p>
-            <p class="text-sm text-slate-500 mt-2">→ Quien escucha entiende: "Esto sigue pasando. Deja lo que estés haciendo."</p>
+            <div class="flex items-start gap-3 mb-2">
+              <p class="text-slate-800 text-lg italic flex-1">"There has been an issue with the deployment."</p>
+              <AudioButton client:load text="There has been an issue with the deployment." lang="en-US" size="sm" />
+            </div>
+            <p class="text-sm text-slate-500">→ Quien escucha entiende: "Esto sigue pasando. Deja lo que estés haciendo."</p>
           </div>
         </div>
 
@@ -154,23 +179,38 @@ const tkey = "course/past-tenses/there-was-vs-there-has-been" as const;
           <div class="space-y-4 print:space-y-2">
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">Hubo un incendio en 2018. Ahora es 2026.</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> a fire — tiempo cerrado.</p>
+              <div class="flex items-center gap-2 text-sm">
+                <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> a fire — tiempo cerrado.</p>
+                <AudioButton client:load text="There was a fire in 2018." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">Llegaron tres mensajes de Slack esta mañana. Todavía es la mañana.</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There have been</strong> three messages — el periodo sigue abierto.</p>
+              <div class="flex items-center gap-2 text-sm">
+                <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There have been</strong> three messages — el periodo sigue abierto.</p>
+                <AudioButton client:load text="There have been three messages this morning." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">Estás explicando un resultado cerrado del Q1 a la junta directiva en el Q3.</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> a 12% dip in Q1 — el Q1 está sellado.</p>
+              <div class="flex items-center gap-2 text-sm">
+                <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> a 12% dip in Q1 — el Q1 está sellado.</p>
+                <AudioButton client:load text="There was a 12% dip in Q1." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start pb-3 border-b border-emerald-200">
               <p class="text-slate-700">Han llegado quejas de clientes toda la semana. Es jueves.</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There have been</strong> complaints this week — la semana no termina.</p>
+              <div class="flex items-center gap-2 text-sm">
+                <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There have been</strong> complaints this week — la semana no termina.</p>
+                <AudioButton client:load text="There have been complaints this week." lang="en-US" size="sm" />
+              </div>
             </div>
             <div class="grid md:grid-cols-2 gap-3 items-start">
               <p class="text-slate-700">Hubo una caída del servidor ayer. Ya está resuelto.</p>
-              <p class="text-sm"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> an outage yesterday — arreglado, cerrado.</p>
+              <div class="flex items-center gap-2 text-sm">
+                <p class="flex-1"><CheckCircle2 class="inline w-4 h-4 text-emerald-600" /> <strong>There was</strong> an outage yesterday — arreglado, cerrado.</p>
+                <AudioButton client:load text="There was an outage yesterday." lang="en-US" size="sm" />
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/es/curso/tiempos-del-pasado/top-10-pares-confundidos.astro
+++ b/src/pages/es/curso/tiempos-del-pasado/top-10-pares-confundidos.astro
@@ -2,6 +2,7 @@
 export const prerender = true;
 
 import Base from "@layouts/Base.astro";
+import AudioButton from "@components/course/AudioButton";
 import {
   ArrowRight,
   ArrowLeft,
@@ -22,6 +23,7 @@ const pairs = [
     spanish: "Ambos vienen de <em>decir</em>.",
     rule: "<strong>Say</strong> las palabras. <strong>Tell</strong> a una persona.",
     good: "She <strong>told me</strong> the news. / She <strong>said</strong> the news was bad.",
+    audioText: "She told me the news. She said the news was bad.",
     trap: "\"She told that…\" — mal. Le dices <em>a alguien</em>. \"She told <strong>me</strong> that…\"",
   },
   {
@@ -31,6 +33,7 @@ const pairs = [
     spanish: "Ambos vienen de <em>hacer</em>.",
     rule: "<strong>Do</strong> una tarea o actividad. <strong>Make</strong> una cosa o un resultado.",
     good: "I <strong>did</strong> the report. / I <strong>made</strong> a decision.",
+    audioText: "I did the report. I made a decision.",
     trap: "\"I made the homework\" — mal. Tarea es actividad → <strong>did</strong> the homework.",
   },
   {
@@ -40,6 +43,7 @@ const pairs = [
     spanish: "Ambos se sienten como <em>acostar(se)</em>.",
     rule: "<strong>Lay</strong> lleva objeto. <strong>Lie</strong> no.",
     good: "I <strong>laid</strong> the report on his desk. / I <strong>lay</strong> on the sofa for an hour.",
+    audioText: "I laid the report on his desk. I lay on the sofa for an hour.",
     trap: "Pasado de <em>lie</em> es <em>lay</em>. Pasado de <em>lay</em> es <em>laid</em>. \"I <strong>lay</strong> down yesterday\" = pasado de <em>lie</em>, sin objeto.",
   },
   {
@@ -49,6 +53,7 @@ const pairs = [
     spanish: "<em>Subir / levantar(se)</em> se traslapan.",
     rule: "<strong>Rise</strong> sube por sí solo. <strong>Raise</strong> lleva objeto.",
     good: "Prices <strong>rose</strong> last quarter. / The CEO <strong>raised</strong> prices last quarter.",
+    audioText: "Prices rose last quarter. The CEO raised prices last quarter.",
     trap: "\"They raised\" sin objeto = mal. Usa <em>rose</em>.",
   },
   {
@@ -58,6 +63,7 @@ const pairs = [
     spanish: "Ambos se sienten como <em>ganar</em>.",
     rule: "<strong>Win</strong> una cosa (un juego, un premio, una discusión). <strong>Beat</strong> a una persona o equipo.",
     good: "We <strong>won</strong> the contract. / We <strong>beat</strong> their team.",
+    audioText: "We won the contract. We beat their team.",
     trap: "\"We won them\" — mal. \"We <strong>beat</strong> them\" o \"we won <strong>against</strong> them.\"",
   },
   {
@@ -67,6 +73,7 @@ const pairs = [
     spanish: "<em>Prestar</em> va en ambas direcciones en español.",
     rule: "<strong>Borrow</strong> = tomar prestado de alguien. <strong>Lend</strong> = prestar a alguien.",
     good: "Can I <strong>borrow</strong> your charger? / Can you <strong>lend</strong> me your charger?",
+    audioText: "Can I borrow your charger? Can you lend me your charger?",
     trap: "\"Can you borrow me…\" — mal. Estarías tomando prestado de ti mismo.",
   },
   {
@@ -76,6 +83,7 @@ const pairs = [
     spanish: "<em>Traer / llevar</em> — pero la perspectiva en inglés cambia.",
     rule: "<strong>Bring</strong> hacia quien habla. <strong>Take</strong> lejos de quien habla.",
     good: "<strong>Bring</strong> the report <em>here</em>. / <strong>Take</strong> the report <em>there</em>.",
+    audioText: "Bring the report here. Take the report there.",
     trap: "\"I'll bring it to the meeting\" (vas <em>a</em> la junta) — usualmente <em>take</em>. Usa <em>bring</em> solo si quien escucha <em>está</em> en la junta.",
   },
   {
@@ -85,6 +93,7 @@ const pairs = [
     spanish: "Ambos pueden caer como <em>recordar</em>.",
     rule: "<strong>Remember</strong> = recordar tú solo. <strong>Remind</strong> = hacer que alguien más recuerde.",
     good: "I <strong>remember</strong> the meeting. / Can you <strong>remind</strong> me about the meeting?",
+    audioText: "I remember the meeting. Can you remind me about the meeting?",
     trap: "\"Remember me to call her\" — mal. \"<strong>Remind</strong> me to call her.\"",
   },
   {
@@ -94,6 +103,7 @@ const pairs = [
     spanish: "<em>Perder</em> cubre ambos en español.",
     rule: "<strong>Miss</strong> una fecha límite, un vuelo, una oportunidad. <strong>Lose</strong> una cosa o una competencia.",
     good: "I <strong>missed</strong> the flight. / I <strong>lost</strong> my keys.",
+    audioText: "I missed the flight. I lost my keys.",
     trap: "\"I lost the bus\" — mal. Lo <strong>missed</strong>. Solo <em>lose</em> cosas que posees.",
   },
   {
@@ -103,6 +113,7 @@ const pairs = [
     spanish: "<em>Escuchar / oír</em> — pero el reparto cambia.",
     rule: "<strong>Listen</strong> es activo (intención). <strong>Hear</strong> es pasivo (solo el sonido).",
     good: "I <strong>listened</strong> to the call carefully. / I <strong>heard</strong> a noise outside.",
+    audioText: "I listened to the call carefully. I heard a noise outside.",
     trap: "\"I'm hearing music\" — usualmente mal. Si la pusiste con intención, estás <strong>listening to</strong> music.",
   },
 ];
@@ -174,9 +185,12 @@ const pairs = [
               <p class="text-xs text-slate-500 italic mb-3 print:text-xs" set:html={p.spanish} />
               <div class="space-y-2.5 text-sm text-slate-700 print:text-xs">
                 <p set:html={`<strong class="text-slate-900">Regla:</strong> ${p.rule}`} />
-                <div class="bg-emerald-50 rounded p-2.5 border border-emerald-200 flex gap-2">
+                <div class="bg-emerald-50 rounded p-2.5 border border-emerald-200 flex gap-2 items-start">
                   <CheckCircle2 class="w-4 h-4 text-emerald-600 shrink-0 mt-0.5" />
-                  <p set:html={p.good} />
+                  <p set:html={p.good} class="flex-1" />
+                  <div class="print:hidden shrink-0">
+                    <AudioButton client:load text={p.audioText} lang="en-US" size="sm" />
+                  </div>
                 </div>
                 <div class="bg-red-50 rounded p-2.5 border border-red-200 flex gap-2">
                   <XCircle class="w-4 h-4 text-red-600 shrink-0 mt-0.5" />


### PR DESCRIPTION
## Summary

- Adds `AudioButton` components to all remaining Past Tenses course pages in both English and Spanish, completing the full audio coverage pass
- Every key English phrase across all 14 course pages (6 lessons + 6 bonuses + 2 practice plans, both languages) now has an on-demand speaker button
- Spanish-language pages play American English audio — learners read in Spanish, hear the target language

## Pages updated in this PR

**English:**
- `story-openers.astro` — 30 openers via `.map()` render (one AudioButton per opener)
- `top-10-confused-pairs.astro` — 10 good-example pairs via `.map()` + `audioText` data field
- `practice-plan.astro` — 3 daily drill example sentences

**Spanish:**
- `leccion-5.astro` — used to/would cards, neg/question forms, choose-it drill (~14 buttons)
- `guia-rapida.astro` — all 4 tense card example boxes + Spanish Mirrors section (16 buttons)
- `knew-vs-found-out.astro` — split panels + 30-second drill (14 buttons)
- `there-was-vs-there-has-been.astro` — split panels + business impact pair + choose-it drill (14 buttons)
- `frases-iniciales.astro` — 30 openers via `.map()` render
- `top-10-pares-confundidos.astro` — 10 good-example pairs via `.map()` + `audioText` data field
- `plan-de-practica.astro` — 3 daily drill example sentences

Previously committed (d9b7951): EN lesson-5, cheat-sheet, knew-vs-found-out, there-was-vs-there-has-been

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Speaker buttons render on EN story-openers page (30 buttons)
- [ ] Speaker buttons render on ES frases-iniciales page (30 buttons)
- [ ] Speaker buttons render on ES guia-rapida page (tense card examples + mirrors)
- [ ] Print layout not broken on pages with print stylesheets (buttons are `print:hidden`)
- [ ] Audio plays on click for all new buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)