### PR TITLE
docs(legal): add WhatsApp section to privacy policy (en + es-MX)

### DIFF
--- a/src/content/legal/en/privacy-policy.md
+++ b/src/content/legal/en/privacy-policy.md
@@ -1,20 +1,20 @@
 ---
 title: "Privacy Policy"
-lastUpdated: "2026-04-10"
+lastUpdated: "2026-06-07"
 translations:
   es: "/es/legal/privacy-policy/"
 seo:
   title: "Privacy Policy - How We Protect Your Information"
-  description: "Understand how we collect, use, and safeguard your personal information on the New York English Teacher website and Facebook Messenger assistant."
+  description: "Understand how New York English collects, uses, and safeguards your information across our website, Facebook Messenger assistant, and WhatsApp reminders."
 ---
 
 ## Privacy Policy
 
-**Last Updated: April 10, 2026**
+**Last Updated: June 7, 2026**
 
 ## Introduction
 
-Welcome to our Privacy Policy. New York English is an executive English coaching service operated by **Robert Cushman**, based in Guadalajara, Mexico. This policy explains how we collect, use, and protect your personal information when you use our website (nyenglishteacher.com) and our Facebook Messenger Assistant.
+Welcome to our Privacy Policy. New York English is an executive English coaching service operated by **Robert Cushman**, based in Guadalajara, Mexico. This policy explains how we collect, use, and protect your personal information when you use our website (nyenglishteacher.com), our Facebook Messenger Assistant, and our WhatsApp reminder and confirmation service.
 
 If you have questions, contact us at **privacy@newyorkenglish.com**.
 
@@ -42,6 +42,18 @@ When you message the New York English Facebook Page and interact with our AI-pow
 
 We do **not** collect your email address, phone number, Facebook friends list, or any other profile data beyond what is listed above.
 
+### WhatsApp Reminders & Confirmations
+
+If you opt in to receive class reminders and payment confirmations from New York English on WhatsApp, we collect and process:
+
+- Your **WhatsApp phone number**
+- Your **name**, as provided when you enroll
+- Your **language preference** (English or Spanish)
+- The **content and timestamps** of messages you exchange with us on WhatsApp
+- Your **class enrollment, attendance confirmations, and payment records** that the reminders and receipts relate to
+
+We send you WhatsApp messages **only after you have opted in**. You can **opt out at any time** by replying **STOP** or **BAJA** to any of our WhatsApp messages — we will stop sending you messages. Reply **ALTA** to opt back in. We use WhatsApp only for service messages (reminders, confirmations, receipts), **not** for advertising or resale.
+
 ## How We Collect Information
 
 Information is collected through:
@@ -50,6 +62,7 @@ Information is collected through:
 - Cookies and tracking technologies
 - Analytics tools (e.g., Google Analytics)
 - The Facebook Messenger Platform (for Messenger Assistant interactions)
+- The WhatsApp Business Platform (for reminders and confirmations you opt in to)
 
 ## How We Use Your Information
 
@@ -57,6 +70,8 @@ We use your data to:
 
 - Provide and improve our coaching services
 - Respond to your inquiries via the website or Messenger Assistant
+- Send the class reminders, attendance confirmations, and payment receipts you opted in to receive on WhatsApp
+- Process opt-in and opt-out requests for WhatsApp messaging
 - Maintain short-term conversation context in the Messenger Assistant
 - Detect and respond in your preferred language (English or Spanish)
 - Analyze site usage and performance
@@ -77,6 +92,8 @@ We use your data to:
 
 We do not maintain long-term storage of Messenger conversations.
 
+**WhatsApp data:** Your phone number, name, enrollment, attendance, payment records, and message log are stored in our database (Cloudflare D1) for as long as you are an active student and as needed for our records and legal obligations. If you opt out, we stop messaging you; we may retain prior records for accounting and legal purposes. Meta deletes message content and user identifiers from its own systems within 30 days.
+
 ## Third Parties
 
 We do **not** sell or rent your personal data. Your data may be shared only when necessary:
