### PR TITLE
fix(legal): mobile-friendly legal pages + warmer es-MX welcome

### DIFF
--- a/src/content/legal/es/privacy-policy.md
+++ b/src/content/legal/es/privacy-policy.md
@@ -14,7 +14,7 @@ seo:
 
 ## Introducción
 
-Bienvenido a nuestra Política de Privacidad. New York English es un servicio de coaching ejecutivo de inglés operado por **Robert Cushman**, con sede en Guadalajara, México. Esta política explica cómo recopilamos, usamos y protegemos tu información personal cuando utilizas nuestro sitio web (nyenglishteacher.com), nuestro Asistente de Facebook Messenger y nuestro servicio de recordatorios y confirmaciones por WhatsApp.
+Te damos la bienvenida a nuestra Política de Privacidad. New York English es un servicio de coaching ejecutivo de inglés operado por **Robert Cushman**, con sede en Guadalajara, México. Esta política explica cómo recopilamos, usamos y protegemos tu información personal cuando utilizas nuestro sitio web (nyenglishteacher.com), nuestro Asistente de Facebook Messenger y nuestro servicio de recordatorios y confirmaciones por WhatsApp.
 
 Si tienes preguntas, contáctanos en **privacy@newyorkenglish.com**.
 

--- a/src/pages/en/legal/data-deletion.astro
+++ b/src/pages/en/legal/data-deletion.astro
@@ -31,7 +31,7 @@ const heroContent = {
   description={entry.data.seo?.description || ""}
 >
   <InnerHero content={heroContent} />
-  <article class="site-container--small mx-auto px-8 prose pb-base pt-16">
+  <article class="site-container--small mx-auto px-4 sm:px-8 prose break-words pb-base pt-16">
     <Content />
   </article>
 </Base>

--- a/src/pages/en/legal/privacy-policy.astro
+++ b/src/pages/en/legal/privacy-policy.astro
@@ -33,7 +33,7 @@ const heroContent = {
   description={entry.data.seo?.description || ""}
 >
   <InnerHero content={heroContent} />
-  <article class="site-container--small mx-auto px-8 prose pb-base pt-16">
+  <article class="site-container--small mx-auto px-4 sm:px-8 prose break-words pb-base pt-16">
     <Content />
   </article>
 </Base>

--- a/src/pages/en/legal/terms-of-service.astro
+++ b/src/pages/en/legal/terms-of-service.astro
@@ -33,7 +33,7 @@ const heroContent = {
   description={entry.data.seo?.description || ''}
 >
   <InnerHero content={heroContent} />
-  <article class="site-container--small mx-auto px-8 prose pb-base pt-16">
+  <article class="site-container--small mx-auto px-4 sm:px-8 prose break-words pb-base pt-16">
     <Content />
   </article>
 </Base>

--- a/src/pages/es/legal/data-deletion.astro
+++ b/src/pages/es/legal/data-deletion.astro
@@ -41,7 +41,7 @@ const footerCta = {
   description={entry.data.seo?.description || ""}
 >
   <InnerHero content={heroContent} />
-  <article class="site-container--small mx-auto px-8 prose pb-base pt-16">
+  <article class="site-container--small mx-auto px-4 sm:px-8 prose break-words pb-base pt-16">
     <Content />
   </article>
 </Base>

--- a/src/pages/es/legal/privacy-policy.astro
+++ b/src/pages/es/legal/privacy-policy.astro
@@ -43,7 +43,7 @@ const footerCta = {
   description={entry.data.seo?.description || ""}
 >
   <InnerHero content={heroContent} />
-  <article class="site-container--small mx-auto px-8 prose pb-base pt-16">
+  <article class="site-container--small mx-auto px-4 sm:px-8 prose break-words pb-base pt-16">
     <Content />
   </article>
 </Base>

--- a/src/pages/es/legal/terms-of-service.astro
+++ b/src/pages/es/legal/terms-of-service.astro
@@ -47,7 +47,7 @@ const footerCta = {
   description={entry.data.seo?.description || ""}
 >
   <InnerHero content={heroContent} />
-  <article class="site-container--small mx-auto px-8 prose pb-base pt-16">
+  <article class="site-container--small mx-auto px-4 sm:px-8 prose break-words pb-base pt-16">
     <Content />
   </article>
 </Base>


### PR DESCRIPTION
## Changes
- **Mobile:** all 6 legal pages (privacy / terms / data-deletion, EN+ES) now use responsive padding (`px-4 sm:px-8`) and `break-words`, so long URLs and email addresses wrap instead of forcing horizontal scroll on narrow phones.
- **Spanish:** warmer, more natural Mexican opening on the privacy policy (`Te damos la bienvenida…`). The rest of the es policy was reviewed — it's already correct Mexican professional Spanish (tú-form, no Iberian markers); intentionally restrained warmth since it's legal copy for a C-suite audience.

## Validation
- `npm run build` passes (meta-description-gate, sitemap, SEO all green).

Note: mobile fix applied via known-good responsive classes; not visually screenshotted. Live after merge:
- https://www.nyenglishteacher.com/es/legal/privacy-policy/

🤖 Generated with [Claude Code](https://claude.com/claude-code)