### PR TITLE
feat(blog): surface Drive the Decision on course-promotion post

### DIFF
--- a/src/content/blog/en/free-english-courses-spanish-speakers.md
+++ b/src/content/blog/en/free-english-courses-spanish-speakers.md
@@ -1,8 +1,8 @@
 ---
-title: "6 Free English Courses Built for Spanish Speakers"
-excerpt: "Six interactive English courses — A1 beginner through C2 executive — with real American English audio on every phrase. No sign-up, no paywall. Real progress from lesson one."
+title: "7 Free English Courses Built for Spanish Speakers"
+excerpt: "Seven interactive English courses — A1 beginner through C2 executive — with real American English audio on every phrase. No sign-up, no paywall. Real progress from lesson one."
 publishDate: "2026-05-17"
-lastmod: "2026-05-17"
+lastmod: "2026-05-21"
 categories:
   - "Business English"
   - "English Coaching"
@@ -16,7 +16,7 @@ translations:
 publish: true
 seo:
   title: "Free English Courses for Spanish Speakers | NY English"
-  description: "Six free English courses with real American English audio on every phrase — beginner through executive. No sign-up, no paywall. Built for Spanish speakers."
+  description: "Seven free English courses with real American English audio on every phrase — beginner through executive. No sign-up, no paywall. Built for Spanish speakers."
 ---
 
 Most free English courses teach you grammar rules. You memorize them. You understand them. And then your manager asks you a question in a meeting — and you freeze anyway.
@@ -53,7 +53,7 @@ These courses don't. Beginner learners activate what's already there. More advan
 
 Each course targets the exact gap Spanish speakers face at that level — not generic English problems, but the specific ones you're actually running into.
 
-## The 6 Courses
+## The 7 Courses
 
 ### Level A1 — First Steps Into English
 *"You Already Speak English. You Just Don't Know It Yet."*
@@ -103,9 +103,17 @@ You know the past tense rules. You still freeze and default to <span class="spea
 
 ---
 
+### Master Class — Drive the Decision
+*"Stop explaining. Start deciding."*
+
+The applied capstone for senior leaders who already finished the Executive course. Ten worked boardroom scenarios — investor pushback on CAC, a missed quarter at the board meeting, announcing a pivot, declining a $2M deal, and six more — each with the weak default response, the model reply, and the decision psychology behind why it lands. The difference between "Well, our burn has been higher than expected and we're looking at different ways to extend runway…" and <span class="speak-en">Nine months is the floor, not the plan. We have three levers active right now.</span> Same situation, opposite room. A 12-item reflex drill installs the patterns over a 30-day cycle until they become your default under pressure.
+[Start the Drive the Decision master class →](/en/course/drive-the-decision/)
+
+---
+
 ## Which Course Should You Start?
 
-If English still feels completely new, start with **Beginner**. If you've covered the basics but can't yet talk about yesterday or make plans, go to **Elementary**. If you can already hold a conversation but you're still translating mentally, jump to **Intermediate**. If your English is fluent but you know it's not polished, go **Advanced**. If you're a senior leader who needs to command in English, go straight to **Executive**. And if past tenses are your specific freeze point regardless of your overall level, the **Past Tenses Master Class** runs alongside any of them — your progress is tracked separately per course.
+If English still feels completely new, start with **Beginner**. If you've covered the basics but can't yet talk about yesterday or make plans, go to **Elementary**. If you can already hold a conversation but you're still translating mentally, jump to **Intermediate**. If your English is fluent but you know it's not polished, go **Advanced**. If you're a senior leader who needs to command in English, go straight to **Executive** — and once you've worked through the frameworks, pair it with **Drive the Decision** to apply them to ten real boardroom scenarios. If past tenses are your specific freeze point regardless of your overall level, the **Past Tenses Master Class** runs alongside any of them — your progress is tracked separately per course.
 
 ## FAQ
 
@@ -113,7 +121,7 @@ If English still feels completely new, start with **Beginner**. If you've covere
 No. Open any course and start Unit 1 immediately. No registration, no email, no paywall.
 
 **How long does each course take?**
-Each course has 10 units. Most people complete a unit in 20–30 minutes, though the drills are designed to be repeated — the more you repeat, the more the audio patterns stick.
+Each leveled course has 10 units, the Past Tenses Master Class is 6 lessons + 6 bonuses, and Drive the Decision is 10 scenarios + a 12-item reflex drill. Most people complete a unit in 20–30 minutes, though the drills are designed to be repeated — the more you repeat, the more the audio patterns stick.
 
 **Are these courses really free — no hidden upgrade?**
 Entirely free. All 10 units, all audio, all exercises. No premium tier, no locked content.
