### PR TITLE
fix(seo): shorten story-openers title to 57 chars

### DIFF
--- a/src/pages/en/course/past-tenses/story-openers.astro
+++ b/src/pages/en/course/past-tenses/story-openers.astro
@@ -85,7 +85,7 @@ const iconMap: Record<string, any> = { Coffee, Briefcase, GitBranch };
 <Base
   lang={lang}
   tkey={tkey}
-  title="30 English Story Openers Native Speakers Actually Use | NY English Teacher"
+  title="30 Story Openers Native Speakers Use | NY English Teacher"
   description="Thirty ready-made launchpads for telling stories in English — casual, professional, and bridges. The phrases native speakers actually reach for."
 >
   <!-- Hero -->


### PR DESCRIPTION
## Summary
- Ahrefs flagged the page title as too long (74 chars) on `/en/course/past-tenses/story-openers/`
- Trimmed to 57 chars while keeping primary keywords ("Story Openers", "Native Speakers") and brand

**Before:** `30 English Story Openers Native Speakers Actually Use | NY English Teacher` (74)
**After:**  `30 Story Openers Native Speakers Use | NY English Teacher` (57)

## Test plan
- [ ] Vercel preview renders the new title in `<head>`
- [ ] Browser tab shows shortened title
- [ ] Ahrefs re-crawl no longer flags this URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)