### PR TITLE
fix(course): rename to Executive Pushback & Objection Handling

### DIFF
--- a/src/components/course/PushbackLessonLayout.astro
+++ b/src/components/course/PushbackLessonLayout.astro
@@ -1,15 +1,15 @@
 ---
-// Shared lesson chrome for the "Diagnose Before You Defend" master class.
-// Renders the hero, previous/next nav, and bonus nudge. The lesson page
-// supplies its unique body via the default <slot/>. Twelve lesson files
-// (6 EN + 6 ES) wrap this component instead of duplicating ~150 lines
-// of layout each.
+// Shared lesson chrome for the "Executive Pushback & Objection Handling"
+// master class. Renders the hero, previous/next nav, and bonus nudge.
+// The lesson page supplies its unique body via the default <slot/>.
+// Twelve lesson files (6 EN + 6 ES) wrap this component instead of
+// duplicating ~150 lines of layout each.
 
 import Base from "@layouts/Base.astro";
 import {
-  diagnoseLessons,
-  diagnoseInfo,
-} from "@data/diagnose-before-defend/lessons";
+  pushbackLessons,
+  pushbackInfo,
+} from "@data/executive-pushback/lessons";
 import {
   ArrowLeft,
   ArrowRight,
@@ -32,16 +32,16 @@ interface Props {
 
 const { lessonId, lang, tkey } = Astro.props as Props;
 
-const lesson = diagnoseLessons.find((l) => l.id === lessonId);
-if (!lesson) throw new Error(`Diagnose lesson ${lessonId} not found`);
+const lesson = pushbackLessons.find((l) => l.id === lessonId);
+if (!lesson) throw new Error(`Pushback lesson ${lessonId} not found`);
 
-const total = diagnoseLessons.length;
-const prev = diagnoseLessons.find((l) => l.id === lessonId - 1);
-const next = diagnoseLessons.find((l) => l.id === lessonId + 1);
+const total = pushbackLessons.length;
+const prev = pushbackLessons.find((l) => l.id === lessonId - 1);
+const next = pushbackLessons.find((l) => l.id === lessonId + 1);
 
 const isEn = lang === "en";
-const basePath = isEn ? diagnoseInfo.basePath.en : diagnoseInfo.basePath.es;
-const bonusSlug = isEn ? diagnoseInfo.bonusSlug.en : diagnoseInfo.bonusSlug.es;
+const basePath = isEn ? pushbackInfo.basePath.en : pushbackInfo.basePath.es;
+const bonusSlug = isEn ? pushbackInfo.bonusSlug.en : pushbackInfo.bonusSlug.es;
 const prevSlug = prev ? (isEn ? prev.slug : prev.slugEs) : null;
 const nextSlug = next ? (isEn ? next.slug : next.slugEs) : null;
 
@@ -51,7 +51,9 @@ const t = {
   prev: isEn ? "Previous lesson" : "Lección anterior",
   next: isEn ? "Next lesson" : "Siguiente lección",
   overview: isEn ? "Course overview" : "Resumen del curso",
-  overviewTitle: isEn ? "Diagnose Before You Defend" : "Diagnostica Antes de Defender",
+  overviewTitle: isEn
+    ? "Executive Pushback & Objection Handling"
+    : "Manejo de Pushback y Objeciones Ejecutivas",
   bonusNudge: isEn
     ? "Already lost composure in a real conversation? The recovery script is your reset."
     : "¿Ya perdiste la compostura en una conversación real? El guion de recuperación es tu reset.",
@@ -78,13 +80,15 @@ const iconMap: Record<string, any> = {
 };
 const LessonIcon = iconMap[lesson.icon];
 
+// SEO title kept under 60 chars. Lesson title alone is the discoverable
+// piece; the course name appears in OG and JSON-LD via the index page.
 const seoTitle = isEn
-  ? `${lesson.title} — Diagnose Before You Defend`
-  : `${lesson.titleEs} — Diagnostica Antes de Defender`;
+  ? `${lesson.title} — Handling Pushback`
+  : `${lesson.titleEs} — Manejo de Pushback`;
 
 const seoDescription = isEn
-  ? `${lesson.subtitle} Free master class on executive pushback for directors and mid-managers under pressure.`
-  : `${lesson.subtitleEs} Master class gratuita para directores y mandos medios bajo presión ejecutiva.`;
+  ? `${lesson.subtitle} Free master class on handling executive pushback and objections under pressure.`
+  : `${lesson.subtitleEs} Master class gratuita sobre el manejo de pushback y objeciones ejecutivas bajo presión.`;
 ---
 
 <Base lang={lang} tkey={tkey} title={seoTitle} description={seoDescription}>

--- a/src/data/executive-pushback/lessons.ts
+++ b/src/data/executive-pushback/lessons.ts
@@ -1,4 +1,5 @@
-// Diagnose Before You Defend — Master Class on Executive Pushback Handling
+// Executive Pushback & Objection Handling — Strategic Communication for
+// High-Pressure Conversations.
 //
 // Audience: directors, ops leaders, sales professionals, procurement,
 // technical managers, and mid-managers who push back on others and get
@@ -7,7 +8,7 @@
 // this course is about the diagnostic and posture work that happens
 // BEFORE the model reply. Six lessons + one recovery-script bonus.
 
-export interface DiagnoseLesson {
+export interface PushbackLesson {
   id: number;
   slug: string;
   slugEs: string;
@@ -22,7 +23,7 @@ export interface DiagnoseLesson {
   available: boolean;
 }
 
-export interface DiagnoseBonus {
+export interface PushbackBonus {
   id: number;
   slug: string;
   slugEs: string;
@@ -34,20 +35,20 @@ export interface DiagnoseBonus {
   available: boolean;
 }
 
-export const diagnoseInfo = {
-  title: "Diagnose Before You Defend",
-  titleEs: "Diagnostica Antes de Defender",
-  tagline: "Read the pressure. Hold your ground. Influence the outcome.",
-  taglineEs: "Lee la presión. Mantén tu posición. Influye el resultado.",
-  shortTagline: "The diagnostic before the defense.",
-  shortTaglineEs: "El diagnóstico antes de la defensa.",
+export const pushbackInfo = {
+  title: "Executive Pushback & Objection Handling",
+  titleEs: "Manejo de Pushback y Objeciones Ejecutivas",
+  tagline: "Strategic Communication for High-Pressure Conversations",
+  taglineEs: "Comunicación estratégica para conversaciones de alta presión",
+  shortTagline: "Handle pushback like an executive.",
+  shortTaglineEs: "Maneja el pushback como un ejecutivo.",
   description:
-    "A focused master class on handling pushback like an executive — without becoming defensive, without overexplaining, and without sounding emotional under pressure. Built for directors, ops leaders, sales professionals, procurement managers, and mid-managers who push back on others and get pushed back on themselves. Where Drive the Decision teaches what to say in the moment, this course teaches what to read, what to feel, and how to hold yourself BEFORE you open your mouth.",
+    "A focused master class on handling pushback and objections like an executive — without becoming defensive, without overexplaining, and without sounding emotional under pressure. Built for directors, ops leaders, sales professionals, procurement managers, and mid-managers who push back on others and get pushed back on themselves. Where Drive the Decision teaches what to say in the moment, this course teaches how to read the real driver under the objection and respond with structure instead of defensiveness.",
   descriptionEs:
-    "Una master class enfocada en manejar el pushback como un ejecutivo — sin ponerte a la defensiva, sin sobreexplicar y sin sonar emocional bajo presión. Hecha para directores, líderes de operaciones, profesionales de ventas, gerentes de compras y mandos medios que dan pushback a otros y reciben pushback a su vez. Donde Dirige la Decisión enseña qué decir en el momento, este curso enseña qué leer, qué sentir y cómo sostenerte ANTES de abrir la boca.",
+    "Una master class enfocada en manejar el pushback y las objeciones como un ejecutivo — sin ponerte a la defensiva, sin sobreexplicar y sin sonar emocional bajo presión. Hecha para directores, líderes de operaciones, profesionales de ventas, gerentes de compras y mandos medios que dan pushback a otros y reciben pushback a su vez. Donde Dirige la Decisión enseña qué decir en el momento, este curso enseña cómo leer el impulsor real debajo de la objeción y responder con estructura en lugar de defensividad.",
   basePath: {
-    en: "/en/course/diagnose-before-defend",
-    es: "/es/curso/diagnostica-antes-de-defender",
+    en: "/en/course/executive-pushback",
+    es: "/es/curso/pushback-ejecutivo",
   },
   bonusSlug: {
     en: "pressure-recovery-script",
@@ -55,7 +56,7 @@ export const diagnoseInfo = {
   },
 };
 
-export const diagnoseLessons: DiagnoseLesson[] = [
+export const pushbackLessons: PushbackLesson[] = [
   {
     id: 1,
     slug: "six-hidden-drivers",
@@ -148,7 +149,7 @@ export const diagnoseLessons: DiagnoseLesson[] = [
   },
 ];
 
-export const diagnoseBonuses: DiagnoseBonus[] = [
+export const pushbackBonuses: PushbackBonus[] = [
   {
     id: 1,
     slug: "pressure-recovery-script",

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -163,14 +163,14 @@ export type TKey =
   | "course/drive-the-decision/missed-quarter"
   | "course/drive-the-decision/declining-major-deal"
   | "course/drive-the-decision/reflex-drill"
-  | "course/diagnose-before-defend"
-  | "course/diagnose-before-defend/six-hidden-drivers"
-  | "course/diagnose-before-defend/diagnostic-pause"
-  | "course/diagnose-before-defend/executive-calm-is-power"
-  | "course/diagnose-before-defend/acknowledge-clarify-redirect"
-  | "course/diagnose-before-defend/commercial-pushback"
-  | "course/diagnose-before-defend/bad-news-steady-voice"
-  | "course/diagnose-before-defend/pressure-recovery-script"
+  | "course/executive-pushback"
+  | "course/executive-pushback/six-hidden-drivers"
+  | "course/executive-pushback/diagnostic-pause"
+  | "course/executive-pushback/executive-calm-is-power"
+  | "course/executive-pushback/acknowledge-clarify-redirect"
+  | "course/executive-pushback/commercial-pushback"
+  | "course/executive-pushback/bad-news-steady-voice"
+  | "course/executive-pushback/pressure-recovery-script"
   | "corporate/for-hr"
   | "meme-portfolio"
   | "site-index";
@@ -345,21 +345,20 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/drive-the-decision/declining-major-deal":
       "/en/course/drive-the-decision/declining-major-deal/",
     "course/drive-the-decision/reflex-drill": "/en/course/drive-the-decision/reflex-drill/",
-    "course/diagnose-before-defend": "/en/course/diagnose-before-defend/",
-    "course/diagnose-before-defend/six-hidden-drivers":
-      "/en/course/diagnose-before-defend/six-hidden-drivers/",
-    "course/diagnose-before-defend/diagnostic-pause":
-      "/en/course/diagnose-before-defend/diagnostic-pause/",
-    "course/diagnose-before-defend/executive-calm-is-power":
-      "/en/course/diagnose-before-defend/executive-calm-is-power/",
-    "course/diagnose-before-defend/acknowledge-clarify-redirect":
-      "/en/course/diagnose-before-defend/acknowledge-clarify-redirect/",
-    "course/diagnose-before-defend/commercial-pushback":
-      "/en/course/diagnose-before-defend/commercial-pushback/",
-    "course/diagnose-before-defend/bad-news-steady-voice":
-      "/en/course/diagnose-before-defend/bad-news-steady-voice/",
-    "course/diagnose-before-defend/pressure-recovery-script":
-      "/en/course/diagnose-before-defend/pressure-recovery-script/",
+    "course/executive-pushback": "/en/course/executive-pushback/",
+    "course/executive-pushback/six-hidden-drivers":
+      "/en/course/executive-pushback/six-hidden-drivers/",
+    "course/executive-pushback/diagnostic-pause": "/en/course/executive-pushback/diagnostic-pause/",
+    "course/executive-pushback/executive-calm-is-power":
+      "/en/course/executive-pushback/executive-calm-is-power/",
+    "course/executive-pushback/acknowledge-clarify-redirect":
+      "/en/course/executive-pushback/acknowledge-clarify-redirect/",
+    "course/executive-pushback/commercial-pushback":
+      "/en/course/executive-pushback/commercial-pushback/",
+    "course/executive-pushback/bad-news-steady-voice":
+      "/en/course/executive-pushback/bad-news-steady-voice/",
+    "course/executive-pushback/pressure-recovery-script":
+      "/en/course/executive-pushback/pressure-recovery-script/",
     "corporate/for-hr": "/en/for-hr-managers/",
     "meme-portfolio": "/en/meme-portfolio/all/",
     "site-index": "/en/site-index/",
@@ -536,21 +535,20 @@ export const routeFor: Record<Locale, Record<TKey, string>> = {
     "course/drive-the-decision/declining-major-deal":
       "/es/curso/dirige-la-decision/rechazar-trato-importante/",
     "course/drive-the-decision/reflex-drill": "/es/curso/dirige-la-decision/drill-reflejo/",
-    "course/diagnose-before-defend": "/es/curso/diagnostica-antes-de-defender/",
-    "course/diagnose-before-defend/six-hidden-drivers":
-      "/es/curso/diagnostica-antes-de-defender/seis-impulsores-ocultos/",
-    "course/diagnose-before-defend/diagnostic-pause":
-      "/es/curso/diagnostica-antes-de-defender/pausa-diagnostica/",
-    "course/diagnose-before-defend/executive-calm-is-power":
-      "/es/curso/diagnostica-antes-de-defender/calma-ejecutiva-es-poder/",
-    "course/diagnose-before-defend/acknowledge-clarify-redirect":
-      "/es/curso/diagnostica-antes-de-defender/reconoce-clarifica-redirige/",
-    "course/diagnose-before-defend/commercial-pushback":
-      "/es/curso/diagnostica-antes-de-defender/pushback-comercial/",
-    "course/diagnose-before-defend/bad-news-steady-voice":
-      "/es/curso/diagnostica-antes-de-defender/malas-noticias-voz-firme/",
-    "course/diagnose-before-defend/pressure-recovery-script":
-      "/es/curso/diagnostica-antes-de-defender/guion-de-recuperacion/",
+    "course/executive-pushback": "/es/curso/pushback-ejecutivo/",
+    "course/executive-pushback/six-hidden-drivers":
+      "/es/curso/pushback-ejecutivo/seis-impulsores-ocultos/",
+    "course/executive-pushback/diagnostic-pause": "/es/curso/pushback-ejecutivo/pausa-diagnostica/",
+    "course/executive-pushback/executive-calm-is-power":
+      "/es/curso/pushback-ejecutivo/calma-ejecutiva-es-poder/",
+    "course/executive-pushback/acknowledge-clarify-redirect":
+      "/es/curso/pushback-ejecutivo/reconoce-clarifica-redirige/",
+    "course/executive-pushback/commercial-pushback":
+      "/es/curso/pushback-ejecutivo/pushback-comercial/",
+    "course/executive-pushback/bad-news-steady-voice":
+      "/es/curso/pushback-ejecutivo/malas-noticias-voz-firme/",
+    "course/executive-pushback/pressure-recovery-script":
+      "/es/curso/pushback-ejecutivo/guion-de-recuperacion/",
     "corporate/for-hr": "/es/para-rh/",
     "meme-portfolio": "/es/meme-portfolio/all/",
     "site-index": "/es/indice-del-sitio/",
@@ -662,14 +660,14 @@ export function getAllTKeys(): TKey[] {
     "course/drive-the-decision/missed-quarter",
     "course/drive-the-decision/declining-major-deal",
     "course/drive-the-decision/reflex-drill",
-    "course/diagnose-before-defend",
-    "course/diagnose-before-defend/six-hidden-drivers",
-    "course/diagnose-before-defend/diagnostic-pause",
-    "course/diagnose-before-defend/executive-calm-is-power",
-    "course/diagnose-before-defend/acknowledge-clarify-redirect",
-    "course/diagnose-before-defend/commercial-pushback",
-    "course/diagnose-before-defend/bad-news-steady-voice",
-    "course/diagnose-before-defend/pressure-recovery-script",
+    "course/executive-pushback",
+    "course/executive-pushback/six-hidden-drivers",
+    "course/executive-pushback/diagnostic-pause",
+    "course/executive-pushback/executive-calm-is-power",
+    "course/executive-pushback/acknowledge-clarify-redirect",
+    "course/executive-pushback/commercial-pushback",
+    "course/executive-pushback/bad-news-steady-voice",
+    "course/executive-pushback/pressure-recovery-script",
     "category/startup-founders",
     "category/tech-english",
     "category/logistics-english",

--- a/src/pages/en/course/executive-pushback/acknowledge-clarify-redirect.astro
+++ b/src/pages/en/course/executive-pushback/acknowledge-clarify-redirect.astro
@@ -1,12 +1,12 @@
 ---
 export const prerender = true;
 
-import DiagnoseLessonLayout from "@components/course/DiagnoseLessonLayout.astro";
+import PushbackLessonLayout from "@components/course/PushbackLessonLayout.astro";
 import AudioButton from "@components/course/AudioButton";
 import { Compass, CheckCircle2, XCircle, Eye, ArrowRightLeft } from "lucide-astro";
 ---
 
-<DiagnoseLessonLayout lessonId={4} lang="en" tkey="course/diagnose-before-defend/acknowledge-clarify-redirect">
+<PushbackLessonLayout lessonId={4} lang="en" tkey="course/executive-pushback/acknowledge-clarify-redirect">
   <!-- Section 1: The Core Idea -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
@@ -255,4 +255,4 @@ import { Compass, CheckCircle2, XCircle, Eye, ArrowRightLeft } from "lucide-astr
       </div>
     </div>
   </section>
-</DiagnoseLessonLayout>
+</PushbackLessonLayout>

--- a/src/pages/en/course/executive-pushback/bad-news-steady-voice.astro
+++ b/src/pages/en/course/executive-pushback/bad-news-steady-voice.astro
@@ -1,34 +1,34 @@
 ---
 export const prerender = true;
 
-import DiagnoseLessonLayout from "@components/course/DiagnoseLessonLayout.astro";
+import PushbackLessonLayout from "@components/course/PushbackLessonLayout.astro";
 import AudioButton from "@components/course/AudioButton";
 import { AlertTriangle, CheckCircle2, XCircle, Eye, ShieldAlert } from "lucide-astro";
 ---
 
-<DiagnoseLessonLayout lessonId={6} lang="es" tkey="course/diagnose-before-defend/bad-news-steady-voice">
-  <!-- Section 1: Core Idea -->
+<PushbackLessonLayout lessonId={6} lang="en" tkey="course/executive-pushback/bad-news-steady-voice">
+  <!-- Section 1: The Core Idea -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-2">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">1</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Los Líderes Transfieren Estabilidad — O Transfieren Pánico</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Leaders Transfer Stability — Or They Transfer Panic</h2>
         </div>
         <div class="ml-11 space-y-5 text-lg text-slate-700 leading-relaxed">
           <p>
-            Cuando das malas noticias — un trimestre perdido, un recorte, un outage de producción, una alianza que se desmorona — la organización te observa por una sola señal: <strong>¿estás regulado o eres contagioso?</strong> Lo que dices apenas importa en los primeros treinta segundos. Qué tan firme suena tu voz determina si la sala se calma contigo o escala alrededor de ti.
+            When you deliver bad news — a missed quarter, a layoff, a production outage, a partnership unraveling — the organization watches you for a single signal: <strong>are you regulated, or are you contagious?</strong> What you say barely matters in the first thirty seconds. How steady your voice is determines whether the room calms with you or escalates around you.
           </p>
           <p>
-            Esta es la habilidad más asimétrica de todo el curso. La mayoría de los profesionales nunca la entrenan. Improvisan a través de los momentos de malas noticias esperando que la adrenalina los lleve. Los líderes que realmente mueven organizaciones a través de momentos difíciles hacen algo distinto: tratan la entrega de malas noticias como un <strong>oficio practicado</strong>, no un evento emocional.
+            This is the most asymmetric skill in the entire course. Most professionals never train it. They wing it through bad-news moments and hope adrenaline carries them. The leaders who actually move organizations through hard moments do something different: they treat bad-news delivery as a <strong>practiced craft</strong>, not an emotional event.
           </p>
           <div class="rounded-2xl border-2 border-indigo-300 bg-indigo-50 p-6 my-6">
             <div class="flex items-center gap-3 mb-3">
               <ShieldAlert class="w-6 h-6 text-indigo-700" />
-              <h3 class="text-lg font-bold text-slate-900">El Principio</h3>
+              <h3 class="text-lg font-bold text-slate-900">The Principle</h3>
             </div>
             <p class="text-slate-800">
-              Bajo presión, los líderes transfieren estabilidad emocional a la organización. La voz que dice "tenemos un problema" es la misma voz que tiene que decir "y así es como lo sostenemos". Contención, no contagio.
+              During pressure, leaders transfer emotional stability to the organization. The voice that says "we have a problem" is the same voice that has to say "here's how we hold it." Containment, not contagion.
             </p>
           </div>
         </div>
@@ -36,51 +36,51 @@ import { AlertTriangle, CheckCircle2, XCircle, Eye, ShieldAlert } from "lucide-a
     </div>
   </section>
 
-  <!-- Section 2: Bad News Structure -->
+  <!-- Section 2: The Bad-News Structure -->
   <section class="py-14 md:py-16 bg-slate-50">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">2</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">La Estructura de Malas Noticias</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Bad-News Structure</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">Cuatro tiempos. En este orden. Saltarse cualquiera crea un tipo distinto de daño.</p>
+        <p class="text-slate-600 mb-6 ml-11">Four beats. In this order. Skipping any of them creates a different kind of damage.</p>
 
         <div class="ml-11 space-y-4">
           <div class="bg-white rounded-xl border border-slate-200 p-6">
             <div class="flex items-center gap-3 mb-2">
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 text-indigo-700 font-bold">1</div>
-              <h3 class="text-lg font-bold text-slate-900">La Declaración Directa</h3>
+              <h3 class="text-lg font-bold text-slate-900">The Direct Statement</h3>
             </div>
-            <p class="text-slate-700 mb-2">Di la mala noticia claramente, en una oración, sin preámbulo. "Perdimos el trimestre por 22%". "Vamos a reducir personal en 15%". "La plataforma estuvo caída seis horas".</p>
-            <p class="text-sm text-slate-500 italic">Enterrar el titular ("So I want to talk through some context first…") señala que le tienes miedo a la noticia. La sala lo lee como inestabilidad.</p>
+            <p class="text-slate-700 mb-2">Say the bad news clearly, in one sentence, with no preamble. "We missed the quarter by 22%." "We're reducing headcount by 15%." "The platform was down for six hours."</p>
+            <p class="text-sm text-slate-500 italic">Burying the headline ("So I want to talk through some context first…") signals you're afraid of the news. The room reads that as instability.</p>
           </div>
 
           <div class="bg-white rounded-xl border border-slate-200 p-6">
             <div class="flex items-center gap-3 mb-2">
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 text-indigo-700 font-bold">2</div>
-              <h3 class="text-lg font-bold text-slate-900">La Causa Específica</h3>
+              <h3 class="text-lg font-bold text-slate-900">The Specific Cause</h3>
             </div>
-            <p class="text-slate-700 mb-2">Nombra la causa en términos operativos concretos. No "condiciones de mercado desafiantes" — el mecanismo real. "El ciclo de ventas en mid-market fue 40 días más largo que el modelo". "Un failover de base de datos no se activó como estaba especificado".</p>
-            <p class="text-sm text-slate-500 italic">Las causas vagas telegrafían que no entiendes lo que pasó o lo estás escondiendo. Ambas destruyen la confianza.</p>
+            <p class="text-slate-700 mb-2">Name the cause in concrete operational terms. Not "challenging market conditions" — the actual mechanism. "Sales cycle in mid-market was 40 days longer than modeled." "A database failover did not trigger as specified."</p>
+            <p class="text-sm text-slate-500 italic">Vague causes telegraph that you either don't understand what happened or you're hiding it. Both destroy trust.</p>
           </div>
 
           <div class="bg-white rounded-xl border border-slate-200 p-6">
             <div class="flex items-center gap-3 mb-2">
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 text-indigo-700 font-bold">3</div>
-              <h3 class="text-lg font-bold text-slate-900">La Acción Ya Tomada</h3>
+              <h3 class="text-lg font-bold text-slate-900">The Action Already Taken</h3>
             </div>
-            <p class="text-slate-700 mb-2">Tiempo pasado, no tiempo futuro. "Ya movimos dos AEs a enterprise esta semana". "Ya desplegamos el fix y reconstruimos el runbook". Las acciones en movimiento antes de que la sala supiera del problema son las que construyen confianza.</p>
-            <p class="text-sm text-slate-500 italic">Promesas en tiempo futuro ("vamos a…") en un momento de malas noticias se leen como improvisación. Acciones en tiempo pasado se leen como competencia.</p>
+            <p class="text-slate-700 mb-2">Past-tense, not future-tense. "We've moved two AEs to enterprise this week." "We've deployed the fix and rebuilt the runbook." The actions in motion before the room knew about the problem are what build confidence.</p>
+            <p class="text-sm text-slate-500 italic">Future-tense promises ("we will…") in a bad-news moment read as scrambling. Past-tense actions read as competence.</p>
           </div>
 
           <div class="bg-white rounded-xl border border-slate-200 p-6">
             <div class="flex items-center gap-3 mb-2">
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 text-indigo-700 font-bold">4</div>
-              <h3 class="text-lg font-bold text-slate-900">El Encuadre Hacia Adelante</h3>
+              <h3 class="text-lg font-bold text-slate-900">The Forward Frame</h3>
             </div>
-            <p class="text-slate-700 mb-2">Cierra con qué sigue y a qué te estás haciendo responsable frente a la sala. "Tendremos visibilidad total del nuevo modelo para el próximo viernes". "Las métricas de fin de trimestre estarán en vivo en el dashboard".</p>
-            <p class="text-sm text-slate-500 italic">Sin encuadre hacia adelante, la sala queda con la ansiedad. Un siguiente paso claro transfiere el trabajo del oyente de vuelta al sistema.</p>
+            <p class="text-slate-700 mb-2">Close with what's next and what you're holding the room accountable to. "We'll have full visibility into the new model by next Friday." "Quarter-end metrics will be on the dashboard live."</p>
+            <p class="text-sm text-slate-500 italic">No forward frame and the room is left holding the anxiety. A clear next step transfers the work from the listener back to the system.</p>
           </div>
         </div>
       </div>
@@ -93,14 +93,14 @@ import { AlertTriangle, CheckCircle2, XCircle, Eye, ShieldAlert } from "lucide-a
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">3</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Entregas Reales de Malas Noticias</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Real Bad-News Deliveries</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">Tres contextos. Misma estructura. Escucha el ritmo controlado en cada uno — esa es la señal ejecutiva que la sala está leyendo.</p>
+        <p class="text-slate-600 mb-6 ml-11">Three contexts. Same structure. Listen for the controlled cadence in each — that's the executive signal the room is reading.</p>
 
         <div class="ml-11 space-y-5">
           <div class="bg-slate-50 rounded-xl border border-slate-200 overflow-hidden">
             <div class="bg-slate-900 text-white px-5 py-3">
-              <p class="text-xs font-bold uppercase tracking-wider text-indigo-400">Contexto · Trimestre perdido a tu equipo</p>
+              <p class="text-xs font-bold uppercase tracking-wider text-indigo-400">Context · Missed quarter to your team</p>
             </div>
             <div class="p-6">
               <div class="flex items-center gap-3">
@@ -112,7 +112,7 @@ import { AlertTriangle, CheckCircle2, XCircle, Eye, ShieldAlert } from "lucide-a
 
           <div class="bg-slate-50 rounded-xl border border-slate-200 overflow-hidden">
             <div class="bg-slate-900 text-white px-5 py-3">
-              <p class="text-xs font-bold uppercase tracking-wider text-indigo-400">Contexto · Anuncio de recorte al equipo de liderazgo</p>
+              <p class="text-xs font-bold uppercase tracking-wider text-indigo-400">Context · Layoff announcement to leadership team</p>
             </div>
             <div class="p-6">
               <div class="flex items-center gap-3">
@@ -124,7 +124,7 @@ import { AlertTriangle, CheckCircle2, XCircle, Eye, ShieldAlert } from "lucide-a
 
           <div class="bg-slate-50 rounded-xl border border-slate-200 overflow-hidden">
             <div class="bg-slate-900 text-white px-5 py-3">
-              <p class="text-xs font-bold uppercase tracking-wider text-indigo-400">Contexto · Update de outage a cliente enterprise</p>
+              <p class="text-xs font-bold uppercase tracking-wider text-indigo-400">Context · Outage update to enterprise customer</p>
             </div>
             <div class="p-6">
               <div class="flex items-center gap-3">
@@ -144,26 +144,26 @@ import { AlertTriangle, CheckCircle2, XCircle, Eye, ShieldAlert } from "lucide-a
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">4</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">La Mecánica Vocal de una Voz Firme</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Vocal Mechanics of a Steady Voice</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">La estructura solo te sostiene si la voz sostiene la estructura. Cuatro mecánicas que ensayar antes de cualquier entrega de malas noticias.</p>
+        <p class="text-slate-600 mb-6 ml-11">The structure carries you only if the voice carries the structure. Four mechanics to rehearse before any bad-news delivery.</p>
 
         <div class="ml-11 grid sm:grid-cols-2 gap-3">
           <div class="bg-white rounded-lg border border-slate-200 p-4">
-            <p class="font-bold text-slate-900 text-sm mb-1">Baja el ritmo 20%</p>
-            <p class="text-xs text-slate-600">La entrega de malas noticias debe sentirse más lenta de lo que crees que necesita ser. La velocidad se lee como pánico.</p>
+            <p class="font-bold text-slate-900 text-sm mb-1">Slow by 20%</p>
+            <p class="text-xs text-slate-600">Bad-news delivery should feel slower than you think it needs to. Speed reads as panic.</p>
           </div>
           <div class="bg-white rounded-lg border border-slate-200 p-4">
-            <p class="font-bold text-slate-900 text-sm mb-1">Baja el tono</p>
-            <p class="text-xs text-slate-600">Más bajo que tu rango conversacional. El tono es la señal emocional más fuerte — mantenlo bajo control.</p>
+            <p class="font-bold text-slate-900 text-sm mb-1">Drop the pitch</p>
+            <p class="text-xs text-slate-600">Lower than your conversational range. Pitch is the loudest emotional signal — keep it under control.</p>
           </div>
           <div class="bg-white rounded-lg border border-slate-200 p-4">
-            <p class="font-bold text-slate-900 text-sm mb-1">Aterriza cada oración</p>
-            <p class="text-xs text-slate-600">Cierres ascendentes convierten afirmaciones en preguntas. Malas noticias entregadas como pregunta se leen como incertidumbre.</p>
+            <p class="font-bold text-slate-900 text-sm mb-1">Land each sentence</p>
+            <p class="text-xs text-slate-600">Rising endings turn statements into questions. Bad news delivered as a question reads as uncertainty.</p>
           </div>
           <div class="bg-white rounded-lg border border-slate-200 p-4">
-            <p class="font-bold text-slate-900 text-sm mb-1">Respira entre tiempos</p>
-            <p class="text-xs text-slate-600">Medio segundo de respiración entre los cuatro tiempos deja que la sala absorba cada uno antes del siguiente.</p>
+            <p class="font-bold text-slate-900 text-sm mb-1">Breathe between beats</p>
+            <p class="text-xs text-slate-600">A half-second breath between the four beats lets the room absorb each one before the next.</p>
           </div>
         </div>
       </div>
@@ -176,20 +176,20 @@ import { AlertTriangle, CheckCircle2, XCircle, Eye, ShieldAlert } from "lucide-a
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">5</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Tres Trampas de Malas Noticias</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Three Bad-News Traps</h2>
         </div>
         <div class="ml-11 space-y-4">
           <div class="bg-amber-50 border border-amber-200 rounded-xl p-5">
-            <p class="font-bold text-slate-900 mb-1">Trampa 1 — Tranquilizar prematuramente</p>
-            <p class="text-slate-700 text-sm">"Todo va a estar bien" antes de que la sala haya absorbido la noticia es condescendiente — y peor, se lee como actuación. Reconoce el peso antes de ofrecer tranquilidad.</p>
+            <p class="font-bold text-slate-900 mb-1">Trap 1 — Premature reassurance</p>
+            <p class="text-slate-700 text-sm">"Everything's going to be fine" before the room has absorbed the news is patronizing — and worse, it reads as performance. Acknowledge weight before offering reassurance.</p>
           </div>
           <div class="bg-amber-50 border border-amber-200 rounded-xl p-5">
-            <p class="font-bold text-slate-900 mb-1">Trampa 2 — La disculpa falsa</p>
-            <p class="text-slate-700 text-sm">"Quiero pedir disculpas por…" antes de que la mala noticia siquiera haya aterrizado es una señal de que estás más preocupado por cómo te ves que por lo que pasó. Guarda la disculpa — si se debe — para después de entregar la estructura.</p>
+            <p class="font-bold text-slate-900 mb-1">Trap 2 — The fake apology</p>
+            <p class="text-slate-700 text-sm">"I want to apologize for…" before the bad news has even landed is a signal you're more concerned with how you look than with what happened. Save the apology — if it's owed — for after the structure is delivered.</p>
           </div>
           <div class="bg-amber-50 border border-amber-200 rounded-xl p-5">
-            <p class="font-bold text-slate-900 mb-1">Trampa 3 — Sobreexplicar la causa</p>
-            <p class="text-slate-700 text-sm">Una oración sobre la causa es suficiente. Cuanto más tiempo pases en lo que salió mal, más la sala lo lee como tú defendiéndote en vez de informándoles.</p>
+            <p class="font-bold text-slate-900 mb-1">Trap 3 — Overexplaining the cause</p>
+            <p class="text-slate-700 text-sm">One sentence on the cause is enough. The longer you spend on what went wrong, the more the room reads it as you defending yourself rather than informing them.</p>
           </div>
         </div>
       </div>
@@ -200,15 +200,15 @@ import { AlertTriangle, CheckCircle2, XCircle, Eye, ShieldAlert } from "lucide-a
   <section class="py-14 md:py-16 bg-slate-50 border-t border-slate-200">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
-        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">El Resumen</h2>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">The Recap</h2>
         <div class="bg-white rounded-2xl border border-slate-200 p-7">
           <ul class="space-y-3 text-slate-700">
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Bajo presión, los líderes <strong>transfieren estabilidad o transfieren pánico</strong>. La voz es el portador.</span></li>
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Cuatro tiempos: <strong>declaración directa → causa específica → acción ya tomada → encuadre hacia adelante</strong>.</span></li>
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>La mecánica vocal importa tanto como la estructura — <strong>lenta, baja, aterrizada, con respiraciones</strong>.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Under pressure, leaders <strong>transfer stability or transfer panic</strong>. Voice is the carrier.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Four beats: <strong>direct statement → specific cause → action already taken → forward frame</strong>.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Vocal mechanics matter as much as structure — <strong>slow, low, landed, breathed</strong>.</span></li>
           </ul>
         </div>
       </div>
     </div>
   </section>
-</DiagnoseLessonLayout>
+</PushbackLessonLayout>

--- a/src/pages/en/course/executive-pushback/commercial-pushback.astro
+++ b/src/pages/en/course/executive-pushback/commercial-pushback.astro
@@ -1,34 +1,34 @@
 ---
 export const prerender = true;
 
-import DiagnoseLessonLayout from "@components/course/DiagnoseLessonLayout.astro";
+import PushbackLessonLayout from "@components/course/PushbackLessonLayout.astro";
 import AudioButton from "@components/course/AudioButton";
 import { DollarSign, CheckCircle2, XCircle, Eye, Target } from "lucide-astro";
 ---
 
-<DiagnoseLessonLayout lessonId={5} lang="es" tkey="course/diagnose-before-defend/commercial-pushback">
-  <!-- Section 1: Core Idea -->
+<PushbackLessonLayout lessonId={5} lang="en" tkey="course/executive-pushback/commercial-pushback">
+  <!-- Section 1: The Core Idea -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-2">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">1</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">El Precio Se Vuelve el Tema Cuando el Valor y la Confianza Son Débiles</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Price Becomes the Focus When Value and Trust Are Weak</h2>
         </div>
         <div class="ml-11 space-y-5 text-lg text-slate-700 leading-relaxed">
           <p>
-            Cuando un comprador pelea contigo sobre el precio, la conversación ya se torció. Las conversaciones comerciales sanas no se quedan en el precio — negocian alcance, términos o tiempo mientras el precio se mantiene anclado. Cuando el precio se vuelve el tema dominante, una de dos cosas pasó: el comprador no ha internalizado el valor, o no confía en la relación lo suficiente para pagarlo.
+            When a buyer fights you on price, the conversation has already gone sideways. Healthy commercial conversations don't dwell on price — they negotiate scope, terms, or timing while price stays roughly anchored. When price becomes the dominant topic, one of two things has happened: the buyer hasn't internalized the value, or they don't trust the relationship enough to pay for it.
           </p>
           <p>
-            Defender el precio directamente es casi siempre el movimiento equivocado. Señala que <strong>tú</strong> crees que el precio es el tema vivo — lo cual valida el encuadre del comprador. El movimiento ejecutivo es diagnosticar <em>por qué</em> el precio se volvió la conversación y abordar la capa de abajo.
+            Defending the price directly is almost always the wrong move. It signals that <strong>you</strong> believe price is the live issue — which validates the buyer's framing. The executive move is to diagnose <em>why</em> price became the conversation and address the layer underneath.
           </p>
           <div class="rounded-2xl border-2 border-indigo-300 bg-indigo-50 p-6 my-6">
             <div class="flex items-center gap-3 mb-3">
               <DollarSign class="w-6 h-6 text-indigo-700" />
-              <h3 class="text-lg font-bold text-slate-900">El Principio</h3>
+              <h3 class="text-lg font-bold text-slate-900">The Principle</h3>
             </div>
             <p class="text-slate-800">
-              Diagnostica la duda <em>antes</em> de defender la oferta. Si estás explicando el precio, ya cediste terreno. Si estás reencuadrando el valor, todavía estás en la sala.
+              Diagnose the hesitation <em>before</em> defending the offer. If you're explaining the price, you've already lost ground. If you're reframing the value, you're still in the room.
             </p>
           </div>
         </div>
@@ -36,76 +36,76 @@ import { DollarSign, CheckCircle2, XCircle, Eye, Target } from "lucide-astro";
     </div>
   </section>
 
-  <!-- Section 2: Four Commercial Drivers -->
+  <!-- Section 2: The Four Commercial Drivers -->
   <section class="py-14 md:py-16 bg-slate-50">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">2</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Qué Está Impulsando el Pushback Comercial</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">What's Actually Driving Commercial Pushback</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">Cuatro impulsores ocultos explican casi todas las objeciones comerciales. Cada uno tiene una respuesta correcta distinta — defender el precio nunca funciona para ninguno.</p>
+        <p class="text-slate-600 mb-6 ml-11">Four hidden drivers account for almost all commercial objections. Each one has a different correct response — defending the price never works for any of them.</p>
 
         <div class="ml-11 space-y-4">
           <div class="bg-white rounded-xl border border-slate-200 p-6">
             <div class="flex items-start gap-3 mb-2">
               <div class="flex items-center justify-center w-9 h-9 rounded-lg bg-amber-100 text-amber-700 shrink-0 font-bold text-sm">1</div>
-              <h3 class="text-lg font-bold text-slate-900">Desconexión de Valor</h3>
+              <h3 class="text-lg font-bold text-slate-900">Value Disconnect</h3>
             </div>
-            <p class="text-slate-700 mb-2">El comprador no ve completamente lo que está recibiendo. El precio se siente alto porque el valor se siente poco claro o no verificado.</p>
-            <p class="text-sm text-slate-500 italic">Pista: lenguaje de comparación ("el competidor X cuesta la mitad"), preguntas sobre features ("¿qué incluye exactamente?").</p>
+            <p class="text-slate-700 mb-2">The buyer doesn't fully see what they're getting. The price feels high because the value feels unclear or unverified.</p>
+            <p class="text-sm text-slate-500 italic">Tell: comparison language ("competitor X is half the price"), feature questions ("what exactly is included?").</p>
           </div>
 
           <div class="bg-white rounded-xl border border-slate-200 p-6">
             <div class="flex items-start gap-3 mb-2">
               <div class="flex items-center justify-center w-9 h-9 rounded-lg bg-amber-100 text-amber-700 shrink-0 font-bold text-sm">2</div>
-              <h3 class="text-lg font-bold text-slate-900">Teatro de Procurement</h3>
+              <h3 class="text-lg font-bold text-slate-900">Procurement Theater</h3>
             </div>
-            <p class="text-slate-700 mb-2">A un gerente de compras le dijeron que negocie. El pushback no es sobre tu precio — es sobre su evaluación de desempeño. Necesita una concesión con la cual salir.</p>
-            <p class="text-sm text-slate-500 italic">Pista: porcentajes arbitrarios pedidos ("necesitamos 15% menos"), referencias a ciclos de presupuesto, frases con guion.</p>
+            <p class="text-slate-700 mb-2">A procurement manager has been told to negotiate. The pushback is not about your price — it's about their performance review. They need a concession to walk out with.</p>
+            <p class="text-sm text-slate-500 italic">Tell: arbitrary percentages requested ("we need 15% off"), references to budget cycles, scripted phrases.</p>
           </div>
 
           <div class="bg-white rounded-xl border border-slate-200 p-6">
             <div class="flex items-start gap-3 mb-2">
               <div class="flex items-center justify-center w-9 h-9 rounded-lg bg-amber-100 text-amber-700 shrink-0 font-bold text-sm">3</div>
-              <h3 class="text-lg font-bold text-slate-900">Riesgo de Aprobación Interna</h3>
+              <h3 class="text-lg font-bold text-slate-900">Internal Approval Risk</h3>
             </div>
-            <p class="text-slate-700 mb-2">El comprador quiere comprar pero no está seguro de poder defender el gasto internamente. La objeción de precio es él ensayando la defensa que tendrá que dar a su jefe.</p>
-            <p class="text-sm text-slate-500 italic">Pista: "necesito llevárselo a…", referencias a aprobación ejecutiva, solicitudes de documentación de ROI.</p>
+            <p class="text-slate-700 mb-2">The buyer wants to buy but isn't sure they can defend the spend internally. The price objection is them rehearsing the defense they'll have to give to their boss.</p>
+            <p class="text-sm text-slate-500 italic">Tell: "I'll need to take this back to…", references to executive approval, requests for ROI documentation.</p>
           </div>
 
           <div class="bg-white rounded-xl border border-slate-200 p-6">
             <div class="flex items-start gap-3 mb-2">
               <div class="flex items-center justify-center w-9 h-9 rounded-lg bg-amber-100 text-amber-700 shrink-0 font-bold text-sm">4</div>
-              <h3 class="text-lg font-bold text-slate-900">Brecha de Confianza</h3>
+              <h3 class="text-lg font-bold text-slate-900">Trust Gap</h3>
             </div>
-            <p class="text-slate-700 mb-2">Todavía no tienen evidencia de que vas a entregar. El precio no es el tema — el riesgo percibido de pagarlo sí lo es.</p>
-            <p class="text-sm text-slate-500 italic">Pista: solicitudes de referencias, propuestas de piloto, encuadre "empecemos en pequeño", lenguaje de avance lento.</p>
+            <p class="text-slate-700 mb-2">They don't have evidence yet that you'll deliver. The price isn't the issue — the perceived risk of paying it is.</p>
+            <p class="text-sm text-slate-500 italic">Tell: requests for references, pilot proposals, "let's start small" framing, slow-walking language.</p>
           </div>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- Section 3: Commercial RCR -->
+  <!-- Section 3: Commercial ACR -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">3</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">RCR Comercial — Cada Impulsor, Cada Respuesta</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Commercial ACR — Each Driver, Each Response</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">La misma línea del comprador, cuatro impulsores posibles, cuatro respuestas distintas. El diagnóstico decide cuál usas.</p>
+        <p class="text-slate-600 mb-6 ml-11">Same buyer line, four possible drivers, four different responses. The diagnosis decides which one you use.</p>
 
         <div class="ml-11 space-y-5">
           <div class="bg-slate-900 text-white rounded-xl overflow-hidden">
             <div class="px-5 py-3 border-b border-white/10">
-              <p class="text-xs font-bold uppercase tracking-wider text-indigo-300">Línea del comprador</p>
+              <p class="text-xs font-bold uppercase tracking-wider text-indigo-300">Buyer line</p>
               <p class="text-lg italic mt-1">"Your price is about 30% over what we had in budget."</p>
             </div>
             <div class="p-5 space-y-4">
               <div class="bg-white/5 rounded-lg p-4">
-                <p class="text-xs font-bold uppercase tracking-wider text-amber-300 mb-2">Si el impulsor es Desconexión de Valor</p>
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-300 mb-2">If the driver is Value Disconnect</p>
                 <div class="flex items-center gap-3">
                   <p class="text-slate-100 flex-1 italic">"That gap usually means we haven't shown enough of the value yet. Can I walk you through the two outcomes we'd actually produce in the first 90 days? If those aren't worth the gap, we shouldn't be working together."</p>
                   <AudioButton client:visible text="That gap usually means we haven't shown enough of the value yet. Can I walk you through the two outcomes we'd actually produce in the first 90 days? If those aren't worth the gap, we shouldn't be working together." lang="en-US" size="sm" />
@@ -113,7 +113,7 @@ import { DollarSign, CheckCircle2, XCircle, Eye, Target } from "lucide-astro";
               </div>
 
               <div class="bg-white/5 rounded-lg p-4">
-                <p class="text-xs font-bold uppercase tracking-wider text-amber-300 mb-2">Si el impulsor es Teatro de Procurement</p>
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-300 mb-2">If the driver is Procurement Theater</p>
                 <div class="flex items-center gap-3">
                   <p class="text-slate-100 flex-1 italic">"I hear you. We're not going to move on rate — but I can move on terms. Annual prepay at a reduced quarterly commitment, or extended payment terms — those are the two levers I have. Which one helps you more?"</p>
                   <AudioButton client:visible text="I hear you. We're not going to move on rate — but I can move on terms. Annual prepay at a reduced quarterly commitment, or extended payment terms — those are the two levers I have. Which one helps you more?" lang="en-US" size="sm" />
@@ -121,7 +121,7 @@ import { DollarSign, CheckCircle2, XCircle, Eye, Target } from "lucide-astro";
               </div>
 
               <div class="bg-white/5 rounded-lg p-4">
-                <p class="text-xs font-bold uppercase tracking-wider text-amber-300 mb-2">Si el impulsor es Riesgo de Aprobación Interna</p>
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-300 mb-2">If the driver is Internal Approval Risk</p>
                 <div class="flex items-center gap-3">
                   <p class="text-slate-100 flex-1 italic">"That's a real gap to defend. Let me give you the three numbers that usually carry the internal conversation — and if those don't fit your CFO's framing, tell me what does and I'll reshape it."</p>
                   <AudioButton client:visible text="That's a real gap to defend. Let me give you the three numbers that usually carry the internal conversation — and if those don't fit your CFO's framing, tell me what does and I'll reshape it." lang="en-US" size="sm" />
@@ -129,7 +129,7 @@ import { DollarSign, CheckCircle2, XCircle, Eye, Target } from "lucide-astro";
               </div>
 
               <div class="bg-white/5 rounded-lg p-4">
-                <p class="text-xs font-bold uppercase tracking-wider text-amber-300 mb-2">Si el impulsor es Brecha de Confianza</p>
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-300 mb-2">If the driver is Trust Gap</p>
                 <div class="flex items-center gap-3">
                   <p class="text-slate-100 flex-1 italic">"That gap feels bigger when you don't yet have evidence we'll deliver. Here's what I'd propose: a structured 60-day milestone with a defined success threshold. If we don't hit it, you exit clean. That removes the risk of paying full price for an unproven outcome."</p>
                   <AudioButton client:visible text="That gap feels bigger when you don't yet have evidence we'll deliver. Here's what I'd propose: a structured 60-day milestone with a defined success threshold. If we don't hit it, you exit clean. That removes the risk of paying full price for an unproven outcome." lang="en-US" size="sm" />
@@ -142,23 +142,23 @@ import { DollarSign, CheckCircle2, XCircle, Eye, Target } from "lucide-astro";
     </div>
   </section>
 
-  <!-- Section 4: Discount Trap -->
+  <!-- Section 4: The Discount Trap -->
   <section class="py-14 md:py-16 bg-slate-50">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">4</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">La Trampa del Descuento</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Discount Trap</h2>
         </div>
         <div class="ml-11 space-y-5 text-lg text-slate-700 leading-relaxed">
           <p>
-            El error comercial más grande bajo presión es ceder en el precio demasiado rápido. El patrón está bien documentado: el comprador pide un descuento, el vendedor cede, el comprador siente que debió haber pedido más, y todo el acuerdo se estructura alrededor del precio en vez del valor. Los entrenaste para negociar cada renovación de la misma manera.
+            The biggest commercial mistake under pressure is conceding on price too quickly. The pattern is well-documented: buyer asks for a discount, seller concedes, buyer feels they should have asked for more, and the entire deal becomes structured around price rather than value. You've trained them to negotiate every renewal the same way.
           </p>
           <p>
-            La respuesta correcta a "¿puedes hacer algo mejor en el precio?" casi nunca es un descuento. Es un <strong>intercambio</strong> — te mueves en precio solo si ellos se mueven en algo más. Duración del término. Tiempos de pago. Volumen de compromiso. Derechos de referencia. Cualquier cosa.
+            The correct response to "can you do better on price" is almost never a discount. It's a <strong>trade</strong> — you move on price only if they move on something else. Term length. Payment timing. Commitment volume. Reference rights. Anything.
           </p>
           <div class="bg-white border border-slate-200 rounded-xl p-5 my-4">
-            <p class="text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">La respuesta de intercambio</p>
+            <p class="text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">The trade response</p>
             <div class="flex items-center gap-3">
               <p class="text-lg text-slate-900 italic flex-1">"I can look at price if you can look at term. A two-year commitment changes my math — a one-year doesn't."</p>
               <AudioButton client:visible text="I can look at price if you can look at term. A two-year commitment changes my math — a one-year doesn't." lang="en-US" size="sm" />
@@ -175,20 +175,20 @@ import { DollarSign, CheckCircle2, XCircle, Eye, Target } from "lucide-astro";
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">5</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Tres Trampas Comerciales</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Three Commercial Traps</h2>
         </div>
         <div class="ml-11 space-y-4">
           <div class="bg-amber-50 border border-amber-200 rounded-xl p-5">
-            <p class="font-bold text-slate-900 mb-1">Trampa 1 — Sonar ansioso</p>
-            <p class="text-slate-700 text-sm">La ansiedad es la señal más cara en una conversación comercial. "We'd love to work with you" temprano en una discusión de precio te cuesta entre 5 y 10% en margen. El desapego calibrado ("if we're the right fit for you") preserva el apalancamiento.</p>
+            <p class="font-bold text-slate-900 mb-1">Trap 1 — Sounding eager</p>
+            <p class="text-slate-700 text-sm">Eagerness is the most expensive signal in a commercial conversation. "We'd love to work with you" early in a price discussion costs you 5-10% in margin. Calibrated detachment ("if we're the right fit for you") preserves leverage.</p>
           </div>
           <div class="bg-amber-50 border border-amber-200 rounded-xl p-5">
-            <p class="font-bold text-slate-900 mb-1">Trampa 2 — Defender las líneas de partida</p>
-            <p class="text-slate-700 text-sm">Cuando empiezas a defender por qué cada línea cuesta lo que cuesta, movieron la conversación del valor a la contabilidad de costos. Siempre vas a perder ese encuadre. Quédate en resultados, no en insumos.</p>
+            <p class="font-bold text-slate-900 mb-1">Trap 2 — Defending the line items</p>
+            <p class="text-slate-700 text-sm">When you start defending why each line item costs what it costs, you've moved the conversation from value to cost accounting. You'll always lose that frame. Stay on outcomes, not inputs.</p>
           </div>
           <div class="bg-amber-50 border border-amber-200 rounded-xl p-5">
-            <p class="font-bold text-slate-900 mb-1">Trampa 3 — Ceder sin intercambio</p>
-            <p class="text-slate-700 text-sm">Si das un descuento sin recibir algo a cambio, le enseñaste al comprador que tu precio era falso. Cada concesión necesita una contraprestación, aunque sea pequeña.</p>
+            <p class="font-bold text-slate-900 mb-1">Trap 3 — Conceding for no trade</p>
+            <p class="text-slate-700 text-sm">If you discount without getting something in return, you've taught the buyer that your price was fake. Every concession needs a corresponding ask, even a small one.</p>
           </div>
         </div>
       </div>
@@ -199,15 +199,15 @@ import { DollarSign, CheckCircle2, XCircle, Eye, Target } from "lucide-astro";
   <section class="py-14 md:py-16 bg-slate-50 border-t border-slate-200">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
-        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">El Resumen</h2>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">The Recap</h2>
         <div class="bg-white rounded-2xl border border-slate-200 p-7">
           <ul class="space-y-3 text-slate-700">
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>El precio se vuelve el tema cuando el valor y la confianza son débiles.</strong> Diagnostica cuál.</span></li>
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Cuatro impulsores: <strong>Desconexión de Valor, Teatro de Procurement, Riesgo de Aprobación Interna, Brecha de Confianza</strong>. Cada uno tiene una respuesta correcta distinta.</span></li>
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Nunca cedas en el precio sin un <strong>intercambio</strong>. Cada descuento necesita una contraprestación.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Price becomes the focus when value and trust are weak.</strong> Diagnose which.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Four drivers: <strong>Value Disconnect, Procurement Theater, Internal Approval Risk, Trust Gap</strong>. Each has a different correct response.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Never concede on price without a <strong>trade</strong>. Every discount needs a corresponding ask.</span></li>
           </ul>
         </div>
       </div>
     </div>
   </section>
-</DiagnoseLessonLayout>
+</PushbackLessonLayout>

--- a/src/pages/en/course/executive-pushback/diagnostic-pause.astro
+++ b/src/pages/en/course/executive-pushback/diagnostic-pause.astro
@@ -1,34 +1,34 @@
 ---
 export const prerender = true;
 
-import DiagnoseLessonLayout from "@components/course/DiagnoseLessonLayout.astro";
+import PushbackLessonLayout from "@components/course/PushbackLessonLayout.astro";
 import AudioButton from "@components/course/AudioButton";
 import { Pause, Clock, Volume2, CheckCircle2, XCircle, Eye } from "lucide-astro";
 ---
 
-<DiagnoseLessonLayout lessonId={2} lang="es" tkey="course/diagnose-before-defend/diagnostic-pause">
+<PushbackLessonLayout lessonId={2} lang="en" tkey="course/executive-pushback/diagnostic-pause">
   <!-- Section 1: The Core Idea -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-2">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">1</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">El Silencio Es Tu Herramienta Más Subutilizada</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Silence Is Your Most Underused Tool</h2>
         </div>
         <div class="ml-11 space-y-5 text-lg text-slate-700 leading-relaxed">
           <p>
-            Cuando alguien te da pushback en una sala, el reflejo profesional por defecto es <strong>responder rápido</strong>. La velocidad se siente como competencia. La vacilación se siente como debilidad. Entonces llenas el espacio — usualmente con la primera respuesta que se te vino a la cabeza, que casi siempre es la equivocada.
+            When someone pushes back on you in a room, the default professional reflex is to <strong>respond fast</strong>. Speed feels like competence. Hesitation feels like weakness. So you fill the space — usually with the first response that came to mind, which is almost always the wrong one.
           </p>
           <p>
-            Los líderes senior hacen lo opuesto. <strong>Pausan</strong>. Dos segundos, a veces tres. Miran a la persona. Consideran. Después responden — más lento, más bajo, más medido de lo que el retador esperaba. La pausa no es una señal de incertidumbre. Es una señal de control.
+            Senior leaders do the opposite. They <strong>pause</strong>. Two seconds, sometimes three. They look at the person. They consider. Then they respond — slower, lower, more measured than the challenger expected. The pause is not a sign of uncertainty. It's a sign of control.
           </p>
           <div class="rounded-2xl border-2 border-indigo-300 bg-indigo-50 p-6 my-6">
             <div class="flex items-center gap-3 mb-3">
               <Eye class="w-6 h-6 text-indigo-700" />
-              <h3 class="text-lg font-bold text-slate-900">El Principio</h3>
+              <h3 class="text-lg font-bold text-slate-900">The Principle</h3>
             </div>
             <p class="text-slate-800">
-              La pausa de 2-3 segundos es el movimiento ejecutivo de mayor apalancamiento que puedes instalar. Te compra diagnóstico, respiración y la atención recalibrada de la sala — a costa de sentirte ligeramente incómodo.
+              The 2-3 second pause is the single highest-leverage executive move you can install. It buys you diagnosis, breath, and the room's recalibrated attention — at the cost of feeling slightly uncomfortable.
             </p>
           </div>
         </div>
@@ -36,88 +36,88 @@ import { Pause, Clock, Volume2, CheckCircle2, XCircle, Eye } from "lucide-astro"
     </div>
   </section>
 
-  <!-- Section 2: What the Pause Buys -->
+  <!-- Section 2: What the Pause Buys You -->
   <section class="py-14 md:py-16 bg-slate-50">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">2</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Qué Te Compra la Pausa</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">What the Pause Buys You</h2>
         </div>
         <div class="ml-11 grid sm:grid-cols-2 gap-4">
           <div class="bg-white rounded-xl border border-slate-200 p-5">
             <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 text-indigo-700 mb-3">
               <Pause class="w-5 h-5" />
             </div>
-            <h3 class="font-bold text-slate-900 mb-1">Tiempo diagnóstico</h3>
-            <p class="text-sm text-slate-600">Dos segundos son suficientes para mapear su objeción a uno de los seis impulsores ocultos y decidir cuál abordar.</p>
+            <h3 class="font-bold text-slate-900 mb-1">Diagnostic time</h3>
+            <p class="text-sm text-slate-600">Two seconds is enough to map their objection to one of the six hidden drivers and decide which one to address.</p>
           </div>
           <div class="bg-white rounded-xl border border-slate-200 p-5">
             <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 text-indigo-700 mb-3">
               <Clock class="w-5 h-5" />
             </div>
-            <h3 class="font-bold text-slate-900 mb-1">Reset del ritmo</h3>
-            <p class="text-sm text-slate-600">Interrumpe el tempo emocional del retador y obliga a la conversación a entrar en tu ritmo en lugar del de ellos.</p>
+            <h3 class="font-bold text-slate-900 mb-1">Pace reset</h3>
+            <p class="text-sm text-slate-600">It interrupts the challenger's emotional tempo and forces the conversation into your rhythm rather than theirs.</p>
           </div>
           <div class="bg-white rounded-xl border border-slate-200 p-5">
             <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 text-indigo-700 mb-3">
               <Volume2 class="w-5 h-5" />
             </div>
-            <h3 class="font-bold text-slate-900 mb-1">Señal de autoridad</h3>
-            <p class="text-sm text-slate-600">Una pausa medida se lee como deliberación. La velocidad se lee como defensividad. Las mismas palabras, la señal opuesta.</p>
+            <h3 class="font-bold text-slate-900 mb-1">Authority signal</h3>
+            <p class="text-sm text-slate-600">A measured pause reads as deliberation. Speed reads as defensiveness. Same words, opposite signal.</p>
           </div>
           <div class="bg-white rounded-xl border border-slate-200 p-5">
             <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 text-indigo-700 mb-3">
               <Eye class="w-5 h-5" />
             </div>
-            <h3 class="font-bold text-slate-900 mb-1">Prueba de escucha</h3>
-            <p class="text-sm text-slate-600">Le dice al retador que realmente lo escuchaste — lo cual frecuentemente desactiva el 30% de la presión antes de que hables.</p>
+            <h3 class="font-bold text-slate-900 mb-1">Listening proof</h3>
+            <p class="text-sm text-slate-600">It tells the challenger you actually heard them — which often defuses 30% of the pressure before you speak.</p>
           </div>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- Section 3: Three Silent Questions -->
+  <!-- Section 3: The Three Questions to Run Silently -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">3</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Qué Ejecutar Silenciosamente en Esos Dos Segundos</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">What to Run Silently in Those Two Seconds</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">Tres preguntas, ejecutadas en este orden. Practica la secuencia lo suficiente para que se vuelva automática — entonces la pausa se vuelve natural en lugar de incómoda.</p>
+        <p class="text-slate-600 mb-6 ml-11">Three questions, run in this order. Practice the sequence enough that it becomes automatic — then the pause becomes effortless rather than awkward.</p>
 
         <div class="ml-11 space-y-4">
           <div class="bg-slate-900 text-white rounded-xl p-6">
-            <p class="text-xs font-bold uppercase tracking-wider text-indigo-400 mb-2">Pregunta 1 — Impulsor</p>
-            <p class="text-lg italic mb-2">"¿Cuál de los seis impulsores se está activando aquí?"</p>
-            <p class="text-sm text-slate-300">Incluso una coincidencia aproximada (riesgo vs. ego, estatus vs. carga de trabajo) modela una mejor respuesta que contestar las palabras literales.</p>
+            <p class="text-xs font-bold uppercase tracking-wider text-indigo-400 mb-2">Question 1 — Driver</p>
+            <p class="text-lg italic mb-2">"Which of the six drivers is firing here?"</p>
+            <p class="text-sm text-slate-300">Even a rough match (risk vs. ego, status vs. workload) shapes a better response than answering the literal words.</p>
           </div>
           <div class="bg-slate-900 text-white rounded-xl p-6">
-            <p class="text-xs font-bold uppercase tracking-wider text-indigo-400 mb-2">Pregunta 2 — Resultado</p>
-            <p class="text-lg italic mb-2">"¿Qué resultado quieren realmente de este intercambio?"</p>
-            <p class="text-sm text-slate-300">A veces quieren que cedas. A veces quieren tranquilidad. A veces quieren que el crédito sea visible. Nombra el resultado internamente antes de responder a las palabras.</p>
+            <p class="text-xs font-bold uppercase tracking-wider text-indigo-400 mb-2">Question 2 — Outcome</p>
+            <p class="text-lg italic mb-2">"What outcome do they actually want from this exchange?"</p>
+            <p class="text-sm text-slate-300">Sometimes they want you to back down. Sometimes they want reassurance. Sometimes they want the credit to be visible. Name the outcome internally before you respond to the words.</p>
           </div>
           <div class="bg-slate-900 text-white rounded-xl p-6">
-            <p class="text-xs font-bold uppercase tracking-wider text-indigo-400 mb-2">Pregunta 3 — Seguridad</p>
-            <p class="text-lg italic mb-2">"¿Cuál es la respuesta más segura a la preocupación real que no rinde mi posición?"</p>
-            <p class="text-sm text-slate-300">Seguro no significa débil. Seguro significa que no escala el ego, no dispara la defensa de carga de trabajo y no transfiere responsabilidad a ti cuando no debería ser tuya.</p>
+            <p class="text-xs font-bold uppercase tracking-wider text-indigo-400 mb-2">Question 3 — Safety</p>
+            <p class="text-lg italic mb-2">"What's the safest response to the real concern that doesn't surrender my position?"</p>
+            <p class="text-sm text-slate-300">Safe doesn't mean weak. Safe means it doesn't escalate ego, doesn't trigger workload defense, and doesn't shift accountability to you when it shouldn't be yours.</p>
           </div>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- Section 4: Pause in Practice -->
+  <!-- Section 4: The Pause in Practice -->
   <section class="py-14 md:py-16 bg-slate-50">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">4</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">La Pausa en la Práctica</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Pause in Practice</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">Mismo pushback, dos respuestas. La diferencia son los dos segundos antes de las palabras. Toca el ícono para escuchar el ritmo de la respuesta pausada.</p>
+        <p class="text-slate-600 mb-6 ml-11">Same pushback, two responses. The difference is the two seconds in front of the words. Tap the speaker to hear the cadence of the paused response.</p>
 
         <div class="ml-11 space-y-5">
           <div class="bg-white rounded-xl border border-slate-200 p-6">
@@ -128,7 +128,7 @@ import { Pause, Clock, Volume2, CheckCircle2, XCircle, Eye } from "lucide-astro"
               <div class="flex items-start gap-3">
                 <XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
                 <div class="flex-1">
-                  <p class="text-xs font-bold uppercase tracking-wider text-red-700 mb-1">Reactivo (sin pausa)</p>
+                  <p class="text-xs font-bold uppercase tracking-wider text-red-700 mb-1">Reactive (no pause)</p>
                   <p class="text-slate-800 italic text-sm">"Yeah, I know it's more aggressive but we modeled it carefully and we think the upside justifies it, and we have a few different scenarios that we can walk through if you'd like to see them…"</p>
                 </div>
               </div>
@@ -138,11 +138,11 @@ import { Pause, Clock, Volume2, CheckCircle2, XCircle, Eye } from "lucide-astro"
               <div class="flex items-start gap-3">
                 <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
                 <div class="flex-1">
-                  <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-1">Con pausa (2 segundos, luego)</p>
+                  <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-1">Paused (2 seconds, then)</p>
                   <p class="text-slate-900 font-medium mb-3">"That's a fair read. It is more aggressive — and that's deliberate. The market conditions that made the conservative model work last cycle don't apply this cycle."</p>
                   <div class="flex items-center gap-2 pt-3 border-t border-emerald-200/60">
                     <AudioButton client:visible text="That's a fair read. It is more aggressive — and that's deliberate. The market conditions that made the conservative model work last cycle don't apply this cycle." lang="en-US" size="sm" />
-                    <span class="text-xs text-slate-600">Escucha el ritmo</span>
+                    <span class="text-xs text-slate-600">Listen to the cadence</span>
                   </div>
                 </div>
               </div>
@@ -157,7 +157,7 @@ import { Pause, Clock, Volume2, CheckCircle2, XCircle, Eye } from "lucide-astro"
               <div class="flex items-start gap-3">
                 <XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
                 <div class="flex-1">
-                  <p class="text-xs font-bold uppercase tracking-wider text-red-700 mb-1">Reactivo (sin pausa)</p>
+                  <p class="text-xs font-bold uppercase tracking-wider text-red-700 mb-1">Reactive (no pause)</p>
                   <p class="text-slate-800 italic text-sm">"Sorry, I know I should have, I just thought I'd wait until I had more details before bringing it to you and then it kind of ran ahead of where I planned…"</p>
                 </div>
               </div>
@@ -167,11 +167,11 @@ import { Pause, Clock, Volume2, CheckCircle2, XCircle, Eye } from "lucide-astro"
               <div class="flex items-start gap-3">
                 <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
                 <div class="flex-1">
-                  <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-1">Con pausa (2 segundos, luego)</p>
+                  <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-1">Paused (2 seconds, then)</p>
                   <p class="text-slate-900 font-medium mb-3">"You should have been in the room earlier. The reason you weren't is that I wanted a clean recommendation rather than a partial one — but that was the wrong call. Here's where we are now."</p>
                   <div class="flex items-center gap-2 pt-3 border-t border-emerald-200/60">
                     <AudioButton client:visible text="You should have been in the room earlier. The reason you weren't is that I wanted a clean recommendation rather than a partial one — but that was the wrong call. Here's where we are now." lang="en-US" size="sm" />
-                    <span class="text-xs text-slate-600">Escucha el ritmo</span>
+                    <span class="text-xs text-slate-600">Listen to the cadence</span>
                   </div>
                 </div>
               </div>
@@ -182,28 +182,28 @@ import { Pause, Clock, Volume2, CheckCircle2, XCircle, Eye } from "lucide-astro"
     </div>
   </section>
 
-  <!-- Section 5: How to Install the Pause -->
+  <!-- Section 5: How to Practice the Pause -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">5</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Cómo Instalar la Pausa</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">How to Install the Pause</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">La pausa se siente profundamente antinatural al principio. Dos segundos de silencio se sienten como diez cuando eres el que está dentro de ellos. Tres patrones de práctica cierran la brecha.</p>
+        <p class="text-slate-600 mb-6 ml-11">The pause feels deeply unnatural at first. Two seconds of silence feels like ten when you're the one inside it. Three practice patterns close the gap.</p>
 
         <div class="ml-11 space-y-4">
           <div class="bg-slate-50 rounded-xl border border-slate-200 p-5">
-            <p class="font-bold text-slate-900 mb-1">Instalación de baja presión: la reacción en juntas</p>
-            <p class="text-sm text-slate-600">Por una semana, cada vez que alguien te haga una pregunta en una junta donde los stakes son bajos, cuenta "uno Mississippi, dos Mississippi" antes de responder. Preguntas aburridas, pausas aburridas. Estás reescribiendo el reflejo cuando nada está en juego.</p>
+            <p class="font-bold text-slate-900 mb-1">Low-stakes installation: the meeting reaction</p>
+            <p class="text-sm text-slate-600">For one week, every time someone asks you a question in a meeting where the stakes are low, count "one Mississippi, two Mississippi" before responding. Boring questions, boring pauses. You're rewiring the reflex when nothing is on the line.</p>
           </div>
           <div class="bg-slate-50 rounded-xl border border-slate-200 p-5">
-            <p class="font-bold text-slate-900 mb-1">Instalación de presión media: pausa escrita</p>
-            <p class="text-sm text-slate-600">En Slack / email, cuando recibas un mensaje de pushback, redacta tu respuesta y siéntate sobre ella 90 segundos antes de enviarla. La pausa escrita construye el mismo hábito diagnóstico sin la incomodidad de la sala en vivo.</p>
+            <p class="font-bold text-slate-900 mb-1">Medium-stakes installation: written pause</p>
+            <p class="text-sm text-slate-600">In Slack / email, when you get a pushback message, draft your reply, then sit on it for 90 seconds before sending. The written pause builds the same diagnostic habit without the live-room discomfort.</p>
           </div>
           <div class="bg-slate-50 rounded-xl border border-slate-200 p-5">
-            <p class="font-bold text-slate-900 mb-1">Instalación de alta presión: la respiración</p>
-            <p class="text-sm text-slate-600">Cuando sientas el calor de un pushback real, toma una respiración lenta por la nariz antes de responder. La respiración es tus dos segundos. No es visible para nadie más y le da tiempo a tu diagnóstico para activarse.</p>
+            <p class="font-bold text-slate-900 mb-1">High-stakes installation: the breath</p>
+            <p class="text-sm text-slate-600">When you feel the heat of a real pushback, take one slow breath in through your nose before you respond. The breath is your two seconds. It's visible to no one else and it gives your diagnostic time to fire.</p>
           </div>
         </div>
       </div>
@@ -214,15 +214,15 @@ import { Pause, Clock, Volume2, CheckCircle2, XCircle, Eye } from "lucide-astro"
   <section class="py-14 md:py-16 bg-slate-50 border-t border-slate-200">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
-        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">El Resumen</h2>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">The Recap</h2>
         <div class="bg-white rounded-2xl border border-slate-200 p-7">
           <ul class="space-y-3 text-slate-700">
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>La <strong>pausa de 2-3 segundos</strong> es el movimiento ejecutivo de mayor apalancamiento bajo presión.</span></li>
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Ejecuta tres preguntas silenciosas: <strong>qué impulsor, qué resultado quieren, respuesta más segura que sostiene tu posición</strong>.</span></li>
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Practica primero a baja presión. La pausa se vuelve natural solo después de aproximadamente 30 repeticiones en contextos sin presión.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>The <strong>2-3 second pause</strong> is the single highest-leverage executive move under pressure.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Run three silent questions: <strong>which driver, what outcome they want, safest response that holds your position</strong>.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Practice low-stakes first. The pause becomes effortless only after roughly 30 reps in non-pressure contexts.</span></li>
           </ul>
         </div>
       </div>
     </div>
   </section>
-</DiagnoseLessonLayout>
+</PushbackLessonLayout>

--- a/src/pages/en/course/executive-pushback/executive-calm-is-power.astro
+++ b/src/pages/en/course/executive-pushback/executive-calm-is-power.astro
@@ -1,12 +1,12 @@
 ---
 export const prerender = true;
 
-import DiagnoseLessonLayout from "@components/course/DiagnoseLessonLayout.astro";
+import PushbackLessonLayout from "@components/course/PushbackLessonLayout.astro";
 import AudioButton from "@components/course/AudioButton";
 import { Shield, Volume2, Mic, CheckCircle2, XCircle, Eye } from "lucide-astro";
 ---
 
-<DiagnoseLessonLayout lessonId={3} lang="en" tkey="course/diagnose-before-defend/executive-calm-is-power">
+<PushbackLessonLayout lessonId={3} lang="en" tkey="course/executive-pushback/executive-calm-is-power">
   <!-- Section 1: The Core Idea -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
@@ -214,4 +214,4 @@ import { Shield, Volume2, Mic, CheckCircle2, XCircle, Eye } from "lucide-astro";
       </div>
     </div>
   </section>
-</DiagnoseLessonLayout>
+</PushbackLessonLayout>

--- a/src/pages/en/course/executive-pushback/index.astro
+++ b/src/pages/en/course/executive-pushback/index.astro
@@ -4,10 +4,10 @@ export const prerender = true;
 import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
 import {
-  diagnoseInfo,
-  diagnoseLessons,
-  diagnoseBonuses,
-} from "@data/diagnose-before-defend/lessons";
+  pushbackInfo,
+  pushbackLessons,
+  pushbackBonuses,
+} from "@data/executive-pushback/lessons";
 import {
   ArrowRight,
   Sparkles,
@@ -23,8 +23,8 @@ import {
   Crown,
 } from "lucide-astro";
 
-const lang = "es";
-const tkey = "course/diagnose-before-defend" as const;
+const lang = "en";
+const tkey = "course/executive-pushback" as const;
 
 const iconMap: Record<string, any> = {
   Search,
@@ -40,8 +40,8 @@ const iconMap: Record<string, any> = {
 <Base
   lang={lang}
   tkey={tkey}
-  title="Diagnostica Antes de Defender — Master Class de Pushback"
-  description="Master class gratuita sobre cómo manejar el pushback ejecutivo. Seis lecciones + un guion de recuperación. Hecha para directores, ventas y mandos medios."
+  title="Executive Pushback & Objection Handling | NY English"
+  description="Free master class on handling executive pushback. Six lessons + one recovery script. Built for directors, sales pros, and mid-managers under pressure."
 >
   <!-- Hero -->
   <section class="relative w-full overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 pt-32 pb-20 md:pt-40 md:pb-28">
@@ -53,31 +53,31 @@ const iconMap: Record<string, any> = {
       <div class="max-w-3xl">
         <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-indigo-500/20 text-indigo-300 text-sm font-semibold mb-6">
           <Crown class="w-4 h-4" />
-          Master Class · C1 → C2 · Gratis
+          Master Class · C1 → C2 · Free
         </div>
         <h1
           class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 leading-tight"
           style="font-family: 'Noto Sans KR', sans-serif;"
         >
-          Diagnostica Antes<br />
-          <span class="text-indigo-400">de Defender.</span>
+          Executive Pushback &<br />
+          <span class="text-indigo-400">Objection Handling.</span>
         </h1>
         <p class="text-xl text-slate-200 mb-4 max-w-2xl leading-relaxed">
-          <strong class="text-white">Lee la presión. Mantén tu posición. Influye el resultado.</strong>
+          <strong class="text-white">Strategic communication for high-pressure conversations.</strong>
         </p>
         <p class="text-lg text-slate-300 mb-8 max-w-2xl leading-relaxed">
-          La mayoría del pushback no es sobre lo que la gente dice que es. El gerente de compras que pide un descuento no está discutiendo sobre el precio. El par que cuestiona tu timeline no está preocupado por la fecha. Seis lecciones que entrenan el diagnóstico — y la postura — que separa a los comunicadores ejecutivos de los defensivos.
+          Most pushback isn't about what people say it's about. The procurement manager naming a discount isn't really arguing about price. The peer challenging your timeline isn't really worried about the date. Six lessons that train the diagnostic — and the posture — that separates executive communicators from defensive ones.
         </p>
         <div class="flex flex-wrap gap-4">
-          <Button href={`${diagnoseInfo.basePath.es}/${diagnoseLessons[0].slugEs}/`} variant="primary" size="lg">
-            Empieza con la Lección 1
+          <Button href={`${pushbackInfo.basePath.en}/${pushbackLessons[0].slug}/`} variant="primary" size="lg">
+            Start with Lesson 1
             <ArrowRight class="w-5 h-5 ml-1" />
           </Button>
           <a
-            href="#lecciones"
+            href="#lessons"
             class="inline-flex items-center gap-2 px-6 py-3 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
           >
-            Ver las 6 lecciones
+            See all 6 lessons
           </a>
         </div>
       </div>
@@ -88,12 +88,12 @@ const iconMap: Record<string, any> = {
   <section class="py-16 md:py-20 bg-white border-b border-slate-100">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto text-center">
-        <p class="text-[11px] font-mono uppercase tracking-[0.3em] text-indigo-600 mb-4">La Tesis</p>
+        <p class="text-[11px] font-mono uppercase tracking-[0.3em] text-indigo-600 mb-4">The Thesis</p>
         <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
-          La gente cuestiona la confianza antes de cuestionar la lógica.
+          People challenge confidence before they challenge logic.
         </h2>
         <p class="text-lg text-slate-600 leading-relaxed">
-          Cuando alguien te da pushback sobre tu decisión, tu timeline, tu precio o tu plan, casi nunca lo hace por la razón que nombra. Está probando tu compostura. Sondeando tu confianza. Protegiendo su ego. Sacando una preocupación de carga de trabajo que no puede decir en voz alta. El comunicador que lee el impulsor real antes de responder gana la sala. El que defiende la razón declarada la pierde.
+          When someone pushes back on your decision, your timeline, your price, or your plan, they are almost never doing it for the reason they name. They're testing composure. Probing trust. Protecting ego. Surfacing a workload concern they can't say out loud. The communicator who reads the real driver before responding wins the room. The one who defends the stated reason loses it.
         </p>
       </div>
     </div>
@@ -104,9 +104,9 @@ const iconMap: Record<string, any> = {
     <div class="site-container mx-auto px-4">
       <div class="max-w-4xl mx-auto">
         <div class="text-center mb-12">
-          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">Los Dos Modos por Defecto</h2>
+          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">The Two Defaults</h2>
           <p class="text-lg text-slate-600 max-w-2xl mx-auto">
-            Bajo presión, todo profesional cae en uno de estos dos patrones. La diferencia entre ellos es casi invisible — hasta que la sala se mueve.
+            Under pressure, every professional defaults to one of these two patterns. The difference between them is mostly invisible — until the room shifts.
           </p>
         </div>
 
@@ -115,12 +115,12 @@ const iconMap: Record<string, any> = {
             <div class="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-red-100 text-red-600 mb-4">
               <Brain class="w-6 h-6" />
             </div>
-            <h3 class="text-xl font-bold text-slate-900 mb-3">El Patrón Reactivo</h3>
+            <h3 class="text-xl font-bold text-slate-900 mb-3">The Reactive Pattern</h3>
             <ul class="space-y-2 text-slate-700">
-              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Defiende la razón declarada</li>
-              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Sobreexplica bajo presión</li>
-              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Iguala el ritmo emocional del retador</li>
-              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Suena inseguro, incluso cuando tiene razón</li>
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Defends the stated reason</li>
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Overexplains under pressure</li>
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Matches emotional pace of the challenger</li>
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Sounds uncertain, even when correct</li>
             </ul>
           </div>
 
@@ -128,12 +128,12 @@ const iconMap: Record<string, any> = {
             <div class="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-indigo-100 text-indigo-700 mb-4">
               <Target class="w-6 h-6" />
             </div>
-            <h3 class="text-xl font-bold text-slate-900 mb-3">El Patrón Estratégico</h3>
+            <h3 class="text-xl font-bold text-slate-900 mb-3">The Strategic Pattern</h3>
             <ul class="space-y-2 text-slate-700">
-              <li class="flex gap-2"><span class="text-indigo-600 shrink-0">✓</span> Lee el impulsor real debajo de la pregunta</li>
-              <li class="flex gap-2"><span class="text-indigo-600 shrink-0">✓</span> Hace una pausa antes de responder</li>
-              <li class="flex gap-2"><span class="text-indigo-600 shrink-0">✓</span> Baja el ritmo de la conversación</li>
-              <li class="flex gap-2"><span class="text-indigo-600 shrink-0">✓</span> Aterriza la respuesta con certeza calibrada</li>
+              <li class="flex gap-2"><span class="text-indigo-600 shrink-0">✓</span> Reads the real driver under the question</li>
+              <li class="flex gap-2"><span class="text-indigo-600 shrink-0">✓</span> Pauses before responding</li>
+              <li class="flex gap-2"><span class="text-indigo-600 shrink-0">✓</span> Slows the conversation down</li>
+              <li class="flex gap-2"><span class="text-indigo-600 shrink-0">✓</span> Lands the response with measured certainty</li>
             </ul>
           </div>
         </div>
@@ -145,36 +145,36 @@ const iconMap: Record<string, any> = {
   <section class="py-16 md:py-20 bg-white">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
-        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6">Para Quién Es Esto</h2>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6">Who This Is For</h2>
         <p class="text-lg text-slate-600 leading-relaxed mb-6">
-          Esta master class es para los profesionales que dan pushback y reciben pushback diariamente — directores, líderes de operaciones, profesionales de ventas, gerentes de compras, gerentes técnicos, líderes de customer success y mandos medios que se comunican hacia arriba con liderazgo senior.
+          This master class is for the professionals who give pushback and get pushed back on, daily — directors, ops leaders, sales professionals, procurement managers, technical managers, customer success leads, and mid-level managers communicating upward into senior leadership.
         </p>
         <p class="text-slate-600 leading-relaxed mb-6">
-          Si tu inglés de negocios ya es fluido pero notas el patrón bajo presión — el medio segundo demasiado rápido, el medio paso demasiado defensivo, la oración extra que te cuesta la sala — este curso aborda exactamente esa brecha. Se combina naturalmente con el curso Ejecutivo (marcos) y Dirige la Decisión (escenarios de junta directiva). Donde esos enseñan qué decir, este enseña qué leer y cómo sostenerte antes de hablar.
+          If your business English is already fluent but you notice the pattern under pressure — the half-second too fast, the half-step too defensive, the extra sentence that costs you the room — this course addresses the exact gap. It pairs naturally with the Executive course (frameworks) and Drive the Decision (boardroom scenarios). Where those teach what to say, this one teaches what to read and how to hold yourself before you say it.
         </p>
       </div>
     </div>
   </section>
 
   <!-- Lessons grid -->
-  <section class="py-16 md:py-20 bg-slate-50" id="lecciones">
+  <section class="py-16 md:py-20 bg-slate-50" id="lessons">
     <div class="site-container mx-auto px-4">
       <div class="text-center max-w-2xl mx-auto mb-12">
         <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4" style="font-family: 'Noto Sans KR', sans-serif;">
-          Seis Lecciones. Un Hábito.
+          Six Lessons. One Habit.
         </h2>
         <p class="text-slate-600 leading-relaxed">
-          Diagnóstico, luego postura, luego marco, luego aplicación. Cada lección dura de 20 a 30 minutos y construye el mismo instinto desde un ángulo distinto.
+          Diagnostic, then posture, then framework, then application. Each lesson runs about 20-30 minutes and builds the same instinct from a different angle.
         </p>
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
-        {diagnoseLessons.map((lesson) => {
+        {pushbackLessons.map((lesson) => {
           const Icon = iconMap[lesson.icon];
           const isAvailable = lesson.available;
           return (
             <a
-              href={isAvailable ? `${diagnoseInfo.basePath.es}/${lesson.slugEs}/` : undefined}
+              href={isAvailable ? `${pushbackInfo.basePath.en}/${lesson.slug}/` : undefined}
               class:list={[
                 "group flex items-start gap-4 p-5 rounded-xl border transition-all duration-200",
                 isAvailable
@@ -193,14 +193,14 @@ const iconMap: Record<string, any> = {
               <div class="flex-1">
                 <div class="flex items-center gap-2">
                   <span class="text-xs font-bold uppercase tracking-wider text-indigo-700">
-                    Lección {lesson.id}
+                    Lesson {lesson.id}
                   </span>
                 </div>
                 <h3 class="text-lg font-bold mt-0.5 text-slate-900">
-                  {lesson.titleEs}
+                  {lesson.title}
                 </h3>
-                <p class="text-sm text-slate-600 mt-1">{lesson.subtitleEs}</p>
-                <p class="text-xs text-indigo-700 mt-1.5 italic">{lesson.angleEs}</p>
+                <p class="text-sm text-slate-600 mt-1">{lesson.subtitle}</p>
+                <p class="text-xs text-indigo-700 mt-1.5 italic">{lesson.angle}</p>
               </div>
             </a>
           );
@@ -216,19 +216,19 @@ const iconMap: Record<string, any> = {
         <div class="text-center mb-12">
           <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-indigo-100 text-indigo-800 text-sm font-semibold mb-4">
             <Sparkles class="w-4 h-4" />
-            Recurso Bonus
+            Bonus Resource
           </div>
-          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">Cuando Ya Perdiste la Compostura</h2>
+          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">When You've Already Lost Composure</h2>
           <p class="text-lg text-slate-600 max-w-2xl mx-auto">
-            El pushback te gana a veces. Alzas la voz, defiendes demasiado o te congelas. Este bonus es el reset de tres oraciones que recupera la sala sin una disculpa.
+            Pushback wins sometimes. You raise your voice, defend too hard, or freeze. This bonus is the three-sentence reset that recovers the room without an apology.
           </p>
         </div>
 
-        {diagnoseBonuses.map((bonus) => {
+        {pushbackBonuses.map((bonus) => {
           const Icon = iconMap[bonus.icon] ?? RefreshCw;
           return (
             <a
-              href={`${diagnoseInfo.basePath.es}/${bonus.slugEs}/`}
+              href={`${pushbackInfo.basePath.en}/${bonus.slug}/`}
               class="block bg-gradient-to-br from-slate-900 via-slate-800 to-indigo-900 rounded-2xl p-8 text-white hover:shadow-xl transition-shadow duration-200"
             >
               <div class="flex items-start gap-5">
@@ -236,10 +236,10 @@ const iconMap: Record<string, any> = {
                   <Icon class="w-7 h-7" />
                 </div>
                 <div class="flex-1">
-                  <h3 class="text-2xl font-bold mb-2">{bonus.titleEs}</h3>
-                  <p class="text-slate-300 leading-relaxed mb-4">{bonus.descriptionEs}</p>
+                  <h3 class="text-2xl font-bold mb-2">{bonus.title}</h3>
+                  <p class="text-slate-300 leading-relaxed mb-4">{bonus.description}</p>
                   <span class="inline-flex items-center gap-1 text-indigo-300 font-semibold text-sm group-hover:gap-2 transition-all">
-                    Abrir el guion de recuperación
+                    Open the recovery script
                     <ArrowRight class="w-4 h-4" />
                   </span>
                 </div>
@@ -255,37 +255,37 @@ const iconMap: Record<string, any> = {
   <section class="py-16 md:py-20 bg-slate-50 border-t border-slate-100">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto text-center">
-        <h2 class="text-2xl font-bold text-slate-900 mb-4">¿Dónde Encaja Esto?</h2>
+        <h2 class="text-2xl font-bold text-slate-900 mb-4">Where Does This Fit?</h2>
         <p class="text-lg text-slate-600 leading-relaxed mb-6">
-          Esta es la <strong>master class diagnóstica</strong> — lo que lees antes de responder. Para el sistema ejecutivo completo (marcos, eliminación de atenuación, respuestas estructuradas, patrones con nombre), revisa <strong>Comunica Como un Líder</strong>. Para escenarios aplicados a nivel junta directiva — pushback de inversionistas, trimestres perdidos, tratos de $2M que rechazas — revisa <strong>Dirige la Decisión</strong>. Para coaching 1-a-1, el enlace de reservación está abajo.
+          This is the <strong>pushback &amp; objection-handling master class</strong> — what you read and how you respond when the room turns on your decision. For the full executive system (frameworks, hedging elimination, structured responses, named patterns), see <strong>Communicate Like a Leader</strong>. For boardroom-level applied scenarios — investor pushback, missed quarters, $2M deals you have to decline — see <strong>Drive the Decision</strong>. For 1-on-1 coaching, the booking link is below.
         </p>
         <div class="flex flex-wrap gap-3 justify-center">
           <a
-            href="/es/curso/ejecutivo/"
+            href="/en/course/executive/"
             class="text-indigo-700 hover:text-indigo-800 font-medium underline underline-offset-2"
           >
-            Curso Ejecutivo
+            Executive course
           </a>
           <span class="text-slate-300">|</span>
           <a
-            href="/es/curso/dirige-la-decision/"
+            href="/en/course/drive-the-decision/"
             class="text-indigo-700 hover:text-indigo-800 font-medium underline underline-offset-2"
           >
-            Dirige la Decisión
+            Drive the Decision
           </a>
           <span class="text-slate-300">|</span>
           <a
-            href="/es/cursos/"
+            href="/en/courses/"
             class="text-indigo-700 hover:text-indigo-800 font-medium underline underline-offset-2"
           >
-            Ver todos los cursos
+            See all courses
           </a>
           <span class="text-slate-300">|</span>
           <a
-            href="/es/reservar/"
+            href="/en/book/"
             class="text-indigo-700 hover:text-indigo-800 font-medium underline underline-offset-2"
           >
-            Trabajar 1-a-1 con Robert
+            Work 1-on-1 with Robert
           </a>
         </div>
       </div>
@@ -295,17 +295,17 @@ const iconMap: Record<string, any> = {
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@type": "Course",
-    "name": "Diagnostica Antes de Defender — Master Class de Pushback",
-    "description": "Master class gratuita sobre cómo manejar el pushback ejecutivo. Seis lecciones + un guion de recuperación bajo presión. Hecha para directores, profesionales de ventas, gerentes de compras y mandos medios.",
+    "name": "Executive Pushback & Objection Handling — Pushback Master Class",
+    "description": "Free master class on handling executive pushback. Six lessons + one pressure-recovery script. Built for directors, sales professionals, procurement managers, and mid-level leaders communicating upward.",
     "provider": { "@type": "Organization", "name": "New York English Teacher", "url": "https://www.nyenglishteacher.com/" },
     "educationalLevel": "Executive (C1-C2)",
-    "inLanguage": "es",
-    "url": "https://www.nyenglishteacher.com/es/curso/diagnostica-antes-de-defender/",
+    "inLanguage": "en",
+    "url": "https://www.nyenglishteacher.com/en/course/executive-pushback/",
     "isAccessibleForFree": true,
     "hasCourseInstance": {
       "@type": "CourseInstance",
       "courseMode": "online",
-      "inLanguage": "es"
+      "inLanguage": "en"
     }
   })} />
 </Base>

--- a/src/pages/en/course/executive-pushback/pressure-recovery-script.astro
+++ b/src/pages/en/course/executive-pushback/pressure-recovery-script.astro
@@ -3,7 +3,7 @@ export const prerender = true;
 
 import Base from "@layouts/Base.astro";
 import AudioButton from "@components/course/AudioButton";
-import { diagnoseInfo } from "@data/diagnose-before-defend/lessons";
+import { pushbackInfo } from "@data/executive-pushback/lessons";
 import {
   ArrowLeft,
   ArrowRight,
@@ -14,15 +14,15 @@ import {
   Eye,
 } from "lucide-astro";
 
-const lang = "es";
-const tkey = "course/diagnose-before-defend/pressure-recovery-script" as const;
+const lang = "en";
+const tkey = "course/executive-pushback/pressure-recovery-script" as const;
 ---
 
 <Base
   lang={lang}
   tkey={tkey}
-  title="El Guion de Recuperación bajo Presión — Diagnostica Antes de Defender"
-  description="Cuando ya perdiste la compostura a mitad de la conversación, tres oraciones que te compran espacio, reinician la sala y recuperan autoridad sin disculpa."
+  title="The Pressure Recovery Script | NY English"
+  description="When you've already lost composure mid-conversation, three sentences that buy you space, restart the room, and recover authority without an apology."
 >
   <!-- Hero -->
   <section class="bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 pt-28 pb-16 md:pt-36 md:pb-20">
@@ -30,46 +30,46 @@ const tkey = "course/diagnose-before-defend/pressure-recovery-script" as const;
       <div class="max-w-3xl">
         <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-indigo-500/20 text-indigo-300 text-sm font-semibold mb-6">
           <Sparkles class="w-4 h-4" />
-          Bonus · El Reset
+          Bonus · The Reset
         </div>
         <h1
           class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
           style="font-family: 'Noto Sans KR', sans-serif;"
         >
-          El Guion de Recuperación bajo Presión
+          The Pressure Recovery Script
         </h1>
         <p class="text-xl text-indigo-200 italic font-light mb-4">
-          Cuando ya perdiste la compostura a mitad de la conversación.
+          When you've already lost composure mid-conversation.
         </p>
         <p class="text-lg text-slate-300 leading-relaxed">
-          A veces pierdes la sala. Alzas la voz, cedes muy rápido, defiendes muy fuerte o te congelas. La pausa no pasó. El diagnóstico no se activó. Este es el reset de tres oraciones que regresa la sala — sin una disculpa y sin re-explicación.
+          Sometimes you lose the room. You raise your voice, you concede too fast, you defend too hard, you freeze. The pause didn't happen. The diagnostic didn't fire. This is the three-sentence reset that brings the room back — without an apology and without a re-explanation.
         </p>
       </div>
     </div>
   </section>
 
-  <!-- Premise -->
+  <!-- The premise -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-2">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">1</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">La Recuperación es un Movimiento, No una Disculpa</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Recovery Is a Move, Not an Apology</h2>
         </div>
         <div class="ml-11 space-y-5 text-lg text-slate-700 leading-relaxed">
           <p>
-            El instinto cuando perdiste la compostura es <strong>disculparte y reiniciar</strong>. "Sorry, let me back up." "I'm getting ahead of myself." "I think I came in too hot." Todas se sienten honestas. Todas te dañan más.
+            The instinct when you've lost composure is to <strong>apologize and restart</strong>. "Sorry, let me back up." "I'm getting ahead of myself." "I think I came in too hot." These all feel honest. They all damage you further.
           </p>
           <p>
-            Disculparte dentro de un momento de presión señala que perdiste la sala, lo cual la sala puede no haber registrado todavía. Estás transmitiendo tu fracaso antes de que ellos lo notaran. El guion de recuperación hace lo opuesto: reinicia la conversación como si el resbalón fuera un tiempo deliberado, no una fuga.
+            Apologizing inside a pressure moment signals that you've lost the room, which the room may not have fully registered yet. You're broadcasting your failure before they noticed. The recovery script does the opposite: it resets the conversation as if the slip was a deliberate beat, not a leak.
           </p>
           <div class="rounded-2xl border-2 border-indigo-300 bg-indigo-50 p-6 my-6">
             <div class="flex items-center gap-3 mb-3">
               <Eye class="w-6 h-6 text-indigo-700" />
-              <h3 class="text-lg font-bold text-slate-900">El Principio</h3>
+              <h3 class="text-lg font-bold text-slate-900">The Principle</h3>
             </div>
             <p class="text-slate-800">
-              La recuperación es estructural, no emocional. Tres oraciones. Sin disculpa. Sin re-explicación. No estás deshaciendo el resbalón — estás caminando frente a él.
+              Recovery is structural, not emotional. Three sentences. No apology. No re-explanation. You're not undoing the slip — you're walking past it.
             </p>
           </div>
         </div>
@@ -83,35 +83,35 @@ const tkey = "course/diagnose-before-defend/pressure-recovery-script" as const;
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">2</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">El Reset de Tres Oraciones</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Three-Sentence Reset</h2>
         </div>
 
         <div class="ml-11 space-y-4">
           <div class="bg-white rounded-xl border border-indigo-300 p-6">
-            <p class="text-xs font-bold uppercase tracking-wider text-indigo-700 mb-2">Oración 1 — Detente</p>
+            <p class="text-xs font-bold uppercase tracking-wider text-indigo-700 mb-2">Sentence 1 — Stop yourself</p>
             <div class="flex items-center gap-3">
               <p class="text-xl text-slate-900 italic flex-1">"Let me take that one carefully."</p>
               <AudioButton client:visible text="Let me take that one carefully." lang="en-US" size="md" />
             </div>
-            <p class="text-sm text-slate-600 mt-3">Cinco palabras. Te detiene, detiene a la sala, te da 3-5 segundos de permiso estructural para pensar. Casi imposible de interrumpir.</p>
+            <p class="text-sm text-slate-600 mt-3">Five words. Slows you, slows the room, gives you 3-5 seconds of structural permission to think. Nearly impossible to interrupt.</p>
           </div>
 
           <div class="bg-white rounded-xl border border-indigo-300 p-6">
-            <p class="text-xs font-bold uppercase tracking-wider text-indigo-700 mb-2">Oración 2 — Reformula la pregunta, no tu respuesta</p>
+            <p class="text-xs font-bold uppercase tracking-wider text-indigo-700 mb-2">Sentence 2 — Restate the question, not your answer</p>
             <div class="flex items-center gap-3">
               <p class="text-xl text-slate-900 italic flex-1">"The real question you're asking is whether [X] or [Y]."</p>
               <AudioButton client:visible text="The real question you're asking is whether X or Y." lang="en-US" size="md" />
             </div>
-            <p class="text-sm text-slate-600 mt-3">Reencuadra todo el intercambio. Te obliga a diagnosticar el impulsor en lugar de defender. Los obliga a confirmar o refinar la pregunta — lo cual te compra otro tiempo.</p>
+            <p class="text-sm text-slate-600 mt-3">Reframes the entire exchange. Forces you to diagnose the driver instead of defending. Forces them to confirm or refine the question — which buys you another beat.</p>
           </div>
 
           <div class="bg-white rounded-xl border border-indigo-300 p-6">
-            <p class="text-xs font-bold uppercase tracking-wider text-indigo-700 mb-2">Oración 3 — Entrega una posición limpia</p>
+            <p class="text-xs font-bold uppercase tracking-wider text-indigo-700 mb-2">Sentence 3 — Deliver one clean position</p>
             <div class="flex items-center gap-3">
               <p class="text-xl text-slate-900 italic flex-1">"Here's the call I'd make, and here's why."</p>
               <AudioButton client:visible text="Here's the call I'd make, and here's why." lang="en-US" size="md" />
             </div>
-            <p class="text-sm text-slate-600 mt-3">Recupera autoridad. Pasa el resbalón. La sala ahora está escuchando la posición, no analizando la fuga. Mantén lo que sigue en menos de dos oraciones.</p>
+            <p class="text-sm text-slate-600 mt-3">Reclaims authority. Past the slip. The room is now listening to the position, not analyzing the leak. Keep what follows under two sentences.</p>
           </div>
         </div>
       </div>
@@ -124,13 +124,13 @@ const tkey = "course/diagnose-before-defend/pressure-recovery-script" as const;
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">3</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">El Guion en la Práctica</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Script in Practice</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">Un intercambio realista. Ya defendiste demasiado fuerte por dos oraciones. Aquí está la recuperación, completa.</p>
+        <p class="text-slate-600 mb-6 ml-11">A realistic exchange. You've already defended too hard for two sentences. Here's the recovery, in full.</p>
 
         <div class="ml-11 bg-slate-50 rounded-xl border border-slate-200 overflow-hidden">
           <div class="bg-slate-900 text-white px-5 py-3">
-            <p class="text-xs font-bold uppercase tracking-wider text-indigo-400">Junta directiva · El CFO cuestiona tu forecast</p>
+            <p class="text-xs font-bold uppercase tracking-wider text-indigo-400">Board meeting · CFO challenges your forecast</p>
           </div>
           <div class="p-6 space-y-4">
             <div class="bg-slate-100 rounded-lg p-4">
@@ -139,19 +139,19 @@ const tkey = "course/diagnose-before-defend/pressure-recovery-script" as const;
             </div>
 
             <div class="bg-red-50 border border-red-200 rounded-lg p-4">
-              <p class="text-xs font-bold uppercase tracking-wider text-red-700 mb-1">Tú — recalentándose</p>
+              <p class="text-xs font-bold uppercase tracking-wider text-red-700 mb-1">You — overheating</p>
               <p class="text-slate-800 italic">"It's absolutely grounded. We spent three weeks on the pipeline review, the team is confident in the close rates, and the conversion data from Q1 supports the model. I'd push back on the suggestion that we're being aggressive — this is calibrated…"</p>
             </div>
 
             <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-4">
-              <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-2">Tú — guion de recuperación (tres oraciones)</p>
+              <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-2">You — recovery script (three sentences)</p>
               <div class="flex items-start gap-3">
                 <p class="text-slate-900 font-medium flex-1 leading-relaxed">"Let me take that one carefully. The real question you're asking is whether the forecast survives a 40-day cycle extension or breaks. Here's the call I'd make: stress-test the model against that assumption tonight and bring you the answer tomorrow morning before the board reconvenes."</p>
                 <AudioButton client:visible text="Let me take that one carefully. The real question you're asking is whether the forecast survives a 40-day cycle extension or breaks. Here's the call I'd make: stress-test the model against that assumption tonight and bring you the answer tomorrow morning before the board reconvenes." lang="en-US" size="sm" />
               </div>
             </div>
 
-            <p class="text-sm text-slate-500"><strong>Qué cambió:</strong> Sin "but" ni "actually". La defensividad se fue. La pregunta se reencuadra limpiamente. Terminaste en acción, no en justificación.</p>
+            <p class="text-sm text-slate-500"><strong>What changed:</strong> No "but" or "actually." The defensiveness is gone. The question is reframed cleanly. You ended on action, not justification.</p>
           </div>
         </div>
       </div>
@@ -164,24 +164,24 @@ const tkey = "course/diagnose-before-defend/pressure-recovery-script" as const;
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">4</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Reglas para Adaptar el Guion</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Rules for Adapting the Script</h2>
         </div>
         <div class="ml-11 space-y-3">
           <div class="bg-white rounded-lg border border-slate-200 p-4 flex items-start gap-3">
             <AlertCircle class="w-5 h-5 text-indigo-600 shrink-0 mt-0.5" />
-            <p class="text-slate-700"><strong>Memoriza el fraseo exacto.</strong> Cuando estás recalentándote, la memoria de trabajo se reduce. No podrás componer una oración de recuperación personalizada. Necesitas el guion listo.</p>
+            <p class="text-slate-700"><strong>Memorize the exact phrasing.</strong> When you're overheating, working memory shrinks. You won't be able to compose a custom recovery sentence. You need the script ready.</p>
           </div>
           <div class="bg-white rounded-lg border border-slate-200 p-4 flex items-start gap-3">
             <AlertCircle class="w-5 h-5 text-indigo-600 shrink-0 mt-0.5" />
-            <p class="text-slate-700"><strong>Baja el volumen en la Oración 1.</strong> Una voz más baja señala una desaceleración deliberada, no retroceso. La mayoría de la gente instintivamente sube el volumen al reafirmarse — resiste.</p>
+            <p class="text-slate-700"><strong>Drop the volume in Sentence 1.</strong> A quieter voice signals deliberate slowing, not retreat. Most people instinctively raise volume when reasserting — resist.</p>
           </div>
           <div class="bg-white rounded-lg border border-slate-200 p-4 flex items-start gap-3">
             <AlertCircle class="w-5 h-5 text-indigo-600 shrink-0 mt-0.5" />
-            <p class="text-slate-700"><strong>Nunca te disculpes entre las oraciones.</strong> Incluso pequeños rellenos ("sorry, just…") cancelan el reset. Tres oraciones limpias, sin calificadores.</p>
+            <p class="text-slate-700"><strong>Never apologize between the sentences.</strong> Even small filler ("sorry, just…") cancels the reset. Three clean sentences, no qualifiers.</p>
           </div>
           <div class="bg-white rounded-lg border border-slate-200 p-4 flex items-start gap-3">
             <AlertCircle class="w-5 h-5 text-indigo-600 shrink-0 mt-0.5" />
-            <p class="text-slate-700"><strong>Úsalo una vez por conversación, máximo.</strong> Usar el guion dos veces en un intercambio señala que no estás recuperándote — solo estás administrando fuga tras fuga.</p>
+            <p class="text-slate-700"><strong>Use it once per conversation, maximum.</strong> Using the script twice in one exchange signals you're not actually recovering — you're just managing leak after leak.</p>
           </div>
         </div>
       </div>
@@ -192,34 +192,34 @@ const tkey = "course/diagnose-before-defend/pressure-recovery-script" as const;
   <section class="py-14 md:py-16 bg-white border-t border-slate-200">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
-        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">El Resumen</h2>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">The Recap</h2>
         <div class="bg-slate-50 rounded-2xl border border-slate-200 p-7 mb-10">
           <ul class="space-y-3 text-slate-700">
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>La recuperación es <strong>estructural, no emocional</strong>. Sin disculpa, sin re-explicación.</span></li>
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Tres oraciones, memorizadas exactamente: <strong>"Let me take that one carefully" → "The real question is X or Y" → "Here's the call I'd make."</strong></span></li>
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Una vez por conversación</strong>. El guion es un reset, no una muleta.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Recovery is <strong>structural, not emotional</strong>. No apology, no re-explanation.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Three sentences, memorized exactly: <strong>"Let me take that one carefully" → "The real question is X or Y" → "Here's the call I'd make."</strong></span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Once per conversation</strong>. The script is a reset, not a crutch.</span></li>
           </ul>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <a
-            href={`${diagnoseInfo.basePath.es}/malas-noticias-voz-firme/`}
+            href={`${pushbackInfo.basePath.en}/bad-news-steady-voice/`}
             class="group flex items-center gap-3 bg-slate-50 rounded-xl border border-slate-200 hover:border-indigo-300 hover:shadow-md transition-all p-5"
           >
             <ArrowLeft class="w-5 h-5 text-slate-400 group-hover:text-indigo-600 transition-colors shrink-0" />
             <div>
-              <p class="text-xs font-bold uppercase tracking-wider text-slate-500 mb-0.5">Última lección</p>
-              <p class="text-slate-900 font-medium">Malas Noticias, Voz Firme</p>
+              <p class="text-xs font-bold uppercase tracking-wider text-slate-500 mb-0.5">Last lesson</p>
+              <p class="text-slate-900 font-medium">Bad News, Steady Voice</p>
             </div>
           </a>
 
           <a
-            href={`${diagnoseInfo.basePath.es}/`}
+            href={`${pushbackInfo.basePath.en}/`}
             class="group flex items-center justify-between gap-3 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl transition-all p-5"
           >
             <div>
-              <p class="text-xs font-bold uppercase tracking-wider text-indigo-100 mb-0.5">Resumen del curso</p>
-              <p class="font-medium">Diagnostica Antes de Defender</p>
+              <p class="text-xs font-bold uppercase tracking-wider text-indigo-100 mb-0.5">Course overview</p>
+              <p class="font-medium">Executive Pushback & Objection Handling</p>
             </div>
             <ArrowRight class="w-5 h-5 shrink-0" />
           </a>

--- a/src/pages/en/course/executive-pushback/six-hidden-drivers.astro
+++ b/src/pages/en/course/executive-pushback/six-hidden-drivers.astro
@@ -1,12 +1,12 @@
 ---
 export const prerender = true;
 
-import DiagnoseLessonLayout from "@components/course/DiagnoseLessonLayout.astro";
+import PushbackLessonLayout from "@components/course/PushbackLessonLayout.astro";
 import AudioButton from "@components/course/AudioButton";
 import { Search, AlertCircle, CheckCircle2, XCircle, Eye } from "lucide-astro";
 ---
 
-<DiagnoseLessonLayout lessonId={1} lang="en" tkey="course/diagnose-before-defend/six-hidden-drivers">
+<PushbackLessonLayout lessonId={1} lang="en" tkey="course/executive-pushback/six-hidden-drivers">
   <!-- Section 1: The Core Idea -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
@@ -247,4 +247,4 @@ import { Search, AlertCircle, CheckCircle2, XCircle, Eye } from "lucide-astro";
       </div>
     </div>
   </section>
-</DiagnoseLessonLayout>
+</PushbackLessonLayout>

--- a/src/pages/en/courses/index.astro
+++ b/src/pages/en/courses/index.astro
@@ -9,7 +9,7 @@ import { intermediateInfo, intermediateUnits } from "@data/intermediate/units";
 import { advancedInfo, advancedUnits } from "@data/advanced/units";
 import { executiveInfo, executiveUnits } from "@data/executive/units";
 import { driveInfo, scenarioMeta } from "@data/drive-the-decision/scenarios";
-import { diagnoseInfo, diagnoseLessons } from "@data/diagnose-before-defend/lessons";
+import { pushbackInfo, pushbackLessons } from "@data/executive-pushback/lessons";
 import {
   Sparkles,
   BookOpen,
@@ -33,7 +33,7 @@ const intermediateAvailable = intermediateUnits.length;
 const advancedAvailable = advancedUnits.length;
 const executiveAvailable = executiveUnits.filter((u) => u.published).length;
 const driveScenariosAvailable = scenarioMeta.filter((s) => s.available).length;
-const diagnoseLessonsAvailable = diagnoseLessons.filter((l) => l.available).length;
+const pushbackLessonsAvailable = pushbackLessons.filter((l) => l.available).length;
 ---
 
 <Base
@@ -60,8 +60,9 @@ const diagnoseLessonsAvailable = diagnoseLessons.filter((l) => l.available).leng
           Eight free, interactive courses built for Spanish speakers — five
           leveled tracks from A1 beginner through C2 executive, plus three
           focused master classes: past tenses, executive decision
-          communication, and pushback diagnostics. No sign-up. No paywall.
-          No textbook drudgery. Just real progress from the first lesson.
+          communication, and executive pushback handling. No sign-up. No
+          paywall. No textbook drudgery. Just real progress from the first
+          lesson.
         </p>
       </div>
     </div>
@@ -416,26 +417,26 @@ const diagnoseLessonsAvailable = diagnoseLessons.filter((l) => l.available).leng
           </div>
         </a>
 
-        <!-- Master Class — Diagnose Before You Defend -->
+        <!-- Master Class — Executive Pushback & Objection Handling -->
         <a
-          href="/en/course/diagnose-before-defend/"
+          href="/en/course/executive-pushback/"
           class="group block bg-white rounded-2xl border-2 border-indigo-400/40 overflow-hidden hover:shadow-xl hover:border-indigo-400 transition-all duration-200"
         >
           <div class="bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-900 p-6 text-white min-h-[180px] flex flex-col justify-end">
             <div class="flex items-center gap-2 text-indigo-300 text-xs font-bold uppercase tracking-wider mb-2">
               <Search class="w-3.5 h-3.5" />
-              Master Class — C1 to C2 Pushback
+              Master Class — C1 to C2 Executive
             </div>
             <h2 class="text-2xl md:text-3xl font-bold mb-2" style="font-family: 'Noto Sans KR', sans-serif;">
-              {diagnoseInfo.title}
+              {pushbackInfo.title}
             </h2>
             <p class="text-indigo-100 text-sm leading-relaxed">
-              {diagnoseInfo.shortTagline}
+              {pushbackInfo.shortTagline}
             </p>
           </div>
           <div class="p-6">
             <p class="text-slate-600 text-sm leading-relaxed mb-4">
-              The diagnostic master class for directors, sales pros, and mid-managers handling pushback under pressure. Read the real driver under the stated objection, hold composure while you do it, and respond with structure instead of defensiveness.
+              The pushback-handling master class for directors, sales pros, and mid-managers under executive pressure. Read the real driver under the stated objection, hold composure while you do it, and respond with structure instead of defensiveness.
             </p>
             <ul class="space-y-2 mb-6">
               <li class="flex items-start gap-2 text-sm text-slate-700">
@@ -453,7 +454,7 @@ const diagnoseLessonsAvailable = diagnoseLessons.filter((l) => l.available).leng
             </ul>
             <div class="flex items-center justify-between">
               <span class="text-xs font-semibold text-indigo-700 uppercase tracking-wider">
-                {diagnoseLessonsAvailable} lessons + bonus
+                {pushbackLessonsAvailable} lessons + bonus
               </span>
               <span class="inline-flex items-center gap-1 text-indigo-700 font-semibold text-sm group-hover:gap-2 transition-all">
                 Start master class
@@ -468,7 +469,7 @@ const diagnoseLessonsAvailable = diagnoseLessons.filter((l) => l.available).leng
       <div class="max-w-3xl mx-auto mt-16 text-center">
         <h3 class="text-2xl font-bold text-slate-900 mb-3">Not sure which one to start?</h3>
         <p class="text-slate-600 mb-6">
-          If English still feels brand new, start with the <strong>beginner</strong> course. If you've finished the basics but can't yet talk about yesterday or make plans, take <strong>elementary</strong>. If you can already hold a conversation, jump to <strong>intermediate</strong>. If your English is fluent but not polished, go to <strong>advanced</strong>. If you're a senior leader who wants to <em>lead</em> in English, go straight to <strong>executive</strong> — and pair it with <strong>Drive the Decision</strong> for applied boardroom scenarios. If you're a director or sales pro who freezes under pushback, the <strong>Diagnose Before You Defend</strong> master class is the diagnostic layer the others assume. If past tenses are your specific freeze point, the <strong>past tenses master class</strong> fits beside any of them. Your progress is saved separately for each course.
+          If English still feels brand new, start with the <strong>beginner</strong> course. If you've finished the basics but can't yet talk about yesterday or make plans, take <strong>elementary</strong>. If you can already hold a conversation, jump to <strong>intermediate</strong>. If your English is fluent but not polished, go to <strong>advanced</strong>. If you're a senior leader who wants to <em>lead</em> in English, go straight to <strong>executive</strong> — and pair it with <strong>Drive the Decision</strong> for applied boardroom scenarios. If you're a director or sales pro who freezes under pushback, the <strong>Executive Pushback & Objection Handling</strong> master class is the diagnostic layer the others assume. If past tenses are your specific freeze point, the <strong>past tenses master class</strong> fits beside any of them. Your progress is saved separately for each course.
         </p>
         <Button href="/en/services/" variant="secondary" size="md">
           Or work 1-on-1 with Robert
@@ -553,8 +554,8 @@ const diagnoseLessonsAvailable = diagnoseLessons.filter((l) => l.available).leng
       "position": 8,
       "item": {
         "@type": "Course",
-        "name": "Diagnose Before You Defend — Pushback Master Class (Free)",
-        "url": "https://www.nyenglishteacher.com/en/course/diagnose-before-defend/"
+        "name": "Executive Pushback & Objection Handling (Free Master Class)",
+        "url": "https://www.nyenglishteacher.com/en/course/executive-pushback/"
       }
     }
   ]

--- a/src/pages/es/curso/pushback-ejecutivo/calma-ejecutiva-es-poder.astro
+++ b/src/pages/es/curso/pushback-ejecutivo/calma-ejecutiva-es-poder.astro
@@ -1,12 +1,12 @@
 ---
 export const prerender = true;
 
-import DiagnoseLessonLayout from "@components/course/DiagnoseLessonLayout.astro";
+import PushbackLessonLayout from "@components/course/PushbackLessonLayout.astro";
 import AudioButton from "@components/course/AudioButton";
 import { Shield, Volume2, Mic, CheckCircle2, XCircle, Eye } from "lucide-astro";
 ---
 
-<DiagnoseLessonLayout lessonId={3} lang="es" tkey="course/diagnose-before-defend/executive-calm-is-power">
+<PushbackLessonLayout lessonId={3} lang="es" tkey="course/executive-pushback/executive-calm-is-power">
   <!-- Section 1: The Core Idea -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
@@ -214,4 +214,4 @@ import { Shield, Volume2, Mic, CheckCircle2, XCircle, Eye } from "lucide-astro";
       </div>
     </div>
   </section>
-</DiagnoseLessonLayout>
+</PushbackLessonLayout>

--- a/src/pages/es/curso/pushback-ejecutivo/guion-de-recuperacion.astro
+++ b/src/pages/es/curso/pushback-ejecutivo/guion-de-recuperacion.astro
@@ -3,7 +3,7 @@ export const prerender = true;
 
 import Base from "@layouts/Base.astro";
 import AudioButton from "@components/course/AudioButton";
-import { diagnoseInfo } from "@data/diagnose-before-defend/lessons";
+import { pushbackInfo } from "@data/executive-pushback/lessons";
 import {
   ArrowLeft,
   ArrowRight,
@@ -14,15 +14,15 @@ import {
   Eye,
 } from "lucide-astro";
 
-const lang = "en";
-const tkey = "course/diagnose-before-defend/pressure-recovery-script" as const;
+const lang = "es";
+const tkey = "course/executive-pushback/pressure-recovery-script" as const;
 ---
 
 <Base
   lang={lang}
   tkey={tkey}
-  title="The Pressure Recovery Script — Diagnose Before You Defend"
-  description="When you've already lost composure mid-conversation, three sentences that buy you space, restart the room, and recover authority without an apology."
+  title="El Guion de Recuperación bajo Presión | NY English"
+  description="Cuando ya perdiste la compostura a mitad de la conversación, tres oraciones que te compran espacio, reinician la sala y recuperan autoridad sin disculpa."
 >
   <!-- Hero -->
   <section class="bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 pt-28 pb-16 md:pt-36 md:pb-20">
@@ -30,46 +30,46 @@ const tkey = "course/diagnose-before-defend/pressure-recovery-script" as const;
       <div class="max-w-3xl">
         <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-indigo-500/20 text-indigo-300 text-sm font-semibold mb-6">
           <Sparkles class="w-4 h-4" />
-          Bonus · The Reset
+          Bonus · El Reset
         </div>
         <h1
           class="text-3xl md:text-5xl font-bold text-white mb-4 leading-tight"
           style="font-family: 'Noto Sans KR', sans-serif;"
         >
-          The Pressure Recovery Script
+          El Guion de Recuperación bajo Presión
         </h1>
         <p class="text-xl text-indigo-200 italic font-light mb-4">
-          When you've already lost composure mid-conversation.
+          Cuando ya perdiste la compostura a mitad de la conversación.
         </p>
         <p class="text-lg text-slate-300 leading-relaxed">
-          Sometimes you lose the room. You raise your voice, you concede too fast, you defend too hard, you freeze. The pause didn't happen. The diagnostic didn't fire. This is the three-sentence reset that brings the room back — without an apology and without a re-explanation.
+          A veces pierdes la sala. Alzas la voz, cedes muy rápido, defiendes muy fuerte o te congelas. La pausa no pasó. El diagnóstico no se activó. Este es el reset de tres oraciones que regresa la sala — sin una disculpa y sin re-explicación.
         </p>
       </div>
     </div>
   </section>
 
-  <!-- The premise -->
+  <!-- Premise -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-2">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">1</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Recovery Is a Move, Not an Apology</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">La Recuperación es un Movimiento, No una Disculpa</h2>
         </div>
         <div class="ml-11 space-y-5 text-lg text-slate-700 leading-relaxed">
           <p>
-            The instinct when you've lost composure is to <strong>apologize and restart</strong>. "Sorry, let me back up." "I'm getting ahead of myself." "I think I came in too hot." These all feel honest. They all damage you further.
+            El instinto cuando perdiste la compostura es <strong>disculparte y reiniciar</strong>. "Sorry, let me back up." "I'm getting ahead of myself." "I think I came in too hot." Todas se sienten honestas. Todas te dañan más.
           </p>
           <p>
-            Apologizing inside a pressure moment signals that you've lost the room, which the room may not have fully registered yet. You're broadcasting your failure before they noticed. The recovery script does the opposite: it resets the conversation as if the slip was a deliberate beat, not a leak.
+            Disculparte dentro de un momento de presión señala que perdiste la sala, lo cual la sala puede no haber registrado todavía. Estás transmitiendo tu fracaso antes de que ellos lo notaran. El guion de recuperación hace lo opuesto: reinicia la conversación como si el resbalón fuera un tiempo deliberado, no una fuga.
           </p>
           <div class="rounded-2xl border-2 border-indigo-300 bg-indigo-50 p-6 my-6">
             <div class="flex items-center gap-3 mb-3">
               <Eye class="w-6 h-6 text-indigo-700" />
-              <h3 class="text-lg font-bold text-slate-900">The Principle</h3>
+              <h3 class="text-lg font-bold text-slate-900">El Principio</h3>
             </div>
             <p class="text-slate-800">
-              Recovery is structural, not emotional. Three sentences. No apology. No re-explanation. You're not undoing the slip — you're walking past it.
+              La recuperación es estructural, no emocional. Tres oraciones. Sin disculpa. Sin re-explicación. No estás deshaciendo el resbalón — estás caminando frente a él.
             </p>
           </div>
         </div>
@@ -83,35 +83,35 @@ const tkey = "course/diagnose-before-defend/pressure-recovery-script" as const;
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">2</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Three-Sentence Reset</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">El Reset de Tres Oraciones</h2>
         </div>
 
         <div class="ml-11 space-y-4">
           <div class="bg-white rounded-xl border border-indigo-300 p-6">
-            <p class="text-xs font-bold uppercase tracking-wider text-indigo-700 mb-2">Sentence 1 — Stop yourself</p>
+            <p class="text-xs font-bold uppercase tracking-wider text-indigo-700 mb-2">Oración 1 — Detente</p>
             <div class="flex items-center gap-3">
               <p class="text-xl text-slate-900 italic flex-1">"Let me take that one carefully."</p>
               <AudioButton client:visible text="Let me take that one carefully." lang="en-US" size="md" />
             </div>
-            <p class="text-sm text-slate-600 mt-3">Five words. Slows you, slows the room, gives you 3-5 seconds of structural permission to think. Nearly impossible to interrupt.</p>
+            <p class="text-sm text-slate-600 mt-3">Cinco palabras. Te detiene, detiene a la sala, te da 3-5 segundos de permiso estructural para pensar. Casi imposible de interrumpir.</p>
           </div>
 
           <div class="bg-white rounded-xl border border-indigo-300 p-6">
-            <p class="text-xs font-bold uppercase tracking-wider text-indigo-700 mb-2">Sentence 2 — Restate the question, not your answer</p>
+            <p class="text-xs font-bold uppercase tracking-wider text-indigo-700 mb-2">Oración 2 — Reformula la pregunta, no tu respuesta</p>
             <div class="flex items-center gap-3">
               <p class="text-xl text-slate-900 italic flex-1">"The real question you're asking is whether [X] or [Y]."</p>
               <AudioButton client:visible text="The real question you're asking is whether X or Y." lang="en-US" size="md" />
             </div>
-            <p class="text-sm text-slate-600 mt-3">Reframes the entire exchange. Forces you to diagnose the driver instead of defending. Forces them to confirm or refine the question — which buys you another beat.</p>
+            <p class="text-sm text-slate-600 mt-3">Reencuadra todo el intercambio. Te obliga a diagnosticar el impulsor en lugar de defender. Los obliga a confirmar o refinar la pregunta — lo cual te compra otro tiempo.</p>
           </div>
 
           <div class="bg-white rounded-xl border border-indigo-300 p-6">
-            <p class="text-xs font-bold uppercase tracking-wider text-indigo-700 mb-2">Sentence 3 — Deliver one clean position</p>
+            <p class="text-xs font-bold uppercase tracking-wider text-indigo-700 mb-2">Oración 3 — Entrega una posición limpia</p>
             <div class="flex items-center gap-3">
               <p class="text-xl text-slate-900 italic flex-1">"Here's the call I'd make, and here's why."</p>
               <AudioButton client:visible text="Here's the call I'd make, and here's why." lang="en-US" size="md" />
             </div>
-            <p class="text-sm text-slate-600 mt-3">Reclaims authority. Past the slip. The room is now listening to the position, not analyzing the leak. Keep what follows under two sentences.</p>
+            <p class="text-sm text-slate-600 mt-3">Recupera autoridad. Pasa el resbalón. La sala ahora está escuchando la posición, no analizando la fuga. Mantén lo que sigue en menos de dos oraciones.</p>
           </div>
         </div>
       </div>
@@ -124,13 +124,13 @@ const tkey = "course/diagnose-before-defend/pressure-recovery-script" as const;
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">3</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Script in Practice</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">El Guion en la Práctica</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">A realistic exchange. You've already defended too hard for two sentences. Here's the recovery, in full.</p>
+        <p class="text-slate-600 mb-6 ml-11">Un intercambio realista. Ya defendiste demasiado fuerte por dos oraciones. Aquí está la recuperación, completa.</p>
 
         <div class="ml-11 bg-slate-50 rounded-xl border border-slate-200 overflow-hidden">
           <div class="bg-slate-900 text-white px-5 py-3">
-            <p class="text-xs font-bold uppercase tracking-wider text-indigo-400">Board meeting · CFO challenges your forecast</p>
+            <p class="text-xs font-bold uppercase tracking-wider text-indigo-400">Junta directiva · El CFO cuestiona tu forecast</p>
           </div>
           <div class="p-6 space-y-4">
             <div class="bg-slate-100 rounded-lg p-4">
@@ -139,19 +139,19 @@ const tkey = "course/diagnose-before-defend/pressure-recovery-script" as const;
             </div>
 
             <div class="bg-red-50 border border-red-200 rounded-lg p-4">
-              <p class="text-xs font-bold uppercase tracking-wider text-red-700 mb-1">You — overheating</p>
+              <p class="text-xs font-bold uppercase tracking-wider text-red-700 mb-1">Tú — recalentándose</p>
               <p class="text-slate-800 italic">"It's absolutely grounded. We spent three weeks on the pipeline review, the team is confident in the close rates, and the conversion data from Q1 supports the model. I'd push back on the suggestion that we're being aggressive — this is calibrated…"</p>
             </div>
 
             <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-4">
-              <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-2">You — recovery script (three sentences)</p>
+              <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-2">Tú — guion de recuperación (tres oraciones)</p>
               <div class="flex items-start gap-3">
                 <p class="text-slate-900 font-medium flex-1 leading-relaxed">"Let me take that one carefully. The real question you're asking is whether the forecast survives a 40-day cycle extension or breaks. Here's the call I'd make: stress-test the model against that assumption tonight and bring you the answer tomorrow morning before the board reconvenes."</p>
                 <AudioButton client:visible text="Let me take that one carefully. The real question you're asking is whether the forecast survives a 40-day cycle extension or breaks. Here's the call I'd make: stress-test the model against that assumption tonight and bring you the answer tomorrow morning before the board reconvenes." lang="en-US" size="sm" />
               </div>
             </div>
 
-            <p class="text-sm text-slate-500"><strong>What changed:</strong> No "but" or "actually." The defensiveness is gone. The question is reframed cleanly. You ended on action, not justification.</p>
+            <p class="text-sm text-slate-500"><strong>Qué cambió:</strong> Sin "but" ni "actually". La defensividad se fue. La pregunta se reencuadra limpiamente. Terminaste en acción, no en justificación.</p>
           </div>
         </div>
       </div>
@@ -164,24 +164,24 @@ const tkey = "course/diagnose-before-defend/pressure-recovery-script" as const;
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">4</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Rules for Adapting the Script</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Reglas para Adaptar el Guion</h2>
         </div>
         <div class="ml-11 space-y-3">
           <div class="bg-white rounded-lg border border-slate-200 p-4 flex items-start gap-3">
             <AlertCircle class="w-5 h-5 text-indigo-600 shrink-0 mt-0.5" />
-            <p class="text-slate-700"><strong>Memorize the exact phrasing.</strong> When you're overheating, working memory shrinks. You won't be able to compose a custom recovery sentence. You need the script ready.</p>
+            <p class="text-slate-700"><strong>Memoriza el fraseo exacto.</strong> Cuando estás recalentándote, la memoria de trabajo se reduce. No podrás componer una oración de recuperación personalizada. Necesitas el guion listo.</p>
           </div>
           <div class="bg-white rounded-lg border border-slate-200 p-4 flex items-start gap-3">
             <AlertCircle class="w-5 h-5 text-indigo-600 shrink-0 mt-0.5" />
-            <p class="text-slate-700"><strong>Drop the volume in Sentence 1.</strong> A quieter voice signals deliberate slowing, not retreat. Most people instinctively raise volume when reasserting — resist.</p>
+            <p class="text-slate-700"><strong>Baja el volumen en la Oración 1.</strong> Una voz más baja señala una desaceleración deliberada, no retroceso. La mayoría de la gente instintivamente sube el volumen al reafirmarse — resiste.</p>
           </div>
           <div class="bg-white rounded-lg border border-slate-200 p-4 flex items-start gap-3">
             <AlertCircle class="w-5 h-5 text-indigo-600 shrink-0 mt-0.5" />
-            <p class="text-slate-700"><strong>Never apologize between the sentences.</strong> Even small filler ("sorry, just…") cancels the reset. Three clean sentences, no qualifiers.</p>
+            <p class="text-slate-700"><strong>Nunca te disculpes entre las oraciones.</strong> Incluso pequeños rellenos ("sorry, just…") cancelan el reset. Tres oraciones limpias, sin calificadores.</p>
           </div>
           <div class="bg-white rounded-lg border border-slate-200 p-4 flex items-start gap-3">
             <AlertCircle class="w-5 h-5 text-indigo-600 shrink-0 mt-0.5" />
-            <p class="text-slate-700"><strong>Use it once per conversation, maximum.</strong> Using the script twice in one exchange signals you're not actually recovering — you're just managing leak after leak.</p>
+            <p class="text-slate-700"><strong>Úsalo una vez por conversación, máximo.</strong> Usar el guion dos veces en un intercambio señala que no estás recuperándote — solo estás administrando fuga tras fuga.</p>
           </div>
         </div>
       </div>
@@ -192,34 +192,34 @@ const tkey = "course/diagnose-before-defend/pressure-recovery-script" as const;
   <section class="py-14 md:py-16 bg-white border-t border-slate-200">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
-        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">The Recap</h2>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">El Resumen</h2>
         <div class="bg-slate-50 rounded-2xl border border-slate-200 p-7 mb-10">
           <ul class="space-y-3 text-slate-700">
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Recovery is <strong>structural, not emotional</strong>. No apology, no re-explanation.</span></li>
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Three sentences, memorized exactly: <strong>"Let me take that one carefully" → "The real question is X or Y" → "Here's the call I'd make."</strong></span></li>
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Once per conversation</strong>. The script is a reset, not a crutch.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>La recuperación es <strong>estructural, no emocional</strong>. Sin disculpa, sin re-explicación.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Tres oraciones, memorizadas exactamente: <strong>"Let me take that one carefully" → "The real question is X or Y" → "Here's the call I'd make."</strong></span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Una vez por conversación</strong>. El guion es un reset, no una muleta.</span></li>
           </ul>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <a
-            href={`${diagnoseInfo.basePath.en}/bad-news-steady-voice/`}
+            href={`${pushbackInfo.basePath.es}/malas-noticias-voz-firme/`}
             class="group flex items-center gap-3 bg-slate-50 rounded-xl border border-slate-200 hover:border-indigo-300 hover:shadow-md transition-all p-5"
           >
             <ArrowLeft class="w-5 h-5 text-slate-400 group-hover:text-indigo-600 transition-colors shrink-0" />
             <div>
-              <p class="text-xs font-bold uppercase tracking-wider text-slate-500 mb-0.5">Last lesson</p>
-              <p class="text-slate-900 font-medium">Bad News, Steady Voice</p>
+              <p class="text-xs font-bold uppercase tracking-wider text-slate-500 mb-0.5">Última lección</p>
+              <p class="text-slate-900 font-medium">Malas Noticias, Voz Firme</p>
             </div>
           </a>
 
           <a
-            href={`${diagnoseInfo.basePath.en}/`}
+            href={`${pushbackInfo.basePath.es}/`}
             class="group flex items-center justify-between gap-3 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl transition-all p-5"
           >
             <div>
-              <p class="text-xs font-bold uppercase tracking-wider text-indigo-100 mb-0.5">Course overview</p>
-              <p class="font-medium">Diagnose Before You Defend</p>
+              <p class="text-xs font-bold uppercase tracking-wider text-indigo-100 mb-0.5">Resumen del curso</p>
+              <p class="font-medium">Manejo de Pushback y Objeciones Ejecutivas</p>
             </div>
             <ArrowRight class="w-5 h-5 shrink-0" />
           </a>

--- a/src/pages/es/curso/pushback-ejecutivo/index.astro
+++ b/src/pages/es/curso/pushback-ejecutivo/index.astro
@@ -4,10 +4,10 @@ export const prerender = true;
 import Base from "@layouts/Base.astro";
 import Button from "@components/ui/Button.astro";
 import {
-  diagnoseInfo,
-  diagnoseLessons,
-  diagnoseBonuses,
-} from "@data/diagnose-before-defend/lessons";
+  pushbackInfo,
+  pushbackLessons,
+  pushbackBonuses,
+} from "@data/executive-pushback/lessons";
 import {
   ArrowRight,
   Sparkles,
@@ -23,8 +23,8 @@ import {
   Crown,
 } from "lucide-astro";
 
-const lang = "en";
-const tkey = "course/diagnose-before-defend" as const;
+const lang = "es";
+const tkey = "course/executive-pushback" as const;
 
 const iconMap: Record<string, any> = {
   Search,
@@ -40,8 +40,8 @@ const iconMap: Record<string, any> = {
 <Base
   lang={lang}
   tkey={tkey}
-  title="Diagnose Before You Defend — Pushback Master Class"
-  description="Free master class on handling executive pushback. Six lessons + one recovery script. Built for directors, sales pros, and mid-managers under pressure."
+  title="Manejo de Pushback y Objeciones Ejecutivas | NY English"
+  description="Master class gratuita sobre cómo manejar el pushback ejecutivo. Seis lecciones + un guion de recuperación. Hecha para directores, ventas y mandos medios."
 >
   <!-- Hero -->
   <section class="relative w-full overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 pt-32 pb-20 md:pt-40 md:pb-28">
@@ -53,31 +53,31 @@ const iconMap: Record<string, any> = {
       <div class="max-w-3xl">
         <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-indigo-500/20 text-indigo-300 text-sm font-semibold mb-6">
           <Crown class="w-4 h-4" />
-          Master Class · C1 → C2 · Free
+          Master Class · C1 → C2 · Gratis
         </div>
         <h1
           class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 leading-tight"
           style="font-family: 'Noto Sans KR', sans-serif;"
         >
-          Diagnose Before<br />
-          <span class="text-indigo-400">You Defend.</span>
+          Manejo de Pushback<br />
+          <span class="text-indigo-400">y Objeciones.</span>
         </h1>
         <p class="text-xl text-slate-200 mb-4 max-w-2xl leading-relaxed">
-          <strong class="text-white">Read the pressure. Hold your ground. Influence the outcome.</strong>
+          <strong class="text-white">Comunicación estratégica para conversaciones de alta presión.</strong>
         </p>
         <p class="text-lg text-slate-300 mb-8 max-w-2xl leading-relaxed">
-          Most pushback isn't about what people say it's about. The procurement manager naming a discount isn't really arguing about price. The peer challenging your timeline isn't really worried about the date. Six lessons that train the diagnostic — and the posture — that separates executive communicators from defensive ones.
+          La mayoría del pushback no es sobre lo que la gente dice que es. El gerente de compras que pide un descuento no está discutiendo sobre el precio. El par que cuestiona tu timeline no está preocupado por la fecha. Seis lecciones que entrenan el diagnóstico — y la postura — que separa a los comunicadores ejecutivos de los defensivos.
         </p>
         <div class="flex flex-wrap gap-4">
-          <Button href={`${diagnoseInfo.basePath.en}/${diagnoseLessons[0].slug}/`} variant="primary" size="lg">
-            Start with Lesson 1
+          <Button href={`${pushbackInfo.basePath.es}/${pushbackLessons[0].slugEs}/`} variant="primary" size="lg">
+            Empieza con la Lección 1
             <ArrowRight class="w-5 h-5 ml-1" />
           </Button>
           <a
-            href="#lessons"
+            href="#lecciones"
             class="inline-flex items-center gap-2 px-6 py-3 rounded-xl border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-colors text-sm font-medium"
           >
-            See all 6 lessons
+            Ver las 6 lecciones
           </a>
         </div>
       </div>
@@ -88,12 +88,12 @@ const iconMap: Record<string, any> = {
   <section class="py-16 md:py-20 bg-white border-b border-slate-100">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto text-center">
-        <p class="text-[11px] font-mono uppercase tracking-[0.3em] text-indigo-600 mb-4">The Thesis</p>
+        <p class="text-[11px] font-mono uppercase tracking-[0.3em] text-indigo-600 mb-4">La Tesis</p>
         <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 leading-tight" style="font-family: 'Noto Sans KR', sans-serif;">
-          People challenge confidence before they challenge logic.
+          La gente cuestiona la confianza antes de cuestionar la lógica.
         </h2>
         <p class="text-lg text-slate-600 leading-relaxed">
-          When someone pushes back on your decision, your timeline, your price, or your plan, they are almost never doing it for the reason they name. They're testing composure. Probing trust. Protecting ego. Surfacing a workload concern they can't say out loud. The communicator who reads the real driver before responding wins the room. The one who defends the stated reason loses it.
+          Cuando alguien te da pushback sobre tu decisión, tu timeline, tu precio o tu plan, casi nunca lo hace por la razón que nombra. Está probando tu compostura. Sondeando tu confianza. Protegiendo su ego. Sacando una preocupación de carga de trabajo que no puede decir en voz alta. El comunicador que lee el impulsor real antes de responder gana la sala. El que defiende la razón declarada la pierde.
         </p>
       </div>
     </div>
@@ -104,9 +104,9 @@ const iconMap: Record<string, any> = {
     <div class="site-container mx-auto px-4">
       <div class="max-w-4xl mx-auto">
         <div class="text-center mb-12">
-          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">The Two Defaults</h2>
+          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">Los Dos Modos por Defecto</h2>
           <p class="text-lg text-slate-600 max-w-2xl mx-auto">
-            Under pressure, every professional defaults to one of these two patterns. The difference between them is mostly invisible — until the room shifts.
+            Bajo presión, todo profesional cae en uno de estos dos patrones. La diferencia entre ellos es casi invisible — hasta que la sala se mueve.
           </p>
         </div>
 
@@ -115,12 +115,12 @@ const iconMap: Record<string, any> = {
             <div class="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-red-100 text-red-600 mb-4">
               <Brain class="w-6 h-6" />
             </div>
-            <h3 class="text-xl font-bold text-slate-900 mb-3">The Reactive Pattern</h3>
+            <h3 class="text-xl font-bold text-slate-900 mb-3">El Patrón Reactivo</h3>
             <ul class="space-y-2 text-slate-700">
-              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Defends the stated reason</li>
-              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Overexplains under pressure</li>
-              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Matches emotional pace of the challenger</li>
-              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Sounds uncertain, even when correct</li>
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Defiende la razón declarada</li>
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Sobreexplica bajo presión</li>
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Iguala el ritmo emocional del retador</li>
+              <li class="flex gap-2"><span class="text-red-500 shrink-0">✗</span> Suena inseguro, incluso cuando tiene razón</li>
             </ul>
           </div>
 
@@ -128,12 +128,12 @@ const iconMap: Record<string, any> = {
             <div class="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-indigo-100 text-indigo-700 mb-4">
               <Target class="w-6 h-6" />
             </div>
-            <h3 class="text-xl font-bold text-slate-900 mb-3">The Strategic Pattern</h3>
+            <h3 class="text-xl font-bold text-slate-900 mb-3">El Patrón Estratégico</h3>
             <ul class="space-y-2 text-slate-700">
-              <li class="flex gap-2"><span class="text-indigo-600 shrink-0">✓</span> Reads the real driver under the question</li>
-              <li class="flex gap-2"><span class="text-indigo-600 shrink-0">✓</span> Pauses before responding</li>
-              <li class="flex gap-2"><span class="text-indigo-600 shrink-0">✓</span> Slows the conversation down</li>
-              <li class="flex gap-2"><span class="text-indigo-600 shrink-0">✓</span> Lands the response with measured certainty</li>
+              <li class="flex gap-2"><span class="text-indigo-600 shrink-0">✓</span> Lee el impulsor real debajo de la pregunta</li>
+              <li class="flex gap-2"><span class="text-indigo-600 shrink-0">✓</span> Hace una pausa antes de responder</li>
+              <li class="flex gap-2"><span class="text-indigo-600 shrink-0">✓</span> Baja el ritmo de la conversación</li>
+              <li class="flex gap-2"><span class="text-indigo-600 shrink-0">✓</span> Aterriza la respuesta con certeza calibrada</li>
             </ul>
           </div>
         </div>
@@ -145,36 +145,36 @@ const iconMap: Record<string, any> = {
   <section class="py-16 md:py-20 bg-white">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
-        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6">Who This Is For</h2>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6">Para Quién Es Esto</h2>
         <p class="text-lg text-slate-600 leading-relaxed mb-6">
-          This master class is for the professionals who give pushback and get pushed back on, daily — directors, ops leaders, sales professionals, procurement managers, technical managers, customer success leads, and mid-level managers communicating upward into senior leadership.
+          Esta master class es para los profesionales que dan pushback y reciben pushback diariamente — directores, líderes de operaciones, profesionales de ventas, gerentes de compras, gerentes técnicos, líderes de customer success y mandos medios que se comunican hacia arriba con liderazgo senior.
         </p>
         <p class="text-slate-600 leading-relaxed mb-6">
-          If your business English is already fluent but you notice the pattern under pressure — the half-second too fast, the half-step too defensive, the extra sentence that costs you the room — this course addresses the exact gap. It pairs naturally with the Executive course (frameworks) and Drive the Decision (boardroom scenarios). Where those teach what to say, this one teaches what to read and how to hold yourself before you say it.
+          Si tu inglés de negocios ya es fluido pero notas el patrón bajo presión — el medio segundo demasiado rápido, el medio paso demasiado defensivo, la oración extra que te cuesta la sala — este curso aborda exactamente esa brecha. Se combina naturalmente con el curso Ejecutivo (marcos) y Dirige la Decisión (escenarios de junta directiva). Donde esos enseñan qué decir, este enseña qué leer y cómo sostenerte antes de hablar.
         </p>
       </div>
     </div>
   </section>
 
   <!-- Lessons grid -->
-  <section class="py-16 md:py-20 bg-slate-50" id="lessons">
+  <section class="py-16 md:py-20 bg-slate-50" id="lecciones">
     <div class="site-container mx-auto px-4">
       <div class="text-center max-w-2xl mx-auto mb-12">
         <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4" style="font-family: 'Noto Sans KR', sans-serif;">
-          Six Lessons. One Habit.
+          Seis Lecciones. Un Hábito.
         </h2>
         <p class="text-slate-600 leading-relaxed">
-          Diagnostic, then posture, then framework, then application. Each lesson runs about 20-30 minutes and builds the same instinct from a different angle.
+          Diagnóstico, luego postura, luego marco, luego aplicación. Cada lección dura de 20 a 30 minutos y construye el mismo instinto desde un ángulo distinto.
         </p>
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
-        {diagnoseLessons.map((lesson) => {
+        {pushbackLessons.map((lesson) => {
           const Icon = iconMap[lesson.icon];
           const isAvailable = lesson.available;
           return (
             <a
-              href={isAvailable ? `${diagnoseInfo.basePath.en}/${lesson.slug}/` : undefined}
+              href={isAvailable ? `${pushbackInfo.basePath.es}/${lesson.slugEs}/` : undefined}
               class:list={[
                 "group flex items-start gap-4 p-5 rounded-xl border transition-all duration-200",
                 isAvailable
@@ -193,14 +193,14 @@ const iconMap: Record<string, any> = {
               <div class="flex-1">
                 <div class="flex items-center gap-2">
                   <span class="text-xs font-bold uppercase tracking-wider text-indigo-700">
-                    Lesson {lesson.id}
+                    Lección {lesson.id}
                   </span>
                 </div>
                 <h3 class="text-lg font-bold mt-0.5 text-slate-900">
-                  {lesson.title}
+                  {lesson.titleEs}
                 </h3>
-                <p class="text-sm text-slate-600 mt-1">{lesson.subtitle}</p>
-                <p class="text-xs text-indigo-700 mt-1.5 italic">{lesson.angle}</p>
+                <p class="text-sm text-slate-600 mt-1">{lesson.subtitleEs}</p>
+                <p class="text-xs text-indigo-700 mt-1.5 italic">{lesson.angleEs}</p>
               </div>
             </a>
           );
@@ -216,19 +216,19 @@ const iconMap: Record<string, any> = {
         <div class="text-center mb-12">
           <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-indigo-100 text-indigo-800 text-sm font-semibold mb-4">
             <Sparkles class="w-4 h-4" />
-            Bonus Resource
+            Recurso Bonus
           </div>
-          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">When You've Already Lost Composure</h2>
+          <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">Cuando Ya Perdiste la Compostura</h2>
           <p class="text-lg text-slate-600 max-w-2xl mx-auto">
-            Pushback wins sometimes. You raise your voice, defend too hard, or freeze. This bonus is the three-sentence reset that recovers the room without an apology.
+            El pushback te gana a veces. Alzas la voz, defiendes demasiado o te congelas. Este bonus es el reset de tres oraciones que recupera la sala sin una disculpa.
           </p>
         </div>
 
-        {diagnoseBonuses.map((bonus) => {
+        {pushbackBonuses.map((bonus) => {
           const Icon = iconMap[bonus.icon] ?? RefreshCw;
           return (
             <a
-              href={`${diagnoseInfo.basePath.en}/${bonus.slug}/`}
+              href={`${pushbackInfo.basePath.es}/${bonus.slugEs}/`}
               class="block bg-gradient-to-br from-slate-900 via-slate-800 to-indigo-900 rounded-2xl p-8 text-white hover:shadow-xl transition-shadow duration-200"
             >
               <div class="flex items-start gap-5">
@@ -236,10 +236,10 @@ const iconMap: Record<string, any> = {
                   <Icon class="w-7 h-7" />
                 </div>
                 <div class="flex-1">
-                  <h3 class="text-2xl font-bold mb-2">{bonus.title}</h3>
-                  <p class="text-slate-300 leading-relaxed mb-4">{bonus.description}</p>
+                  <h3 class="text-2xl font-bold mb-2">{bonus.titleEs}</h3>
+                  <p class="text-slate-300 leading-relaxed mb-4">{bonus.descriptionEs}</p>
                   <span class="inline-flex items-center gap-1 text-indigo-300 font-semibold text-sm group-hover:gap-2 transition-all">
-                    Open the recovery script
+                    Abrir el guion de recuperación
                     <ArrowRight class="w-4 h-4" />
                   </span>
                 </div>
@@ -255,37 +255,37 @@ const iconMap: Record<string, any> = {
   <section class="py-16 md:py-20 bg-slate-50 border-t border-slate-100">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto text-center">
-        <h2 class="text-2xl font-bold text-slate-900 mb-4">Where Does This Fit?</h2>
+        <h2 class="text-2xl font-bold text-slate-900 mb-4">¿Dónde Encaja Esto?</h2>
         <p class="text-lg text-slate-600 leading-relaxed mb-6">
-          This is the <strong>diagnostic master class</strong> — what you read before you respond. For the full executive system (frameworks, hedging elimination, structured responses, named patterns), see <strong>Communicate Like a Leader</strong>. For boardroom-level applied scenarios — investor pushback, missed quarters, $2M deals you have to decline — see <strong>Drive the Decision</strong>. For 1-on-1 coaching, the booking link is below.
+          Esta es la <strong>master class de manejo de pushback y objeciones</strong> — lo que lees y cómo respondes cuando la sala se vuelve contra tu decisión. Para el sistema ejecutivo completo (marcos, eliminación de atenuación, respuestas estructuradas, patrones con nombre), revisa <strong>Comunica Como un Líder</strong>. Para escenarios aplicados a nivel junta directiva — pushback de inversionistas, trimestres perdidos, tratos de $2M que rechazas — revisa <strong>Dirige la Decisión</strong>. Para coaching 1-a-1, el enlace de reservación está abajo.
         </p>
         <div class="flex flex-wrap gap-3 justify-center">
           <a
-            href="/en/course/executive/"
+            href="/es/curso/ejecutivo/"
             class="text-indigo-700 hover:text-indigo-800 font-medium underline underline-offset-2"
           >
-            Executive course
+            Curso Ejecutivo
           </a>
           <span class="text-slate-300">|</span>
           <a
-            href="/en/course/drive-the-decision/"
+            href="/es/curso/dirige-la-decision/"
             class="text-indigo-700 hover:text-indigo-800 font-medium underline underline-offset-2"
           >
-            Drive the Decision
+            Dirige la Decisión
           </a>
           <span class="text-slate-300">|</span>
           <a
-            href="/en/courses/"
+            href="/es/cursos/"
             class="text-indigo-700 hover:text-indigo-800 font-medium underline underline-offset-2"
           >
-            See all courses
+            Ver todos los cursos
           </a>
           <span class="text-slate-300">|</span>
           <a
-            href="/en/book/"
+            href="/es/reservar/"
             class="text-indigo-700 hover:text-indigo-800 font-medium underline underline-offset-2"
           >
-            Work 1-on-1 with Robert
+            Trabajar 1-a-1 con Robert
           </a>
         </div>
       </div>
@@ -295,17 +295,17 @@ const iconMap: Record<string, any> = {
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@type": "Course",
-    "name": "Diagnose Before You Defend — Pushback Master Class",
-    "description": "Free master class on handling executive pushback. Six lessons + one pressure-recovery script. Built for directors, sales professionals, procurement managers, and mid-level leaders communicating upward.",
+    "name": "Manejo de Pushback y Objeciones Ejecutivas — Master Class de Pushback",
+    "description": "Master class gratuita sobre cómo manejar el pushback ejecutivo. Seis lecciones + un guion de recuperación bajo presión. Hecha para directores, profesionales de ventas, gerentes de compras y mandos medios.",
     "provider": { "@type": "Organization", "name": "New York English Teacher", "url": "https://www.nyenglishteacher.com/" },
     "educationalLevel": "Executive (C1-C2)",
-    "inLanguage": "en",
-    "url": "https://www.nyenglishteacher.com/en/course/diagnose-before-defend/",
+    "inLanguage": "es",
+    "url": "https://www.nyenglishteacher.com/es/curso/pushback-ejecutivo/",
     "isAccessibleForFree": true,
     "hasCourseInstance": {
       "@type": "CourseInstance",
       "courseMode": "online",
-      "inLanguage": "en"
+      "inLanguage": "es"
     }
   })} />
 </Base>

--- a/src/pages/es/curso/pushback-ejecutivo/malas-noticias-voz-firme.astro
+++ b/src/pages/es/curso/pushback-ejecutivo/malas-noticias-voz-firme.astro
@@ -1,34 +1,34 @@
 ---
 export const prerender = true;
 
-import DiagnoseLessonLayout from "@components/course/DiagnoseLessonLayout.astro";
+import PushbackLessonLayout from "@components/course/PushbackLessonLayout.astro";
 import AudioButton from "@components/course/AudioButton";
 import { AlertTriangle, CheckCircle2, XCircle, Eye, ShieldAlert } from "lucide-astro";
 ---
 
-<DiagnoseLessonLayout lessonId={6} lang="en" tkey="course/diagnose-before-defend/bad-news-steady-voice">
-  <!-- Section 1: The Core Idea -->
+<PushbackLessonLayout lessonId={6} lang="es" tkey="course/executive-pushback/bad-news-steady-voice">
+  <!-- Section 1: Core Idea -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-2">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">1</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Leaders Transfer Stability — Or They Transfer Panic</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Los Líderes Transfieren Estabilidad — O Transfieren Pánico</h2>
         </div>
         <div class="ml-11 space-y-5 text-lg text-slate-700 leading-relaxed">
           <p>
-            When you deliver bad news — a missed quarter, a layoff, a production outage, a partnership unraveling — the organization watches you for a single signal: <strong>are you regulated, or are you contagious?</strong> What you say barely matters in the first thirty seconds. How steady your voice is determines whether the room calms with you or escalates around you.
+            Cuando das malas noticias — un trimestre perdido, un recorte, un outage de producción, una alianza que se desmorona — la organización te observa por una sola señal: <strong>¿estás regulado o eres contagioso?</strong> Lo que dices apenas importa en los primeros treinta segundos. Qué tan firme suena tu voz determina si la sala se calma contigo o escala alrededor de ti.
           </p>
           <p>
-            This is the most asymmetric skill in the entire course. Most professionals never train it. They wing it through bad-news moments and hope adrenaline carries them. The leaders who actually move organizations through hard moments do something different: they treat bad-news delivery as a <strong>practiced craft</strong>, not an emotional event.
+            Esta es la habilidad más asimétrica de todo el curso. La mayoría de los profesionales nunca la entrenan. Improvisan a través de los momentos de malas noticias esperando que la adrenalina los lleve. Los líderes que realmente mueven organizaciones a través de momentos difíciles hacen algo distinto: tratan la entrega de malas noticias como un <strong>oficio practicado</strong>, no un evento emocional.
           </p>
           <div class="rounded-2xl border-2 border-indigo-300 bg-indigo-50 p-6 my-6">
             <div class="flex items-center gap-3 mb-3">
               <ShieldAlert class="w-6 h-6 text-indigo-700" />
-              <h3 class="text-lg font-bold text-slate-900">The Principle</h3>
+              <h3 class="text-lg font-bold text-slate-900">El Principio</h3>
             </div>
             <p class="text-slate-800">
-              During pressure, leaders transfer emotional stability to the organization. The voice that says "we have a problem" is the same voice that has to say "here's how we hold it." Containment, not contagion.
+              Bajo presión, los líderes transfieren estabilidad emocional a la organización. La voz que dice "tenemos un problema" es la misma voz que tiene que decir "y así es como lo sostenemos". Contención, no contagio.
             </p>
           </div>
         </div>
@@ -36,51 +36,51 @@ import { AlertTriangle, CheckCircle2, XCircle, Eye, ShieldAlert } from "lucide-a
     </div>
   </section>
 
-  <!-- Section 2: The Bad-News Structure -->
+  <!-- Section 2: Bad News Structure -->
   <section class="py-14 md:py-16 bg-slate-50">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">2</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Bad-News Structure</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">La Estructura de Malas Noticias</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">Four beats. In this order. Skipping any of them creates a different kind of damage.</p>
+        <p class="text-slate-600 mb-6 ml-11">Cuatro tiempos. En este orden. Saltarse cualquiera crea un tipo distinto de daño.</p>
 
         <div class="ml-11 space-y-4">
           <div class="bg-white rounded-xl border border-slate-200 p-6">
             <div class="flex items-center gap-3 mb-2">
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 text-indigo-700 font-bold">1</div>
-              <h3 class="text-lg font-bold text-slate-900">The Direct Statement</h3>
+              <h3 class="text-lg font-bold text-slate-900">La Declaración Directa</h3>
             </div>
-            <p class="text-slate-700 mb-2">Say the bad news clearly, in one sentence, with no preamble. "We missed the quarter by 22%." "We're reducing headcount by 15%." "The platform was down for six hours."</p>
-            <p class="text-sm text-slate-500 italic">Burying the headline ("So I want to talk through some context first…") signals you're afraid of the news. The room reads that as instability.</p>
+            <p class="text-slate-700 mb-2">Di la mala noticia claramente, en una oración, sin preámbulo. "Perdimos el trimestre por 22%". "Vamos a reducir personal en 15%". "La plataforma estuvo caída seis horas".</p>
+            <p class="text-sm text-slate-500 italic">Enterrar el titular ("So I want to talk through some context first…") señala que le tienes miedo a la noticia. La sala lo lee como inestabilidad.</p>
           </div>
 
           <div class="bg-white rounded-xl border border-slate-200 p-6">
             <div class="flex items-center gap-3 mb-2">
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 text-indigo-700 font-bold">2</div>
-              <h3 class="text-lg font-bold text-slate-900">The Specific Cause</h3>
+              <h3 class="text-lg font-bold text-slate-900">La Causa Específica</h3>
             </div>
-            <p class="text-slate-700 mb-2">Name the cause in concrete operational terms. Not "challenging market conditions" — the actual mechanism. "Sales cycle in mid-market was 40 days longer than modeled." "A database failover did not trigger as specified."</p>
-            <p class="text-sm text-slate-500 italic">Vague causes telegraph that you either don't understand what happened or you're hiding it. Both destroy trust.</p>
+            <p class="text-slate-700 mb-2">Nombra la causa en términos operativos concretos. No "condiciones de mercado desafiantes" — el mecanismo real. "El ciclo de ventas en mid-market fue 40 días más largo que el modelo". "Un failover de base de datos no se activó como estaba especificado".</p>
+            <p class="text-sm text-slate-500 italic">Las causas vagas telegrafían que no entiendes lo que pasó o lo estás escondiendo. Ambas destruyen la confianza.</p>
           </div>
 
           <div class="bg-white rounded-xl border border-slate-200 p-6">
             <div class="flex items-center gap-3 mb-2">
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 text-indigo-700 font-bold">3</div>
-              <h3 class="text-lg font-bold text-slate-900">The Action Already Taken</h3>
+              <h3 class="text-lg font-bold text-slate-900">La Acción Ya Tomada</h3>
             </div>
-            <p class="text-slate-700 mb-2">Past-tense, not future-tense. "We've moved two AEs to enterprise this week." "We've deployed the fix and rebuilt the runbook." The actions in motion before the room knew about the problem are what build confidence.</p>
-            <p class="text-sm text-slate-500 italic">Future-tense promises ("we will…") in a bad-news moment read as scrambling. Past-tense actions read as competence.</p>
+            <p class="text-slate-700 mb-2">Tiempo pasado, no tiempo futuro. "Ya movimos dos AEs a enterprise esta semana". "Ya desplegamos el fix y reconstruimos el runbook". Las acciones en movimiento antes de que la sala supiera del problema son las que construyen confianza.</p>
+            <p class="text-sm text-slate-500 italic">Promesas en tiempo futuro ("vamos a…") en un momento de malas noticias se leen como improvisación. Acciones en tiempo pasado se leen como competencia.</p>
           </div>
 
           <div class="bg-white rounded-xl border border-slate-200 p-6">
             <div class="flex items-center gap-3 mb-2">
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 text-indigo-700 font-bold">4</div>
-              <h3 class="text-lg font-bold text-slate-900">The Forward Frame</h3>
+              <h3 class="text-lg font-bold text-slate-900">El Encuadre Hacia Adelante</h3>
             </div>
-            <p class="text-slate-700 mb-2">Close with what's next and what you're holding the room accountable to. "We'll have full visibility into the new model by next Friday." "Quarter-end metrics will be on the dashboard live."</p>
-            <p class="text-sm text-slate-500 italic">No forward frame and the room is left holding the anxiety. A clear next step transfers the work from the listener back to the system.</p>
+            <p class="text-slate-700 mb-2">Cierra con qué sigue y a qué te estás haciendo responsable frente a la sala. "Tendremos visibilidad total del nuevo modelo para el próximo viernes". "Las métricas de fin de trimestre estarán en vivo en el dashboard".</p>
+            <p class="text-sm text-slate-500 italic">Sin encuadre hacia adelante, la sala queda con la ansiedad. Un siguiente paso claro transfiere el trabajo del oyente de vuelta al sistema.</p>
           </div>
         </div>
       </div>
@@ -93,14 +93,14 @@ import { AlertTriangle, CheckCircle2, XCircle, Eye, ShieldAlert } from "lucide-a
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">3</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Real Bad-News Deliveries</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Entregas Reales de Malas Noticias</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">Three contexts. Same structure. Listen for the controlled cadence in each — that's the executive signal the room is reading.</p>
+        <p class="text-slate-600 mb-6 ml-11">Tres contextos. Misma estructura. Escucha el ritmo controlado en cada uno — esa es la señal ejecutiva que la sala está leyendo.</p>
 
         <div class="ml-11 space-y-5">
           <div class="bg-slate-50 rounded-xl border border-slate-200 overflow-hidden">
             <div class="bg-slate-900 text-white px-5 py-3">
-              <p class="text-xs font-bold uppercase tracking-wider text-indigo-400">Context · Missed quarter to your team</p>
+              <p class="text-xs font-bold uppercase tracking-wider text-indigo-400">Contexto · Trimestre perdido a tu equipo</p>
             </div>
             <div class="p-6">
               <div class="flex items-center gap-3">
@@ -112,7 +112,7 @@ import { AlertTriangle, CheckCircle2, XCircle, Eye, ShieldAlert } from "lucide-a
 
           <div class="bg-slate-50 rounded-xl border border-slate-200 overflow-hidden">
             <div class="bg-slate-900 text-white px-5 py-3">
-              <p class="text-xs font-bold uppercase tracking-wider text-indigo-400">Context · Layoff announcement to leadership team</p>
+              <p class="text-xs font-bold uppercase tracking-wider text-indigo-400">Contexto · Anuncio de recorte al equipo de liderazgo</p>
             </div>
             <div class="p-6">
               <div class="flex items-center gap-3">
@@ -124,7 +124,7 @@ import { AlertTriangle, CheckCircle2, XCircle, Eye, ShieldAlert } from "lucide-a
 
           <div class="bg-slate-50 rounded-xl border border-slate-200 overflow-hidden">
             <div class="bg-slate-900 text-white px-5 py-3">
-              <p class="text-xs font-bold uppercase tracking-wider text-indigo-400">Context · Outage update to enterprise customer</p>
+              <p class="text-xs font-bold uppercase tracking-wider text-indigo-400">Contexto · Update de outage a cliente enterprise</p>
             </div>
             <div class="p-6">
               <div class="flex items-center gap-3">
@@ -144,26 +144,26 @@ import { AlertTriangle, CheckCircle2, XCircle, Eye, ShieldAlert } from "lucide-a
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">4</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Vocal Mechanics of a Steady Voice</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">La Mecánica Vocal de una Voz Firme</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">The structure carries you only if the voice carries the structure. Four mechanics to rehearse before any bad-news delivery.</p>
+        <p class="text-slate-600 mb-6 ml-11">La estructura solo te sostiene si la voz sostiene la estructura. Cuatro mecánicas que ensayar antes de cualquier entrega de malas noticias.</p>
 
         <div class="ml-11 grid sm:grid-cols-2 gap-3">
           <div class="bg-white rounded-lg border border-slate-200 p-4">
-            <p class="font-bold text-slate-900 text-sm mb-1">Slow by 20%</p>
-            <p class="text-xs text-slate-600">Bad-news delivery should feel slower than you think it needs to. Speed reads as panic.</p>
+            <p class="font-bold text-slate-900 text-sm mb-1">Baja el ritmo 20%</p>
+            <p class="text-xs text-slate-600">La entrega de malas noticias debe sentirse más lenta de lo que crees que necesita ser. La velocidad se lee como pánico.</p>
           </div>
           <div class="bg-white rounded-lg border border-slate-200 p-4">
-            <p class="font-bold text-slate-900 text-sm mb-1">Drop the pitch</p>
-            <p class="text-xs text-slate-600">Lower than your conversational range. Pitch is the loudest emotional signal — keep it under control.</p>
+            <p class="font-bold text-slate-900 text-sm mb-1">Baja el tono</p>
+            <p class="text-xs text-slate-600">Más bajo que tu rango conversacional. El tono es la señal emocional más fuerte — mantenlo bajo control.</p>
           </div>
           <div class="bg-white rounded-lg border border-slate-200 p-4">
-            <p class="font-bold text-slate-900 text-sm mb-1">Land each sentence</p>
-            <p class="text-xs text-slate-600">Rising endings turn statements into questions. Bad news delivered as a question reads as uncertainty.</p>
+            <p class="font-bold text-slate-900 text-sm mb-1">Aterriza cada oración</p>
+            <p class="text-xs text-slate-600">Cierres ascendentes convierten afirmaciones en preguntas. Malas noticias entregadas como pregunta se leen como incertidumbre.</p>
           </div>
           <div class="bg-white rounded-lg border border-slate-200 p-4">
-            <p class="font-bold text-slate-900 text-sm mb-1">Breathe between beats</p>
-            <p class="text-xs text-slate-600">A half-second breath between the four beats lets the room absorb each one before the next.</p>
+            <p class="font-bold text-slate-900 text-sm mb-1">Respira entre tiempos</p>
+            <p class="text-xs text-slate-600">Medio segundo de respiración entre los cuatro tiempos deja que la sala absorba cada uno antes del siguiente.</p>
           </div>
         </div>
       </div>
@@ -176,20 +176,20 @@ import { AlertTriangle, CheckCircle2, XCircle, Eye, ShieldAlert } from "lucide-a
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">5</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Three Bad-News Traps</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Tres Trampas de Malas Noticias</h2>
         </div>
         <div class="ml-11 space-y-4">
           <div class="bg-amber-50 border border-amber-200 rounded-xl p-5">
-            <p class="font-bold text-slate-900 mb-1">Trap 1 — Premature reassurance</p>
-            <p class="text-slate-700 text-sm">"Everything's going to be fine" before the room has absorbed the news is patronizing — and worse, it reads as performance. Acknowledge weight before offering reassurance.</p>
+            <p class="font-bold text-slate-900 mb-1">Trampa 1 — Tranquilizar prematuramente</p>
+            <p class="text-slate-700 text-sm">"Todo va a estar bien" antes de que la sala haya absorbido la noticia es condescendiente — y peor, se lee como actuación. Reconoce el peso antes de ofrecer tranquilidad.</p>
           </div>
           <div class="bg-amber-50 border border-amber-200 rounded-xl p-5">
-            <p class="font-bold text-slate-900 mb-1">Trap 2 — The fake apology</p>
-            <p class="text-slate-700 text-sm">"I want to apologize for…" before the bad news has even landed is a signal you're more concerned with how you look than with what happened. Save the apology — if it's owed — for after the structure is delivered.</p>
+            <p class="font-bold text-slate-900 mb-1">Trampa 2 — La disculpa falsa</p>
+            <p class="text-slate-700 text-sm">"Quiero pedir disculpas por…" antes de que la mala noticia siquiera haya aterrizado es una señal de que estás más preocupado por cómo te ves que por lo que pasó. Guarda la disculpa — si se debe — para después de entregar la estructura.</p>
           </div>
           <div class="bg-amber-50 border border-amber-200 rounded-xl p-5">
-            <p class="font-bold text-slate-900 mb-1">Trap 3 — Overexplaining the cause</p>
-            <p class="text-slate-700 text-sm">One sentence on the cause is enough. The longer you spend on what went wrong, the more the room reads it as you defending yourself rather than informing them.</p>
+            <p class="font-bold text-slate-900 mb-1">Trampa 3 — Sobreexplicar la causa</p>
+            <p class="text-slate-700 text-sm">Una oración sobre la causa es suficiente. Cuanto más tiempo pases en lo que salió mal, más la sala lo lee como tú defendiéndote en vez de informándoles.</p>
           </div>
         </div>
       </div>
@@ -200,15 +200,15 @@ import { AlertTriangle, CheckCircle2, XCircle, Eye, ShieldAlert } from "lucide-a
   <section class="py-14 md:py-16 bg-slate-50 border-t border-slate-200">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
-        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">The Recap</h2>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">El Resumen</h2>
         <div class="bg-white rounded-2xl border border-slate-200 p-7">
           <ul class="space-y-3 text-slate-700">
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Under pressure, leaders <strong>transfer stability or transfer panic</strong>. Voice is the carrier.</span></li>
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Four beats: <strong>direct statement → specific cause → action already taken → forward frame</strong>.</span></li>
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Vocal mechanics matter as much as structure — <strong>slow, low, landed, breathed</strong>.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Bajo presión, los líderes <strong>transfieren estabilidad o transfieren pánico</strong>. La voz es el portador.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Cuatro tiempos: <strong>declaración directa → causa específica → acción ya tomada → encuadre hacia adelante</strong>.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>La mecánica vocal importa tanto como la estructura — <strong>lenta, baja, aterrizada, con respiraciones</strong>.</span></li>
           </ul>
         </div>
       </div>
     </div>
   </section>
-</DiagnoseLessonLayout>
+</PushbackLessonLayout>

--- a/src/pages/es/curso/pushback-ejecutivo/pausa-diagnostica.astro
+++ b/src/pages/es/curso/pushback-ejecutivo/pausa-diagnostica.astro
@@ -1,34 +1,34 @@
 ---
 export const prerender = true;
 
-import DiagnoseLessonLayout from "@components/course/DiagnoseLessonLayout.astro";
+import PushbackLessonLayout from "@components/course/PushbackLessonLayout.astro";
 import AudioButton from "@components/course/AudioButton";
 import { Pause, Clock, Volume2, CheckCircle2, XCircle, Eye } from "lucide-astro";
 ---
 
-<DiagnoseLessonLayout lessonId={2} lang="en" tkey="course/diagnose-before-defend/diagnostic-pause">
+<PushbackLessonLayout lessonId={2} lang="es" tkey="course/executive-pushback/diagnostic-pause">
   <!-- Section 1: The Core Idea -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-2">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">1</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Silence Is Your Most Underused Tool</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">El Silencio Es Tu Herramienta Más Subutilizada</h2>
         </div>
         <div class="ml-11 space-y-5 text-lg text-slate-700 leading-relaxed">
           <p>
-            When someone pushes back on you in a room, the default professional reflex is to <strong>respond fast</strong>. Speed feels like competence. Hesitation feels like weakness. So you fill the space — usually with the first response that came to mind, which is almost always the wrong one.
+            Cuando alguien te da pushback en una sala, el reflejo profesional por defecto es <strong>responder rápido</strong>. La velocidad se siente como competencia. La vacilación se siente como debilidad. Entonces llenas el espacio — usualmente con la primera respuesta que se te vino a la cabeza, que casi siempre es la equivocada.
           </p>
           <p>
-            Senior leaders do the opposite. They <strong>pause</strong>. Two seconds, sometimes three. They look at the person. They consider. Then they respond — slower, lower, more measured than the challenger expected. The pause is not a sign of uncertainty. It's a sign of control.
+            Los líderes senior hacen lo opuesto. <strong>Pausan</strong>. Dos segundos, a veces tres. Miran a la persona. Consideran. Después responden — más lento, más bajo, más medido de lo que el retador esperaba. La pausa no es una señal de incertidumbre. Es una señal de control.
           </p>
           <div class="rounded-2xl border-2 border-indigo-300 bg-indigo-50 p-6 my-6">
             <div class="flex items-center gap-3 mb-3">
               <Eye class="w-6 h-6 text-indigo-700" />
-              <h3 class="text-lg font-bold text-slate-900">The Principle</h3>
+              <h3 class="text-lg font-bold text-slate-900">El Principio</h3>
             </div>
             <p class="text-slate-800">
-              The 2-3 second pause is the single highest-leverage executive move you can install. It buys you diagnosis, breath, and the room's recalibrated attention — at the cost of feeling slightly uncomfortable.
+              La pausa de 2-3 segundos es el movimiento ejecutivo de mayor apalancamiento que puedes instalar. Te compra diagnóstico, respiración y la atención recalibrada de la sala — a costa de sentirte ligeramente incómodo.
             </p>
           </div>
         </div>
@@ -36,88 +36,88 @@ import { Pause, Clock, Volume2, CheckCircle2, XCircle, Eye } from "lucide-astro"
     </div>
   </section>
 
-  <!-- Section 2: What the Pause Buys You -->
+  <!-- Section 2: What the Pause Buys -->
   <section class="py-14 md:py-16 bg-slate-50">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">2</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">What the Pause Buys You</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Qué Te Compra la Pausa</h2>
         </div>
         <div class="ml-11 grid sm:grid-cols-2 gap-4">
           <div class="bg-white rounded-xl border border-slate-200 p-5">
             <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 text-indigo-700 mb-3">
               <Pause class="w-5 h-5" />
             </div>
-            <h3 class="font-bold text-slate-900 mb-1">Diagnostic time</h3>
-            <p class="text-sm text-slate-600">Two seconds is enough to map their objection to one of the six hidden drivers and decide which one to address.</p>
+            <h3 class="font-bold text-slate-900 mb-1">Tiempo diagnóstico</h3>
+            <p class="text-sm text-slate-600">Dos segundos son suficientes para mapear su objeción a uno de los seis impulsores ocultos y decidir cuál abordar.</p>
           </div>
           <div class="bg-white rounded-xl border border-slate-200 p-5">
             <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 text-indigo-700 mb-3">
               <Clock class="w-5 h-5" />
             </div>
-            <h3 class="font-bold text-slate-900 mb-1">Pace reset</h3>
-            <p class="text-sm text-slate-600">It interrupts the challenger's emotional tempo and forces the conversation into your rhythm rather than theirs.</p>
+            <h3 class="font-bold text-slate-900 mb-1">Reset del ritmo</h3>
+            <p class="text-sm text-slate-600">Interrumpe el tempo emocional del retador y obliga a la conversación a entrar en tu ritmo en lugar del de ellos.</p>
           </div>
           <div class="bg-white rounded-xl border border-slate-200 p-5">
             <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 text-indigo-700 mb-3">
               <Volume2 class="w-5 h-5" />
             </div>
-            <h3 class="font-bold text-slate-900 mb-1">Authority signal</h3>
-            <p class="text-sm text-slate-600">A measured pause reads as deliberation. Speed reads as defensiveness. Same words, opposite signal.</p>
+            <h3 class="font-bold text-slate-900 mb-1">Señal de autoridad</h3>
+            <p class="text-sm text-slate-600">Una pausa medida se lee como deliberación. La velocidad se lee como defensividad. Las mismas palabras, la señal opuesta.</p>
           </div>
           <div class="bg-white rounded-xl border border-slate-200 p-5">
             <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 text-indigo-700 mb-3">
               <Eye class="w-5 h-5" />
             </div>
-            <h3 class="font-bold text-slate-900 mb-1">Listening proof</h3>
-            <p class="text-sm text-slate-600">It tells the challenger you actually heard them — which often defuses 30% of the pressure before you speak.</p>
+            <h3 class="font-bold text-slate-900 mb-1">Prueba de escucha</h3>
+            <p class="text-sm text-slate-600">Le dice al retador que realmente lo escuchaste — lo cual frecuentemente desactiva el 30% de la presión antes de que hables.</p>
           </div>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- Section 3: The Three Questions to Run Silently -->
+  <!-- Section 3: Three Silent Questions -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">3</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">What to Run Silently in Those Two Seconds</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Qué Ejecutar Silenciosamente en Esos Dos Segundos</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">Three questions, run in this order. Practice the sequence enough that it becomes automatic — then the pause becomes effortless rather than awkward.</p>
+        <p class="text-slate-600 mb-6 ml-11">Tres preguntas, ejecutadas en este orden. Practica la secuencia lo suficiente para que se vuelva automática — entonces la pausa se vuelve natural en lugar de incómoda.</p>
 
         <div class="ml-11 space-y-4">
           <div class="bg-slate-900 text-white rounded-xl p-6">
-            <p class="text-xs font-bold uppercase tracking-wider text-indigo-400 mb-2">Question 1 — Driver</p>
-            <p class="text-lg italic mb-2">"Which of the six drivers is firing here?"</p>
-            <p class="text-sm text-slate-300">Even a rough match (risk vs. ego, status vs. workload) shapes a better response than answering the literal words.</p>
+            <p class="text-xs font-bold uppercase tracking-wider text-indigo-400 mb-2">Pregunta 1 — Impulsor</p>
+            <p class="text-lg italic mb-2">"¿Cuál de los seis impulsores se está activando aquí?"</p>
+            <p class="text-sm text-slate-300">Incluso una coincidencia aproximada (riesgo vs. ego, estatus vs. carga de trabajo) modela una mejor respuesta que contestar las palabras literales.</p>
           </div>
           <div class="bg-slate-900 text-white rounded-xl p-6">
-            <p class="text-xs font-bold uppercase tracking-wider text-indigo-400 mb-2">Question 2 — Outcome</p>
-            <p class="text-lg italic mb-2">"What outcome do they actually want from this exchange?"</p>
-            <p class="text-sm text-slate-300">Sometimes they want you to back down. Sometimes they want reassurance. Sometimes they want the credit to be visible. Name the outcome internally before you respond to the words.</p>
+            <p class="text-xs font-bold uppercase tracking-wider text-indigo-400 mb-2">Pregunta 2 — Resultado</p>
+            <p class="text-lg italic mb-2">"¿Qué resultado quieren realmente de este intercambio?"</p>
+            <p class="text-sm text-slate-300">A veces quieren que cedas. A veces quieren tranquilidad. A veces quieren que el crédito sea visible. Nombra el resultado internamente antes de responder a las palabras.</p>
           </div>
           <div class="bg-slate-900 text-white rounded-xl p-6">
-            <p class="text-xs font-bold uppercase tracking-wider text-indigo-400 mb-2">Question 3 — Safety</p>
-            <p class="text-lg italic mb-2">"What's the safest response to the real concern that doesn't surrender my position?"</p>
-            <p class="text-sm text-slate-300">Safe doesn't mean weak. Safe means it doesn't escalate ego, doesn't trigger workload defense, and doesn't shift accountability to you when it shouldn't be yours.</p>
+            <p class="text-xs font-bold uppercase tracking-wider text-indigo-400 mb-2">Pregunta 3 — Seguridad</p>
+            <p class="text-lg italic mb-2">"¿Cuál es la respuesta más segura a la preocupación real que no rinde mi posición?"</p>
+            <p class="text-sm text-slate-300">Seguro no significa débil. Seguro significa que no escala el ego, no dispara la defensa de carga de trabajo y no transfiere responsabilidad a ti cuando no debería ser tuya.</p>
           </div>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- Section 4: The Pause in Practice -->
+  <!-- Section 4: Pause in Practice -->
   <section class="py-14 md:py-16 bg-slate-50">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">4</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Pause in Practice</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">La Pausa en la Práctica</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">Same pushback, two responses. The difference is the two seconds in front of the words. Tap the speaker to hear the cadence of the paused response.</p>
+        <p class="text-slate-600 mb-6 ml-11">Mismo pushback, dos respuestas. La diferencia son los dos segundos antes de las palabras. Toca el ícono para escuchar el ritmo de la respuesta pausada.</p>
 
         <div class="ml-11 space-y-5">
           <div class="bg-white rounded-xl border border-slate-200 p-6">
@@ -128,7 +128,7 @@ import { Pause, Clock, Volume2, CheckCircle2, XCircle, Eye } from "lucide-astro"
               <div class="flex items-start gap-3">
                 <XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
                 <div class="flex-1">
-                  <p class="text-xs font-bold uppercase tracking-wider text-red-700 mb-1">Reactive (no pause)</p>
+                  <p class="text-xs font-bold uppercase tracking-wider text-red-700 mb-1">Reactivo (sin pausa)</p>
                   <p class="text-slate-800 italic text-sm">"Yeah, I know it's more aggressive but we modeled it carefully and we think the upside justifies it, and we have a few different scenarios that we can walk through if you'd like to see them…"</p>
                 </div>
               </div>
@@ -138,11 +138,11 @@ import { Pause, Clock, Volume2, CheckCircle2, XCircle, Eye } from "lucide-astro"
               <div class="flex items-start gap-3">
                 <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
                 <div class="flex-1">
-                  <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-1">Paused (2 seconds, then)</p>
+                  <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-1">Con pausa (2 segundos, luego)</p>
                   <p class="text-slate-900 font-medium mb-3">"That's a fair read. It is more aggressive — and that's deliberate. The market conditions that made the conservative model work last cycle don't apply this cycle."</p>
                   <div class="flex items-center gap-2 pt-3 border-t border-emerald-200/60">
                     <AudioButton client:visible text="That's a fair read. It is more aggressive — and that's deliberate. The market conditions that made the conservative model work last cycle don't apply this cycle." lang="en-US" size="sm" />
-                    <span class="text-xs text-slate-600">Listen to the cadence</span>
+                    <span class="text-xs text-slate-600">Escucha el ritmo</span>
                   </div>
                 </div>
               </div>
@@ -157,7 +157,7 @@ import { Pause, Clock, Volume2, CheckCircle2, XCircle, Eye } from "lucide-astro"
               <div class="flex items-start gap-3">
                 <XCircle class="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
                 <div class="flex-1">
-                  <p class="text-xs font-bold uppercase tracking-wider text-red-700 mb-1">Reactive (no pause)</p>
+                  <p class="text-xs font-bold uppercase tracking-wider text-red-700 mb-1">Reactivo (sin pausa)</p>
                   <p class="text-slate-800 italic text-sm">"Sorry, I know I should have, I just thought I'd wait until I had more details before bringing it to you and then it kind of ran ahead of where I planned…"</p>
                 </div>
               </div>
@@ -167,11 +167,11 @@ import { Pause, Clock, Volume2, CheckCircle2, XCircle, Eye } from "lucide-astro"
               <div class="flex items-start gap-3">
                 <CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
                 <div class="flex-1">
-                  <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-1">Paused (2 seconds, then)</p>
+                  <p class="text-xs font-bold uppercase tracking-wider text-emerald-700 mb-1">Con pausa (2 segundos, luego)</p>
                   <p class="text-slate-900 font-medium mb-3">"You should have been in the room earlier. The reason you weren't is that I wanted a clean recommendation rather than a partial one — but that was the wrong call. Here's where we are now."</p>
                   <div class="flex items-center gap-2 pt-3 border-t border-emerald-200/60">
                     <AudioButton client:visible text="You should have been in the room earlier. The reason you weren't is that I wanted a clean recommendation rather than a partial one — but that was the wrong call. Here's where we are now." lang="en-US" size="sm" />
-                    <span class="text-xs text-slate-600">Listen to the cadence</span>
+                    <span class="text-xs text-slate-600">Escucha el ritmo</span>
                   </div>
                 </div>
               </div>
@@ -182,28 +182,28 @@ import { Pause, Clock, Volume2, CheckCircle2, XCircle, Eye } from "lucide-astro"
     </div>
   </section>
 
-  <!-- Section 5: How to Practice the Pause -->
+  <!-- Section 5: How to Install the Pause -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">5</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">How to Install the Pause</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Cómo Instalar la Pausa</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">The pause feels deeply unnatural at first. Two seconds of silence feels like ten when you're the one inside it. Three practice patterns close the gap.</p>
+        <p class="text-slate-600 mb-6 ml-11">La pausa se siente profundamente antinatural al principio. Dos segundos de silencio se sienten como diez cuando eres el que está dentro de ellos. Tres patrones de práctica cierran la brecha.</p>
 
         <div class="ml-11 space-y-4">
           <div class="bg-slate-50 rounded-xl border border-slate-200 p-5">
-            <p class="font-bold text-slate-900 mb-1">Low-stakes installation: the meeting reaction</p>
-            <p class="text-sm text-slate-600">For one week, every time someone asks you a question in a meeting where the stakes are low, count "one Mississippi, two Mississippi" before responding. Boring questions, boring pauses. You're rewiring the reflex when nothing is on the line.</p>
+            <p class="font-bold text-slate-900 mb-1">Instalación de baja presión: la reacción en juntas</p>
+            <p class="text-sm text-slate-600">Por una semana, cada vez que alguien te haga una pregunta en una junta donde los stakes son bajos, cuenta "uno Mississippi, dos Mississippi" antes de responder. Preguntas aburridas, pausas aburridas. Estás reescribiendo el reflejo cuando nada está en juego.</p>
           </div>
           <div class="bg-slate-50 rounded-xl border border-slate-200 p-5">
-            <p class="font-bold text-slate-900 mb-1">Medium-stakes installation: written pause</p>
-            <p class="text-sm text-slate-600">In Slack / email, when you get a pushback message, draft your reply, then sit on it for 90 seconds before sending. The written pause builds the same diagnostic habit without the live-room discomfort.</p>
+            <p class="font-bold text-slate-900 mb-1">Instalación de presión media: pausa escrita</p>
+            <p class="text-sm text-slate-600">En Slack / email, cuando recibas un mensaje de pushback, redacta tu respuesta y siéntate sobre ella 90 segundos antes de enviarla. La pausa escrita construye el mismo hábito diagnóstico sin la incomodidad de la sala en vivo.</p>
           </div>
           <div class="bg-slate-50 rounded-xl border border-slate-200 p-5">
-            <p class="font-bold text-slate-900 mb-1">High-stakes installation: the breath</p>
-            <p class="text-sm text-slate-600">When you feel the heat of a real pushback, take one slow breath in through your nose before you respond. The breath is your two seconds. It's visible to no one else and it gives your diagnostic time to fire.</p>
+            <p class="font-bold text-slate-900 mb-1">Instalación de alta presión: la respiración</p>
+            <p class="text-sm text-slate-600">Cuando sientas el calor de un pushback real, toma una respiración lenta por la nariz antes de responder. La respiración es tus dos segundos. No es visible para nadie más y le da tiempo a tu diagnóstico para activarse.</p>
           </div>
         </div>
       </div>
@@ -214,15 +214,15 @@ import { Pause, Clock, Volume2, CheckCircle2, XCircle, Eye } from "lucide-astro"
   <section class="py-14 md:py-16 bg-slate-50 border-t border-slate-200">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
-        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">The Recap</h2>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">El Resumen</h2>
         <div class="bg-white rounded-2xl border border-slate-200 p-7">
           <ul class="space-y-3 text-slate-700">
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>The <strong>2-3 second pause</strong> is the single highest-leverage executive move under pressure.</span></li>
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Run three silent questions: <strong>which driver, what outcome they want, safest response that holds your position</strong>.</span></li>
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Practice low-stakes first. The pause becomes effortless only after roughly 30 reps in non-pressure contexts.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>La <strong>pausa de 2-3 segundos</strong> es el movimiento ejecutivo de mayor apalancamiento bajo presión.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Ejecuta tres preguntas silenciosas: <strong>qué impulsor, qué resultado quieren, respuesta más segura que sostiene tu posición</strong>.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Practica primero a baja presión. La pausa se vuelve natural solo después de aproximadamente 30 repeticiones en contextos sin presión.</span></li>
           </ul>
         </div>
       </div>
     </div>
   </section>
-</DiagnoseLessonLayout>
+</PushbackLessonLayout>

--- a/src/pages/es/curso/pushback-ejecutivo/pushback-comercial.astro
+++ b/src/pages/es/curso/pushback-ejecutivo/pushback-comercial.astro
@@ -1,34 +1,34 @@
 ---
 export const prerender = true;
 
-import DiagnoseLessonLayout from "@components/course/DiagnoseLessonLayout.astro";
+import PushbackLessonLayout from "@components/course/PushbackLessonLayout.astro";
 import AudioButton from "@components/course/AudioButton";
 import { DollarSign, CheckCircle2, XCircle, Eye, Target } from "lucide-astro";
 ---
 
-<DiagnoseLessonLayout lessonId={5} lang="en" tkey="course/diagnose-before-defend/commercial-pushback">
-  <!-- Section 1: The Core Idea -->
+<PushbackLessonLayout lessonId={5} lang="es" tkey="course/executive-pushback/commercial-pushback">
+  <!-- Section 1: Core Idea -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-2">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">1</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Price Becomes the Focus When Value and Trust Are Weak</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">El Precio Se Vuelve el Tema Cuando el Valor y la Confianza Son Débiles</h2>
         </div>
         <div class="ml-11 space-y-5 text-lg text-slate-700 leading-relaxed">
           <p>
-            When a buyer fights you on price, the conversation has already gone sideways. Healthy commercial conversations don't dwell on price — they negotiate scope, terms, or timing while price stays roughly anchored. When price becomes the dominant topic, one of two things has happened: the buyer hasn't internalized the value, or they don't trust the relationship enough to pay for it.
+            Cuando un comprador pelea contigo sobre el precio, la conversación ya se torció. Las conversaciones comerciales sanas no se quedan en el precio — negocian alcance, términos o tiempo mientras el precio se mantiene anclado. Cuando el precio se vuelve el tema dominante, una de dos cosas pasó: el comprador no ha internalizado el valor, o no confía en la relación lo suficiente para pagarlo.
           </p>
           <p>
-            Defending the price directly is almost always the wrong move. It signals that <strong>you</strong> believe price is the live issue — which validates the buyer's framing. The executive move is to diagnose <em>why</em> price became the conversation and address the layer underneath.
+            Defender el precio directamente es casi siempre el movimiento equivocado. Señala que <strong>tú</strong> crees que el precio es el tema vivo — lo cual valida el encuadre del comprador. El movimiento ejecutivo es diagnosticar <em>por qué</em> el precio se volvió la conversación y abordar la capa de abajo.
           </p>
           <div class="rounded-2xl border-2 border-indigo-300 bg-indigo-50 p-6 my-6">
             <div class="flex items-center gap-3 mb-3">
               <DollarSign class="w-6 h-6 text-indigo-700" />
-              <h3 class="text-lg font-bold text-slate-900">The Principle</h3>
+              <h3 class="text-lg font-bold text-slate-900">El Principio</h3>
             </div>
             <p class="text-slate-800">
-              Diagnose the hesitation <em>before</em> defending the offer. If you're explaining the price, you've already lost ground. If you're reframing the value, you're still in the room.
+              Diagnostica la duda <em>antes</em> de defender la oferta. Si estás explicando el precio, ya cediste terreno. Si estás reencuadrando el valor, todavía estás en la sala.
             </p>
           </div>
         </div>
@@ -36,76 +36,76 @@ import { DollarSign, CheckCircle2, XCircle, Eye, Target } from "lucide-astro";
     </div>
   </section>
 
-  <!-- Section 2: The Four Commercial Drivers -->
+  <!-- Section 2: Four Commercial Drivers -->
   <section class="py-14 md:py-16 bg-slate-50">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">2</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">What's Actually Driving Commercial Pushback</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Qué Está Impulsando el Pushback Comercial</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">Four hidden drivers account for almost all commercial objections. Each one has a different correct response — defending the price never works for any of them.</p>
+        <p class="text-slate-600 mb-6 ml-11">Cuatro impulsores ocultos explican casi todas las objeciones comerciales. Cada uno tiene una respuesta correcta distinta — defender el precio nunca funciona para ninguno.</p>
 
         <div class="ml-11 space-y-4">
           <div class="bg-white rounded-xl border border-slate-200 p-6">
             <div class="flex items-start gap-3 mb-2">
               <div class="flex items-center justify-center w-9 h-9 rounded-lg bg-amber-100 text-amber-700 shrink-0 font-bold text-sm">1</div>
-              <h3 class="text-lg font-bold text-slate-900">Value Disconnect</h3>
+              <h3 class="text-lg font-bold text-slate-900">Desconexión de Valor</h3>
             </div>
-            <p class="text-slate-700 mb-2">The buyer doesn't fully see what they're getting. The price feels high because the value feels unclear or unverified.</p>
-            <p class="text-sm text-slate-500 italic">Tell: comparison language ("competitor X is half the price"), feature questions ("what exactly is included?").</p>
+            <p class="text-slate-700 mb-2">El comprador no ve completamente lo que está recibiendo. El precio se siente alto porque el valor se siente poco claro o no verificado.</p>
+            <p class="text-sm text-slate-500 italic">Pista: lenguaje de comparación ("el competidor X cuesta la mitad"), preguntas sobre features ("¿qué incluye exactamente?").</p>
           </div>
 
           <div class="bg-white rounded-xl border border-slate-200 p-6">
             <div class="flex items-start gap-3 mb-2">
               <div class="flex items-center justify-center w-9 h-9 rounded-lg bg-amber-100 text-amber-700 shrink-0 font-bold text-sm">2</div>
-              <h3 class="text-lg font-bold text-slate-900">Procurement Theater</h3>
+              <h3 class="text-lg font-bold text-slate-900">Teatro de Procurement</h3>
             </div>
-            <p class="text-slate-700 mb-2">A procurement manager has been told to negotiate. The pushback is not about your price — it's about their performance review. They need a concession to walk out with.</p>
-            <p class="text-sm text-slate-500 italic">Tell: arbitrary percentages requested ("we need 15% off"), references to budget cycles, scripted phrases.</p>
+            <p class="text-slate-700 mb-2">A un gerente de compras le dijeron que negocie. El pushback no es sobre tu precio — es sobre su evaluación de desempeño. Necesita una concesión con la cual salir.</p>
+            <p class="text-sm text-slate-500 italic">Pista: porcentajes arbitrarios pedidos ("necesitamos 15% menos"), referencias a ciclos de presupuesto, frases con guion.</p>
           </div>
 
           <div class="bg-white rounded-xl border border-slate-200 p-6">
             <div class="flex items-start gap-3 mb-2">
               <div class="flex items-center justify-center w-9 h-9 rounded-lg bg-amber-100 text-amber-700 shrink-0 font-bold text-sm">3</div>
-              <h3 class="text-lg font-bold text-slate-900">Internal Approval Risk</h3>
+              <h3 class="text-lg font-bold text-slate-900">Riesgo de Aprobación Interna</h3>
             </div>
-            <p class="text-slate-700 mb-2">The buyer wants to buy but isn't sure they can defend the spend internally. The price objection is them rehearsing the defense they'll have to give to their boss.</p>
-            <p class="text-sm text-slate-500 italic">Tell: "I'll need to take this back to…", references to executive approval, requests for ROI documentation.</p>
+            <p class="text-slate-700 mb-2">El comprador quiere comprar pero no está seguro de poder defender el gasto internamente. La objeción de precio es él ensayando la defensa que tendrá que dar a su jefe.</p>
+            <p class="text-sm text-slate-500 italic">Pista: "necesito llevárselo a…", referencias a aprobación ejecutiva, solicitudes de documentación de ROI.</p>
           </div>
 
           <div class="bg-white rounded-xl border border-slate-200 p-6">
             <div class="flex items-start gap-3 mb-2">
               <div class="flex items-center justify-center w-9 h-9 rounded-lg bg-amber-100 text-amber-700 shrink-0 font-bold text-sm">4</div>
-              <h3 class="text-lg font-bold text-slate-900">Trust Gap</h3>
+              <h3 class="text-lg font-bold text-slate-900">Brecha de Confianza</h3>
             </div>
-            <p class="text-slate-700 mb-2">They don't have evidence yet that you'll deliver. The price isn't the issue — the perceived risk of paying it is.</p>
-            <p class="text-sm text-slate-500 italic">Tell: requests for references, pilot proposals, "let's start small" framing, slow-walking language.</p>
+            <p class="text-slate-700 mb-2">Todavía no tienen evidencia de que vas a entregar. El precio no es el tema — el riesgo percibido de pagarlo sí lo es.</p>
+            <p class="text-sm text-slate-500 italic">Pista: solicitudes de referencias, propuestas de piloto, encuadre "empecemos en pequeño", lenguaje de avance lento.</p>
           </div>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- Section 3: Commercial ACR -->
+  <!-- Section 3: Commercial RCR -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-600 text-white text-sm font-bold">3</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Commercial ACR — Each Driver, Each Response</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">RCR Comercial — Cada Impulsor, Cada Respuesta</h2>
         </div>
-        <p class="text-slate-600 mb-6 ml-11">Same buyer line, four possible drivers, four different responses. The diagnosis decides which one you use.</p>
+        <p class="text-slate-600 mb-6 ml-11">La misma línea del comprador, cuatro impulsores posibles, cuatro respuestas distintas. El diagnóstico decide cuál usas.</p>
 
         <div class="ml-11 space-y-5">
           <div class="bg-slate-900 text-white rounded-xl overflow-hidden">
             <div class="px-5 py-3 border-b border-white/10">
-              <p class="text-xs font-bold uppercase tracking-wider text-indigo-300">Buyer line</p>
+              <p class="text-xs font-bold uppercase tracking-wider text-indigo-300">Línea del comprador</p>
               <p class="text-lg italic mt-1">"Your price is about 30% over what we had in budget."</p>
             </div>
             <div class="p-5 space-y-4">
               <div class="bg-white/5 rounded-lg p-4">
-                <p class="text-xs font-bold uppercase tracking-wider text-amber-300 mb-2">If the driver is Value Disconnect</p>
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-300 mb-2">Si el impulsor es Desconexión de Valor</p>
                 <div class="flex items-center gap-3">
                   <p class="text-slate-100 flex-1 italic">"That gap usually means we haven't shown enough of the value yet. Can I walk you through the two outcomes we'd actually produce in the first 90 days? If those aren't worth the gap, we shouldn't be working together."</p>
                   <AudioButton client:visible text="That gap usually means we haven't shown enough of the value yet. Can I walk you through the two outcomes we'd actually produce in the first 90 days? If those aren't worth the gap, we shouldn't be working together." lang="en-US" size="sm" />
@@ -113,7 +113,7 @@ import { DollarSign, CheckCircle2, XCircle, Eye, Target } from "lucide-astro";
               </div>
 
               <div class="bg-white/5 rounded-lg p-4">
-                <p class="text-xs font-bold uppercase tracking-wider text-amber-300 mb-2">If the driver is Procurement Theater</p>
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-300 mb-2">Si el impulsor es Teatro de Procurement</p>
                 <div class="flex items-center gap-3">
                   <p class="text-slate-100 flex-1 italic">"I hear you. We're not going to move on rate — but I can move on terms. Annual prepay at a reduced quarterly commitment, or extended payment terms — those are the two levers I have. Which one helps you more?"</p>
                   <AudioButton client:visible text="I hear you. We're not going to move on rate — but I can move on terms. Annual prepay at a reduced quarterly commitment, or extended payment terms — those are the two levers I have. Which one helps you more?" lang="en-US" size="sm" />
@@ -121,7 +121,7 @@ import { DollarSign, CheckCircle2, XCircle, Eye, Target } from "lucide-astro";
               </div>
 
               <div class="bg-white/5 rounded-lg p-4">
-                <p class="text-xs font-bold uppercase tracking-wider text-amber-300 mb-2">If the driver is Internal Approval Risk</p>
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-300 mb-2">Si el impulsor es Riesgo de Aprobación Interna</p>
                 <div class="flex items-center gap-3">
                   <p class="text-slate-100 flex-1 italic">"That's a real gap to defend. Let me give you the three numbers that usually carry the internal conversation — and if those don't fit your CFO's framing, tell me what does and I'll reshape it."</p>
                   <AudioButton client:visible text="That's a real gap to defend. Let me give you the three numbers that usually carry the internal conversation — and if those don't fit your CFO's framing, tell me what does and I'll reshape it." lang="en-US" size="sm" />
@@ -129,7 +129,7 @@ import { DollarSign, CheckCircle2, XCircle, Eye, Target } from "lucide-astro";
               </div>
 
               <div class="bg-white/5 rounded-lg p-4">
-                <p class="text-xs font-bold uppercase tracking-wider text-amber-300 mb-2">If the driver is Trust Gap</p>
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-300 mb-2">Si el impulsor es Brecha de Confianza</p>
                 <div class="flex items-center gap-3">
                   <p class="text-slate-100 flex-1 italic">"That gap feels bigger when you don't yet have evidence we'll deliver. Here's what I'd propose: a structured 60-day milestone with a defined success threshold. If we don't hit it, you exit clean. That removes the risk of paying full price for an unproven outcome."</p>
                   <AudioButton client:visible text="That gap feels bigger when you don't yet have evidence we'll deliver. Here's what I'd propose: a structured 60-day milestone with a defined success threshold. If we don't hit it, you exit clean. That removes the risk of paying full price for an unproven outcome." lang="en-US" size="sm" />
@@ -142,23 +142,23 @@ import { DollarSign, CheckCircle2, XCircle, Eye, Target } from "lucide-astro";
     </div>
   </section>
 
-  <!-- Section 4: The Discount Trap -->
+  <!-- Section 4: Discount Trap -->
   <section class="py-14 md:py-16 bg-slate-50">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">4</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">The Discount Trap</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">La Trampa del Descuento</h2>
         </div>
         <div class="ml-11 space-y-5 text-lg text-slate-700 leading-relaxed">
           <p>
-            The biggest commercial mistake under pressure is conceding on price too quickly. The pattern is well-documented: buyer asks for a discount, seller concedes, buyer feels they should have asked for more, and the entire deal becomes structured around price rather than value. You've trained them to negotiate every renewal the same way.
+            El error comercial más grande bajo presión es ceder en el precio demasiado rápido. El patrón está bien documentado: el comprador pide un descuento, el vendedor cede, el comprador siente que debió haber pedido más, y todo el acuerdo se estructura alrededor del precio en vez del valor. Los entrenaste para negociar cada renovación de la misma manera.
           </p>
           <p>
-            The correct response to "can you do better on price" is almost never a discount. It's a <strong>trade</strong> — you move on price only if they move on something else. Term length. Payment timing. Commitment volume. Reference rights. Anything.
+            La respuesta correcta a "¿puedes hacer algo mejor en el precio?" casi nunca es un descuento. Es un <strong>intercambio</strong> — te mueves en precio solo si ellos se mueven en algo más. Duración del término. Tiempos de pago. Volumen de compromiso. Derechos de referencia. Cualquier cosa.
           </p>
           <div class="bg-white border border-slate-200 rounded-xl p-5 my-4">
-            <p class="text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">The trade response</p>
+            <p class="text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">La respuesta de intercambio</p>
             <div class="flex items-center gap-3">
               <p class="text-lg text-slate-900 italic flex-1">"I can look at price if you can look at term. A two-year commitment changes my math — a one-year doesn't."</p>
               <AudioButton client:visible text="I can look at price if you can look at term. A two-year commitment changes my math — a one-year doesn't." lang="en-US" size="sm" />
@@ -175,20 +175,20 @@ import { DollarSign, CheckCircle2, XCircle, Eye, Target } from "lucide-astro";
       <div class="max-w-3xl mx-auto">
         <div class="flex items-center gap-3 mb-6">
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white text-sm font-bold">5</span>
-          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Three Commercial Traps</h2>
+          <h2 class="text-2xl md:text-3xl font-bold text-slate-900">Tres Trampas Comerciales</h2>
         </div>
         <div class="ml-11 space-y-4">
           <div class="bg-amber-50 border border-amber-200 rounded-xl p-5">
-            <p class="font-bold text-slate-900 mb-1">Trap 1 — Sounding eager</p>
-            <p class="text-slate-700 text-sm">Eagerness is the most expensive signal in a commercial conversation. "We'd love to work with you" early in a price discussion costs you 5-10% in margin. Calibrated detachment ("if we're the right fit for you") preserves leverage.</p>
+            <p class="font-bold text-slate-900 mb-1">Trampa 1 — Sonar ansioso</p>
+            <p class="text-slate-700 text-sm">La ansiedad es la señal más cara en una conversación comercial. "We'd love to work with you" temprano en una discusión de precio te cuesta entre 5 y 10% en margen. El desapego calibrado ("if we're the right fit for you") preserva el apalancamiento.</p>
           </div>
           <div class="bg-amber-50 border border-amber-200 rounded-xl p-5">
-            <p class="font-bold text-slate-900 mb-1">Trap 2 — Defending the line items</p>
-            <p class="text-slate-700 text-sm">When you start defending why each line item costs what it costs, you've moved the conversation from value to cost accounting. You'll always lose that frame. Stay on outcomes, not inputs.</p>
+            <p class="font-bold text-slate-900 mb-1">Trampa 2 — Defender las líneas de partida</p>
+            <p class="text-slate-700 text-sm">Cuando empiezas a defender por qué cada línea cuesta lo que cuesta, movieron la conversación del valor a la contabilidad de costos. Siempre vas a perder ese encuadre. Quédate en resultados, no en insumos.</p>
           </div>
           <div class="bg-amber-50 border border-amber-200 rounded-xl p-5">
-            <p class="font-bold text-slate-900 mb-1">Trap 3 — Conceding for no trade</p>
-            <p class="text-slate-700 text-sm">If you discount without getting something in return, you've taught the buyer that your price was fake. Every concession needs a corresponding ask, even a small one.</p>
+            <p class="font-bold text-slate-900 mb-1">Trampa 3 — Ceder sin intercambio</p>
+            <p class="text-slate-700 text-sm">Si das un descuento sin recibir algo a cambio, le enseñaste al comprador que tu precio era falso. Cada concesión necesita una contraprestación, aunque sea pequeña.</p>
           </div>
         </div>
       </div>
@@ -199,15 +199,15 @@ import { DollarSign, CheckCircle2, XCircle, Eye, Target } from "lucide-astro";
   <section class="py-14 md:py-16 bg-slate-50 border-t border-slate-200">
     <div class="site-container mx-auto px-4">
       <div class="max-w-3xl mx-auto">
-        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">The Recap</h2>
+        <h2 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6 text-center">El Resumen</h2>
         <div class="bg-white rounded-2xl border border-slate-200 p-7">
           <ul class="space-y-3 text-slate-700">
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>Price becomes the focus when value and trust are weak.</strong> Diagnose which.</span></li>
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Four drivers: <strong>Value Disconnect, Procurement Theater, Internal Approval Risk, Trust Gap</strong>. Each has a different correct response.</span></li>
-            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Never concede on price without a <strong>trade</strong>. Every discount needs a corresponding ask.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span><strong>El precio se vuelve el tema cuando el valor y la confianza son débiles.</strong> Diagnostica cuál.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Cuatro impulsores: <strong>Desconexión de Valor, Teatro de Procurement, Riesgo de Aprobación Interna, Brecha de Confianza</strong>. Cada uno tiene una respuesta correcta distinta.</span></li>
+            <li class="flex gap-3"><CheckCircle2 class="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" /><span>Nunca cedas en el precio sin un <strong>intercambio</strong>. Cada descuento necesita una contraprestación.</span></li>
           </ul>
         </div>
       </div>
     </div>
   </section>
-</DiagnoseLessonLayout>
+</PushbackLessonLayout>

--- a/src/pages/es/curso/pushback-ejecutivo/reconoce-clarifica-redirige.astro
+++ b/src/pages/es/curso/pushback-ejecutivo/reconoce-clarifica-redirige.astro
@@ -1,12 +1,12 @@
 ---
 export const prerender = true;
 
-import DiagnoseLessonLayout from "@components/course/DiagnoseLessonLayout.astro";
+import PushbackLessonLayout from "@components/course/PushbackLessonLayout.astro";
 import AudioButton from "@components/course/AudioButton";
 import { Compass, CheckCircle2, XCircle, Eye, ArrowRightLeft } from "lucide-astro";
 ---
 
-<DiagnoseLessonLayout lessonId={4} lang="es" tkey="course/diagnose-before-defend/acknowledge-clarify-redirect">
+<PushbackLessonLayout lessonId={4} lang="es" tkey="course/executive-pushback/acknowledge-clarify-redirect">
   <!-- Section 1: Core Idea -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
@@ -255,4 +255,4 @@ import { Compass, CheckCircle2, XCircle, Eye, ArrowRightLeft } from "lucide-astr
       </div>
     </div>
   </section>
-</DiagnoseLessonLayout>
+</PushbackLessonLayout>

--- a/src/pages/es/curso/pushback-ejecutivo/seis-impulsores-ocultos.astro
+++ b/src/pages/es/curso/pushback-ejecutivo/seis-impulsores-ocultos.astro
@@ -1,12 +1,12 @@
 ---
 export const prerender = true;
 
-import DiagnoseLessonLayout from "@components/course/DiagnoseLessonLayout.astro";
+import PushbackLessonLayout from "@components/course/PushbackLessonLayout.astro";
 import AudioButton from "@components/course/AudioButton";
 import { Search, AlertCircle, CheckCircle2, XCircle, Eye } from "lucide-astro";
 ---
 
-<DiagnoseLessonLayout lessonId={1} lang="es" tkey="course/diagnose-before-defend/six-hidden-drivers">
+<PushbackLessonLayout lessonId={1} lang="es" tkey="course/executive-pushback/six-hidden-drivers">
   <!-- Section 1: La Idea Central -->
   <section class="py-14 md:py-16 bg-white">
     <div class="site-container mx-auto px-4">
@@ -247,4 +247,4 @@ import { Search, AlertCircle, CheckCircle2, XCircle, Eye } from "lucide-astro";
       </div>
     </div>
   </section>
-</DiagnoseLessonLayout>
+</PushbackLessonLayout>

--- a/src/pages/es/cursos/index.astro
+++ b/src/pages/es/cursos/index.astro
@@ -9,7 +9,7 @@ import { intermediateInfo, intermediateUnits } from "@data/intermediate/units";
 import { advancedInfo, advancedUnits } from "@data/advanced/units";
 import { executiveInfo, executiveUnits } from "@data/executive/units";
 import { driveInfo, scenarioMeta } from "@data/drive-the-decision/scenarios";
-import { diagnoseInfo, diagnoseLessons } from "@data/diagnose-before-defend/lessons";
+import { pushbackInfo, pushbackLessons } from "@data/executive-pushback/lessons";
 import {
   Sparkles,
   BookOpen,
@@ -33,7 +33,7 @@ const intermediateAvailable = intermediateUnits.length;
 const advancedAvailable = advancedUnits.length;
 const executiveAvailable = executiveUnits.filter((u) => u.published).length;
 const driveScenariosAvailable = scenarioMeta.filter((s) => s.available).length;
-const diagnoseLessonsAvailable = diagnoseLessons.filter((l) => l.available).length;
+const pushbackLessonsAvailable = pushbackLessons.filter((l) => l.available).length;
 ---
 
 <Base
@@ -59,7 +59,7 @@ const diagnoseLessonsAvailable = diagnoseLessons.filter((l) => l.available).leng
           Ocho cursos gratuitos e interactivos hechos para hispanohablantes —
           cinco rutas por nivel, de A1 principiante a C2 ejecutivo, más tres
           clases magistrales enfocadas: tiempos del pasado, comunicación
-          ejecutiva de decisión y diagnóstico del pushback. Sin registro.
+          ejecutiva de decisión y manejo de pushback ejecutivo. Sin registro.
           Sin barreras. Solo progreso real desde la primera lección.
         </p>
       </div>
@@ -417,26 +417,26 @@ const diagnoseLessonsAvailable = diagnoseLessons.filter((l) => l.available).leng
           </div>
         </a>
 
-        <!-- Clase Magistral — Diagnostica Antes de Defender -->
+        <!-- Clase Magistral — Manejo de Pushback y Objeciones Ejecutivas -->
         <a
-          href="/es/curso/diagnostica-antes-de-defender/"
+          href="/es/curso/pushback-ejecutivo/"
           class="group block bg-white rounded-2xl border-2 border-indigo-400/40 overflow-hidden hover:shadow-xl hover:border-indigo-400 transition-all duration-200"
         >
           <div class="bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-900 p-6 text-white min-h-[180px] flex flex-col justify-end">
             <div class="flex items-center gap-2 text-indigo-300 text-xs font-bold uppercase tracking-wider mb-2">
               <Search class="w-3.5 h-3.5" />
-              Clase Magistral — C1 a C2 Pushback
+              Clase Magistral — C1 a C2 Ejecutivo
             </div>
             <h2 class="text-2xl md:text-3xl font-bold mb-2" style="font-family: 'Noto Sans KR', sans-serif;">
-              {diagnoseInfo.titleEs}
+              {pushbackInfo.titleEs}
             </h2>
             <p class="text-indigo-100 text-sm leading-relaxed">
-              {diagnoseInfo.shortTaglineEs}
+              {pushbackInfo.shortTaglineEs}
             </p>
           </div>
           <div class="p-6">
             <p class="text-slate-600 text-sm leading-relaxed mb-4">
-              La master class diagnóstica para directores, ventas y mandos medios que manejan pushback bajo presión. Lee el impulsor real debajo de la objeción declarada, sostén la compostura mientras lo haces y responde con estructura en lugar de defensividad.
+              La master class de manejo de pushback para directores, ventas y mandos medios bajo presión ejecutiva. Lee el impulsor real debajo de la objeción declarada, sostén la compostura mientras lo haces y responde con estructura en lugar de defensividad.
             </p>
             <ul class="space-y-2 mb-6">
               <li class="flex items-start gap-2 text-sm text-slate-700">
@@ -454,7 +454,7 @@ const diagnoseLessonsAvailable = diagnoseLessons.filter((l) => l.available).leng
             </ul>
             <div class="flex items-center justify-between">
               <span class="text-xs font-semibold text-indigo-700 uppercase tracking-wider">
-                {diagnoseLessonsAvailable} lecciones + bonus
+                {pushbackLessonsAvailable} lecciones + bonus
               </span>
               <span class="inline-flex items-center gap-1 text-indigo-700 font-semibold text-sm group-hover:gap-2 transition-all">
                 Empezar la clase magistral
@@ -468,7 +468,7 @@ const diagnoseLessonsAvailable = diagnoseLessons.filter((l) => l.available).leng
       <div class="max-w-3xl mx-auto mt-16 text-center">
         <h3 class="text-2xl font-bold text-slate-900 mb-3">¿No sabes con cuál empezar?</h3>
         <p class="text-slate-600 mb-6">
-          Si el inglés todavía se siente totalmente nuevo, empieza con el curso <strong>principiante</strong>. Si terminaste lo básico pero todavía no puedes hablar de ayer ni hacer planes, toma <strong>elemental</strong>. Si ya puedes sostener una conversación, salta a <strong>intermedio</strong>. Si tu inglés es fluido pero no pulido, pasa a <strong>avanzado</strong>. Si eres un líder senior que quiere <em>liderar</em> en inglés, ve directo al curso <strong>ejecutivo</strong> — y combínalo con <strong>Dirige la Decisión</strong> para escenarios aplicados de junta directiva. Si eres director o vendedor que se congela bajo pushback, la clase magistral <strong>Diagnostica Antes de Defender</strong> es la capa diagnóstica que las otras asumen. Si te congelas específicamente con los tiempos del pasado, la <strong>clase magistral de tiempos del pasado</strong> encaja al lado de cualquiera. Tu progreso se guarda por separado para cada curso.
+          Si el inglés todavía se siente totalmente nuevo, empieza con el curso <strong>principiante</strong>. Si terminaste lo básico pero todavía no puedes hablar de ayer ni hacer planes, toma <strong>elemental</strong>. Si ya puedes sostener una conversación, salta a <strong>intermedio</strong>. Si tu inglés es fluido pero no pulido, pasa a <strong>avanzado</strong>. Si eres un líder senior que quiere <em>liderar</em> en inglés, ve directo al curso <strong>ejecutivo</strong> — y combínalo con <strong>Dirige la Decisión</strong> para escenarios aplicados de junta directiva. Si eres director o vendedor que se congela bajo pushback, la clase magistral <strong>Manejo de Pushback y Objeciones Ejecutivas</strong> es la capa diagnóstica que las otras asumen. Si te congelas específicamente con los tiempos del pasado, la <strong>clase magistral de tiempos del pasado</strong> encaja al lado de cualquiera. Tu progreso se guarda por separado para cada curso.
         </p>
         <Button href="/es/servicios/" variant="secondary" size="md">
           O trabaja 1-a-1 con Robert
@@ -553,8 +553,8 @@ const diagnoseLessonsAvailable = diagnoseLessons.filter((l) => l.available).leng
       "position": 8,
       "item": {
         "@type": "Course",
-        "name": "Diagnostica Antes de Defender - Master Class de Pushback (Gratis)",
-        "url": "https://www.nyenglishteacher.com/es/curso/diagnostica-antes-de-defender/"
+        "name": "Manejo de Pushback y Objeciones Ejecutivas (Clase Magistral Gratis)",
+        "url": "https://www.nyenglishteacher.com/es/curso/pushback-ejecutivo/"
       }
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -16,17 +16,81 @@
       "destination": "/en/",
       "permanent": false
     },
-    { "source": "/en/category/english-for-executives", "destination": "/en/category/executive-english/", "permanent": true },
-    { "source": "/en/category/business-english-coaching", "destination": "/en/category/business-english/", "permanent": true },
-    { "source": "/en/category/high-impact-communication-english", "destination": "/en/category/high-impact-communication/", "permanent": true },
-    { "source": "/en/blog/executive-presence-on-video-calls", "destination": "/en/blog/executive-video-call/", "permanent": true },
-    { "source": "/es/blog/como-negociar-en-ingles-framework", "destination": "/es/blog/como-negociar-en-ingles-marco/", "permanent": true },
-    { "source": "/es/blog/presencia-ejecutiva-videollamadas", "destination": "/es/blog/presencia-ejecutiva-en-videollamadas/", "permanent": true },
-    { "source": "/es/servicios/ingles-alto-impacto", "destination": "/es/servicios/ingles-para-presentaciones/", "permanent": true },
-    { "source": "/es/servicios/tech-english", "destination": "/es/servicios/ingles-para-tecnologia/", "permanent": true },
-    { "source": "/es/servicios/ingles-ejecutivo", "destination": "/es/servicios/ingles-para-ejecutivos/", "permanent": true },
-    { "source": "/en/quiz/speaking-confidence", "destination": "/en/quiz/it-services/", "permanent": true },
-    { "source": "/es/quiz/speaking-confidence", "destination": "/es/quiz/it-services/", "permanent": true },
+    {
+      "source": "/en/course/diagnose-before-defend",
+      "destination": "/en/course/executive-pushback/",
+      "permanent": true
+    },
+    {
+      "source": "/en/course/diagnose-before-defend/:slug",
+      "destination": "/en/course/executive-pushback/:slug",
+      "permanent": true
+    },
+    {
+      "source": "/es/curso/diagnostica-antes-de-defender",
+      "destination": "/es/curso/pushback-ejecutivo/",
+      "permanent": true
+    },
+    {
+      "source": "/es/curso/diagnostica-antes-de-defender/:slug",
+      "destination": "/es/curso/pushback-ejecutivo/:slug",
+      "permanent": true
+    },
+    {
+      "source": "/en/category/english-for-executives",
+      "destination": "/en/category/executive-english/",
+      "permanent": true
+    },
+    {
+      "source": "/en/category/business-english-coaching",
+      "destination": "/en/category/business-english/",
+      "permanent": true
+    },
+    {
+      "source": "/en/category/high-impact-communication-english",
+      "destination": "/en/category/high-impact-communication/",
+      "permanent": true
+    },
+    {
+      "source": "/en/blog/executive-presence-on-video-calls",
+      "destination": "/en/blog/executive-video-call/",
+      "permanent": true
+    },
+    {
+      "source": "/es/blog/como-negociar-en-ingles-framework",
+      "destination": "/es/blog/como-negociar-en-ingles-marco/",
+      "permanent": true
+    },
+    {
+      "source": "/es/blog/presencia-ejecutiva-videollamadas",
+      "destination": "/es/blog/presencia-ejecutiva-en-videollamadas/",
+      "permanent": true
+    },
+    {
+      "source": "/es/servicios/ingles-alto-impacto",
+      "destination": "/es/servicios/ingles-para-presentaciones/",
+      "permanent": true
+    },
+    {
+      "source": "/es/servicios/tech-english",
+      "destination": "/es/servicios/ingles-para-tecnologia/",
+      "permanent": true
+    },
+    {
+      "source": "/es/servicios/ingles-ejecutivo",
+      "destination": "/es/servicios/ingles-para-ejecutivos/",
+      "permanent": true
+    },
+    {
+      "source": "/en/quiz/speaking-confidence",
+      "destination": "/en/quiz/it-services/",
+      "permanent": true
+    },
+    {
+      "source": "/es/quiz/speaking-confidence",
+      "destination": "/es/quiz/it-services/",
+      "permanent": true
+    },
     { "source": "/blog", "destination": "/en/blog/", "permanent": true },
     { "source": "/services", "destination": "/en/services/", "permanent": true },
     { "source": "/contact", "destination": "/en/contact/", "permanent": true },
@@ -43,49 +107,139 @@
     { "source": "/es/testimonios/all/", "destination": "/es/testimonios/", "permanent": true },
     { "source": "/es/services", "destination": "/es/servicios/", "permanent": true },
     { "source": "/es/book", "destination": "/es/reservar/", "permanent": true },
-    { "source": "/es/category/business-english", "destination": "/es/categoria/ingles-para-negocios/", "permanent": true },
-    { "source": "/es/category/career-leadership", "destination": "/es/categoria/carrera-liderazgo/", "permanent": true },
-    { "source": "/es/category/carrera-y-liderazgo", "destination": "/es/categoria/carrera-liderazgo/", "permanent": true },
-    { "source": "/es/category/carrera-liderazgo", "destination": "/es/categoria/carrera-liderazgo/", "permanent": true },
-    { "source": "/es/category/coaching-en-ingles", "destination": "/es/categoria/coaching-en-ingles/", "permanent": true },
-    { "source": "/es/category/comunicacion-de-alto-impacto", "destination": "/es/categoria/comunicacion-de-alto-impacto/", "permanent": true },
-    { "source": "/es/category/english-coaching", "destination": "/es/categoria/coaching-en-ingles/", "permanent": true },
-    { "source": "/es/category/executive-english", "destination": "/es/categoria/ingles-ejecutivo/", "permanent": true },
-    { "source": "/es/category/high-impact-communication", "destination": "/es/categoria/comunicacion-de-alto-impacto/", "permanent": true },
-    { "source": "/es/category/high-stakes-english", "destination": "/es/categoria/ingles-ejecutivo/", "permanent": true },
-    { "source": "/es/category/ingles-ejecutivo", "destination": "/es/categoria/ingles-ejecutivo/", "permanent": true },
-    { "source": "/es/category/ingles-para-fundadores-de-startups", "destination": "/es/categoria/ingles-para-fundadores-de-startups/", "permanent": true },
-    { "source": "/es/category/ingles-para-logistica", "destination": "/es/categoria/ingles-para-logistica/", "permanent": true },
-    { "source": "/es/category/ingles-de-negocios", "destination": "/es/categoria/ingles-para-negocios/", "permanent": true },
-    { "source": "/es/categoria/ingles-de-negocios", "destination": "/es/categoria/ingles-para-negocios/", "permanent": true },
-    { "source": "/es/categoria/ingles-de-negocios/", "destination": "/es/categoria/ingles-para-negocios/", "permanent": true },
-    { "source": "/es/category/ingles-para-negocios", "destination": "/es/categoria/ingles-para-negocios/", "permanent": true },
-    { "source": "/es/category/ingles-para-presentaciones", "destination": "/es/categoria/ingles-para-presentaciones/", "permanent": true },
-    { "source": "/es/category/ingles-para-profesionales", "destination": "/es/categoria/ingles-para-profesionales/", "permanent": true },
-    { "source": "/es/category/ingles-para-tecnologia", "destination": "/es/categoria/ingles-para-tecnologia/", "permanent": true },
-    { "source": "/es/category/logistics-english", "destination": "/es/categoria/ingles-para-logistica/", "permanent": true },
-    { "source": "/es/category/professional-english", "destination": "/es/categoria/ingles-para-profesionales/", "permanent": true },
-    { "source": "/es/category/startup-founders", "destination": "/es/categoria/ingles-para-fundadores-de-startups/", "permanent": true },
-    { "source": "/es/category/tech-english", "destination": "/es/categoria/ingles-para-tecnologia/", "permanent": true }
+    {
+      "source": "/es/category/business-english",
+      "destination": "/es/categoria/ingles-para-negocios/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/career-leadership",
+      "destination": "/es/categoria/carrera-liderazgo/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/carrera-y-liderazgo",
+      "destination": "/es/categoria/carrera-liderazgo/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/carrera-liderazgo",
+      "destination": "/es/categoria/carrera-liderazgo/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/coaching-en-ingles",
+      "destination": "/es/categoria/coaching-en-ingles/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/comunicacion-de-alto-impacto",
+      "destination": "/es/categoria/comunicacion-de-alto-impacto/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/english-coaching",
+      "destination": "/es/categoria/coaching-en-ingles/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/executive-english",
+      "destination": "/es/categoria/ingles-ejecutivo/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/high-impact-communication",
+      "destination": "/es/categoria/comunicacion-de-alto-impacto/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/high-stakes-english",
+      "destination": "/es/categoria/ingles-ejecutivo/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/ingles-ejecutivo",
+      "destination": "/es/categoria/ingles-ejecutivo/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/ingles-para-fundadores-de-startups",
+      "destination": "/es/categoria/ingles-para-fundadores-de-startups/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/ingles-para-logistica",
+      "destination": "/es/categoria/ingles-para-logistica/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/ingles-de-negocios",
+      "destination": "/es/categoria/ingles-para-negocios/",
+      "permanent": true
+    },
+    {
+      "source": "/es/categoria/ingles-de-negocios",
+      "destination": "/es/categoria/ingles-para-negocios/",
+      "permanent": true
+    },
+    {
+      "source": "/es/categoria/ingles-de-negocios/",
+      "destination": "/es/categoria/ingles-para-negocios/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/ingles-para-negocios",
+      "destination": "/es/categoria/ingles-para-negocios/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/ingles-para-presentaciones",
+      "destination": "/es/categoria/ingles-para-presentaciones/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/ingles-para-profesionales",
+      "destination": "/es/categoria/ingles-para-profesionales/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/ingles-para-tecnologia",
+      "destination": "/es/categoria/ingles-para-tecnologia/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/logistics-english",
+      "destination": "/es/categoria/ingles-para-logistica/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/professional-english",
+      "destination": "/es/categoria/ingles-para-profesionales/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/startup-founders",
+      "destination": "/es/categoria/ingles-para-fundadores-de-startups/",
+      "permanent": true
+    },
+    {
+      "source": "/es/category/tech-english",
+      "destination": "/es/categoria/ingles-para-tecnologia/",
+      "permanent": true
+    }
   ],
   "headers": [
     {
       "source": "/images/(.*)",
-      "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
-      ]
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
     },
     {
       "source": "/_astro/(.*)",
-      "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
-      ]
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
     },
     {
       "source": "/fonts/(.*)",
-      "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
-      ]
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
     },
     {
       "source": "/(.*)",
@@ -94,8 +248,14 @@
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://ny-ai-chatbot.vercel.app https://chat.nyenglishteacher.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src 'self' https://ny-ai-chatbot.vercel.app https://chat.nyenglishteacher.com; connect-src 'self' https://www.google-analytics.com https://plain-mode-42c4.rcushmaniii.workers.dev https://ny-ai-chatbot.vercel.app https://chat.nyenglishteacher.com https://ny-eng.vercel.app https://formspree.io https://o4511162786185216.ingest.us.sentry.io https://*.public.blob.vercel-storage.com https://vercel.com; media-src 'self' blob: https://*.public.blob.vercel-storage.com; worker-src blob:;" }
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://ny-ai-chatbot.vercel.app https://chat.nyenglishteacher.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src 'self' https://ny-ai-chatbot.vercel.app https://chat.nyenglishteacher.com; connect-src 'self' https://www.google-analytics.com https://plain-mode-42c4.rcushmaniii.workers.dev https://ny-ai-chatbot.vercel.app https://chat.nyenglishteacher.com https://ny-eng.vercel.app https://formspree.io https://o4511162786185216.ingest.us.sentry.io https://*.public.blob.vercel-storage.com https://vercel.com; media-src 'self' blob: https://*.public.blob.vercel-storage.com; worker-src blob:;"
+        }
       ]
     }
   ]


### PR DESCRIPTION
## Summary

Reverts the course title to Robert's original: **Executive Pushback & Objection Handling** (subtitle: *Strategic Communication for High-Pressure Conversations*). The prior \"Diagnose Before You Defend\" framing obfuscated the SEO keywords (\"handling pushback,\" \"objection handling\") and lost direct buyer clarity.

## Changes

- Title verbatim from source content: **\"Executive Pushback & Objection Handling\"** / ES: **\"Manejo de Pushback y Objeciones Ejecutivas\"**
- URL slug: \`/en/course/executive-pushback/\` and \`/es/curso/pushback-ejecutivo/\`
- All 22 files git-mv'd (history preserved), variable names renamed (\`diagnoseInfo\` → \`pushbackInfo\`), component renamed (\`DiagnoseLessonLayout\` → \`PushbackLessonLayout\`)
- Hero H1s, catalog cards, JSON-LD, SEO titles, cross-links — all updated
- Lesson topic slugs preserved (they describe lesson topics, not the course)

## Safety

- **4 wildcard 301 redirects** added to \`vercel.json\` so any URL crawled from the prior PR continues to resolve:
  - \`/en/course/diagnose-before-defend\` → \`/en/course/executive-pushback/\`
  - \`/en/course/diagnose-before-defend/:slug\` → \`/en/course/executive-pushback/:slug\`
  - \`/es/curso/diagnostica-antes-de-defender\` → \`/es/curso/pushback-ejecutivo/\`
  - \`/es/curso/diagnostica-antes-de-defender/:slug\` → \`/es/curso/pushback-ejecutivo/:slug\`
- Lesson body content (verb usage of \"diagnose\" / \"diagnostica\") preserved — the lessons still teach diagnostic thinking; only the course-level title changes.
- Build clean: 424 pages, 0 errors, meta-description-gate passes.

## Memory saved

`feedback_preserve_user_supplied_titles.md` — durable feedback so this doesn't repeat: when Robert supplies content with a title, use it verbatim, don't rename for cleverness.

## Test plan

- [ ] Preview EN: https://ny-eng-git-fix-rename-pushback-course-rcushmaniii-projects.vercel.app/en/course/executive-pushback/
- [ ] Preview ES: https://ny-eng-git-fix-rename-pushback-course-rcushmaniii-projects.vercel.app/es/curso/pushback-ejecutivo/
- [ ] Verify the H1 reads \"Executive Pushback & Objection Handling\"
- [ ] Verify the old URL redirects: https://ny-eng-git-fix-rename-pushback-course-rcushmaniii-projects.vercel.app/en/course/diagnose-before-defend/ should 301 to the new URL
- [ ] Confirm catalog card on /courses/ shows new title

🤖 Generated with [Claude Code](https://claude.com/claude-code)