### PR TITLE
feat(course): add Drive the Decision executive master class

### DIFF
--- a/src/components/course/DriveScenarioPage.astro
+++ b/src/components/course/DriveScenarioPage.astro
@@ -1,0 +1,357 @@
+---
+// Shared scenario template for "Drive the Decision" master class.
+// Renders the full scenario page (hero, setup, weak vs model, why it works,
+// your turn) given a scenarioId and language. Each /en/.../[slug].astro
+// and /es/.../[slug].astro file is a thin wrapper around this.
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import AudioButton from "@components/course/AudioButton";
+import {
+  scenarios,
+  driveInfo,
+} from "@data/drive-the-decision/scenarios";
+import {
+  ArrowRight,
+  ArrowLeft,
+  MessageCircleQuestion,
+  XCircle,
+  CheckCircle2,
+  Sparkles,
+  Mic,
+  Lightbulb,
+  TrendingUp,
+  Clock,
+  Compass,
+  Wrench,
+  AlertOctagon,
+  Split,
+  Shield,
+  Users,
+  BarChart3,
+  Volume2,
+} from "lucide-astro";
+import type { TKey } from "../../lib/i18n";
+
+interface Props {
+  scenarioId: number;
+  lang: "en" | "es";
+  tkey: TKey;
+}
+
+const { scenarioId, lang, tkey } = Astro.props as Props;
+
+const scenario = scenarios.find((s) => s.id === scenarioId);
+if (!scenario) {
+  throw new Error(`Scenario ${scenarioId} not found`);
+}
+
+const total = scenarios.length;
+const prev = scenarios.find((s) => s.id === scenarioId - 1);
+const next = scenarios.find((s) => s.id === scenarioId + 1);
+
+const isEn = lang === "en";
+const basePath = isEn ? driveInfo.basePath.en : driveInfo.basePath.es;
+const drillSlug = isEn ? driveInfo.drillSlug.en : driveInfo.drillSlug.es;
+
+const prevSlug = prev ? (isEn ? prev.slug : prev.slugEs) : null;
+const nextSlug = next ? (isEn ? next.slug : next.slugEs) : null;
+
+// Strings
+const t = {
+  scenarioLabel: isEn ? "Scenario" : "Escenario",
+  ofTotal: isEn ? `of ${total}` : `de ${total}`,
+  theSetup: isEn ? "The Setup" : "El Escenario",
+  theChallenge: isEn ? "The Challenge" : "El Desafío",
+  weakDefault: isEn ? "The Weak Default" : "La Respuesta Débil por Defecto",
+  weakHint: isEn
+    ? "What most leaders say when caught off guard. No audio — don't drill the wrong pattern."
+    : "Lo que dicen la mayoría de los líderes cuando los toman desprevenidos. Sin audio — no practiques el patrón equivocado.",
+  theModelReply: isEn ? "The Model Reply" : "La Respuesta Modelo",
+  modelHint: isEn
+    ? "Outcome-first. Structured. Decisive. Tap the speaker to hear the cadence."
+    : "Outcome-first. Estructurada. Decisiva. Toca el ícono para escuchar el ritmo.",
+  whyItWorks: isEn ? "Why It Works" : "Por Qué Funciona",
+  yourTurn: isEn ? "Your Turn" : "Tu Turno",
+  yourTurnSub: isEn
+    ? "Build the response in your head, then say it out loud. Three rounds: slow, natural, decisive."
+    : "Construye la respuesta en tu cabeza, luego dila en voz alta. Tres rondas: lenta, natural, decisiva.",
+  starterLabel: isEn ? "Starter phrase" : "Frase de arranque",
+  prevScenario: isEn ? "Previous scenario" : "Escenario anterior",
+  nextScenario: isEn ? "Next scenario" : "Siguiente escenario",
+  backToOverview: isEn
+    ? "← Back to course overview"
+    : "← Volver al curso",
+  reflexDrillCta: isEn
+    ? "After all 10 scenarios, install the reflex"
+    : "Después de los 10 escenarios, instala el reflejo",
+  reflexDrillButton: isEn ? "Open the 12-item drill" : "Abrir el drill de 12 items",
+  challengerLabel: isEn ? scenario.challenger : scenario.challengerEs,
+  title: isEn ? scenario.title : scenario.titleEs,
+  subtitle: isEn ? scenario.subtitle : scenario.subtitleEs,
+  setting: isEn ? scenario.setting : scenario.settingEs,
+  setup: isEn ? scenario.setup : scenario.setupEs,
+  challenge: isEn ? scenario.challenge : scenario.challengeEs,
+  weakResponse: isEn ? scenario.weakResponse : scenario.weakResponseEs,
+  modelResponse: isEn ? scenario.modelResponse : scenario.modelResponseEs,
+  yourTurnPrompt: isEn ? scenario.yourTurnPrompt : scenario.yourTurnPromptEs,
+  yourTurnStarter: isEn ? scenario.yourTurnStarter : scenario.yourTurnStarterEs,
+};
+
+// Audio always plays the English model — Mexican learners are training their English delivery
+const modelAudioText = scenario.modelResponse;
+
+// SEO titles kept under 60 chars (CLAUDE.md memory) by dropping the "Drive the
+// Decision · " brand prefix — the brand stays in the H1, OG image, and breadcrumbs.
+const seoTitle = isEn
+  ? `${scenario.title} — NY English`
+  : `${scenario.titleEs} — NY English`;
+
+const seoDescription = isEn
+  ? `${scenario.subtitle} Worked model reply with decision-psychology breakdown. Free master class for senior leaders.`
+  : `${scenario.subtitleEs} Respuesta modelo con análisis de psicología. Master class gratuita para líderes.`;
+
+const iconMap: Record<string, any> = {
+  TrendingUp,
+  Clock,
+  Compass,
+  Wrench,
+  AlertOctagon,
+  Split,
+  Shield,
+  Users,
+  BarChart3,
+  XCircle,
+};
+const ScenarioIcon = iconMap[scenario.icon];
+
+const whyItWorksList = scenario.whyItWorks.map((b) => (isEn ? b.en : b.es));
+---
+
+<Base lang={lang} tkey={tkey} title={seoTitle} description={seoDescription}>
+  <!-- Hero -->
+  <section class="bg-gradient-to-b from-slate-950 to-amber-950 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-2 text-amber-400 text-sm font-semibold mb-3">
+          {ScenarioIcon && <ScenarioIcon class="w-4 h-4" />}
+          {t.scenarioLabel} {scenarioId} {t.ofTotal}
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          {t.title}
+        </h1>
+        <p class="text-xl text-amber-200 italic font-light mb-4">{t.subtitle}</p>
+        <p class="text-base text-slate-300 leading-relaxed">{t.setting}</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Setup -->
+  <section class="py-14 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-slate-900 text-white text-sm font-bold">1</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{t.theSetup}</h2>
+        </div>
+        <p class="text-lg text-slate-700 leading-relaxed ml-11">{t.setup}</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Challenge -->
+  <section class="py-14 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-6">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">2</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{t.theChallenge}</h2>
+        </div>
+        <div class="bg-white rounded-xl border-l-4 border-amber-500 shadow-sm p-6 md:p-8 ml-11">
+          <div class="flex items-start gap-3 mb-3">
+            <MessageCircleQuestion class="w-6 h-6 text-amber-600 shrink-0 mt-1" />
+            <p class="text-xs font-bold uppercase tracking-wider text-amber-700">{t.challengerLabel}</p>
+          </div>
+          <p class="text-xl md:text-2xl text-slate-900 italic leading-relaxed">
+            "{t.challenge}"
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Weak default -->
+  <section class="py-14 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-red-500 text-white text-sm font-bold">3</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{t.weakDefault}</h2>
+        </div>
+        <p class="text-sm text-slate-500 mb-6 ml-11">{t.weakHint}</p>
+        <div class="bg-red-50 border border-red-200 rounded-xl p-6 md:p-7 ml-11">
+          <div class="flex items-start gap-3">
+            <XCircle class="w-6 h-6 text-red-500 shrink-0 mt-1" />
+            <p class="text-lg text-slate-800 leading-relaxed italic">"{t.weakResponse}"</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Model reply -->
+  <section class="py-14 md:py-16 bg-gradient-to-b from-amber-50 to-amber-50/30">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-600 text-white text-sm font-bold">4</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{t.theModelReply}</h2>
+        </div>
+        <p class="text-sm text-slate-600 mb-6 ml-11 flex items-center gap-2">
+          <Volume2 class="w-4 h-4 text-amber-600" />
+          {t.modelHint}
+        </p>
+        <div class="bg-white border-2 border-amber-400 rounded-xl shadow-md p-6 md:p-8 ml-11">
+          <div class="flex items-start gap-4">
+            <CheckCircle2 class="w-7 h-7 text-emerald-600 shrink-0 mt-1" />
+            <div class="flex-1">
+              <p class="text-lg md:text-xl text-slate-900 leading-relaxed mb-4">"{t.modelResponse}"</p>
+              <div class="flex items-center gap-3 pt-4 border-t border-slate-100">
+                <AudioButton client:visible text={modelAudioText} lang="en-US" size="md" />
+                <span class="text-sm text-slate-600">{isEn ? "Listen to the model delivery" : "Escucha la entrega modelo"}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Why it works -->
+  <section class="py-14 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-6">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-slate-900 text-white text-sm font-bold">5</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{t.whyItWorks}</h2>
+        </div>
+        <div class="ml-11 space-y-3">
+          {whyItWorksList.map((point) => (
+            <div class="flex items-start gap-3 bg-white rounded-lg border border-slate-200 p-4">
+              <Lightbulb class="w-5 h-5 text-amber-500 shrink-0 mt-0.5" />
+              <p class="text-slate-700 leading-relaxed" set:html={point} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Your turn -->
+  <section class="py-14 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">6</span>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">{t.yourTurn}</h2>
+        </div>
+        <p class="text-slate-500 mb-6 ml-11">{t.yourTurnSub}</p>
+        <div class="bg-gradient-to-br from-slate-900 to-slate-800 text-white rounded-xl p-6 md:p-8 ml-11">
+          <div class="flex items-start gap-3 mb-4">
+            <Mic class="w-6 h-6 text-amber-400 shrink-0 mt-1" />
+            <p class="text-lg leading-relaxed">{t.yourTurnPrompt}</p>
+          </div>
+          <div class="mt-4 pt-4 border-t border-white/10">
+            <p class="text-xs font-bold uppercase tracking-wider text-amber-300 mb-2">{t.starterLabel}</p>
+            <p class="text-slate-200 italic">{t.yourTurnStarter}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Reflex Drill nudge -->
+  <section class="py-12 md:py-14 bg-amber-50 border-t border-amber-100">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto flex flex-col md:flex-row gap-4 items-start md:items-center justify-between">
+        <div class="flex items-start gap-3">
+          <Sparkles class="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
+          <p class="text-slate-700">{t.reflexDrillCta}</p>
+        </div>
+        <Button href={`${basePath}/${drillSlug}/`} variant="secondary" size="md">
+          {t.reflexDrillButton}
+          <ArrowRight class="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 md:py-14 bg-slate-50 border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {prevSlug ? (
+            <a
+              href={`${basePath}/${prevSlug}/`}
+              class="group flex items-center gap-3 bg-white rounded-xl border border-slate-200 hover:border-amber-300 hover:shadow-md transition-all p-5"
+            >
+              <ArrowLeft class="w-5 h-5 text-slate-400 group-hover:text-amber-600 transition-colors shrink-0" />
+              <div>
+                <p class="text-xs font-bold uppercase tracking-wider text-slate-500 mb-0.5">{t.prevScenario}</p>
+                <p class="text-slate-900 font-medium">{isEn ? prev?.title : prev?.titleEs}</p>
+              </div>
+            </a>
+          ) : (
+            <a
+              href={basePath + "/"}
+              class="group flex items-center gap-3 bg-white rounded-xl border border-slate-200 hover:border-amber-300 hover:shadow-md transition-all p-5"
+            >
+              <ArrowLeft class="w-5 h-5 text-slate-400 group-hover:text-amber-600 transition-colors shrink-0" />
+              <div>
+                <p class="text-xs font-bold uppercase tracking-wider text-slate-500 mb-0.5">{isEn ? "Overview" : "Resumen"}</p>
+                <p class="text-slate-900 font-medium">{isEn ? "Drive the Decision" : "Dirige la Decisión"}</p>
+              </div>
+            </a>
+          )}
+
+          {nextSlug ? (
+            <a
+              href={`${basePath}/${nextSlug}/`}
+              class="group flex items-center justify-between gap-3 bg-amber-500 hover:bg-amber-600 text-white rounded-xl transition-all p-5"
+            >
+              <div>
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-100 mb-0.5">{t.nextScenario}</p>
+                <p class="font-medium">{isEn ? next?.title : next?.titleEs}</p>
+              </div>
+              <ArrowRight class="w-5 h-5 shrink-0" />
+            </a>
+          ) : (
+            <a
+              href={`${basePath}/${drillSlug}/`}
+              class="group flex items-center justify-between gap-3 bg-amber-500 hover:bg-amber-600 text-white rounded-xl transition-all p-5"
+            >
+              <div>
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-100 mb-0.5">{isEn ? "Finish with the drill" : "Termina con el drill"}</p>
+                <p class="font-medium">{isEn ? "The 12-Item Reflex Drill" : "El Drill de Reflejo de 12 Items"}</p>
+              </div>
+              <ArrowRight class="w-5 h-5 shrink-0" />
+            </a>
+          )}
+        </div>
+
+        <div class="mt-8 text-center">
+          <a
+            href={basePath + "/"}
+            class="text-sm text-slate-600 hover:text-amber-700 underline underline-offset-2"
+          >
+            {t.backToOverview}
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/data/drive-the-decision/scenarios.ts
+++ b/src/data/drive-the-decision/scenarios.ts
@@ -1,0 +1,837 @@
+// Drive the Decision — Master Class on Executive Decision Communication
+// 10 boardroom scenarios + 12-item reflex drill bonus.
+//
+// Audience: C1-C2 Mexican executives who already speak fluent English but
+// freeze under pressure, default to explaining instead of deciding, and
+// hedge when they should commit. Sits parallel to the Executive course
+// (Communicate Like a Leader) — applied scenarios, not framework theory.
+
+export interface ScenarioMeta {
+  id: number;
+  slug: string;
+  slugEs: string;
+  title: string;
+  titleEs: string;
+  subtitle: string;
+  subtitleEs: string;
+  setting: string;
+  settingEs: string;
+  icon: string;
+  available: boolean;
+}
+
+export interface ScenarioContent extends ScenarioMeta {
+  /** Context and stakes */
+  setup: string;
+  setupEs: string;
+  /** Exactly what's asked — verbatim quote */
+  challenge: string;
+  challengeEs: string;
+  /** Who is asking — for the dialogue label */
+  challenger: string;
+  challengerEs: string;
+  /** The default-trap response (no audio — learner shouldn't drill the wrong pattern) */
+  weakResponse: string;
+  weakResponseEs: string;
+  /** The model response — what they should say */
+  modelResponse: string;
+  modelResponseEs: string;
+  /** 3-4 bullet points: why the model response works */
+  whyItWorks: { en: string; es: string }[];
+  /** A variation the learner builds — your-turn prompt */
+  yourTurnPrompt: string;
+  yourTurnPromptEs: string;
+  /** A short hint or starter phrase they can use */
+  yourTurnStarter: string;
+  yourTurnStarterEs: string;
+}
+
+export interface DrillItem {
+  id: number;
+  category: string;
+  categoryEs: string;
+  prompt: string;
+  promptEs: string;
+  weakResponse: string;
+  weakResponseEs: string;
+  modelResponse: string;
+  modelResponseEs: string;
+}
+
+export interface DriveBonus {
+  id: number;
+  slug: string;
+  slugEs: string;
+  title: string;
+  titleEs: string;
+  description: string;
+  descriptionEs: string;
+  icon: string;
+  available: boolean;
+}
+
+export const driveInfo = {
+  title: "Drive the Decision",
+  titleEs: "Dirige la Decisión",
+  tagline: "Executive Communication That Moves the Room",
+  taglineEs: "Comunicación ejecutiva que mueve la sala",
+  shortTagline: "Stop explaining. Start deciding.",
+  shortTaglineEs: "Deja de explicar. Empieza a decidir.",
+  description:
+    "Ten boardroom scenarios with worked model replies. The applied capstone for senior leaders who have already studied the Executive frameworks and need to stress-test them against the conversations they actually face — investor pushback, missed quarters, layoffs, declining a $2M deal, and the five other moments where the room is waiting for a decision.",
+  descriptionEs:
+    "Diez escenarios de junta directiva con respuestas modelo trabajadas. La aplicación práctica para líderes senior que ya estudiaron los marcos del curso Ejecutivo y necesitan probarlos contra las conversaciones que realmente enfrentan — pushback de inversionistas, trimestres perdidos, recortes, rechazar un trato de $2M y los otros cinco momentos donde la sala espera una decisión.",
+  basePath: {
+    en: "/en/course/drive-the-decision",
+    es: "/es/curso/dirige-la-decision",
+  },
+  drillSlug: {
+    en: "reflex-drill",
+    es: "drill-reflejo",
+  },
+};
+
+export const scenarios: ScenarioContent[] = [
+  {
+    id: 1,
+    slug: "series-a-cac-pushback",
+    slugEs: "pushback-cac-serie-a",
+    title: "Series A — CAC Pushback",
+    titleEs: "Serie A — Pushback sobre CAC",
+    subtitle: "Your customer acquisition cost is double the benchmark.",
+    subtitleEs: "Tu costo de adquisición de cliente es el doble del benchmark.",
+    setting: "Investor Pitch · Series A",
+    settingEs: "Pitch a inversionistas · Serie A",
+    icon: "TrendingUp",
+    available: true,
+    setup:
+      "You're 15 minutes into your Series A pitch. The slides are flowing. Numbers are landing. Then the lead investor leans forward — and the temperature in the room changes.",
+    setupEs:
+      "Llevas 15 minutos en tu pitch de Serie A. Las diapositivas fluyen. Los números aterrizan. Entonces el inversionista líder se inclina hacia adelante — y la temperatura en la sala cambia.",
+    challenge: "Your CAC is double the industry benchmark. Why should we believe this scales?",
+    challengeEs:
+      "Tu CAC es el doble del benchmark de la industria. ¿Por qué deberíamos creer que esto escala?",
+    challenger: "Lead Investor",
+    challengerEs: "Inversionista líder",
+    weakResponse:
+      "Well, our CAC is high right now but we believe over time as we scale we'll see efficiencies and the LTV-to-CAC ratio will improve and we have a few initiatives that we think will bring the number down…",
+    weakResponseEs:
+      "Bueno, nuestro CAC es alto ahora mismo pero creemos que con el tiempo a medida que escalemos veremos eficiencias y la relación LTV-a-CAC mejorará y tenemos algunas iniciativas que pensamos traerán el número abajo…",
+    modelResponse:
+      "Our CAC is high because we're targeting enterprise from day one. That's a deliberate trade-off. Two things support the scale case. First, our LTV is 6x industry — we're acquiring expensive but keeping them long. Second, our payback period is 14 months, not 36. So the CAC isn't a scale problem — it's a capital efficiency choice we're making to dominate a high-value segment.",
+    modelResponseEs:
+      "Our CAC is high because we're targeting enterprise from day one. That's a deliberate trade-off. Two things support the scale case. First, our LTV is 6x industry — we're acquiring expensive but keeping them long. Second, our payback period is 14 months, not 36. So the CAC isn't a scale problem — it's a capital efficiency choice we're making to dominate a high-value segment.",
+    whyItWorks: [
+      {
+        en: "Owns the data — no deflection, no apology. The number is what it is.",
+        es: "Se apropia del dato — sin deflexión, sin disculpa. El número es lo que es.",
+      },
+      {
+        en: '"Deliberate trade-off" reframes a weakness into a strategy.',
+        es: '"Deliberate trade-off" reencuadra una debilidad como estrategia.',
+      },
+      {
+        en: "Specific numbers — 6x LTV, 14-month payback — not vague claims.",
+        es: "Números específicos — 6x LTV, payback de 14 meses — no afirmaciones vagas.",
+      },
+      {
+        en: 'Lands on positioning, not metrics: "capital efficiency choice."',
+        es: 'Aterriza en posicionamiento, no en métricas: "capital efficiency choice."',
+      },
+    ],
+    yourTurnPrompt:
+      "An investor challenges a single metric in your business — gross margin, burn rate, retention. Build a 4-sentence model response that owns the number, names the deliberate choice behind it, and lands on positioning.",
+    yourTurnPromptEs:
+      "Un inversionista cuestiona una sola métrica de tu negocio — margen bruto, burn rate, retención. Construye una respuesta modelo de 4 oraciones que se apropie del número, nombre la decisión deliberada detrás de él, y aterrice en posicionamiento.",
+    yourTurnStarter:
+      "Try opening with: \"Our [metric] is [number] because we're [deliberate choice]. That's a trade-off…\"",
+    yourTurnStarterEs:
+      "Intenta abrir con: \"Our [metric] is [number] because we're [deliberate choice]. That's a trade-off…\"",
+  },
+  {
+    id: 2,
+    slug: "board-meeting-burn-rate",
+    slugEs: "junta-directiva-burn-rate",
+    title: "Board Meeting — Burn Rate Concern",
+    titleEs: "Junta Directiva — Preocupación por Burn Rate",
+    subtitle: "Nine months of runway. The board is watching.",
+    subtitleEs: "Nueve meses de runway. La junta está observando.",
+    setting: "Quarterly Board Meeting · Q3 Review",
+    settingEs: "Junta Directiva Trimestral · Revisión Q3",
+    icon: "Clock",
+    available: true,
+    setup:
+      "Q3 board meeting. The deck shows cash is tighter than projected — operating expenses overshot the plan by 12%. A board member you respect cuts in before you finish the slide.",
+    setupEs:
+      "Junta directiva del Q3. La presentación muestra que el efectivo está más ajustado de lo proyectado — los gastos operativos rebasaron el plan en un 12%. Un miembro de la junta a quien respetas te interrumpe antes de que termines la diapositiva.",
+    challenge: "At current burn, you have 9 months of runway. How do you respond?",
+    challengeEs: "Al ritmo actual de burn, tienes 9 meses de runway. ¿Cómo respondes?",
+    challenger: "Board Member",
+    challengerEs: "Miembro de la junta",
+    weakResponse:
+      "Yeah, the burn has been higher than we expected and we're looking at different ways to extend runway, we have some ideas around cost reduction and there are a few customer conversations that might help…",
+    weakResponseEs:
+      "Sí, el burn ha sido más alto de lo que esperábamos y estamos viendo diferentes maneras de extender el runway, tenemos algunas ideas alrededor de reducción de costos y hay algunas conversaciones con clientes que podrían ayudar…",
+    modelResponse:
+      "Nine months is the floor, not the plan. We have three levers active right now. First, we're closing two enterprise deals in November that extend runway by four months. Second, we've identified $80,000 monthly in non-critical spend we can cut without touching growth. Third, we have a bridge conversation already initiated with two existing investors. The plan is 18 months of runway by end of Q4.",
+    modelResponseEs:
+      "Nine months is the floor, not the plan. We have three levers active right now. First, we're closing two enterprise deals in November that extend runway by four months. Second, we've identified $80,000 monthly in non-critical spend we can cut without touching growth. Third, we have a bridge conversation already initiated with two existing investors. The plan is 18 months of runway by end of Q4.",
+    whyItWorks: [
+      {
+        en: 'Reframes the question immediately — "floor, not the plan" — refuses the premise.',
+        es: 'Reencuadra la pregunta de inmediato — "floor, not the plan" — rechaza la premisa.',
+      },
+      {
+        en: "Numbered three-lever structure signals control under pressure.",
+        es: "Estructura numerada de tres palancas señala control bajo presión.",
+      },
+      {
+        en: "Specific actions already in motion — not promises, ongoing execution.",
+        es: "Acciones específicas ya en movimiento — no promesas, ejecución en curso.",
+      },
+      {
+        en: 'Closes with a target: "18 months by Q4" — gives the board something to hold you to.',
+        es: 'Cierra con una meta: "18 months by Q4" — le da a la junta algo a lo cual responsabilizarte.',
+      },
+    ],
+    yourTurnPrompt:
+      "A board member challenges a number that looks bad on the surface. Build a 5-sentence model response: reframe the number, lay out three concrete levers already in motion, and close with a specific target.",
+    yourTurnPromptEs:
+      "Un miembro de la junta cuestiona un número que se ve mal en la superficie. Construye una respuesta modelo de 5 oraciones: reencuadra el número, expón tres palancas concretas ya en movimiento y cierra con una meta específica.",
+    yourTurnStarter:
+      'Open with the reframe before the levers: "That\'s the floor, not the plan. We have three levers active…"',
+    yourTurnStarterEs:
+      'Abre con el reencuadre antes de las palancas: "That\'s the floor, not the plan. We have three levers active…"',
+  },
+  {
+    id: 3,
+    slug: "all-hands-pivot",
+    slugEs: "all-hands-pivot",
+    title: "All-Hands — Announcing a Pivot",
+    titleEs: "All-Hands — Anunciar un Pivot",
+    subtitle: "Eighteen months of work. The market said no. Now what?",
+    subtitleEs: "Dieciocho meses de trabajo. El mercado dijo no. ¿Ahora qué?",
+    setting: "Company All-Hands · Strategic Shift",
+    settingEs: "All-Hands de la empresa · Cambio estratégico",
+    icon: "Compass",
+    available: true,
+    setup:
+      "Your team has spent 18 months building toward a market that isn't responding. You're announcing a strategic shift. Someone in the second row raises their hand before you finish.",
+    setupEs:
+      "Tu equipo ha pasado 18 meses construyendo hacia un mercado que no está respondiendo. Estás anunciando un cambio estratégico. Alguien en la segunda fila levanta la mano antes de que termines.",
+    challenge: "We've worked on this for 18 months. Why are we changing direction?",
+    challengeEs:
+      "Hemos trabajado en esto durante 18 meses. ¿Por qué estamos cambiando de dirección?",
+    challenger: "Team Member",
+    challengerEs: "Miembro del equipo",
+    weakResponse:
+      "I know this is hard and I appreciate everyone's work, but we've been seeing some signals that suggest we need to consider new directions, and after a lot of discussion we think this is the right move even though it's difficult…",
+    weakResponseEs:
+      "Sé que esto es difícil y aprecio el trabajo de todos, pero hemos estado viendo algunas señales que sugieren que necesitamos considerar nuevas direcciones, y después de mucha discusión pensamos que este es el movimiento correcto aunque sea difícil…",
+    modelResponse:
+      "Because the market told us we built the wrong thing. That's not a failure — it's information we couldn't have had 18 months ago. What we built is still valuable. What we learned is more valuable. The pivot uses both: same core technology, applied to a market that's already showing demand. We're not starting over. We're finally starting in the right place.",
+    modelResponseEs:
+      "Because the market told us we built the wrong thing. That's not a failure — it's information we couldn't have had 18 months ago. What we built is still valuable. What we learned is more valuable. The pivot uses both: same core technology, applied to a market that's already showing demand. We're not starting over. We're finally starting in the right place.",
+    whyItWorks: [
+      {
+        en: 'Owns it directly — "we built the wrong thing" — no euphemism.',
+        es: 'Se apropia directamente — "we built the wrong thing" — sin eufemismo.',
+      },
+      {
+        en: "Reframes failure as data — protects team morale without softening the honesty.",
+        es: "Reencuadra el fracaso como datos — protege la moral del equipo sin suavizar la honestidad.",
+      },
+      {
+        en: 'Preserves identity — "same core technology, finally in the right place."',
+        es: 'Preserva la identidad — "same core technology, finally in the right place."',
+      },
+      {
+        en: "No apology, no retreat — leadership posture intact through the hard news.",
+        es: "Sin disculpa, sin retroceso — la postura de liderazgo se mantiene a través de la noticia difícil.",
+      },
+    ],
+    yourTurnPrompt:
+      "You're announcing a change that asks your team to abandon work they care about. Build a 5-sentence model response that owns the decision, reframes the past work as valuable, and lands on identity preservation.",
+    yourTurnPromptEs:
+      "Estás anunciando un cambio que le pide a tu equipo abandonar trabajo que les importa. Construye una respuesta modelo de 5 oraciones que se apropie de la decisión, reencuadre el trabajo pasado como valioso y aterrice en preservación de identidad.",
+    yourTurnStarter:
+      "Open with the direct ownership before the reframe: \"Because [direct truth]. That's not [feared interpretation] — it's [reframe]…\"",
+    yourTurnStarterEs:
+      "Abre con la apropiación directa antes del reencuadre: \"Because [direct truth]. That's not [feared interpretation] — it's [reframe]…\"",
+  },
+  {
+    id: 4,
+    slug: "ceo-technical-debt",
+    slugEs: "ceo-deuda-tecnica",
+    title: "CEO Challenge — Defending Technical Debt Work",
+    titleEs: "Desafío del CEO — Defender el Trabajo de Deuda Técnica",
+    subtitle: "Two sprints of refactoring. Engineering velocity is down.",
+    subtitleEs: "Dos sprints de refactor. La velocidad de ingeniería bajó.",
+    setting: "Engineering Review · 1-on-1 with CEO",
+    settingEs: "Revisión de Ingeniería · 1-a-1 con el CEO",
+    icon: "Wrench",
+    available: true,
+    setup:
+      "Engineering velocity has slowed because you've prioritized two sprints of refactoring instead of new features. The CEO has questions — and not the curious kind.",
+    setupEs:
+      "La velocidad de ingeniería se ha desacelerado porque priorizaste dos sprints de refactor en lugar de nuevas funcionalidades. El CEO tiene preguntas — y no del tipo curioso.",
+    challenge: "We're behind on features. Why are you slowing us down to refactor?",
+    challengeEs:
+      "Estamos atrasados en funcionalidades. ¿Por qué nos estás frenando para refactorizar?",
+    challenger: "CEO",
+    challengerEs: "CEO",
+    weakResponse:
+      "I understand the pressure on features but we really need to address some technical debt before we can keep moving forward at the pace we need, and I think this will actually help us in the long run even though it's painful right now…",
+    weakResponseEs:
+      "Entiendo la presión sobre las funcionalidades pero realmente necesitamos abordar algo de deuda técnica antes de poder seguir avanzando al ritmo que necesitamos, y creo que esto realmente nos ayudará a largo plazo aunque sea doloroso ahora…",
+    modelResponse:
+      "Because shipping more features on the current foundation will cost us more than it earns. We're seeing two compounding problems: deploy times have tripled, and our last three bugs took 4x longer to isolate. Two sprints of refactoring buys us six months of faster shipping. The slowdown is now or later — I'm choosing now, when we can afford it.",
+    modelResponseEs:
+      "Because shipping more features on the current foundation will cost us more than it earns. We're seeing two compounding problems: deploy times have tripled, and our last three bugs took 4x longer to isolate. Two sprints of refactoring buys us six months of faster shipping. The slowdown is now or later — I'm choosing now, when we can afford it.",
+    whyItWorks: [
+      {
+        en: 'Direct cost framing — "cost more than it earns" speaks the CEO\'s language.',
+        es: 'Encuadre directo de costo — "cost more than it earns" habla el idioma del CEO.',
+      },
+      {
+        en: "Evidence, not opinion — two specific data points (deploy time, bug isolation).",
+        es: "Evidencia, no opinión — dos datos específicos (tiempo de deploy, aislamiento de bugs).",
+      },
+      {
+        en: 'Quantified trade-off — "2 sprints buys 6 months" makes the math obvious.',
+        es: 'Trade-off cuantificado — "2 sprints buys 6 months" hace obvia la matemática.',
+      },
+      {
+        en: 'Owns the choice — "I\'m choosing now" — leadership, not deflection.',
+        es: 'Se apropia de la decisión — "I\'m choosing now" — liderazgo, no deflexión.',
+      },
+    ],
+    yourTurnPrompt:
+      "You've made an unpopular technical or operational decision that slows visible progress. Defend it in 4 sentences: cost framing, two pieces of evidence, quantified trade-off, owned choice.",
+    yourTurnPromptEs:
+      "Tomaste una decisión técnica u operativa impopular que desacelera el progreso visible. Defiéndela en 4 oraciones: encuadre de costo, dos piezas de evidencia, trade-off cuantificado, decisión apropiada.",
+    yourTurnStarter:
+      'Open with the inverted cost: "Because [the alternative] will cost us more than it earns…"',
+    yourTurnStarterEs:
+      'Abre con el costo invertido: "Because [the alternative] will cost us more than it earns…"',
+  },
+  {
+    id: 5,
+    slug: "enterprise-outage",
+    slugEs: "outage-enterprise",
+    title: "Enterprise Customer — 6-Hour Outage",
+    titleEs: "Cliente Enterprise — Outage de 6 Horas",
+    subtitle: "$400K in lost revenue. Their CTO is on the call.",
+    subtitleEs: "$400,000 en ingresos perdidos. Su CTO está en la llamada.",
+    setting: "Customer Escalation Call · Post-Incident",
+    settingEs: "Llamada de escalación con cliente · Post-incidente",
+    icon: "AlertOctagon",
+    available: true,
+    setup:
+      "Your largest enterprise customer experienced a six-hour outage. Their CTO is on the call. Their CFO is on the call. Their procurement lead is silently taking notes. You have one opening.",
+    setupEs:
+      "Tu cliente enterprise más grande experimentó un outage de seis horas. Su CTO está en la llamada. Su CFO está en la llamada. Su líder de procurement está tomando notas en silencio. Tienes una sola apertura.",
+    challenge: "We lost $400,000 in revenue during your outage. What's your plan?",
+    challengeEs: "Perdimos $400,000 en ingresos durante su outage. ¿Cuál es tu plan?",
+    challenger: "Customer CTO",
+    challengerEs: "CTO del cliente",
+    weakResponse:
+      "We're really sorry about the outage and we're committed to making sure this doesn't happen again, we're already looking at the root cause and we'll have a full report out for you as soon as we can…",
+    weakResponseEs:
+      "Realmente lamentamos el outage y estamos comprometidos a asegurarnos de que esto no vuelva a pasar, ya estamos viendo la causa raíz y tendremos un reporte completo para ustedes tan pronto como podamos…",
+    modelResponse:
+      "First, you'll see a service credit for the full quarter in your next invoice — that's automatic. Second, here's what happened technically: a database failover didn't trigger the way our runbook specified. We've already deployed the fix and rebuilt the runbook. Third, we're giving you direct access to our SRE lead and a private status channel — so the next time something looks off, you know before we do. The $400,000 we can't undo. The next $400,000 we can prevent.",
+    modelResponseEs:
+      "First, you'll see a service credit for the full quarter in your next invoice — that's automatic. Second, here's what happened technically: a database failover didn't trigger the way our runbook specified. We've already deployed the fix and rebuilt the runbook. Third, we're giving you direct access to our SRE lead and a private status channel — so the next time something looks off, you know before we do. The $400,000 we can't undo. The next $400,000 we can prevent.",
+    whyItWorks: [
+      {
+        en: "Action before apology — money back first signals seriousness, not contrition.",
+        es: "Acción antes que disculpa — devolver el dinero primero señala seriedad, no contrición.",
+      },
+      {
+        en: "Specific technical cause, not vague — names the failure honestly.",
+        es: "Causa técnica específica, no vaga — nombra el fallo honestamente.",
+      },
+      {
+        en: "Three concrete commitments — credit, fix, access — not promises, deliverables.",
+        es: "Tres compromisos concretos — crédito, fix, acceso — no promesas, entregables.",
+      },
+      {
+        en: "Closing line carries both emotional resolution and business commitment.",
+        es: "La línea final lleva tanto resolución emocional como compromiso de negocio.",
+      },
+    ],
+    yourTurnPrompt:
+      "A customer is escalating a serious failure on your side. Build a 5-sentence response: lead with the action they get, name the failure specifically, lay out three commitments, close with the emotional + business line.",
+    yourTurnPromptEs:
+      "Un cliente está escalando un fallo serio de tu lado. Construye una respuesta de 5 oraciones: lidera con la acción que recibirán, nombra el fallo específicamente, expón tres compromisos, cierra con la línea emocional + de negocio.",
+    yourTurnStarter:
+      "Open with what they receive, not what you feel: \"First, you'll see [concrete action] — that's automatic…\"",
+    yourTurnStarterEs:
+      "Abre con lo que reciben, no con lo que sientes: \"First, you'll see [concrete action] — that's automatic…\"",
+  },
+  {
+    id: 6,
+    slug: "sales-product-conflict",
+    slugEs: "conflicto-ventas-producto",
+    title: "Sales vs Product — Roadmap Conflict",
+    titleEs: "Ventas vs Producto — Conflicto de Roadmap",
+    subtitle: "A custom integration. A major deal. A roadmap line.",
+    subtitleEs: "Una integración custom. Un trato importante. Una línea en el roadmap.",
+    setting: "Cross-functional Sync · Sales vs Product",
+    settingEs: "Sync interfuncional · Ventas vs Producto",
+    icon: "Split",
+    available: true,
+    setup:
+      "Sales is pushing for a custom integration to close a major deal. Product wants to maintain roadmap discipline. The VP of Sales corners you after the executive sync.",
+    setupEs:
+      "Ventas está empujando por una integración custom para cerrar un trato importante. Producto quiere mantener disciplina de roadmap. El VP de Ventas te aborda después del sync ejecutivo.",
+    challenge: "Product won't ship what the deal needs. We're losing the contract.",
+    challengeEs: "Producto no va a enviar lo que el trato necesita. Estamos perdiendo el contrato.",
+    challenger: "VP of Sales",
+    challengerEs: "VP de Ventas",
+    weakResponse:
+      "I hear you on the urgency but the roadmap is locked and we can't just shift things around without disrupting everything else, and I'm not sure we can really build what they need in time anyway…",
+    weakResponseEs:
+      "Te escucho sobre la urgencia pero el roadmap está fijo y no podemos simplemente cambiar las cosas sin disrumpir todo lo demás, y de cualquier forma no estoy seguro de que podamos construir lo que necesitan a tiempo…",
+    modelResponse:
+      "We're not losing the contract — we're testing whether it's the right contract. If a single-customer integration is what stands between us and the deal, that deal is the wrong shape for our product. We have two options: I can give you a roadmap commitment for Q2 that they can build against, or I can write a custom integration as a paid services engagement at full cost. What I won't do is fork the product for one customer.",
+    modelResponseEs:
+      "We're not losing the contract — we're testing whether it's the right contract. If a single-customer integration is what stands between us and the deal, that deal is the wrong shape for our product. We have two options: I can give you a roadmap commitment for Q2 that they can build against, or I can write a custom integration as a paid services engagement at full cost. What I won't do is fork the product for one customer.",
+    whyItWorks: [
+      {
+        en: 'Refuses the premise — "right contract" reframes the question entirely.',
+        es: 'Rechaza la premisa — "right contract" reencuadra la pregunta completamente.',
+      },
+      {
+        en: "Two clear options — gives Sales something concrete to work with.",
+        es: "Dos opciones claras — le da a Ventas algo concreto con lo cual trabajar.",
+      },
+      {
+        en: "One clear no — \"I won't fork the product\" — names the line that doesn't move.",
+        es: 'Un no claro — "I won\'t fork the product" — nombra la línea que no se mueve.',
+      },
+      {
+        en: "Strategic, not personal — protects the relationship while holding the call.",
+        es: "Estratégico, no personal — protege la relación mientras sostiene la decisión.",
+      },
+    ],
+    yourTurnPrompt:
+      "A peer is pressuring you to break a policy for a single high-value exception. Build a 5-sentence response: reframe the question, offer two real alternatives, name the line you won't cross.",
+    yourTurnPromptEs:
+      "Un par te está presionando para romper una política por una sola excepción de alto valor. Construye una respuesta de 5 oraciones: reencuadra la pregunta, ofrece dos alternativas reales, nombra la línea que no cruzarás.",
+    yourTurnStarter:
+      "Open with the reframe before the options: \"We're not [their framing] — we're [your framing]…\"",
+    yourTurnStarterEs:
+      "Abre con el reencuadre antes de las opciones: \"We're not [their framing] — we're [your framing]…\"",
+  },
+  {
+    id: 7,
+    slug: "series-b-competitor",
+    slugEs: "serie-b-competidor",
+    title: "Series B — Competitor Threat",
+    titleEs: "Serie B — Amenaza de Competidor",
+    subtitle: "Big Tech just announced a product in your space.",
+    subtitleEs: "Big Tech acaba de anunciar un producto en tu espacio.",
+    setting: "Investor Update · Series B Conversations",
+    settingEs: "Actualización a inversionistas · Conversaciones Serie B",
+    icon: "Shield",
+    available: true,
+    setup:
+      "You're 30 minutes into a Series B conversation when the news breaks: a major tech company has just announced a product in your space. The investor across the table refreshes their phone.",
+    setupEs:
+      "Llevas 30 minutos en una conversación de Serie B cuando estalla la noticia: una compañía tecnológica importante acaba de anunciar un producto en tu espacio. El inversionista al otro lado de la mesa actualiza su teléfono.",
+    challenge: "Big Tech just announced they're entering your space. What's your moat?",
+    challengeEs: "Big Tech acaba de anunciar que entran a tu espacio. ¿Cuál es tu moat?",
+    challenger: "Investor",
+    challengerEs: "Inversionista",
+    weakResponse:
+      "Yeah we've been watching them and we think we have some advantages because we're more focused and we have better customer relationships and we move faster…",
+    weakResponseEs:
+      "Sí, los hemos estado observando y pensamos que tenemos algunas ventajas porque estamos más enfocados y tenemos mejores relaciones con clientes y nos movemos más rápido…",
+    modelResponse:
+      "Their announcement is good news, not bad news. It validates the market — which is why you're here. Our moat isn't technical, it's positional. We've spent three years building integrations with the 47 systems our customers actually run. They'd need to rebuild that stack to compete on our terms. They're competing on features. We're competing on switching cost. Different game.",
+    modelResponseEs:
+      "Their announcement is good news, not bad news. It validates the market — which is why you're here. Our moat isn't technical, it's positional. We've spent three years building integrations with the 47 systems our customers actually run. They'd need to rebuild that stack to compete on our terms. They're competing on features. We're competing on switching cost. Different game.",
+    whyItWorks: [
+      {
+        en: 'Reframes the threat — "good news, not bad news" — inverts the panic.',
+        es: 'Reencuadra la amenaza — "good news, not bad news" — invierte el pánico.',
+      },
+      {
+        en: "Specific moat — names the actual defensibility (47 systems, switching cost).",
+        es: "Moat específico — nombra la defensibilidad real (47 sistemas, switching cost).",
+      },
+      {
+        en: 'Drops the false comparison — "different game" refuses head-to-head framing.',
+        es: 'Suelta la comparación falsa — "different game" rechaza el encuadre cara-a-cara.',
+      },
+      {
+        en: 'Investor language — "switching cost" is what investors actually want to hear.',
+        es: 'Lenguaje de inversionista — "switching cost" es lo que los inversionistas realmente quieren oír.',
+      },
+    ],
+    yourTurnPrompt:
+      "A larger competitor enters your market. Build a 5-sentence response: reframe the threat, name the specific positional moat, refuse the feature-by-feature comparison, land on the language investors use.",
+    yourTurnPromptEs:
+      "Un competidor más grande entra a tu mercado. Construye una respuesta de 5 oraciones: reencuadra la amenaza, nombra el moat posicional específico, rechaza la comparación funcionalidad-por-funcionalidad, aterriza en el lenguaje que usan los inversionistas.",
+    yourTurnStarter:
+      'Open with the inversion: "Their announcement is good news, not bad news. It [validates / proves / confirms]…"',
+    yourTurnStarterEs:
+      'Abre con la inversión: "Their announcement is good news, not bad news. It [validates / proves / confirms]…"',
+  },
+  {
+    id: 8,
+    slug: "layoff-communication",
+    slugEs: "comunicacion-recorte",
+    title: "Org Restructure — Communicating Layoffs",
+    titleEs: "Restructura — Comunicar Recortes",
+    subtitle: "Fifteen percent reduction. Trust on the line.",
+    subtitleEs: "Reducción del quince por ciento. Confianza en juego.",
+    setting: "Leadership Pre-Brief · Before All-Hands",
+    settingEs: "Pre-brief a líderes · Antes del All-Hands",
+    icon: "Users",
+    available: true,
+    setup:
+      "You're announcing a 15% reduction to your leadership team an hour before the company all-hands. They have to lead the message to their teams — and they don't know how to frame it without losing trust.",
+    setupEs:
+      "Estás anunciando una reducción del 15% a tu equipo de liderazgo una hora antes del all-hands de la empresa. Ellos tienen que llevar el mensaje a sus equipos — y no saben cómo encuadrarlo sin perder confianza.",
+    challenge: "How do we explain this to our teams without losing trust?",
+    challengeEs: "¿Cómo explicamos esto a nuestros equipos sin perder confianza?",
+    challenger: "Leadership Team",
+    challengerEs: "Equipo de liderazgo",
+    weakResponse:
+      "We need to be honest about the business situation but also reassuring, and we want people to know that we care and that this was a really difficult decision and we're going to support everyone through it…",
+    weakResponseEs:
+      "Necesitamos ser honestos sobre la situación del negocio pero también tranquilizadores, y queremos que la gente sepa que nos importa y que esta fue una decisión realmente difícil y vamos a apoyar a todos a través de ello…",
+    modelResponse:
+      "By telling them the truth, in this order. First: what we decided and why — not 'a difficult decision' but the actual business logic. Second: how it affects them specifically — not corporate language, real impact on their work and team. Third: what we're not doing — we're not pausing investment in their priorities, and here's the evidence. The trust comes from specificity, not reassurance. Vague optimism is what breaks trust right now.",
+    modelResponseEs:
+      "By telling them the truth, in this order. First: what we decided and why — not 'a difficult decision' but the actual business logic. Second: how it affects them specifically — not corporate language, real impact on their work and team. Third: what we're not doing — we're not pausing investment in their priorities, and here's the evidence. The trust comes from specificity, not reassurance. Vague optimism is what breaks trust right now.",
+    whyItWorks: [
+      {
+        en: "Structured response under emotional weight — three numbered steps anchor the listener.",
+        es: "Respuesta estructurada bajo peso emocional — tres pasos numerados anclan al oyente.",
+      },
+      {
+        en: 'Names the trap — "vague optimism is what breaks trust" — calls out the failure mode.',
+        es: 'Nombra la trampa — "vague optimism is what breaks trust" — señala el modo de fallo.',
+      },
+      {
+        en: "Operational, not philosophical — gives leaders something to actually do.",
+        es: "Operativo, no filosófico — le da a los líderes algo que realmente hacer.",
+      },
+      {
+        en: 'Lands on a principle — "trust comes from specificity" — quotable, transferable.',
+        es: 'Aterriza en un principio — "trust comes from specificity" — citable, transferible.',
+      },
+    ],
+    yourTurnPrompt:
+      "You're coaching another leader through a hard message they have to deliver. Build a 5-sentence response: name the three-step structure, list what to include in each, and close with a principle they can carry.",
+    yourTurnPromptEs:
+      "Estás coacheando a otro líder a través de un mensaje difícil que tiene que entregar. Construye una respuesta de 5 oraciones: nombra la estructura de tres pasos, lista qué incluir en cada uno, y cierra con un principio que puedan llevarse.",
+    yourTurnStarter:
+      'Open with the method, not the comfort: "By telling them the truth, in this order…"',
+    yourTurnStarterEs:
+      'Abre con el método, no con el consuelo: "By telling them the truth, in this order…"',
+  },
+  {
+    id: 9,
+    slug: "missed-quarter",
+    slugEs: "trimestre-perdido",
+    title: "Missed Quarter at Board Meeting",
+    titleEs: "Trimestre Perdido en Junta Directiva",
+    subtitle: "Twenty-two percent below target. The room wants answers.",
+    subtitleEs: "Veintidós por ciento bajo la meta. La sala quiere respuestas.",
+    setting: "Board Meeting · Q-End Review",
+    settingEs: "Junta Directiva · Revisión de fin de trimestre",
+    icon: "BarChart3",
+    available: true,
+    setup:
+      "You missed the quarterly revenue target by 22%. The board chair opens the call by holding the number up to the room. There's no preamble. There's no warm-up.",
+    setupEs:
+      "Perdiste la meta trimestral de ingresos por 22%. El presidente de la junta abre la llamada sosteniendo el número frente a la sala. No hay preámbulo. No hay calentamiento.",
+    challenge: "You missed the quarter by 22%. What are you doing differently?",
+    challengeEs: "Perdiste el trimestre por 22%. ¿Qué estás haciendo diferente?",
+    challenger: "Board Chair",
+    challengerEs: "Presidente de la junta",
+    weakResponse:
+      "Yeah we missed and we're already implementing changes to address the issues we saw, we have a lot of learnings from this quarter and we're confident we can get back on track…",
+    weakResponseEs:
+      "Sí, perdimos y ya estamos implementando cambios para abordar los problemas que vimos, tenemos muchos aprendizajes de este trimestre y estamos confiados en que podemos volver al camino…",
+    modelResponse:
+      "Three things. First, the miss came from one segment — mid-market — where our sales cycle assumption was wrong by 40 days. We've corrected the model. Second, our enterprise pipeline is up 60% — that's the segment we now know is our actual market. Third, I've moved two AEs from mid-market to enterprise this week. The 22% miss isn't a sales problem — it was a targeting problem. That's already fixed.",
+    modelResponseEs:
+      "Three things. First, the miss came from one segment — mid-market — where our sales cycle assumption was wrong by 40 days. We've corrected the model. Second, our enterprise pipeline is up 60% — that's the segment we now know is our actual market. Third, I've moved two AEs from mid-market to enterprise this week. The 22% miss isn't a sales problem — it was a targeting problem. That's already fixed.",
+    whyItWorks: [
+      {
+        en: 'Diagnoses the miss — not "we missed," but "here\'s exactly why."',
+        es: 'Diagnostica la pérdida — no "we missed," sino "here\'s exactly why."',
+      },
+      {
+        en: "Already-taken action — past tense, not future promise.",
+        es: "Acción ya tomada — tiempo pasado, no promesa futura.",
+      },
+      {
+        en: 'Reframes the problem — "targeting, not sales" changes what gets fixed.',
+        es: 'Reencuadra el problema — "targeting, not sales" cambia qué se arregla.',
+      },
+      {
+        en: "Confidence without arrogance — owns the data, owns the fix, owns the next quarter.",
+        es: "Confianza sin arrogancia — se apropia del dato, del fix, del próximo trimestre.",
+      },
+    ],
+    yourTurnPrompt:
+      "You missed a major target. The board wants the diagnosis, not the apology. Build a 5-sentence response: three numbered points, each containing diagnosis + already-completed action, and a closing reframe.",
+    yourTurnPromptEs:
+      "Perdiste una meta importante. La junta quiere el diagnóstico, no la disculpa. Construye una respuesta de 5 oraciones: tres puntos numerados, cada uno con diagnóstico + acción ya completada, y un reencuadre final.",
+    yourTurnStarter:
+      'Open with the structure, not the apology: "Three things. First, [diagnosis]. We\'ve [action]…"',
+    yourTurnStarterEs:
+      'Abre con la estructura, no con la disculpa: "Three things. First, [diagnosis]. We\'ve [action]…"',
+  },
+  {
+    id: 10,
+    slug: "declining-major-deal",
+    slugEs: "rechazar-trato-importante",
+    title: "Declining a $2M Strategic Deal",
+    titleEs: "Rechazar un Trato Estratégico de $2M",
+    subtitle: "A custom integration that breaks your model.",
+    subtitleEs: "Una integración custom que rompe tu modelo.",
+    setting: "Partnership Conversation · CEO-to-CEO",
+    settingEs: "Conversación de partnership · CEO-a-CEO",
+    icon: "XCircle",
+    available: true,
+    setup:
+      "A potential partner wants a custom integration that doesn't align with your strategy. Their CEO is on the call and just put the number on the table. The pressure to say yes is real — and it would be a mistake.",
+    setupEs:
+      "Un socio potencial quiere una integración custom que no se alinea con tu estrategia. Su CEO está en la llamada y acaba de poner el número sobre la mesa. La presión para decir sí es real — y sería un error.",
+    challenge: "Why won't you do this integration? It's a $2 million opportunity.",
+    challengeEs: "¿Por qué no harán esta integración? Es una oportunidad de $2 millones.",
+    challenger: "Prospect CEO",
+    challengerEs: "CEO del prospecto",
+    weakResponse:
+      "We'd love to work with you but the integration would require resources we don't currently have, and we're really focused on a few core priorities right now that we can't move off of…",
+    weakResponseEs:
+      "Nos encantaría trabajar con ustedes pero la integración requeriría recursos que actualmente no tenemos, y estamos muy enfocados en algunas prioridades clave en este momento que no podemos mover…",
+    modelResponse:
+      "Because $2 million today costs us $20 million next year. The integration you're describing would require us to maintain a custom version of our product for one customer. That's a model we've deliberately avoided — and the customers who've made us successful are the ones who fit our standard product. We'd rather partner with you on a path that doesn't break that model. Here's what that could look like.",
+    modelResponseEs:
+      "Because $2 million today costs us $20 million next year. The integration you're describing would require us to maintain a custom version of our product for one customer. That's a model we've deliberately avoided — and the customers who've made us successful are the ones who fit our standard product. We'd rather partner with you on a path that doesn't break that model. Here's what that could look like.",
+    whyItWorks: [
+      {
+        en: 'Quantifies the cost — "$2M today costs us $20M next year" — math beats opinion.',
+        es: 'Cuantifica el costo — "$2M today costs us $20M next year" — la matemática vence la opinión.',
+      },
+      {
+        en: 'Names the principle — "deliberately avoided" — turns the no into discipline.',
+        es: 'Nombra el principio — "deliberately avoided" — convierte el no en disciplina.',
+      },
+      {
+        en: "Owns the no, then offers a yes — closes the door, opens a window.",
+        es: "Se apropia del no, luego ofrece un sí — cierra la puerta, abre una ventana.",
+      },
+      {
+        en: "Respect, not apology — peer-to-peer language preserves the relationship.",
+        es: "Respeto, no disculpa — lenguaje par-a-par preserva la relación.",
+      },
+    ],
+    yourTurnPrompt:
+      "Someone offers you a high-value opportunity that violates a strategic principle. Build a 5-sentence response: quantify the hidden cost, name the principle you've held, refuse without apologizing, offer the alternative.",
+    yourTurnPromptEs:
+      "Alguien te ofrece una oportunidad de alto valor que viola un principio estratégico. Construye una respuesta de 5 oraciones: cuantifica el costo oculto, nombra el principio que has mantenido, rechaza sin disculparte, ofrece la alternativa.",
+    yourTurnStarter:
+      'Open with the hidden math: "Because [their offer] today costs us [larger cost] next year…"',
+    yourTurnStarterEs:
+      'Abre con la matemática oculta: "Because [their offer] today costs us [larger cost] next year…"',
+  },
+];
+
+export const scenarioMeta: ScenarioMeta[] = scenarios.map((s) => ({
+  id: s.id,
+  slug: s.slug,
+  slugEs: s.slugEs,
+  title: s.title,
+  titleEs: s.titleEs,
+  subtitle: s.subtitle,
+  subtitleEs: s.subtitleEs,
+  setting: s.setting,
+  settingEs: s.settingEs,
+  icon: s.icon,
+  available: s.available,
+}));
+
+export const drillItems: DrillItem[] = [
+  {
+    id: 1,
+    category: "Strategic Alignment",
+    categoryEs: "Alineación Estratégica",
+    prompt: "Are we aligned on the current operating model?",
+    promptEs: "Are we aligned on the current operating model?",
+    weakResponse: "Well, I think overall we are aligned but there are some areas where…",
+    weakResponseEs: "Well, I think overall we are aligned but there are some areas where…",
+    modelResponse:
+      "We are not fully aligned — there are inconsistencies across regions. That's what's limiting speed and decision clarity.",
+    modelResponseEs:
+      "We are not fully aligned — there are inconsistencies across regions. That's what's limiting speed and decision clarity.",
+  },
+  {
+    id: 2,
+    category: "Problem Framing",
+    categoryEs: "Encuadre del Problema",
+    prompt: "What is the core issue we're solving?",
+    promptEs: "What is the core issue we're solving?",
+    weakResponse: "So there are several things happening across the organization…",
+    weakResponseEs: "So there are several things happening across the organization…",
+    modelResponse:
+      "The issue is fragmentation in how the model operates. Ownership and decision-making are not consistent.",
+    modelResponseEs:
+      "The issue is fragmentation in how the model operates. Ownership and decision-making are not consistent.",
+  },
+  {
+    id: 3,
+    category: "Why Change",
+    categoryEs: "Por Qué Cambiar",
+    prompt: "Why do we need to change now?",
+    promptEs: "Why do we need to change now?",
+    weakResponse: "Well, over time things have evolved and we've seen…",
+    weakResponseEs: "Well, over time things have evolved and we've seen…",
+    modelResponse:
+      "Because the current model is already limiting performance. We're losing scale and slowing decisions.",
+    modelResponseEs:
+      "Because the current model is already limiting performance. We're losing scale and slowing decisions.",
+  },
+  {
+    id: 4,
+    category: "Decision Clarity",
+    categoryEs: "Claridad de Decisión",
+    prompt: "What are you proposing?",
+    promptEs: "What are you proposing?",
+    weakResponse: "So what we're looking at is potentially moving toward…",
+    weakResponseEs: "So what we're looking at is potentially moving toward…",
+    modelResponse:
+      "We are moving to a hybrid, center-led model. This centralizes strategy while keeping strong local execution.",
+    modelResponseEs:
+      "We are moving to a hybrid, center-led model. This centralizes strategy while keeping strong local execution.",
+  },
+  {
+    id: 5,
+    category: "Value Statement",
+    categoryEs: "Declaración de Valor",
+    prompt: "What do we gain from this?",
+    promptEs: "What do we gain from this?",
+    weakResponse: "This could potentially help improve different areas…",
+    weakResponseEs: "This could potentially help improve different areas…",
+    modelResponse:
+      "We gain scale, speed, and clear accountability. That translates into better decisions and stronger business impact.",
+    modelResponseEs:
+      "We gain scale, speed, and clear accountability. That translates into better decisions and stronger business impact.",
+  },
+  {
+    id: 6,
+    category: "Risk Handling",
+    categoryEs: "Manejo de Riesgo",
+    prompt: "What is the main risk?",
+    promptEs: "What is the main risk?",
+    weakResponse: "There are a few risks we should consider…",
+    weakResponseEs: "There are a few risks we should consider…",
+    modelResponse:
+      "The main risk is poor execution, not the model itself. If roles and decision rights are unclear, performance will suffer.",
+    modelResponseEs:
+      "The main risk is poor execution, not the model itself. If roles and decision rights are unclear, performance will suffer.",
+  },
+  {
+    id: 7,
+    category: "Pushback — Local Resistance",
+    categoryEs: "Pushback — Resistencia Local",
+    prompt: "This will reduce flexibility at the local level.",
+    promptEs: "This will reduce flexibility at the local level.",
+    weakResponse: "I understand the concern and we can try to…",
+    weakResponseEs: "I understand the concern and we can try to…",
+    modelResponse:
+      "It doesn't reduce flexibility — it clarifies it. Local teams keep business ownership while strategy is centralized.",
+    modelResponseEs:
+      "It doesn't reduce flexibility — it clarifies it. Local teams keep business ownership while strategy is centralized.",
+  },
+  {
+    id: 8,
+    category: "Prioritization",
+    categoryEs: "Priorización",
+    prompt: "What should we focus on first?",
+    promptEs: "What should we focus on first?",
+    weakResponse: "There are several areas we could potentially start with…",
+    weakResponseEs: "There are several areas we could potentially start with…",
+    modelResponse:
+      "We start with role clarity and decision rights. Without that, the model won't function.",
+    modelResponseEs:
+      "We start with role clarity and decision rights. Without that, the model won't function.",
+  },
+  {
+    id: 9,
+    category: "Simplification",
+    categoryEs: "Simplificación",
+    prompt: "This sounds complex.",
+    promptEs: "This sounds complex.",
+    weakResponse: "It is complex but we've tried to simplify…",
+    weakResponseEs: "It is complex but we've tried to simplify…",
+    modelResponse:
+      "The design is simple — the execution requires discipline. Three levels, clear roles, structured decisions.",
+    modelResponseEs:
+      "The design is simple — the execution requires discipline. Three levels, clear roles, structured decisions.",
+  },
+  {
+    id: 10,
+    category: "Accountability",
+    categoryEs: "Rendición de Cuentas",
+    prompt: "Who owns this?",
+    promptEs: "Who owns this?",
+    weakResponse: "So ownership will depend on different levels…",
+    weakResponseEs: "So ownership will depend on different levels…",
+    modelResponse:
+      "Global owns strategy, regions own execution, local owns business partnership. Ownership is clearly defined by level.",
+    modelResponseEs:
+      "Global owns strategy, regions own execution, local owns business partnership. Ownership is clearly defined by level.",
+  },
+  {
+    id: 11,
+    category: "Timing",
+    categoryEs: "Tiempos",
+    prompt: "How fast can we implement?",
+    promptEs: "How fast can we implement?",
+    weakResponse: "It depends on multiple factors and we need to…",
+    weakResponseEs: "It depends on multiple factors and we need to…",
+    modelResponse:
+      "We can begin immediately after alignment. Full deployment will follow a phased approach.",
+    modelResponseEs:
+      "We can begin immediately after alignment. Full deployment will follow a phased approach.",
+  },
+  {
+    id: 12,
+    category: "Closing for Decision",
+    categoryEs: "Cierre para Decisión",
+    prompt: "What do you need from us today?",
+    promptEs: "What do you need from us today?",
+    weakResponse: "We'd like to get your thoughts and feedback…",
+    weakResponseEs: "We'd like to get your thoughts and feedback…",
+    modelResponse:
+      "We need alignment on the model direction. That allows us to move into detailed design and execution.",
+    modelResponseEs:
+      "We need alignment on the model direction. That allows us to move into detailed design and execution.",
+  },
+];
+
+export const driveBonuses: DriveBonus[] = [
+  {
+    id: 1,
+    slug: "reflex-drill",
+    slugEs: "drill-reflejo",
+    title: "The 12-Item Reflex Drill",
+    titleEs: "El Drill de Reflejo de 12 Items",
+    description:
+      "The 30-day daily practice that rewires your default response under pressure. Twelve prompts, three rounds, one habit installed.",
+    descriptionEs:
+      "La práctica diaria de 30 días que reescribe tu respuesta por defecto bajo presión. Doce prompts, tres rondas, un hábito instalado.",
+    icon: "Zap",
+    available: true,
+  },
+];

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -151,6 +151,18 @@ export type TKey =
   | "course/past-tenses/knew-vs-found-out"
   | "course/past-tenses/story-openers"
   | "course/past-tenses/there-was-vs-there-has-been"
+  | "course/drive-the-decision"
+  | "course/drive-the-decision/series-a-cac-pushback"
+  | "course/drive-the-decision/board-meeting-burn-rate"
+  | "course/drive-the-decision/all-hands-pivot"
+  | "course/drive-the-decision/ceo-technical-debt"
+  | "course/drive-the-decision/enterprise-outage"
+  | "course/drive-the-decision/sales-product-conflict"
+  | "course/drive-the-decision/series-b-competitor"
+  | "course/drive-the-decision/layoff-communication"
+  | "course/drive-the-decision/missed-quarter"
+  | "course/drive-the-decision/declining-major-deal"
+  | "course/drive-the-decision/reflex-drill"
   | "corporate/for-hr"
   | "meme-portfolio"
   | "site-index";
@@ -171,16 +183,12 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     faqs: "/en/faqs/",
     resources: "/en/resources/",
     "resources/5-questions": "/en/resources/5-questions/",
-    "resources/5-minute-negotiation-script":
-      "/en/resources/5-minute-negotiation-script/",
-    "resources/7-sentences-leadership-english":
-      "/en/resources/7-sentences-leadership-english/",
-    "resources/5-principles-executive-english":
-      "/en/resources/5-principles-executive-english/",
+    "resources/5-minute-negotiation-script": "/en/resources/5-minute-negotiation-script/",
+    "resources/7-sentences-leadership-english": "/en/resources/7-sentences-leadership-english/",
+    "resources/5-principles-executive-english": "/en/resources/5-principles-executive-english/",
     "resources/10-common-mistakes-executive-english":
       "/en/resources/10-common-mistakes-executive-english/",
-    "resources/5-quick-wins-executive-english":
-      "/en/resources/5-quick-wins-executive-english/",
+    "resources/5-quick-wins-executive-english": "/en/resources/5-quick-wins-executive-english/",
     "resources/60-second-self-introduction-template":
       "/en/resources/60-second-self-introduction-template/",
     "resources/client-call-opening-closing-framework":
@@ -188,25 +196,17 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "resources/pushback-playbook": "/en/resources/pushback-playbook/",
     "resources/email-templates-difficult-situations":
       "/en/resources/email-templates-difficult-situations/",
-    "resources/executive-summary-formula":
-      "/en/resources/executive-summary-formula/",
+    "resources/executive-summary-formula": "/en/resources/executive-summary-formula/",
     "resources/feedback-framework": "/en/resources/feedback-framework/",
-    "resources/interview-answer-templates":
-      "/en/resources/interview-answer-templates/",
+    "resources/interview-answer-templates": "/en/resources/interview-answer-templates/",
     "resources/meeting-rescue-phrases": "/en/resources/meeting-rescue-phrases/",
     "resources/status-update-script": "/en/resources/status-update-script/",
-    "resources/questions-that-close-deals":
-      "/en/resources/questions-that-close-deals/",
-    "resources/technical-explanation-formula":
-      "/en/resources/technical-explanation-formula/",
-    "resources/difficult-conversation-checklist":
-      "/en/resources/difficult-conversation-checklist/",
-    "resources/professional-apology-framework":
-      "/en/resources/professional-apology-framework/",
-    "resources/phrases-aggressive-clients":
-      "/en/resources/phrases-aggressive-clients/",
-    "resources/salary-negotiation-script":
-      "/en/resources/salary-negotiation-script/",
+    "resources/questions-that-close-deals": "/en/resources/questions-that-close-deals/",
+    "resources/technical-explanation-formula": "/en/resources/technical-explanation-formula/",
+    "resources/difficult-conversation-checklist": "/en/resources/difficult-conversation-checklist/",
+    "resources/professional-apology-framework": "/en/resources/professional-apology-framework/",
+    "resources/phrases-aggressive-clients": "/en/resources/phrases-aggressive-clients/",
+    "resources/salary-negotiation-script": "/en/resources/salary-negotiation-script/",
     "legal/privacy-policy": "/en/legal/privacy-policy/",
     "legal/terms-of-service": "/en/legal/terms-of-service/",
     "legal/data-deletion": "/en/legal/data-deletion/",
@@ -228,8 +228,7 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "category/professional-english": "/en/category/professional-english/",
     "category/high-stakes-english": "/en/category/high-stakes-english/",
     "category/business-english": "/en/category/business-english/",
-    "category/high-impact-communication":
-      "/en/category/high-impact-communication/",
+    "category/high-impact-communication": "/en/category/high-impact-communication/",
     "category/career-leadership": "/en/category/career-leadership/",
     "category/english-coaching": "/en/category/english-coaching/",
     "category/executive-english": "/en/category/executive-english/",
@@ -312,15 +311,32 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/past-tenses/lesson-5": "/en/course/past-tenses/lesson-5/",
     "course/past-tenses/lesson-6": "/en/course/past-tenses/lesson-6/",
     "course/past-tenses/cheat-sheet": "/en/course/past-tenses/cheat-sheet/",
-    "course/past-tenses/practice-plan":
-      "/en/course/past-tenses/practice-plan/",
-    "course/past-tenses/top-10-confused-pairs":
-      "/en/course/past-tenses/top-10-confused-pairs/",
-    "course/past-tenses/knew-vs-found-out":
-      "/en/course/past-tenses/knew-vs-found-out/",
+    "course/past-tenses/practice-plan": "/en/course/past-tenses/practice-plan/",
+    "course/past-tenses/top-10-confused-pairs": "/en/course/past-tenses/top-10-confused-pairs/",
+    "course/past-tenses/knew-vs-found-out": "/en/course/past-tenses/knew-vs-found-out/",
     "course/past-tenses/story-openers": "/en/course/past-tenses/story-openers/",
     "course/past-tenses/there-was-vs-there-has-been":
       "/en/course/past-tenses/there-was-vs-there-has-been/",
+    "course/drive-the-decision": "/en/course/drive-the-decision/",
+    "course/drive-the-decision/series-a-cac-pushback":
+      "/en/course/drive-the-decision/series-a-cac-pushback/",
+    "course/drive-the-decision/board-meeting-burn-rate":
+      "/en/course/drive-the-decision/board-meeting-burn-rate/",
+    "course/drive-the-decision/all-hands-pivot": "/en/course/drive-the-decision/all-hands-pivot/",
+    "course/drive-the-decision/ceo-technical-debt":
+      "/en/course/drive-the-decision/ceo-technical-debt/",
+    "course/drive-the-decision/enterprise-outage":
+      "/en/course/drive-the-decision/enterprise-outage/",
+    "course/drive-the-decision/sales-product-conflict":
+      "/en/course/drive-the-decision/sales-product-conflict/",
+    "course/drive-the-decision/series-b-competitor":
+      "/en/course/drive-the-decision/series-b-competitor/",
+    "course/drive-the-decision/layoff-communication":
+      "/en/course/drive-the-decision/layoff-communication/",
+    "course/drive-the-decision/missed-quarter": "/en/course/drive-the-decision/missed-quarter/",
+    "course/drive-the-decision/declining-major-deal":
+      "/en/course/drive-the-decision/declining-major-deal/",
+    "course/drive-the-decision/reflex-drill": "/en/course/drive-the-decision/reflex-drill/",
     "corporate/for-hr": "/en/for-hr-managers/",
     "meme-portfolio": "/en/meme-portfolio/all/",
     "site-index": "/en/site-index/",
@@ -340,12 +356,9 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     faqs: "/es/faqs/",
     resources: "/es/recursos/",
     "resources/5-questions": "/es/recursos/5-preguntas/",
-    "resources/5-minute-negotiation-script":
-      "/es/recursos/guion-negociacion-5-minutos/",
-    "resources/7-sentences-leadership-english":
-      "/es/recursos/7-frases-liderazgo-ingles/",
-    "resources/5-principles-executive-english":
-      "/es/recursos/5-principios-ingles-ejecutivo/",
+    "resources/5-minute-negotiation-script": "/es/recursos/guion-negociacion-5-minutos/",
+    "resources/7-sentences-leadership-english": "/es/recursos/7-frases-liderazgo-ingles/",
+    "resources/5-principles-executive-english": "/es/recursos/5-principios-ingles-ejecutivo/",
     "resources/10-common-mistakes-executive-english":
       "/es/recursos/10-errores-comunes-ingles-ejecutivo/",
     "resources/5-quick-wins-executive-english":
@@ -357,27 +370,18 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "resources/pushback-playbook": "/es/recursos/guia-para-decir-no/",
     "resources/email-templates-difficult-situations":
       "/es/recursos/plantillas-email-situaciones-dificiles/",
-    "resources/executive-summary-formula":
-      "/es/recursos/formula-resumen-ejecutivo/",
+    "resources/executive-summary-formula": "/es/recursos/formula-resumen-ejecutivo/",
     "resources/feedback-framework": "/es/recursos/marco-retroalimentacion/",
-    "resources/interview-answer-templates":
-      "/es/recursos/plantillas-respuestas-entrevista/",
-    "resources/meeting-rescue-phrases":
-      "/es/recursos/frases-rescate-reuniones/",
-    "resources/status-update-script":
-      "/es/recursos/script-actualizacion-estado/",
-    "resources/questions-that-close-deals":
-      "/es/recursos/preguntas-que-cierran-ventas/",
-    "resources/technical-explanation-formula":
-      "/es/recursos/formula-explicacion-tecnica/",
+    "resources/interview-answer-templates": "/es/recursos/plantillas-respuestas-entrevista/",
+    "resources/meeting-rescue-phrases": "/es/recursos/frases-rescate-reuniones/",
+    "resources/status-update-script": "/es/recursos/script-actualizacion-estado/",
+    "resources/questions-that-close-deals": "/es/recursos/preguntas-que-cierran-ventas/",
+    "resources/technical-explanation-formula": "/es/recursos/formula-explicacion-tecnica/",
     "resources/difficult-conversation-checklist":
       "/es/recursos/checklist-conversaciones-dificiles/",
-    "resources/professional-apology-framework":
-      "/es/recursos/marco-disculpa-profesional/",
-    "resources/phrases-aggressive-clients":
-      "/es/recursos/frases-clientes-agresivos/",
-    "resources/salary-negotiation-script":
-      "/es/recursos/script-negociacion-salario/",
+    "resources/professional-apology-framework": "/es/recursos/marco-disculpa-profesional/",
+    "resources/phrases-aggressive-clients": "/es/recursos/frases-clientes-agresivos/",
+    "resources/salary-negotiation-script": "/es/recursos/script-negociacion-salario/",
     "legal/privacy-policy": "/es/legal/privacy-policy/",
     "legal/terms-of-service": "/es/legal/terms-of-service/",
     "legal/data-deletion": "/es/legal/data-deletion/",
@@ -388,22 +392,18 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "services/medical-english": "/es/servicios/ingles-para-medicos/",
     "services/professional-english": "/es/servicios/ingles-para-profesionales/",
     "services/public-speaking-english": "/es/servicios/hablar-en-publico/",
-    "services/startup-founders":
-      "/es/servicios/ingles-para-fundadores-de-startups/",
+    "services/startup-founders": "/es/servicios/ingles-para-fundadores-de-startups/",
     "services/tech-english": "/es/servicios/ingles-para-tecnologia/",
-    "services/technical-sales-english":
-      "/es/servicios/ingles-para-ventas-tecnicas/",
+    "services/technical-sales-english": "/es/servicios/ingles-para-ventas-tecnicas/",
     "services/corporate-package": "/es/servicios/paquete-corporativo/",
     "services/ongoing-coaching": "/es/servicios/coaching-continuo/",
-    "category/startup-founders":
-      "/es/categoria/ingles-para-fundadores-de-startups/",
+    "category/startup-founders": "/es/categoria/ingles-para-fundadores-de-startups/",
     "category/tech-english": "/es/categoria/ingles-para-tecnologia/",
     "category/logistics-english": "/es/categoria/ingles-para-logistica/",
     "category/professional-english": "/es/categoria/ingles-para-profesionales/",
     "category/high-stakes-english": "/es/categoria/ingles-para-presentaciones/",
     "category/business-english": "/es/categoria/ingles-para-negocios/",
-    "category/high-impact-communication":
-      "/es/categoria/comunicacion-de-alto-impacto/",
+    "category/high-impact-communication": "/es/categoria/comunicacion-de-alto-impacto/",
     "category/career-leadership": "/es/categoria/carrera-liderazgo/",
     "category/english-coaching": "/es/categoria/coaching-en-ingles/",
     "category/executive-english": "/es/categoria/ingles-ejecutivo/",
@@ -486,16 +486,33 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/past-tenses/lesson-5": "/es/curso/tiempos-del-pasado/leccion-5/",
     "course/past-tenses/lesson-6": "/es/curso/tiempos-del-pasado/leccion-6/",
     "course/past-tenses/cheat-sheet": "/es/curso/tiempos-del-pasado/guia-rapida/",
-    "course/past-tenses/practice-plan":
-      "/es/curso/tiempos-del-pasado/plan-de-practica/",
+    "course/past-tenses/practice-plan": "/es/curso/tiempos-del-pasado/plan-de-practica/",
     "course/past-tenses/top-10-confused-pairs":
       "/es/curso/tiempos-del-pasado/top-10-pares-confundidos/",
-    "course/past-tenses/knew-vs-found-out":
-      "/es/curso/tiempos-del-pasado/knew-vs-found-out/",
-    "course/past-tenses/story-openers":
-      "/es/curso/tiempos-del-pasado/frases-iniciales/",
+    "course/past-tenses/knew-vs-found-out": "/es/curso/tiempos-del-pasado/knew-vs-found-out/",
+    "course/past-tenses/story-openers": "/es/curso/tiempos-del-pasado/frases-iniciales/",
     "course/past-tenses/there-was-vs-there-has-been":
       "/es/curso/tiempos-del-pasado/there-was-vs-there-has-been/",
+    "course/drive-the-decision": "/es/curso/dirige-la-decision/",
+    "course/drive-the-decision/series-a-cac-pushback":
+      "/es/curso/dirige-la-decision/pushback-cac-serie-a/",
+    "course/drive-the-decision/board-meeting-burn-rate":
+      "/es/curso/dirige-la-decision/junta-directiva-burn-rate/",
+    "course/drive-the-decision/all-hands-pivot": "/es/curso/dirige-la-decision/all-hands-pivot/",
+    "course/drive-the-decision/ceo-technical-debt":
+      "/es/curso/dirige-la-decision/ceo-deuda-tecnica/",
+    "course/drive-the-decision/enterprise-outage":
+      "/es/curso/dirige-la-decision/outage-enterprise/",
+    "course/drive-the-decision/sales-product-conflict":
+      "/es/curso/dirige-la-decision/conflicto-ventas-producto/",
+    "course/drive-the-decision/series-b-competitor":
+      "/es/curso/dirige-la-decision/serie-b-competidor/",
+    "course/drive-the-decision/layoff-communication":
+      "/es/curso/dirige-la-decision/comunicacion-recorte/",
+    "course/drive-the-decision/missed-quarter": "/es/curso/dirige-la-decision/trimestre-perdido/",
+    "course/drive-the-decision/declining-major-deal":
+      "/es/curso/dirige-la-decision/rechazar-trato-importante/",
+    "course/drive-the-decision/reflex-drill": "/es/curso/dirige-la-decision/drill-reflejo/",
     "corporate/for-hr": "/es/para-rh/",
     "meme-portfolio": "/es/meme-portfolio/all/",
     "site-index": "/es/indice-del-sitio/",
@@ -595,6 +612,18 @@ export function getAllTKeys(): TKey[] {
     "course/past-tenses/knew-vs-found-out",
     "course/past-tenses/story-openers",
     "course/past-tenses/there-was-vs-there-has-been",
+    "course/drive-the-decision",
+    "course/drive-the-decision/series-a-cac-pushback",
+    "course/drive-the-decision/board-meeting-burn-rate",
+    "course/drive-the-decision/all-hands-pivot",
+    "course/drive-the-decision/ceo-technical-debt",
+    "course/drive-the-decision/enterprise-outage",
+    "course/drive-the-decision/sales-product-conflict",
+    "course/drive-the-decision/series-b-competitor",
+    "course/drive-the-decision/layoff-communication",
+    "course/drive-the-decision/missed-quarter",
+    "course/drive-the-decision/declining-major-deal",
+    "course/drive-the-decision/reflex-drill",
     "category/startup-founders",
     "category/tech-english",
     "category/logistics-english",

--- a/src/pages/en/course/drive-the-decision/all-hands-pivot.astro
+++ b/src/pages/en/course/drive-the-decision/all-hands-pivot.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={3} lang="en" tkey="course/drive-the-decision/all-hands-pivot" />

--- a/src/pages/en/course/drive-the-decision/board-meeting-burn-rate.astro
+++ b/src/pages/en/course/drive-the-decision/board-meeting-burn-rate.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={2} lang="en" tkey="course/drive-the-decision/board-meeting-burn-rate" />

--- a/src/pages/en/course/drive-the-decision/ceo-technical-debt.astro
+++ b/src/pages/en/course/drive-the-decision/ceo-technical-debt.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={4} lang="en" tkey="course/drive-the-decision/ceo-technical-debt" />

--- a/src/pages/en/course/drive-the-decision/declining-major-deal.astro
+++ b/src/pages/en/course/drive-the-decision/declining-major-deal.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={10} lang="en" tkey="course/drive-the-decision/declining-major-deal" />

--- a/src/pages/en/course/drive-the-decision/enterprise-outage.astro
+++ b/src/pages/en/course/drive-the-decision/enterprise-outage.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={5} lang="en" tkey="course/drive-the-decision/enterprise-outage" />

--- a/src/pages/en/course/drive-the-decision/index.astro
+++ b/src/pages/en/course/drive-the-decision/index.astro
@@ -1,0 +1,349 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import {
+  driveInfo,
+  scenarioMeta,
+  driveBonuses,
+} from "@data/drive-the-decision/scenarios";
+import {
+  ArrowRight,
+  Sparkles,
+  Mic,
+  TrendingUp,
+  Clock,
+  Compass,
+  Wrench,
+  AlertOctagon,
+  Split,
+  Shield,
+  Users,
+  BarChart3,
+  XCircle,
+  Zap,
+  Crown,
+  CheckCircle2,
+  Brain,
+  Target,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/drive-the-decision" as const;
+
+const iconMap: Record<string, any> = {
+  TrendingUp,
+  Clock,
+  Compass,
+  Wrench,
+  AlertOctagon,
+  Split,
+  Shield,
+  Users,
+  BarChart3,
+  XCircle,
+  Zap,
+};
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Drive the Decision — Boardroom Simulation | NY English"
+  description="Free master class: 10 boardroom scenarios with model replies that move the room. Built for senior leaders who already speak fluent English."
+>
+  <!-- Hero -->
+  <section class="relative w-full overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-amber-950 pt-32 pb-20 md:pt-40 md:pb-28">
+    <div class="absolute inset-0 opacity-10">
+      <div class="absolute top-20 left-10 w-72 h-72 bg-amber-500 rounded-full blur-3xl"></div>
+      <div class="absolute bottom-10 right-10 w-96 h-96 bg-slate-400 rounded-full blur-3xl"></div>
+    </div>
+    <div class="site-container mx-auto px-4 relative z-10 text-white">
+      <div class="max-w-3xl">
+        <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-300 text-sm font-semibold mb-6">
+          <Crown class="w-4 h-4" />
+          Master Class · C1 → C2 · Free
+        </div>
+        <h1
+          class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Drive the Decision.<br />
+          <span class="text-amber-400">Move the Room.</span>
+        </h1>
+        <p class="text-xl text-slate-200 mb-4 max-w-2xl leading-relaxed">
+          <strong class="text-white">Stop explaining. Start deciding.</strong>
+        </p>
+        <p class="text-lg text-slate-300 mb-8 max-w-2xl leading-relaxed">
+          Ten boardroom scenarios with worked model replies — investor pushback, missed quarters, layoffs, $2M deals you have to decline. Each scenario shows the weak default, the model response, and the decision psychology that makes it land. Built for senior leaders who already speak fluent English but freeze when the room turns to them.
+        </p>
+        <div class="flex flex-wrap gap-4">
+          <Button href={`${driveInfo.basePath.en}/${scenarioMeta[0].slug}/`} variant="primary" size="lg">
+            Start with Scenario 1
+            <ArrowRight class="w-5 h-5 ml-1" />
+          </Button>
+          <a
+            href="#scenarios"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            See all 10 scenarios
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Thesis band -->
+  <section class="py-16 md:py-20 bg-white border-b border-slate-100">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <p class="text-[11px] font-mono uppercase tracking-[0.3em] text-amber-600 mb-4">The Thesis</p>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Executives don't process information linearly.<br />
+          They process: <em>Conclusion → Logic → Implication.</em>
+        </h2>
+        <p class="text-lg text-slate-600 leading-relaxed">
+          When you delay your conclusion, you create three problems at once — cognitive friction, lost attention, and the unintended signal of hesitation. The fluent speaker who buries the decision under five sentences of context loses the room before they reach their point. This master class drills the fix: lead with the outcome, support with structure, close with what you need.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Explain vs Decide contrast -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="text-center mb-12">
+          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">The Shift That Changes Every Conversation</h2>
+          <p class="text-lg text-slate-600 max-w-2xl mx-auto">
+            Fluent English isn't the bar at this level. The bar is whether your language compresses cleanly into the moment the room needs a decision.
+          </p>
+        </div>
+
+        <div class="grid md:grid-cols-2 gap-6">
+          <div class="rounded-2xl border-2 border-red-200 bg-red-50/50 p-8">
+            <div class="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-red-100 text-red-600 mb-4">
+              <Brain class="w-6 h-6" />
+            </div>
+            <h3 class="text-xl font-bold text-slate-900 mb-3">The Explainer Pattern</h3>
+            <ul class="space-y-2 text-slate-700">
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Buildup: "Well, what we're seeing is…"</li>
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Hedge: "I think… maybe… potentially…"</li>
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Conclusion arrives at sentence 6 — after the room moved on</li>
+            </ul>
+          </div>
+
+          <div class="rounded-2xl border-2 border-amber-300 bg-amber-50 p-8">
+            <div class="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-amber-100 text-amber-700 mb-4">
+              <Target class="w-6 h-6" />
+            </div>
+            <h3 class="text-xl font-bold text-slate-900 mb-3">The Decider Pattern</h3>
+            <ul class="space-y-2 text-slate-700">
+              <li class="flex gap-2"><span class="text-amber-600 shrink-0">✓</span> Outcome first: "The decision is…"</li>
+              <li class="flex gap-2"><span class="text-amber-600 shrink-0">✓</span> Numbered support: "Two reasons. First…"</li>
+              <li class="flex gap-2"><span class="text-amber-600 shrink-0">✓</span> Close with what you need: "Today we need alignment on X."</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Who this is for -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6">Who This Is For</h2>
+        <p class="text-lg text-slate-600 leading-relaxed mb-6">
+          You already speak English at a high level. You've made it into rooms where decisions get made. But under pressure, you notice the pattern:
+        </p>
+        <ul class="space-y-3 text-lg text-slate-700 leading-relaxed mb-8">
+          <li class="flex gap-3"><span class="text-amber-600 shrink-0">→</span> You explain when you should decide.</li>
+          <li class="flex gap-3"><span class="text-amber-600 shrink-0">→</span> You build slides when you should build conclusions.</li>
+          <li class="flex gap-3"><span class="text-amber-600 shrink-0">→</span> You hedge when you should commit.</li>
+          <li class="flex gap-3"><span class="text-amber-600 shrink-0">→</span> You ramble when you should land.</li>
+        </ul>
+        <p class="text-slate-600 leading-relaxed">
+          This isn't a language problem. It's a <strong>delivery architecture</strong> problem — and it shows up most in the rooms where it costs you the most. The fix is reflex, not vocabulary. That's what this master class installs.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Scenarios grid -->
+  <section class="py-16 md:py-20 bg-slate-50" id="scenarios">
+    <div class="site-container mx-auto px-4">
+      <div class="text-center max-w-2xl mx-auto mb-12">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4" style="font-family: 'Noto Sans KR', sans-serif;">
+          Ten Scenarios. Ten Decisions.
+        </h2>
+        <p class="text-slate-600 leading-relaxed">
+          Each scenario gives you the setup, the pushback, the weak default response, the model reply, and the decision psychology behind why it works. Then you build your own version.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
+        {scenarioMeta.map((scenario) => {
+          const Icon = iconMap[scenario.icon];
+          const isAvailable = scenario.available;
+          return (
+            <a
+              href={isAvailable ? `${driveInfo.basePath.en}/${scenario.slug}/` : undefined}
+              class:list={[
+                "group flex items-start gap-4 p-5 rounded-xl border transition-all duration-200",
+                isAvailable
+                  ? "bg-amber-50 border-amber-300 hover:shadow-md hover:border-amber-400 cursor-pointer"
+                  : "bg-white border-slate-200 opacity-75",
+              ]}
+            >
+              <div
+                class:list={[
+                  "flex items-center justify-center w-12 h-12 rounded-xl shrink-0",
+                  isAvailable ? "bg-amber-500 text-white" : "bg-slate-100 text-slate-400",
+                ]}
+              >
+                {Icon && <Icon class="w-6 h-6" />}
+              </div>
+              <div class="flex-1">
+                <div class="flex items-center gap-2">
+                  <span
+                    class:list={[
+                      "text-xs font-bold uppercase tracking-wider",
+                      isAvailable ? "text-amber-700" : "text-slate-400",
+                    ]}
+                  >
+                    Scenario {scenario.id}
+                  </span>
+                </div>
+                <h3
+                  class:list={[
+                    "text-lg font-bold mt-0.5",
+                    isAvailable ? "text-slate-900" : "text-slate-600",
+                  ]}
+                >
+                  {scenario.title}
+                </h3>
+                <p class="text-sm text-slate-600 mt-1">{scenario.subtitle}</p>
+                <p class="text-xs text-amber-700 mt-1.5 italic">{scenario.setting}</p>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <!-- Reflex Drill bonus -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="text-center mb-12">
+          <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-100 text-amber-800 text-sm font-semibold mb-4">
+            <Sparkles class="w-4 h-4" />
+            Bonus Resource
+          </div>
+          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">The 30-Day Reflex Drill</h2>
+          <p class="text-lg text-slate-600 max-w-2xl mx-auto">
+            Twelve high-pressure prompts. Three rounds of execution. Thirty days. After this, the patterns are no longer conscious — they become your default.
+          </p>
+        </div>
+
+        {driveBonuses.map((bonus) => {
+          const Icon = iconMap[bonus.icon] ?? Zap;
+          return (
+            <a
+              href={`${driveInfo.basePath.en}/${bonus.slug}/`}
+              class="block bg-gradient-to-br from-slate-900 via-slate-800 to-amber-900 rounded-2xl p-8 text-white hover:shadow-xl transition-shadow duration-200"
+            >
+              <div class="flex items-start gap-5">
+                <div class="flex items-center justify-center w-14 h-14 rounded-xl bg-amber-500 text-white shrink-0">
+                  <Icon class="w-7 h-7" />
+                </div>
+                <div class="flex-1">
+                  <h3 class="text-2xl font-bold mb-2">{bonus.title}</h3>
+                  <p class="text-slate-300 leading-relaxed mb-4">{bonus.description}</p>
+                  <span class="inline-flex items-center gap-1 text-amber-300 font-semibold text-sm group-hover:gap-2 transition-all">
+                    Open the drill
+                    <ArrowRight class="w-4 h-4" />
+                  </span>
+                </div>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <!-- Why this works -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-6 text-center">Why Worked Scenarios Beat Theory</h2>
+        <div class="space-y-6 text-lg text-slate-700 leading-relaxed">
+          <p>
+            Reading frameworks doesn't install them. Speaking model replies under pressure does. This master class skips the framework-explanation layer and goes straight to the artifacts — the exact words that work in the exact rooms where everything is on the line.
+          </p>
+          <p>
+            Each scenario uses the structural mechanics from the <a href="/en/course/executive/" class="text-amber-700 hover:text-amber-800 underline underline-offset-2 font-medium">Executive course</a> — outcome-first delivery, numbered support, reframes, decisive closes. Here you see them applied to investor pushback, board questions, customer escalations, and the moments where leaders quietly lose the room.
+          </p>
+          <p>
+            For Mexican executives specifically, this master class addresses a hidden translation tax. Spanish-to-English instinct produces hedges (<em>"Considero que…"</em> → <em>"I consider that…"</em>) and softeners (<em>"Podríamos…"</em> → <em>"We could…"</em>) that read as uncertainty in English boardrooms. The model replies show the cleaner pattern — and the reflex drill installs it.
+        </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Cross-link -->
+  <section class="py-16 md:py-20 bg-white border-t border-slate-100">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-2xl font-bold text-slate-900 mb-4">Where Does This Fit?</h2>
+        <p class="text-lg text-slate-600 leading-relaxed mb-6">
+          This is a <strong>focused master class</strong> — applied scenarios for senior leaders who already have the frameworks. For the full executive system (word choice, hedging elimination, three-tier reframes, named frameworks), see <strong>Communicate Like a Leader</strong>. For 1-on-1 coaching, the booking link is below.
+        </p>
+        <div class="flex flex-wrap gap-3 justify-center">
+          <a
+            href="/en/course/executive/"
+            class="text-amber-700 hover:text-amber-800 font-medium underline underline-offset-2"
+          >
+            Executive course (Communicate Like a Leader)
+          </a>
+          <span class="text-slate-300">|</span>
+          <a
+            href="/en/courses/"
+            class="text-amber-700 hover:text-amber-800 font-medium underline underline-offset-2"
+          >
+            See all courses
+          </a>
+          <span class="text-slate-300">|</span>
+          <a
+            href="/en/book/"
+            class="text-amber-700 hover:text-amber-800 font-medium underline underline-offset-2"
+          >
+            Work 1-on-1 with Robert
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "Course",
+    "name": "Drive the Decision — Executive Boardroom Simulation",
+    "description": "Free master class with 10 worked boardroom scenarios and a 12-item reflex drill. Built for C1-C2 senior leaders who already speak fluent English but need to lead under pressure.",
+    "provider": { "@type": "Organization", "name": "New York English Teacher", "url": "https://www.nyenglishteacher.com/" },
+    "educationalLevel": "Executive (C1-C2)",
+    "inLanguage": "en",
+    "url": "https://www.nyenglishteacher.com/en/course/drive-the-decision/",
+    "isAccessibleForFree": true,
+    "hasCourseInstance": {
+      "@type": "CourseInstance",
+      "courseMode": "online",
+      "inLanguage": "en"
+    }
+  })} />
+</Base>

--- a/src/pages/en/course/drive-the-decision/layoff-communication.astro
+++ b/src/pages/en/course/drive-the-decision/layoff-communication.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={8} lang="en" tkey="course/drive-the-decision/layoff-communication" />

--- a/src/pages/en/course/drive-the-decision/missed-quarter.astro
+++ b/src/pages/en/course/drive-the-decision/missed-quarter.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={9} lang="en" tkey="course/drive-the-decision/missed-quarter" />

--- a/src/pages/en/course/drive-the-decision/reflex-drill.astro
+++ b/src/pages/en/course/drive-the-decision/reflex-drill.astro
@@ -1,0 +1,258 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import AudioButton from "@components/course/AudioButton";
+import { driveInfo, drillItems } from "@data/drive-the-decision/scenarios";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Zap,
+  XCircle,
+  CheckCircle2,
+  Volume2,
+  Clock,
+  Target,
+  Sparkles,
+  Repeat,
+  Calendar,
+} from "lucide-astro";
+
+const lang = "en";
+const tkey = "course/drive-the-decision/reflex-drill" as const;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="The 12-Item Reflex Drill — Drive the Decision | NY English"
+  description="The 30-day daily reflex drill that rewires your default response under executive pressure. 12 prompts, 3 rounds, 1 habit installed. Free for senior leaders."
+>
+  <!-- Hero -->
+  <section class="bg-gradient-to-br from-slate-950 via-slate-900 to-amber-950 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-300 text-sm font-semibold mb-6">
+          <Sparkles class="w-4 h-4" />
+          Bonus · The Reflex Installer
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          The 12-Item Reflex Drill
+        </h1>
+        <p class="text-xl text-amber-200 italic font-light mb-4">
+          Stop thinking about the framework. Install it as your default.
+        </p>
+        <p class="text-lg text-slate-300 leading-relaxed">
+          This is a behavior module, not a content module. You're not learning new ideas — you're installing reflexes. Ten minutes a day for 30 days. After that, the patterns are no longer conscious. They become how you respond.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Rules -->
+  <section class="py-14 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6">Rules — Non-Negotiable</h2>
+        <div class="grid sm:grid-cols-2 gap-3">
+          <div class="bg-red-50 border border-red-200 rounded-lg p-4">
+            <p class="text-red-700 font-medium text-sm">✗ No "I think…"</p>
+          </div>
+          <div class="bg-red-50 border border-red-200 rounded-lg p-4">
+            <p class="text-red-700 font-medium text-sm">✗ No "So basically…"</p>
+          </div>
+          <div class="bg-red-50 border border-red-200 rounded-lg p-4">
+            <p class="text-red-700 font-medium text-sm">✗ No explanation before conclusion</p>
+          </div>
+          <div class="bg-red-50 border border-red-200 rounded-lg p-4">
+            <p class="text-red-700 font-medium text-sm">✗ No response longer than 10–12 seconds</p>
+          </div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-4 sm:col-span-2">
+            <p class="text-emerald-700 font-medium text-sm">✓ Outcome first. Support second. Land clean.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Three rounds explanation -->
+  <section class="py-14 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6">Three Rounds — Per Item, Every Time</h2>
+        <div class="space-y-3">
+          <div class="flex items-start gap-4 bg-white rounded-xl border border-slate-200 p-5">
+            <div class="flex items-center justify-center w-10 h-10 rounded-full bg-slate-100 text-slate-700 font-bold shrink-0">1</div>
+            <div>
+              <p class="font-bold text-slate-900">Slow, controlled, deliberate</p>
+              <p class="text-slate-600 text-sm">Lock the structure. Don't worry about pace. The shape comes first.</p>
+            </div>
+          </div>
+          <div class="flex items-start gap-4 bg-white rounded-xl border border-slate-200 p-5">
+            <div class="flex items-center justify-center w-10 h-10 rounded-full bg-amber-100 text-amber-700 font-bold shrink-0">2</div>
+            <div>
+              <p class="font-bold text-slate-900">Natural pace</p>
+              <p class="text-slate-600 text-sm">Build rhythm. Move from "constructing" to "speaking."</p>
+            </div>
+          </div>
+          <div class="flex items-start gap-4 bg-white rounded-xl border border-amber-300 p-5">
+            <div class="flex items-center justify-center w-10 h-10 rounded-full bg-amber-500 text-white font-bold shrink-0">3</div>
+            <div>
+              <p class="font-bold text-slate-900">Immediate — no thinking time</p>
+              <p class="text-slate-600 text-sm">This is where the reflex installs. Hear prompt. Speak response. No pause.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 12 drill items -->
+  <section class="py-14 md:py-16 bg-white" id="drill-items">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-2">The 12 Items</h2>
+        <p class="text-slate-600 mb-8 flex items-center gap-2">
+          <Volume2 class="w-4 h-4 text-amber-600" />
+          Tap the speaker on the prompt to hear it, then say the model response aloud. Tap the second speaker to check your delivery.
+        </p>
+
+        <div class="space-y-6">
+          {drillItems.map((item) => (
+            <div class="bg-slate-50 rounded-xl border border-slate-200 overflow-hidden">
+              <div class="bg-slate-900 text-white px-5 py-3 flex items-center justify-between">
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-400">
+                  Item {item.id} — {item.category}
+                </p>
+              </div>
+              <div class="p-5 md:p-6 space-y-4">
+                <div class="bg-white rounded-lg border border-slate-200 p-4">
+                  <p class="text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Prompt</p>
+                  <div class="flex items-center gap-3">
+                    <p class="text-lg text-slate-900 italic flex-1">"{item.prompt}"</p>
+                    <AudioButton client:visible text={item.prompt} lang="en-US" size="sm" />
+                  </div>
+                </div>
+
+                <div class="bg-red-50/60 border border-red-200 rounded-lg p-4">
+                  <div class="flex items-start gap-3">
+                    <XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
+                    <div class="flex-1">
+                      <p class="text-xs font-bold uppercase tracking-wider text-red-700 mb-1">Weak</p>
+                      <p class="text-slate-800 italic">"{item.weakResponse}"</p>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-4">
+                  <div class="flex items-start gap-3">
+                    <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+                    <div class="flex-1">
+                      <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-1">Model</p>
+                      <p class="text-slate-900 font-medium leading-relaxed mb-3">"{item.modelResponse}"</p>
+                      <div class="flex items-center gap-2 pt-3 border-t border-emerald-200/60">
+                        <AudioButton client:visible text={item.modelResponse} lang="en-US" size="sm" />
+                        <span class="text-xs text-slate-600">Listen to the model delivery</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 30-day cycle -->
+  <section class="py-14 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="text-center mb-8">
+          <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-100 text-amber-800 text-sm font-semibold mb-3">
+            <Calendar class="w-4 h-4" />
+            The 30-Day Cycle
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">How To Install The Reflex</h2>
+        </div>
+
+        <div class="space-y-4">
+          <div class="bg-white rounded-xl border border-slate-200 p-6">
+            <div class="flex items-start gap-4">
+              <div class="flex items-center justify-center w-12 h-12 rounded-lg bg-amber-100 text-amber-700 shrink-0">
+                <Repeat class="w-6 h-6" />
+              </div>
+              <div>
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">Days 1 — 10</p>
+                <p class="font-bold text-slate-900 mb-1">All 12 items, all 3 rounds, daily</p>
+                <p class="text-slate-600 text-sm">Roughly 10–15 minutes per day. Don't skip rounds. The structure has to lock before speed matters.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="bg-white rounded-xl border border-slate-200 p-6">
+            <div class="flex items-start gap-4">
+              <div class="flex items-center justify-center w-12 h-12 rounded-lg bg-amber-100 text-amber-700 shrink-0">
+                <Target class="w-6 h-6" />
+              </div>
+              <div>
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">Days 11 — 20</p>
+                <p class="font-bold text-slate-900 mb-1">Random 6 items per day, rounds 2 and 3 only</p>
+                <p class="text-slate-600 text-sm">Drop round 1. Mix the order so your brain stops anticipating. You're moving from rehearsal to retrieval.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="bg-white rounded-xl border border-amber-300 p-6">
+            <div class="flex items-start gap-4">
+              <div class="flex items-center justify-center w-12 h-12 rounded-lg bg-amber-500 text-white shrink-0">
+                <Zap class="w-6 h-6" />
+              </div>
+              <div>
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">Days 21 — 30</p>
+                <p class="font-bold text-slate-900 mb-1">Random 3 items per day, round 3 only — full pressure</p>
+                <p class="text-slate-600 text-sm">Prompt → response, immediate. No thinking gap. This is where the reflex becomes default. After 30 days, the patterns aren't conscious anymore.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 md:py-14 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <a
+            href={`${driveInfo.basePath.en}/declining-major-deal/`}
+            class="group flex items-center gap-3 bg-slate-50 rounded-xl border border-slate-200 hover:border-amber-300 hover:shadow-md transition-all p-5"
+          >
+            <ArrowLeft class="w-5 h-5 text-slate-400 group-hover:text-amber-600 transition-colors shrink-0" />
+            <div>
+              <p class="text-xs font-bold uppercase tracking-wider text-slate-500 mb-0.5">Last scenario</p>
+              <p class="text-slate-900 font-medium">Declining a $2M Strategic Deal</p>
+            </div>
+          </a>
+
+          <a
+            href={`${driveInfo.basePath.en}/`}
+            class="group flex items-center justify-between gap-3 bg-amber-500 hover:bg-amber-600 text-white rounded-xl transition-all p-5"
+          >
+            <div>
+              <p class="text-xs font-bold uppercase tracking-wider text-amber-100 mb-0.5">Course overview</p>
+              <p class="font-medium">Drive the Decision</p>
+            </div>
+            <ArrowRight class="w-5 h-5 shrink-0" />
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/en/course/drive-the-decision/sales-product-conflict.astro
+++ b/src/pages/en/course/drive-the-decision/sales-product-conflict.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={6} lang="en" tkey="course/drive-the-decision/sales-product-conflict" />

--- a/src/pages/en/course/drive-the-decision/series-a-cac-pushback.astro
+++ b/src/pages/en/course/drive-the-decision/series-a-cac-pushback.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={1} lang="en" tkey="course/drive-the-decision/series-a-cac-pushback" />

--- a/src/pages/en/course/drive-the-decision/series-b-competitor.astro
+++ b/src/pages/en/course/drive-the-decision/series-b-competitor.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={7} lang="en" tkey="course/drive-the-decision/series-b-competitor" />

--- a/src/pages/en/courses/index.astro
+++ b/src/pages/en/courses/index.astro
@@ -8,6 +8,7 @@ import { elementaryInfo, elementaryUnits } from "@data/elementary/units";
 import { intermediateInfo, intermediateUnits } from "@data/intermediate/units";
 import { advancedInfo, advancedUnits } from "@data/advanced/units";
 import { executiveInfo, executiveUnits } from "@data/executive/units";
+import { driveInfo, scenarioMeta } from "@data/drive-the-decision/scenarios";
 import {
   Sparkles,
   BookOpen,
@@ -17,6 +18,7 @@ import {
   CheckCircle2,
   GraduationCap,
   Target,
+  Zap,
 } from "lucide-astro";
 
 const lang = "en";
@@ -28,6 +30,7 @@ const elementaryTotal = elementaryUnits.length;
 const intermediateAvailable = intermediateUnits.length;
 const advancedAvailable = advancedUnits.length;
 const executiveAvailable = executiveUnits.filter((u) => u.published).length;
+const driveScenariosAvailable = scenarioMeta.filter((s) => s.available).length;
 ---
 
 <Base
@@ -51,10 +54,11 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
           English Courses That Actually Work for Spanish Speakers
         </h1>
         <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
-          Six free, interactive courses built for Spanish speakers — five
-          leveled tracks from A1 beginner through C2 executive, plus a focused
-          master class on past tenses. No sign-up. No paywall. No textbook
-          drudgery. Just real progress from the first lesson.
+          Seven free, interactive courses built for Spanish speakers — five
+          leveled tracks from A1 beginner through C2 executive, plus two
+          focused master classes: past tenses and executive decision
+          communication. No sign-up. No paywall. No textbook drudgery. Just
+          real progress from the first lesson.
         </p>
       </div>
     </div>
@@ -361,13 +365,60 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
             </div>
           </div>
         </a>
+
+        <!-- Master Class — Drive the Decision -->
+        <a
+          href="/en/course/drive-the-decision/"
+          class="group block bg-white rounded-2xl border-2 border-amber-400/40 overflow-hidden hover:shadow-xl hover:border-amber-400 transition-all duration-200"
+        >
+          <div class="bg-gradient-to-br from-slate-950 via-slate-900 to-amber-900 p-6 text-white min-h-[180px] flex flex-col justify-end">
+            <div class="flex items-center gap-2 text-amber-300 text-xs font-bold uppercase tracking-wider mb-2">
+              <Zap class="w-3.5 h-3.5" />
+              Master Class — C1 to C2 Executive
+            </div>
+            <h2 class="text-2xl md:text-3xl font-bold mb-2" style="font-family: 'Noto Sans KR', sans-serif;">
+              {driveInfo.title}
+            </h2>
+            <p class="text-amber-100 text-sm leading-relaxed">
+              {driveInfo.shortTagline}
+            </p>
+          </div>
+          <div class="p-6">
+            <p class="text-slate-600 text-sm leading-relaxed mb-4">
+              The applied capstone for senior leaders. Ten worked boardroom scenarios — investor pushback, missed quarters, layoffs, $2M deals you have to decline — with model replies and the decision psychology behind them.
+            </p>
+            <ul class="space-y-2 mb-6">
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>10 boardroom scenarios with worked model replies</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>12-item reflex drill (30-day installation cycle)</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>Audio model replies to lock the cadence</span>
+              </li>
+            </ul>
+            <div class="flex items-center justify-between">
+              <span class="text-xs font-semibold text-amber-700 uppercase tracking-wider">
+                {driveScenariosAvailable} scenarios + drill
+              </span>
+              <span class="inline-flex items-center gap-1 text-amber-700 font-semibold text-sm group-hover:gap-2 transition-all">
+                Start master class
+                <ArrowRight class="w-4 h-4" />
+              </span>
+            </div>
+          </div>
+        </a>
       </div>
 
       <!-- Which one? -->
       <div class="max-w-3xl mx-auto mt-16 text-center">
         <h3 class="text-2xl font-bold text-slate-900 mb-3">Not sure which one to start?</h3>
         <p class="text-slate-600 mb-6">
-          If English still feels brand new, start with the <strong>beginner</strong> course. If you've finished the basics but can't yet talk about yesterday or make plans, take <strong>elementary</strong>. If you can already hold a conversation, jump to <strong>intermediate</strong>. If your English is fluent but not polished, go to <strong>advanced</strong>. If you're a senior leader who wants to <em>lead</em> in English, go straight to <strong>executive</strong>. And if you keep freezing on past tense specifically, the <strong>past tenses master class</strong> fits beside any of them. Your progress is saved separately for each course.
+          If English still feels brand new, start with the <strong>beginner</strong> course. If you've finished the basics but can't yet talk about yesterday or make plans, take <strong>elementary</strong>. If you can already hold a conversation, jump to <strong>intermediate</strong>. If your English is fluent but not polished, go to <strong>advanced</strong>. If you're a senior leader who wants to <em>lead</em> in English, go straight to <strong>executive</strong> — and pair it with <strong>Drive the Decision</strong> for applied boardroom scenarios. If you keep freezing on past tense specifically, the <strong>past tenses master class</strong> fits beside any of them. Your progress is saved separately for each course.
         </p>
         <Button href="/en/services/" variant="secondary" size="md">
           Or work 1-on-1 with Robert
@@ -436,6 +487,15 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
         "@type": "Course",
         "name": "Master English Past Tenses (Free Master Class)",
         "url": "https://www.nyenglishteacher.com/en/course/past-tenses/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 7,
+      "item": {
+        "@type": "Course",
+        "name": "Drive the Decision — Executive Boardroom Simulation (Free Master Class)",
+        "url": "https://www.nyenglishteacher.com/en/course/drive-the-decision/"
       }
     }
   ]

--- a/src/pages/es/curso/dirige-la-decision/all-hands-pivot.astro
+++ b/src/pages/es/curso/dirige-la-decision/all-hands-pivot.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={3} lang="es" tkey="course/drive-the-decision/all-hands-pivot" />

--- a/src/pages/es/curso/dirige-la-decision/ceo-deuda-tecnica.astro
+++ b/src/pages/es/curso/dirige-la-decision/ceo-deuda-tecnica.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={4} lang="es" tkey="course/drive-the-decision/ceo-technical-debt" />

--- a/src/pages/es/curso/dirige-la-decision/comunicacion-recorte.astro
+++ b/src/pages/es/curso/dirige-la-decision/comunicacion-recorte.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={8} lang="es" tkey="course/drive-the-decision/layoff-communication" />

--- a/src/pages/es/curso/dirige-la-decision/conflicto-ventas-producto.astro
+++ b/src/pages/es/curso/dirige-la-decision/conflicto-ventas-producto.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={6} lang="es" tkey="course/drive-the-decision/sales-product-conflict" />

--- a/src/pages/es/curso/dirige-la-decision/drill-reflejo.astro
+++ b/src/pages/es/curso/dirige-la-decision/drill-reflejo.astro
@@ -1,0 +1,257 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import AudioButton from "@components/course/AudioButton";
+import { driveInfo, drillItems } from "@data/drive-the-decision/scenarios";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Zap,
+  XCircle,
+  CheckCircle2,
+  Volume2,
+  Target,
+  Sparkles,
+  Repeat,
+  Calendar,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/drive-the-decision/reflex-drill" as const;
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Drill de Reflejo de 12 Items — Dirige la Decisión"
+  description="El drill diario de 30 días que reescribe tu respuesta por defecto bajo presión. 12 prompts, 3 rondas, un hábito instalado."
+>
+  <!-- Hero -->
+  <section class="bg-gradient-to-br from-slate-950 via-slate-900 to-amber-950 pt-28 pb-16 md:pt-36 md:pb-20">
+    <div class="site-container mx-auto px-4 text-white">
+      <div class="max-w-3xl">
+        <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-300 text-sm font-semibold mb-6">
+          <Sparkles class="w-4 h-4" />
+          Bonus · El Instalador de Reflejo
+        </div>
+        <h1
+          class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          El Drill de Reflejo de 12 Items
+        </h1>
+        <p class="text-xl text-amber-200 italic font-light mb-4">
+          Deja de pensar en el marco. Instálalo como tu respuesta por defecto.
+        </p>
+        <p class="text-lg text-slate-300 leading-relaxed">
+          Este es un módulo de comportamiento, no de contenido. No estás aprendiendo ideas nuevas — estás instalando reflejos. Diez minutos al día por 30 días. Después, los patrones ya no son conscientes. Se vuelven la forma en que respondes.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Rules -->
+  <section class="py-14 md:py-16 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6">Reglas — No Negociables</h2>
+        <div class="grid sm:grid-cols-2 gap-3">
+          <div class="bg-red-50 border border-red-200 rounded-lg p-4">
+            <p class="text-red-700 font-medium text-sm">✗ Nada de "I think…"</p>
+          </div>
+          <div class="bg-red-50 border border-red-200 rounded-lg p-4">
+            <p class="text-red-700 font-medium text-sm">✗ Nada de "So basically…"</p>
+          </div>
+          <div class="bg-red-50 border border-red-200 rounded-lg p-4">
+            <p class="text-red-700 font-medium text-sm">✗ Nada de explicación antes de la conclusión</p>
+          </div>
+          <div class="bg-red-50 border border-red-200 rounded-lg p-4">
+            <p class="text-red-700 font-medium text-sm">✗ Ninguna respuesta mayor a 10–12 segundos</p>
+          </div>
+          <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-4 sm:col-span-2">
+            <p class="text-emerald-700 font-medium text-sm">✓ Resultado primero. Sostén segundo. Aterriza limpio.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Three rounds -->
+  <section class="py-14 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6">Tres Rondas — Por Item, Cada Vez</h2>
+        <div class="space-y-3">
+          <div class="flex items-start gap-4 bg-white rounded-xl border border-slate-200 p-5">
+            <div class="flex items-center justify-center w-10 h-10 rounded-full bg-slate-100 text-slate-700 font-bold shrink-0">1</div>
+            <div>
+              <p class="font-bold text-slate-900">Lenta, controlada, deliberada</p>
+              <p class="text-slate-600 text-sm">Asegura la estructura. No te preocupes por el ritmo. La forma va primero.</p>
+            </div>
+          </div>
+          <div class="flex items-start gap-4 bg-white rounded-xl border border-slate-200 p-5">
+            <div class="flex items-center justify-center w-10 h-10 rounded-full bg-amber-100 text-amber-700 font-bold shrink-0">2</div>
+            <div>
+              <p class="font-bold text-slate-900">Ritmo natural</p>
+              <p class="text-slate-600 text-sm">Construye flujo. Pasa de "armar" a "hablar."</p>
+            </div>
+          </div>
+          <div class="flex items-start gap-4 bg-white rounded-xl border border-amber-300 p-5">
+            <div class="flex items-center justify-center w-10 h-10 rounded-full bg-amber-500 text-white font-bold shrink-0">3</div>
+            <div>
+              <p class="font-bold text-slate-900">Inmediata — sin tiempo para pensar</p>
+              <p class="text-slate-600 text-sm">Aquí es donde se instala el reflejo. Escuchas el prompt. Hablas la respuesta. Sin pausa.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 12 drill items -->
+  <section class="py-14 md:py-16 bg-white" id="drill-items">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-2">Los 12 Items</h2>
+        <p class="text-slate-600 mb-8 flex items-center gap-2">
+          <Volume2 class="w-4 h-4 text-amber-600" />
+          Toca el ícono del prompt para escucharlo, luego di la respuesta modelo en voz alta. Toca el segundo ícono para revisar tu entrega.
+        </p>
+
+        <div class="space-y-6">
+          {drillItems.map((item) => (
+            <div class="bg-slate-50 rounded-xl border border-slate-200 overflow-hidden">
+              <div class="bg-slate-900 text-white px-5 py-3 flex items-center justify-between">
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-400">
+                  Item {item.id} — {item.categoryEs}
+                </p>
+              </div>
+              <div class="p-5 md:p-6 space-y-4">
+                <div class="bg-white rounded-lg border border-slate-200 p-4">
+                  <p class="text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Prompt</p>
+                  <div class="flex items-center gap-3">
+                    <p class="text-lg text-slate-900 italic flex-1">"{item.prompt}"</p>
+                    <AudioButton client:visible text={item.prompt} lang="en-US" size="sm" />
+                  </div>
+                </div>
+
+                <div class="bg-red-50/60 border border-red-200 rounded-lg p-4">
+                  <div class="flex items-start gap-3">
+                    <XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
+                    <div class="flex-1">
+                      <p class="text-xs font-bold uppercase tracking-wider text-red-700 mb-1">Débil</p>
+                      <p class="text-slate-800 italic">"{item.weakResponse}"</p>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-4">
+                  <div class="flex items-start gap-3">
+                    <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
+                    <div class="flex-1">
+                      <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-1">Modelo</p>
+                      <p class="text-slate-900 font-medium leading-relaxed mb-3">"{item.modelResponse}"</p>
+                      <div class="flex items-center gap-2 pt-3 border-t border-emerald-200/60">
+                        <AudioButton client:visible text={item.modelResponse} lang="en-US" size="sm" />
+                        <span class="text-xs text-slate-600">Escucha la entrega modelo</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 30-day cycle -->
+  <section class="py-14 md:py-16 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="text-center mb-8">
+          <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-100 text-amber-800 text-sm font-semibold mb-3">
+            <Calendar class="w-4 h-4" />
+            El Ciclo de 30 Días
+          </div>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Cómo Instalar el Reflejo</h2>
+        </div>
+
+        <div class="space-y-4">
+          <div class="bg-white rounded-xl border border-slate-200 p-6">
+            <div class="flex items-start gap-4">
+              <div class="flex items-center justify-center w-12 h-12 rounded-lg bg-amber-100 text-amber-700 shrink-0">
+                <Repeat class="w-6 h-6" />
+              </div>
+              <div>
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">Días 1 — 10</p>
+                <p class="font-bold text-slate-900 mb-1">Los 12 items, las 3 rondas, diario</p>
+                <p class="text-slate-600 text-sm">Aproximadamente 10–15 minutos al día. No te saltes rondas. La estructura tiene que asegurarse antes de que la velocidad importe.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="bg-white rounded-xl border border-slate-200 p-6">
+            <div class="flex items-start gap-4">
+              <div class="flex items-center justify-center w-12 h-12 rounded-lg bg-amber-100 text-amber-700 shrink-0">
+                <Target class="w-6 h-6" />
+              </div>
+              <div>
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">Días 11 — 20</p>
+                <p class="font-bold text-slate-900 mb-1">6 items aleatorios al día, solo rondas 2 y 3</p>
+                <p class="text-slate-600 text-sm">Suelta la ronda 1. Mezcla el orden para que tu cerebro deje de anticipar. Pasas de ensayo a recuperación.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="bg-white rounded-xl border border-amber-300 p-6">
+            <div class="flex items-start gap-4">
+              <div class="flex items-center justify-center w-12 h-12 rounded-lg bg-amber-500 text-white shrink-0">
+                <Zap class="w-6 h-6" />
+              </div>
+              <div>
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">Días 21 — 30</p>
+                <p class="font-bold text-slate-900 mb-1">3 items aleatorios al día, solo ronda 3 — presión total</p>
+                <p class="text-slate-600 text-sm">Prompt → respuesta, inmediata. Sin espacio para pensar. Aquí es donde el reflejo se vuelve default. Después de 30 días, los patrones ya no son conscientes.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Navigation -->
+  <section class="py-12 md:py-14 bg-white border-t border-slate-200">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <a
+            href={`${driveInfo.basePath.es}/rechazar-trato-importante/`}
+            class="group flex items-center gap-3 bg-slate-50 rounded-xl border border-slate-200 hover:border-amber-300 hover:shadow-md transition-all p-5"
+          >
+            <ArrowLeft class="w-5 h-5 text-slate-400 group-hover:text-amber-600 transition-colors shrink-0" />
+            <div>
+              <p class="text-xs font-bold uppercase tracking-wider text-slate-500 mb-0.5">Último escenario</p>
+              <p class="text-slate-900 font-medium">Rechazar un Trato Estratégico de $2M</p>
+            </div>
+          </a>
+
+          <a
+            href={`${driveInfo.basePath.es}/`}
+            class="group flex items-center justify-between gap-3 bg-amber-500 hover:bg-amber-600 text-white rounded-xl transition-all p-5"
+          >
+            <div>
+              <p class="text-xs font-bold uppercase tracking-wider text-amber-100 mb-0.5">Resumen del curso</p>
+              <p class="font-medium">Dirige la Decisión</p>
+            </div>
+            <ArrowRight class="w-5 h-5 shrink-0" />
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/es/curso/dirige-la-decision/index.astro
+++ b/src/pages/es/curso/dirige-la-decision/index.astro
@@ -1,0 +1,347 @@
+---
+export const prerender = true;
+
+import Base from "@layouts/Base.astro";
+import Button from "@components/ui/Button.astro";
+import {
+  driveInfo,
+  scenarioMeta,
+  driveBonuses,
+} from "@data/drive-the-decision/scenarios";
+import {
+  ArrowRight,
+  Sparkles,
+  TrendingUp,
+  Clock,
+  Compass,
+  Wrench,
+  AlertOctagon,
+  Split,
+  Shield,
+  Users,
+  BarChart3,
+  XCircle,
+  Zap,
+  Crown,
+  Brain,
+  Target,
+} from "lucide-astro";
+
+const lang = "es";
+const tkey = "course/drive-the-decision" as const;
+
+const iconMap: Record<string, any> = {
+  TrendingUp,
+  Clock,
+  Compass,
+  Wrench,
+  AlertOctagon,
+  Split,
+  Shield,
+  Users,
+  BarChart3,
+  XCircle,
+  Zap,
+};
+---
+
+<Base
+  lang={lang}
+  tkey={tkey}
+  title="Dirige la Decisión — Simulación Ejecutiva | NY English"
+  description="Master class gratuita: 10 escenarios de junta con respuestas modelo que mueven la sala. Hecha para líderes senior que ya hablan inglés fluido."
+>
+  <!-- Hero -->
+  <section class="relative w-full overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-amber-950 pt-32 pb-20 md:pt-40 md:pb-28">
+    <div class="absolute inset-0 opacity-10">
+      <div class="absolute top-20 left-10 w-72 h-72 bg-amber-500 rounded-full blur-3xl"></div>
+      <div class="absolute bottom-10 right-10 w-96 h-96 bg-slate-400 rounded-full blur-3xl"></div>
+    </div>
+    <div class="site-container mx-auto px-4 relative z-10 text-white">
+      <div class="max-w-3xl">
+        <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-500/20 text-amber-300 text-sm font-semibold mb-6">
+          <Crown class="w-4 h-4" />
+          Master Class · C1 → C2 · Gratis
+        </div>
+        <h1
+          class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 leading-tight"
+          style="font-family: 'Noto Sans KR', sans-serif;"
+        >
+          Dirige la Decisión.<br />
+          <span class="text-amber-400">Mueve la Sala.</span>
+        </h1>
+        <p class="text-xl text-slate-200 mb-4 max-w-2xl leading-relaxed">
+          <strong class="text-white">Deja de explicar. Empieza a decidir.</strong>
+        </p>
+        <p class="text-lg text-slate-300 mb-8 max-w-2xl leading-relaxed">
+          Diez escenarios de junta directiva con respuestas modelo trabajadas — pushback de inversionistas, trimestres perdidos, recortes, tratos de $2M que tienes que rechazar. Cada escenario muestra la respuesta débil por defecto, la respuesta modelo y la psicología de decisión que la hace aterrizar. Hecha para líderes senior que ya hablan inglés fluido pero se congelan cuando la sala voltea hacia ellos.
+        </p>
+        <div class="flex flex-wrap gap-4">
+          <Button href={`${driveInfo.basePath.es}/${scenarioMeta[0].slugEs}/`} variant="primary" size="lg">
+            Empieza con el Escenario 1
+            <ArrowRight class="w-5 h-5 ml-1" />
+          </Button>
+          <a
+            href="#scenarios"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
+          >
+            Ver los 10 escenarios
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Thesis band -->
+  <section class="py-16 md:py-20 bg-white border-b border-slate-100">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <p class="text-[11px] font-mono uppercase tracking-[0.3em] text-amber-600 mb-4">La Tesis</p>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
+          Los ejecutivos no procesan información de forma lineal.<br />
+          La procesan así: <em>Conclusión → Lógica → Implicación.</em>
+        </h2>
+        <p class="text-lg text-slate-600 leading-relaxed">
+          Cuando retrasas tu conclusión, generas tres problemas a la vez — fricción cognitiva, atención perdida y la señal involuntaria de vacilación. El hablante fluido que entierra la decisión bajo cinco oraciones de contexto pierde la sala antes de llegar a su punto. Esta master class entrena el ajuste: lidera con el resultado, sostén con estructura, cierra con lo que necesitas.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Explain vs Decide contrast -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="text-center mb-12">
+          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">El Cambio que Transforma Cada Conversación</h2>
+          <p class="text-lg text-slate-600 max-w-2xl mx-auto">
+            El inglés fluido no es el estándar en este nivel. El estándar es si tu lenguaje se comprime limpiamente en el momento en que la sala necesita una decisión.
+          </p>
+        </div>
+
+        <div class="grid md:grid-cols-2 gap-6">
+          <div class="rounded-2xl border-2 border-red-200 bg-red-50/50 p-8">
+            <div class="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-red-100 text-red-600 mb-4">
+              <Brain class="w-6 h-6" />
+            </div>
+            <h3 class="text-xl font-bold text-slate-900 mb-3">El Patrón del que Explica</h3>
+            <ul class="space-y-2 text-slate-700">
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Calentamiento: "Well, what we're seeing is…"</li>
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Atenuación: "I think… maybe… potentially…"</li>
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> La conclusión llega en la oración 6 — cuando la sala ya se fue</li>
+            </ul>
+          </div>
+
+          <div class="rounded-2xl border-2 border-amber-300 bg-amber-50 p-8">
+            <div class="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-amber-100 text-amber-700 mb-4">
+              <Target class="w-6 h-6" />
+            </div>
+            <h3 class="text-xl font-bold text-slate-900 mb-3">El Patrón del que Decide</h3>
+            <ul class="space-y-2 text-slate-700">
+              <li class="flex gap-2"><span class="text-amber-600 shrink-0">✓</span> Resultado primero: "The decision is…"</li>
+              <li class="flex gap-2"><span class="text-amber-600 shrink-0">✓</span> Sostén numerado: "Two reasons. First…"</li>
+              <li class="flex gap-2"><span class="text-amber-600 shrink-0">✓</span> Cierra con lo que necesitas: "Today we need alignment on X."</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Who this is for -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6">Para Quién Es Esto</h2>
+        <p class="text-lg text-slate-600 leading-relaxed mb-6">
+          Ya hablas inglés a un nivel alto. Has entrado a salas donde se toman decisiones. Pero bajo presión notas el patrón:
+        </p>
+        <ul class="space-y-3 text-lg text-slate-700 leading-relaxed mb-8">
+          <li class="flex gap-3"><span class="text-amber-600 shrink-0">→</span> Explicas cuando deberías decidir.</li>
+          <li class="flex gap-3"><span class="text-amber-600 shrink-0">→</span> Construyes slides cuando deberías construir conclusiones.</li>
+          <li class="flex gap-3"><span class="text-amber-600 shrink-0">→</span> Atenúas cuando deberías comprometerte.</li>
+          <li class="flex gap-3"><span class="text-amber-600 shrink-0">→</span> Divagas cuando deberías aterrizar.</li>
+        </ul>
+        <p class="text-slate-600 leading-relaxed">
+          Esto no es un problema de idioma. Es un problema de <strong>arquitectura de entrega</strong> — y aparece más fuerte en las salas donde te cuesta más caro. La solución es reflejo, no vocabulario. Eso es lo que instala esta master class.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Scenarios grid -->
+  <section class="py-16 md:py-20 bg-slate-50" id="scenarios">
+    <div class="site-container mx-auto px-4">
+      <div class="text-center max-w-2xl mx-auto mb-12">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4" style="font-family: 'Noto Sans KR', sans-serif;">
+          Diez Escenarios. Diez Decisiones.
+        </h2>
+        <p class="text-slate-600 leading-relaxed">
+          Cada escenario te da el contexto, el desafío, la respuesta débil por defecto, la respuesta modelo y la psicología de decisión detrás de por qué funciona. Después construyes tu propia versión.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
+        {scenarioMeta.map((scenario) => {
+          const Icon = iconMap[scenario.icon];
+          const isAvailable = scenario.available;
+          return (
+            <a
+              href={isAvailable ? `${driveInfo.basePath.es}/${scenario.slugEs}/` : undefined}
+              class:list={[
+                "group flex items-start gap-4 p-5 rounded-xl border transition-all duration-200",
+                isAvailable
+                  ? "bg-amber-50 border-amber-300 hover:shadow-md hover:border-amber-400 cursor-pointer"
+                  : "bg-white border-slate-200 opacity-75",
+              ]}
+            >
+              <div
+                class:list={[
+                  "flex items-center justify-center w-12 h-12 rounded-xl shrink-0",
+                  isAvailable ? "bg-amber-500 text-white" : "bg-slate-100 text-slate-400",
+                ]}
+              >
+                {Icon && <Icon class="w-6 h-6" />}
+              </div>
+              <div class="flex-1">
+                <div class="flex items-center gap-2">
+                  <span
+                    class:list={[
+                      "text-xs font-bold uppercase tracking-wider",
+                      isAvailable ? "text-amber-700" : "text-slate-400",
+                    ]}
+                  >
+                    Escenario {scenario.id}
+                  </span>
+                </div>
+                <h3
+                  class:list={[
+                    "text-lg font-bold mt-0.5",
+                    isAvailable ? "text-slate-900" : "text-slate-600",
+                  ]}
+                >
+                  {scenario.titleEs}
+                </h3>
+                <p class="text-sm text-slate-600 mt-1">{scenario.subtitleEs}</p>
+                <p class="text-xs text-amber-700 mt-1.5 italic">{scenario.settingEs}</p>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <!-- Reflex Drill bonus -->
+  <section class="py-16 md:py-20 bg-white">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="text-center mb-12">
+          <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-100 text-amber-800 text-sm font-semibold mb-4">
+            <Sparkles class="w-4 h-4" />
+            Recurso Bonus
+          </div>
+          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">El Drill de Reflejo de 30 Días</h2>
+          <p class="text-lg text-slate-600 max-w-2xl mx-auto">
+            Doce prompts de alta presión. Tres rondas de ejecución. Treinta días. Después de esto, los patrones ya no son conscientes — se vuelven tu respuesta por defecto.
+          </p>
+        </div>
+
+        {driveBonuses.map((bonus) => {
+          const Icon = iconMap[bonus.icon] ?? Zap;
+          return (
+            <a
+              href={`${driveInfo.basePath.es}/${bonus.slugEs}/`}
+              class="block bg-gradient-to-br from-slate-900 via-slate-800 to-amber-900 rounded-2xl p-8 text-white hover:shadow-xl transition-shadow duration-200"
+            >
+              <div class="flex items-start gap-5">
+                <div class="flex items-center justify-center w-14 h-14 rounded-xl bg-amber-500 text-white shrink-0">
+                  <Icon class="w-7 h-7" />
+                </div>
+                <div class="flex-1">
+                  <h3 class="text-2xl font-bold mb-2">{bonus.titleEs}</h3>
+                  <p class="text-slate-300 leading-relaxed mb-4">{bonus.descriptionEs}</p>
+                  <span class="inline-flex items-center gap-1 text-amber-300 font-semibold text-sm group-hover:gap-2 transition-all">
+                    Abrir el drill
+                    <ArrowRight class="w-4 h-4" />
+                  </span>
+                </div>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <!-- Why this works -->
+  <section class="py-16 md:py-20 bg-slate-50">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-6 text-center">Por Qué los Escenarios Trabajados le Ganan a la Teoría</h2>
+        <div class="space-y-6 text-lg text-slate-700 leading-relaxed">
+          <p>
+            Leer marcos no los instala. Hablar respuestas modelo bajo presión sí. Esta master class se salta la capa de explicación de marcos y va directo a los artefactos — las palabras exactas que funcionan en las salas exactas donde todo está en juego.
+          </p>
+          <p>
+            Cada escenario usa la mecánica estructural del <a href="/es/curso/ejecutivo/" class="text-amber-700 hover:text-amber-800 underline underline-offset-2 font-medium">curso Ejecutivo</a> — entrega outcome-first, sostén numerado, reencuadres, cierres decisivos. Aquí los ves aplicados a pushback de inversionistas, preguntas de la junta, escalaciones de clientes y los momentos donde los líderes pierden la sala en silencio.
+          </p>
+          <p>
+            Para ejecutivos mexicanos específicamente, esta master class aborda un impuesto oculto de traducción. El instinto español-a-inglés produce atenuaciones (<em>"Considero que…"</em> → <em>"I consider that…"</em>) y suavizadores (<em>"Podríamos…"</em> → <em>"We could…"</em>) que se leen como incertidumbre en juntas directivas en inglés. Las respuestas modelo muestran el patrón más limpio — y el drill de reflejo lo instala.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Cross-link -->
+  <section class="py-16 md:py-20 bg-white border-t border-slate-100">
+    <div class="site-container mx-auto px-4">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-2xl font-bold text-slate-900 mb-4">¿Dónde Encaja Esto?</h2>
+        <p class="text-lg text-slate-600 leading-relaxed mb-6">
+          Esta es una <strong>master class enfocada</strong> — escenarios aplicados para líderes senior que ya tienen los marcos. Para el sistema ejecutivo completo (elección de palabras, eliminación de atenuación, reencuadres de tres niveles, marcos con nombre), revisa <strong>Comunica Como un Líder</strong>. Para coaching 1-a-1, el enlace de reservación está abajo.
+        </p>
+        <div class="flex flex-wrap gap-3 justify-center">
+          <a
+            href="/es/curso/ejecutivo/"
+            class="text-amber-700 hover:text-amber-800 font-medium underline underline-offset-2"
+          >
+            Curso Ejecutivo (Comunica Como un Líder)
+          </a>
+          <span class="text-slate-300">|</span>
+          <a
+            href="/es/cursos/"
+            class="text-amber-700 hover:text-amber-800 font-medium underline underline-offset-2"
+          >
+            Ver todos los cursos
+          </a>
+          <span class="text-slate-300">|</span>
+          <a
+            href="/es/reservar/"
+            class="text-amber-700 hover:text-amber-800 font-medium underline underline-offset-2"
+          >
+            Trabajar 1-a-1 con Robert
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "Course",
+    "name": "Dirige la Decisión — Simulación de Junta Directiva",
+    "description": "Master class gratuita con 10 escenarios de junta trabajados y un drill de reflejo de 12 items. Hecha para líderes senior C1-C2 que ya hablan inglés fluido pero necesitan liderar bajo presión.",
+    "provider": { "@type": "Organization", "name": "New York English Teacher", "url": "https://www.nyenglishteacher.com/" },
+    "educationalLevel": "Executive (C1-C2)",
+    "inLanguage": "es",
+    "url": "https://www.nyenglishteacher.com/es/curso/dirige-la-decision/",
+    "isAccessibleForFree": true,
+    "hasCourseInstance": {
+      "@type": "CourseInstance",
+      "courseMode": "online",
+      "inLanguage": "es"
+    }
+  })} />
+</Base>

--- a/src/pages/es/curso/dirige-la-decision/junta-directiva-burn-rate.astro
+++ b/src/pages/es/curso/dirige-la-decision/junta-directiva-burn-rate.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={2} lang="es" tkey="course/drive-the-decision/board-meeting-burn-rate" />

--- a/src/pages/es/curso/dirige-la-decision/outage-enterprise.astro
+++ b/src/pages/es/curso/dirige-la-decision/outage-enterprise.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={5} lang="es" tkey="course/drive-the-decision/enterprise-outage" />

--- a/src/pages/es/curso/dirige-la-decision/pushback-cac-serie-a.astro
+++ b/src/pages/es/curso/dirige-la-decision/pushback-cac-serie-a.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={1} lang="es" tkey="course/drive-the-decision/series-a-cac-pushback" />

--- a/src/pages/es/curso/dirige-la-decision/rechazar-trato-importante.astro
+++ b/src/pages/es/curso/dirige-la-decision/rechazar-trato-importante.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={10} lang="es" tkey="course/drive-the-decision/declining-major-deal" />

--- a/src/pages/es/curso/dirige-la-decision/serie-b-competidor.astro
+++ b/src/pages/es/curso/dirige-la-decision/serie-b-competidor.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={7} lang="es" tkey="course/drive-the-decision/series-b-competitor" />

--- a/src/pages/es/curso/dirige-la-decision/trimestre-perdido.astro
+++ b/src/pages/es/curso/dirige-la-decision/trimestre-perdido.astro
@@ -1,0 +1,6 @@
+---
+export const prerender = true;
+import DriveScenarioPage from "@components/course/DriveScenarioPage.astro";
+---
+
+<DriveScenarioPage scenarioId={9} lang="es" tkey="course/drive-the-decision/missed-quarter" />

--- a/src/pages/es/cursos/index.astro
+++ b/src/pages/es/cursos/index.astro
@@ -8,6 +8,7 @@ import { elementaryInfo, elementaryUnits } from "@data/elementary/units";
 import { intermediateInfo, intermediateUnits } from "@data/intermediate/units";
 import { advancedInfo, advancedUnits } from "@data/advanced/units";
 import { executiveInfo, executiveUnits } from "@data/executive/units";
+import { driveInfo, scenarioMeta } from "@data/drive-the-decision/scenarios";
 import {
   Sparkles,
   BookOpen,
@@ -17,6 +18,7 @@ import {
   CheckCircle2,
   GraduationCap,
   Target,
+  Zap,
 } from "lucide-astro";
 
 const lang = "es";
@@ -28,6 +30,7 @@ const elementaryTotal = elementaryUnits.length;
 const intermediateAvailable = intermediateUnits.length;
 const advancedAvailable = advancedUnits.length;
 const executiveAvailable = executiveUnits.filter((u) => u.published).length;
+const driveScenariosAvailable = scenarioMeta.filter((s) => s.available).length;
 ---
 
 <Base
@@ -50,11 +53,11 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
           Cursos de Inglés que Realmente Funcionan para Hispanohablantes
         </h1>
         <p class="text-lg text-slate-300 max-w-2xl leading-relaxed">
-          Seis cursos gratuitos e interactivos hechos para hispanohablantes —
-          cinco rutas por nivel, de A1 principiante a C2 ejecutivo, más una
-          clase magistral enfocada en los tiempos del pasado. Sin registro.
-          Sin barreras. Sin la pesadez de los libros de texto. Solo progreso
-          real desde la primera lección.
+          Siete cursos gratuitos e interactivos hechos para hispanohablantes —
+          cinco rutas por nivel, de A1 principiante a C2 ejecutivo, más dos
+          clases magistrales enfocadas: tiempos del pasado y comunicación
+          ejecutiva de decisión. Sin registro. Sin barreras. Sin la pesadez
+          de los libros de texto. Solo progreso real desde la primera lección.
         </p>
       </div>
     </div>
@@ -363,12 +366,59 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
             </div>
           </div>
         </a>
+
+        <!-- Clase Magistral — Dirige la Decisión -->
+        <a
+          href="/es/curso/dirige-la-decision/"
+          class="group block bg-white rounded-2xl border-2 border-amber-400/40 overflow-hidden hover:shadow-xl hover:border-amber-400 transition-all duration-200"
+        >
+          <div class="bg-gradient-to-br from-slate-950 via-slate-900 to-amber-900 p-6 text-white min-h-[180px] flex flex-col justify-end">
+            <div class="flex items-center gap-2 text-amber-300 text-xs font-bold uppercase tracking-wider mb-2">
+              <Zap class="w-3.5 h-3.5" />
+              Clase Magistral — C1 a C2 Ejecutivo
+            </div>
+            <h2 class="text-2xl md:text-3xl font-bold mb-2" style="font-family: 'Noto Sans KR', sans-serif;">
+              {driveInfo.titleEs}
+            </h2>
+            <p class="text-amber-100 text-sm leading-relaxed">
+              {driveInfo.shortTaglineEs}
+            </p>
+          </div>
+          <div class="p-6">
+            <p class="text-slate-600 text-sm leading-relaxed mb-4">
+              La aplicación práctica para líderes senior. Diez escenarios de junta trabajados — pushback de inversionistas, trimestres perdidos, recortes, tratos de $2M que tienes que rechazar — con respuestas modelo y la psicología de decisión detrás de cada una.
+            </p>
+            <ul class="space-y-2 mb-6">
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>10 escenarios de junta con respuestas modelo trabajadas</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>Drill de reflejo de 12 items (ciclo de instalación de 30 días)</span>
+              </li>
+              <li class="flex items-start gap-2 text-sm text-slate-700">
+                <CheckCircle2 class="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <span>Audio en las respuestas modelo para fijar el ritmo</span>
+              </li>
+            </ul>
+            <div class="flex items-center justify-between">
+              <span class="text-xs font-semibold text-amber-700 uppercase tracking-wider">
+                {driveScenariosAvailable} escenarios + drill
+              </span>
+              <span class="inline-flex items-center gap-1 text-amber-700 font-semibold text-sm group-hover:gap-2 transition-all">
+                Empezar la clase magistral
+                <ArrowRight class="w-4 h-4" />
+              </span>
+            </div>
+          </div>
+        </a>
       </div>
 
       <div class="max-w-3xl mx-auto mt-16 text-center">
         <h3 class="text-2xl font-bold text-slate-900 mb-3">¿No sabes con cuál empezar?</h3>
         <p class="text-slate-600 mb-6">
-          Si el inglés todavía se siente totalmente nuevo, empieza con el curso <strong>principiante</strong>. Si terminaste lo básico pero todavía no puedes hablar de ayer ni hacer planes, toma <strong>elemental</strong>. Si ya puedes sostener una conversación, salta a <strong>intermedio</strong>. Si tu inglés es fluido pero no pulido, pasa a <strong>avanzado</strong>. Si eres un líder senior que quiere <em>liderar</em> en inglés, ve directo al curso <strong>ejecutivo</strong>. Y si te congelas específicamente con los tiempos del pasado, la <strong>clase magistral de tiempos del pasado</strong> encaja al lado de cualquiera. Tu progreso se guarda por separado para cada curso.
+          Si el inglés todavía se siente totalmente nuevo, empieza con el curso <strong>principiante</strong>. Si terminaste lo básico pero todavía no puedes hablar de ayer ni hacer planes, toma <strong>elemental</strong>. Si ya puedes sostener una conversación, salta a <strong>intermedio</strong>. Si tu inglés es fluido pero no pulido, pasa a <strong>avanzado</strong>. Si eres un líder senior que quiere <em>liderar</em> en inglés, ve directo al curso <strong>ejecutivo</strong> — y combínalo con <strong>Dirige la Decisión</strong> para escenarios aplicados de junta directiva. Si te congelas específicamente con los tiempos del pasado, la <strong>clase magistral de tiempos del pasado</strong> encaja al lado de cualquiera. Tu progreso se guarda por separado para cada curso.
         </p>
         <Button href="/es/servicios/" variant="secondary" size="md">
           O trabaja 1-a-1 con Robert
@@ -437,6 +487,15 @@ const executiveAvailable = executiveUnits.filter((u) => u.published).length;
         "@type": "Course",
         "name": "Domina los Tiempos del Pasado en Ingles (Clase Magistral Gratis)",
         "url": "https://www.nyenglishteacher.com/es/curso/tiempos-del-pasado/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 7,
+      "item": {
+        "@type": "Course",
+        "name": "Dirige la Decision - Simulacion de Junta Directiva (Clase Magistral Gratis)",
+        "url": "https://www.nyenglishteacher.com/es/curso/dirige-la-decision/"
       }
     }
   ]


### PR DESCRIPTION
## Summary

New free C1–C2 master class — **Drive the Decision** — with 10 worked boardroom scenarios and a 12-item reflex drill bonus. Mirrors the Past Tenses master class pattern and sits beside the existing Executive course as the applied capstone for senior leaders who already have the frameworks.

- **10 boardroom scenarios** with weak/model contrast + decision-psychology breakdown (Series A CAC pushback, board burn rate, layoffs, missed quarters, declining a \$2M deal, etc.)
- **12-item reflex drill** with the 30-day installation cycle
- **Azure Neural TTS** (AudioButton component) on every model reply and drill prompt — learner hears the cadence, not just reads it
- **Fully bilingual** — Mexican Professional Spanish throughout, no Iberian markers
- **7th card added** to `/en/courses/` and `/es/cursos/` catalog pages, positioned after Past Tenses (the two master classes group together)
- **i18n + sitemap hreflang** wired for all 12 new TKey routes

## Architecture decision

Source content proposed a 5-module course, but ~80% of those modules duplicated the existing Executive course (Communicate Like a Leader). The unique value was the 10 scenarios + drill — so this ships as a Master Class (Past Tenses pattern), not a standalone course. Avoids cannibalizing Executive and lets the unique content breathe. Stripped the source doc's paid pricing tiers — stays consistent with the free funnel.

## Files

- `src/data/drive-the-decision/scenarios.ts` — all scenarios + drill items as data
- `src/components/course/DriveScenarioPage.astro` — shared scenario template (10 thin page wrappers import it)
- `src/pages/en/course/drive-the-decision/` — 11 EN pages (index + 10 scenarios + drill)
- `src/pages/es/curso/dirige-la-decision/` — 11 ES pages (same structure, MX Spanish)
- `src/lib/i18n.ts` — 12 new TKey routes registered in EN, ES, and getAllTKeys
- `src/pages/{en,es}/courses,cursos/index.astro` — added 7th catalog card

## Test plan

- [ ] Preview EN index: https://ny-eng-git-feat-drive-the-decision-master-class-rcushmaniii-projects.vercel.app/en/course/drive-the-decision/
- [ ] Preview ES index: https://ny-eng-git-feat-drive-the-decision-master-class-rcushmaniii-projects.vercel.app/es/curso/dirige-la-decision/
- [ ] Preview a scenario (EN): https://ny-eng-git-feat-drive-the-decision-master-class-rcushmaniii-projects.vercel.app/en/course/drive-the-decision/series-a-cac-pushback/
- [ ] Preview the reflex drill (EN): https://ny-eng-git-feat-drive-the-decision-master-class-rcushmaniii-projects.vercel.app/en/course/drive-the-decision/reflex-drill/
- [ ] Confirm Azure TTS audio plays on the model reply (tap the speaker icon)
- [ ] Confirm catalog card appears on `/en/courses/` and `/es/cursos/`
- [ ] Build passes — 509 pages, meta-description-gate clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)