@@ -122,10 +130,10 @@ Entirely free. All 10 units, all audio, all exercises. No premium tier, no locke
 It's Azure Neural TTS — the same AI voice technology used by Microsoft, Adobe, and LinkedIn. It's not a recording of a person, but it sounds like one. Natural rhythm, natural intonation, no robotic cadence. The executive course uses a different voice profile calibrated to a more formal register.
 
 **Can I take more than one course at the same time?**
-Yes. Progress is tracked independently per course, so you can work through the Past Tenses Master Class while continuing your main level track.
+Yes. Progress is tracked independently per course, so you can work through the Past Tenses Master Class or Drive the Decision while continuing your main level track.
 
 ---
 
-[Browse all 6 courses →](/en/courses/)
+[Browse all 7 courses →](/en/courses/)
 
 Or if you'd rather work on your English directly with a native New York English teacher: [book a session →](/en/book/)

--- a/src/content/blog/es/cursos-ingles-gratis-hispanohablantes.md
+++ b/src/content/blog/es/cursos-ingles-gratis-hispanohablantes.md
@@ -1,8 +1,8 @@
 ---
-title: "6 Cursos de Inglés Gratis para Hispanohablantes"
-excerpt: "Seis cursos de inglés interactivos — de A1 principiante a C2 ejecutivo — con audio real de pronunciación americana en cada frase. Sin registro ni barreras. Progreso real desde la primera lección."
+title: "7 Cursos de Inglés Gratis para Hispanohablantes"
+excerpt: "Siete cursos de inglés interactivos — de A1 principiante a C2 ejecutivo — con audio real de pronunciación americana en cada frase. Sin registro ni barreras. Progreso real desde la primera lección."
 publishDate: "2026-05-17"
-lastmod: "2026-05-17"
+lastmod: "2026-05-21"
 categories:
   - "Business English"
   - "English Coaching"
@@ -16,7 +16,7 @@ translations:
 publish: true
 seo:
   title: "Cursos de Inglés Gratis para Hispanohablantes | NY English"
-  description: "Seis cursos de inglés gratuitos con audio de pronunciación americana en cada frase — de principiante a ejecutivo. Sin registro. Hechos para hispanohablantes."
+  description: "Siete cursos de inglés gratuitos con audio de pronunciación americana en cada frase — de principiante a ejecutivo. Sin registro. Hechos para hispanohablantes."
 ---
 
 La mayoría de los cursos de inglés gratuitos te enseñan reglas gramaticales. Las memorizas. Las entiendes. Y luego tu jefe te hace una pregunta en inglés en una junta — y te congelas de todas formas.
@@ -53,7 +53,7 @@ Estos cursos no. Los principiantes activan lo que ya está ahí. Los estudiantes
 
 Cada curso apunta exactamente a la brecha que los hispanohablantes enfrentan en ese nivel — no problemas genéricos de inglés, sino los que tú realmente estás viviendo.
 
-## Los 6 Cursos
+## Los 7 Cursos
 
 ### Nivel A1 — Primeros Pasos en Inglés
 *"Ya hablas inglés. Solo no lo sabes todavía."*
@@ -103,9 +103,17 @@ Sabes las reglas del pasado. Aun así te congelas y usas <span class="speak-en">
 
 ---
 
+### Clase Magistral — Dirige la Decisión
+*"Deja de explicar. Empieza a decidir."*
+
+La aplicación práctica para líderes senior que ya terminaron el curso Ejecutivo. Diez escenarios de junta directiva trabajados — pushback de un inversionista sobre el CAC, un trimestre perdido frente a la junta, anunciar un pivot, rechazar un trato de $2M y seis más — cada uno con la respuesta débil por defecto, la respuesta modelo y la psicología de decisión detrás de por qué aterriza. La diferencia entre "Well, our burn has been higher than expected and we're looking at different ways to extend runway…" y <span class="speak-en">Nine months is the floor, not the plan. We have three levers active right now.</span> Misma situación, sala opuesta. Un drill de reflejo de 12 items instala los patrones en un ciclo de 30 días hasta que se vuelven tu respuesta por defecto bajo presión.
+[Empezar la clase magistral Dirige la Decisión →](/es/curso/dirige-la-decision/)
+
+---
+
 ## ¿Con Cuál Deberías Empezar?
 