@@ -90,6 +107,13 @@ For the Messenger Assistant specifically, your messages are transmitted to the f
 - **Anthropic, PBC** — provides the Claude AI model that generates responses. [Privacy Policy](https://www.anthropic.com/legal/privacy)
 - **Cloudflare, Inc.** — hosts the Worker, provides KV storage and AI Gateway routing. [Privacy Policy](https://www.cloudflare.com/privacypolicy/)
 - **Functional Software, Inc. (Sentry)** — receives error reports for monitoring purposes. [Privacy Policy](https://sentry.io/privacy/)
+
+For **WhatsApp reminders and confirmations**, your data is processed by:
+
+- **Meta Platforms, Inc.** — delivers messages via the WhatsApp Business Platform. [Privacy Policy](https://www.whatsapp.com/legal/privacy-policy)
+- **Cloudflare, Inc.** — hosts the service and stores your records (Workers + D1 database). [Privacy Policy](https://www.cloudflare.com/privacypolicy/)
+
+The WhatsApp reminder service does **not** use any AI model; messages are sent from fixed, pre-approved templates.
 
 ## Your Rights
 

--- a/src/content/legal/es/privacy-policy.md
+++ b/src/content/legal/es/privacy-policy.md
@@ -1,20 +1,20 @@
 ---
 title: "Política de Privacidad"
-lastUpdated: "2026-04-10"
+lastUpdated: "2026-06-07"
 translations:
   en: "/en/legal/privacy-policy/"
 seo:
   title: "Política de Privacidad - Cómo Protegemos Tu Información"
-  description: "Comprende cómo recopilamos, usamos y protegemos tu información personal en el sitio web de New York English Teacher y el asistente de Facebook Messenger."
+  description: "Conoce cómo New York English recopila, usa y protege tu información en nuestro sitio web, el asistente de Facebook Messenger y los recordatorios por WhatsApp."
 ---
 
 ## Política de Privacidad
 
-**Última Actualización: 10 de abril de 2026**
+**Última Actualización: 7 de junio de 2026**
 
 ## Introducción
 
-Bienvenido a nuestra Política de Privacidad. New York English es un servicio de coaching ejecutivo de inglés operado por **Robert Cushman**, con sede en Guadalajara, México. Esta política explica cómo recopilamos, usamos y protegemos tu información personal cuando utilizas nuestro sitio web (nyenglishteacher.com) y nuestro Asistente de Facebook Messenger.
+Bienvenido a nuestra Política de Privacidad. New York English es un servicio de coaching ejecutivo de inglés operado por **Robert Cushman**, con sede en Guadalajara, México. Esta política explica cómo recopilamos, usamos y protegemos tu información personal cuando utilizas nuestro sitio web (nyenglishteacher.com), nuestro Asistente de Facebook Messenger y nuestro servicio de recordatorios y confirmaciones por WhatsApp.
 
 Si tienes preguntas, contáctanos en **privacy@newyorkenglish.com**.
 
@@ -42,6 +42,18 @@ Cuando envías un mensaje a la página de Facebook de New York English e interac
 
 **No** recopilamos tu correo electrónico, número de teléfono, lista de amigos de Facebook ni ningún otro dato de perfil más allá de lo indicado anteriormente.
 
+### Recordatorios y Confirmaciones por WhatsApp
+
+Si aceptas recibir recordatorios de clase y confirmaciones de pago de New York English por WhatsApp, recopilamos y procesamos:
+
+- Tu **número de WhatsApp**
+- Tu **nombre**, tal como lo proporcionas al inscribirte
+- Tu **preferencia de idioma** (inglés o español)
+- El **contenido y las marcas de tiempo** de los mensajes que intercambias con nosotros por WhatsApp
+- Tus **registros de inscripción, confirmaciones de asistencia y pagos** con los que se relacionan los recordatorios y recibos
+
+Te enviamos mensajes por WhatsApp **solo después de que hayas dado tu consentimiento**. Puedes **darte de baja en cualquier momento** respondiendo **STOP** o **BAJA** a cualquiera de nuestros mensajes de WhatsApp; dejaremos de enviarte mensajes. Responde **ALTA** para volver a suscribirte. Usamos WhatsApp únicamente para mensajes de servicio (recordatorios, confirmaciones, recibos), **no** para publicidad ni reventa.
+
 ## Cómo Recopilamos Información
 
 La información se recopila a través de:
@@ -50,6 +62,7 @@ La información se recopila a través de:
 - Cookies y tecnologías de seguimiento
 - Herramientas de análisis (por ejemplo, Google Analytics)
 - La Plataforma de Facebook Messenger (para interacciones con el Asistente de Messenger)
+- La Plataforma de WhatsApp Business (para los recordatorios y confirmaciones que aceptas recibir)
 
 ## Cómo Usamos Tu Información
 
@@ -57,6 +70,8 @@ Usamos tus datos para:
 
 - Proveer y mejorar nuestros servicios de coaching
 - Responder a tus consultas a través del sitio web o el Asistente de Messenger
+- Enviar los recordatorios de clase, confirmaciones de asistencia y recibos de pago que aceptaste recibir por WhatsApp
+- Procesar las solicitudes de alta y baja para los mensajes de WhatsApp
 - Mantener el contexto breve de la conversación en el Asistente de Messenger
 - Detectar y responder en tu idioma preferido (inglés o español)
 - Analizar el uso y rendimiento del sitio
@@ -77,6 +92,8 @@ Usamos tus datos para:
 
 No mantenemos almacenamiento a largo plazo de conversaciones de Messenger.
 
+**Datos de WhatsApp:** Tu número de teléfono, nombre, registros de inscripción, asistencia, pagos e historial de mensajes se almacenan en nuestra base de datos (Cloudflare D1) durante el tiempo en que seas estudiante activo y según sea necesario para nuestros registros y obligaciones legales. Si te das de baja, dejamos de enviarte mensajes; podemos conservar los registros previos para fines contables y legales. Meta elimina el contenido de los mensajes y los identificadores de usuario de sus propios sistemas en un plazo de 30 días.
+
 ## Terceros
 
 **No vendemos ni rentamos** tu información personal. Tus datos pueden ser compartidos solo cuando sea necesario:
@@ -90,6 +107,13 @@ Específicamente para el Asistente de Messenger, tus mensajes son transmitidos a
 - **Anthropic, PBC** — proporciona el modelo de IA Claude que genera las respuestas. [Política de Privacidad](https://www.anthropic.com/legal/privacy)
 - **Cloudflare, Inc.** — aloja el Worker y proporciona almacenamiento KV y enrutamiento de AI Gateway. [Política de Privacidad](https://www.cloudflare.com/privacypolicy/)
 - **Functional Software, Inc. (Sentry)** — recibe informes de errores para monitoreo. [Política de Privacidad](https://sentry.io/privacy/)
+
+Para los **recordatorios y confirmaciones por WhatsApp**, tus datos son procesados por:
+
+- **Meta Platforms, Inc.** — entrega los mensajes a través de la Plataforma de WhatsApp Business. [Política de Privacidad](https://www.whatsapp.com/legal/privacy-policy)
+- **Cloudflare, Inc.** — aloja el servicio y almacena tus registros (Workers + base de datos D1). [Política de Privacidad](https://www.cloudflare.com/privacypolicy/)
+
+El servicio de recordatorios por WhatsApp **no** utiliza ningún modelo de IA; los mensajes se envían a partir de plantillas fijas previamente aprobadas.
 
 ## Tus Derechos
 


### PR DESCRIPTION
## Why
Required for the WhatsApp Business Platform (Meta) submission for cushlabs-whatsapp. Meta wants the public privacy policy to describe WhatsApp data handling; the policy previously covered only the Facebook Messenger assistant.

## Changes (both EN and ES)
- New **WhatsApp Reminders & Confirmations** subsection under *Information We Collect* — data collected, explicit opt-in, and STOP/BAJA opt-out (ALTA to re-subscribe).
- WhatsApp entries added to *How We Collect*, *How We Use*, *Data Retention*, and *Third Parties* (Meta + Cloudflare as processors; explicitly notes no AI model is used).
- Last Updated bumped to 2026-06-07.
- ES is Mexican Professional Spanish (verified no Iberian markers).

## Validation
- `npm run build` passes: meta-description-gate PASS (424 pages, 0 failures), sitemap 400/400, 0 errors.
- SEO descriptions within the 120–160 char gate (en 153, es 158).

Live after merge:
- https://www.nyenglishteacher.com/en/legal/privacy-policy/
- https://www.nyenglishteacher.com/es/legal/privacy-policy/

🤖 Generated with [Claude Code](https://claude.com/claude-code)