-Si el inglés todavía se siente completamente nuevo, empieza con **Principiante**. Si ya cubriste lo básico pero todavía no puedes hablar de ayer ni hacer planes, ve a **Elemental**. Si ya puedes sostener una conversación pero todavía estás traduciendo mentalmente, salta a **Intermedio**. Si tu inglés es fluido pero sabes que no está pulido, ve a **Avanzado**. Si eres un líder senior que necesita mandar en inglés, ve directo a **Ejecutivo**. Y si los tiempos del pasado son tu punto de congelamiento específico sin importar tu nivel general, la **Clase Magistral de Tiempos del Pasado** corre junto a cualquiera de ellos — tu progreso se registra de forma independiente por curso.
+Si el inglés todavía se siente completamente nuevo, empieza con **Principiante**. Si ya cubriste lo básico pero todavía no puedes hablar de ayer ni hacer planes, ve a **Elemental**. Si ya puedes sostener una conversación pero todavía estás traduciendo mentalmente, salta a **Intermedio**. Si tu inglés es fluido pero sabes que no está pulido, ve a **Avanzado**. Si eres un líder senior que necesita mandar en inglés, ve directo a **Ejecutivo** — y una vez que trabajes los marcos, combínalo con **Dirige la Decisión** para aplicarlos a diez escenarios reales de junta directiva. Si los tiempos del pasado son tu punto de congelamiento específico sin importar tu nivel general, la **Clase Magistral de Tiempos del Pasado** corre junto a cualquiera de ellos — tu progreso se registra de forma independiente por curso.
 
 ## Preguntas Frecuentes
 
@@ -113,7 +121,7 @@ Si el inglés todavía se siente completamente nuevo, empieza con **Principiante
 No. Abre cualquier curso y empieza la Unidad 1 de inmediato. Sin registro, sin correo electrónico, sin barreras.
 
 **¿Cuánto tiempo toma cada curso?**
-Cada curso tiene 10 unidades. La mayoría de las personas completa una unidad en 20 a 30 minutos, aunque los drills están diseñados para repetirse — cuanto más los repitas, más se fijan los patrones de audio en tu memoria.
+Cada curso por nivel tiene 10 unidades, la Clase Magistral de Tiempos del Pasado es 6 lecciones + 6 bonos, y Dirige la Decisión es 10 escenarios + un drill de reflejo de 12 items. La mayoría de las personas completa una unidad en 20 a 30 minutos, aunque los drills están diseñados para repetirse — cuanto más los repitas, más se fijan los patrones de audio en tu memoria.
 
 **¿Estos cursos son realmente gratis — no hay una mejora oculta de pago?**
 Completamente gratis. Las 10 unidades, todo el audio, todos los ejercicios. Sin nivel premium, sin contenido bloqueado.
@@ -122,10 +130,10 @@ Completamente gratis. Las 10 unidades, todo el audio, todos los ejercicios. Sin 
 Es Azure Neural TTS — la misma tecnología de voz con inteligencia artificial que usan Microsoft, Adobe y LinkedIn. No es una grabación de una persona, pero suena como tal. Ritmo natural, entonación natural, sin cadencia robótica. El curso ejecutivo usa un perfil de voz diferente calibrado a un registro más formal.
 
 **¿Puedo tomar más de un curso al mismo tiempo?**
-Sí. El progreso se registra de forma independiente por curso, así que puedes trabajar en la Clase Magistral de Tiempos del Pasado mientras continúas con tu nivel principal.
+Sí. El progreso se registra de forma independiente por curso, así que puedes trabajar en la Clase Magistral de Tiempos del Pasado o en Dirige la Decisión mientras continúas con tu nivel principal.
 
 ---
 
-[Ver los 6 cursos →](/es/cursos/)
+[Ver los 7 cursos →](/es/cursos/)
 
 O si prefieres trabajar tu inglés directamente con un maestro nativo de Nueva York: [reserva una sesión →](/es/contact/)


### PR DESCRIPTION
## Summary

Adds the new Drive the Decision master class to the dedicated course-promotion blog post in both languages. The post is the SEO-canonical \"6 Free English Courses\" article ranking for free-courses queries — now updated to \"7\" with a new section, refreshed which-one guidance, FAQ, and bottom CTA.

- EN: `src/content/blog/en/free-english-courses-spanish-speakers.md`
- ES: `src/content/blog/es/cursos-ingles-gratis-hispanohablantes.md` (Mexican Professional Spanish)

The new section uses Scenario 2 (board meeting burn rate) as the demo — weak default vs. \"Nine months is the floor, not the plan. We have three levers active right now.\" That sentence carries the Azure TTS speak-en class so the audio plays inline on the article.

## Test plan

- [ ] Preview EN post: https://ny-eng-git-feat-promo-drive-the-decision-rcushmaniii-projects.vercel.app/en/blog/free-english-courses-spanish-speakers/
- [ ] Preview ES post: https://ny-eng-git-feat-promo-drive-the-decision-rcushmaniii-projects.vercel.app/es/blog/cursos-ingles-gratis-hispanohablantes/
- [ ] Confirm the new Drive the Decision section renders between Past Tenses and \"Which Course Should You Start?\"
- [ ] Click the speaker on the model reply quote to verify Azure TTS plays
- [ ] Build passes — 509 pages, meta-description-gate clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)