### PR TITLE
feat(blog): bilingual interview phrases + pronunciation guide

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -50,6 +50,7 @@ const blogTranslations = {
   "daily-standup-english": "/es/blog/ingles-para-daily-standup-frases/",
   "customs-freight-english": "/es/blog/ingles-aduanas-comercio-exterior/",
   "us-interview-prep": "/es/blog/entrevista-trabajo-empresa-americana/",
+  "business-english-interview-phrases": "/es/blog/frases-ingles-entrevista-trabajo/",
   "slack-english-write-like-a-pro": "/es/blog/ingles-para-slack-profesional/",
   "executive-reframing-drills": "/es/blog/ejercicios-reformulacion-ejecutiva/",
   "why-you-struggle-speaking-english-in-meetings":

--- a/content-marketing/business-english-interview-phrases-social.md
+++ b/content-marketing/business-english-interview-phrases-social.md
@@ -1,0 +1,148 @@
+# Social Media Content: 30 Business English Interview Phrases
+
+**Blog Post (EN):** https://www.nyenglishteacher.com/en/blog/business-english-interview-phrases/
+**Blog Post (ES):** https://www.nyenglishteacher.com/es/blog/frases-ingles-entrevista-trabajo/
+**Published:** 2026-06-09
+
+---
+
+## ⭐ Google Business Profile Post (PRIMARY — Mexican Professional Spanish)
+
+> **Post type:** "What's new" (Novedades) · **Button:** "Más información" → https://www.nyenglishteacher.com/es/blog/frases-ingles-entrevista-trabajo/
+
+**Post text (copy/paste into Google Business Profile):**
+
+¿Entrevista de trabajo en inglés esta semana? No es tu nivel de inglés lo que te traiciona — es *cómo* salen las palabras bajo presión.
+
+Aquí van 3 frases que te hacen sonar seguro, con su pronunciación exacta:
+
+🔹 "I'm confident I can contribute to your team."
+→ "contribute" se dice **kon-TRIB-yut** (énfasis en medio, no "CON-tri-bute").
+
+🔹 "Based on my research, I'm targeting a range of…"
+→ "research" como sustantivo: **RI-surch** (énfasis adelante).
+
+🔹 "What does success look like in the first 90 days?"
+→ "success" se dice **suk-SES** (énfasis en la segunda sílaba).
+
+Práctico, enfocado en resultados de carrera — no gramática de memoria. 30 frases completas, por etapa de la entrevista, en el artículo. 👇
+
+#InglésDeNegocios #EntrevistaDeTrabajo #InglésParaProfesionales #Guadalajara #BúsquedaDeEmpleo
+
+---
+
+## 📸 Carousel / Slide Captions (optional images to attach to the GBP post)
+
+**Slide 1 (cover):**
+3 Frases en Inglés que Ganan Entrevistas
+(y cómo pronunciarlas)
+
+**Slide 2:**
+"I'm confident I can contribute to your team."
+👄 kon-TRIB-yut — énfasis en MEDIO
+Reemplaza el "I think maybe I could…"
+
+**Slide 3:**
+"Based on my research, I'm targeting a range of…"
+👄 RI-surch — énfasis adelante
+Da tu número con aplomo, no con rodeos.
+
+**Slide 4:**
+"What does success look like in the first 90 days?"
+👄 suk-SES — énfasis en la 2ª sílaba
+La pregunta que te hace ver como alguien que ya está entregando.
+
+**Slide 5 (CTA):**
+30 frases completas, por etapa.
+nyenglishteacher.com → Blog
+NY English Teacher · Coaching de comunicación ejecutiva
+
+---
+
+## LinkedIn Post (EN)
+
+You can know exactly what you want to say in an interview — and still lose the room because the words came out wrong.
+
+Not grammatically wrong. Pronounced wrong. Hedged wrong. Buried under so much padding the interviewer stopped listening.
+
+In an English interview, *how* you say it is half of what's being evaluated.
+
+Three phrases that fix the most common slips:
+
+→ "I'm confident I can contribute to your team."
+The trap: "contribute" is **kon-TRIB-yut** — stress in the middle, not "CON-tri-bute."
+
+→ "Based on my research, I'm targeting a range of…"
+"research" (noun) is **RI-surch** — stress up front.
+
+→ "What does success look like in the first 90 days?"
+"success" is **suk-SES** — stress on the second syllable.
+
+The lesson behind all three: English crushes unstressed syllables. Find the stressed one, hit it, let the rest blur.
+
+I just published 30 interview phrases — by interview stage, each with a pronunciation tip — for professionals who interview in English.
+
+Full guide: https://www.nyenglishteacher.com/en/blog/business-english-interview-phrases/
+
+#BusinessEnglish #JobInterview #CareerDevelopment #InterviewPrep #ExecutiveCommunication #ProfessionalDevelopment #ESL
+
+---
+
+## Twitter/X Thread (EN)
+
+**Tweet 1 (Hook):**
+You can know exactly what to say in a job interview and still blow it — because the words came out wrong.
+
+Not grammar. Pronunciation. Hedging. Padding.
+
+3 English interview phrases + how to actually say them 🧵
+
+**Tweet 2:**
+"I'm confident I can contribute to your team."
+
+The trap: "contribute" = kon-TRIB-yut
+
+Stress is in the MIDDLE. Most people say "CON-tri-bute" and it sounds off.
+
+Lead with "I'm confident" — drop "I think maybe I could…"
+
+**Tweet 3:**
+"Based on my research, I'm targeting a range of…"
+
+"research" (the noun) = RI-surch. Stress up front.
+
+This is your salary line. Give a number with composure, not a shrug.
+
+**Tweet 4:**
+"What does success look like in the first 90 days?"
+
+"success" = suk-SES. Stress on the 2nd syllable.
+
+The question that makes you sound like someone already thinking about delivering.
+
+**Tweet 5 (CTA):**
+The pattern behind all 3: English crushes unstressed syllables. Find the stressed one, hit it, blur the rest.
+
+30 phrases, by interview stage, each with a pronunciation tip:
+https://www.nyenglishteacher.com/en/blog/business-english-interview-phrases/
+
+#BusinessEnglish #InterviewPrep
+
+---
+
+## Facebook Post (EN)
+
+Ever walked out of an interview knowing your English *level* was fine — but something still felt off?
+
+It's usually not your grammar. It's how the words land under pressure: the stress on the wrong syllable, the nervous hedging, the extra padding that buries your point.
+
+I just published a guide with 30 business English interview phrases — organized by the stage of the interview you'll use them in, each with a simple pronunciation tip so the words come out the way you mean them.
+
+Three to start with:
+• "I'm confident I can contribute to your team." (contribute = kon-TRIB-yut)
+• "Based on my research, I'm targeting a range of…" (research = RI-surch)
+• "What does success look like in the first 90 days?" (success = suk-SES)
+
+Practical, career-focused, ready to rehearse before your next interview.
+
+Read it here: https://www.nyenglishteacher.com/en/blog/business-english-interview-phrases/

--- a/src/content/blog/en/business-english-interview-phrases.md
+++ b/src/content/blog/en/business-english-interview-phrases.md
@@ -1,0 +1,292 @@
+---
+title: "30 Business English Interview Phrases — and Exactly How to Say Them"
+excerpt: "The exact English phrases that make you sound confident in a job interview — organized by interview stage, each with a pronunciation tip so the words land the way you mean them."
+publishDate: "2026-06-09"
+lastmod: "2026-06-09"
+categories:
+  - "Business English"
+  - "Career & Leadership"
+readingTime: "9 min read"
+audience: "Mexican professionals preparing for an interview conducted in English"
+featuredImage: "./images/us-interview-prep.webp"
+imageAlt: "Mexican professional speaking confidently in an English-language job interview"
+translations:
+  es: "/es/blog/frases-ingles-entrevista-trabajo/"
+publish: true
+seo:
+  title: "30 Business English Interview Phrases (+ Pronunciation)"
+  description: "The exact English phrases to sound confident in a job interview, by stage — with a pronunciation tip for each so the words land the way you mean them."
+---
+
+You can know exactly what you want to say in an interview and still lose the room — because the *words came out wrong.* Not grammatically wrong. Pronounced wrong, hedged wrong, or delivered with so much padding that the interviewer stopped listening before you reached your point.
+
+This is the gap the strategy never closes. You can read every guide on interview structure and still freeze when the recruiter says, *"So, tell me about yourself."* What you need in that moment isn't theory. It's a **phrase you've already said out loud fifty times** — one that comes out clean and confident because your mouth already knows the shape of it.
+
+That's what this guide gives you: 30 business English phrases for the interview, organized by the stage you'll use them in. For each one, you get **when to use it** and a **pronunciation tip** for the word most likely to trip you — because in an English interview, *how* you say the phrase is half of what's being evaluated.
+
+This is the tactical companion to our full playbook on [how US interviews actually work](/en/blog/us-interview-prep/). That post is the strategy. This one is the script.
+
+---
+
+## How to Use This Guide
+
+Don't read these silently. Say each phrase **out loud** — slowly first, then at natural speed — until it stops feeling like a foreign object in your mouth. The pronunciation notes use simple phonetic spelling (the way the word actually sounds, not the dictionary symbols), with the **stressed syllable in capitals.**
+
+Pick the 8–10 phrases that match the questions you expect, and drill those. Ten phrases said perfectly beat thirty said hesitantly.
+
+---
+
+## Stage 1: The Opening — "Tell Me About Yourself"
+
+The first 90 seconds set the tone. These phrases let you open with a value proposition instead of a nervous resume recap.
+
+### 1. <span class="speak-en">"I'm a [role] with [X] years of experience in [specialty]."</span>
+
+**When:** Your very first sentence. It frames you as a professional with a focus, not a list of past jobs.
+
+**Pronunciation tip:** The word <span class="speak-en" data-say="EX-peer-ee-ence">experience</span> is four syllables with stress on the *second* — "ex-PEER-ee-ence" — not "ex-pee-ree-EN-cia." Drop the Spanish "-cia" ending completely.
+
+### 2. <span class="speak-en">"My specialty is [outcome you deliver]."</span>
+
+**When:** Right after your opener, to sharpen the focus before you give numbers.
+
+**Pronunciation tip:** <span class="speak-en" data-say="SPEH-shul-tee">Specialty</span> has the stress up front — "SPEH-shul-tee," three syllables. Avoid the Spanish instinct to say "es-peh-see-al-i-DAD."
+
+### 3. <span class="speak-en">"What I'm most proud of is [quantified result]."</span>
+
+**When:** To introduce your strongest number — "I cut our delivery time from 14 days to 6."
+
+**Pronunciation tip:** <span class="speak-en" data-say="prowd">Proud</span> rhymes with "loud" — one syllable, "prowd." Don't add a vowel: not "pe-roud."
+
+### 4. <span class="speak-en">"I'm excited about this role because [link to their need]."</span>
+
+**When:** To close your opener by connecting your experience to *their* job, not your career.
+
+**Pronunciation tip:** <span class="speak-en" data-say="ek-SY-ted">Excited</span> — "ek-SY-ted," stress on the middle. The "x" sounds like "ks," and the "ci" is a long "eye" sound, not "see."
+
+---
+
+## Stage 2: Behavioral Questions — Setting Up a STAR Story
+
+US-style interviews live on *"Tell me about a time when…"* These phrases give you a confident on-ramp into your example while your brain catches up.
+
+### 5. <span class="speak-en">"A good example of that was when…"</span>
+
+**When:** Your default opener for any behavioral question. It buys you two seconds and signals a real story is coming.
+
+**Pronunciation tip:** <span class="speak-en" data-say="ig-ZAM-pul">Example</span> — "ig-ZAM-pul." The "x" here is a soft "z" sound, and there's no "e" at the end: not "ex-AM-pleh."
+
+### 6. <span class="speak-en">"To give you some context…"</span>
+
+**When:** The "Situation" part of STAR — setting the scene before the action.
+
+**Pronunciation tip:** <span class="speak-en" data-say="CON-text">Context</span> stresses the first syllable — "CON-text." Keep the final "t" crisp; don't soften it to "con-TEX-to."
+
+### 7. <span class="speak-en">"My responsibility was to…"</span>
+
+**When:** The "Task" — making clear what *you* owned.
+
+**Pronunciation tip:** <span class="speak-en" data-say="ris-pon-suh-BIL-uh-tee">Responsibility</span> is a marathon word: six syllables, stress on "BIL" — "ris-pon-suh-BIL-uh-tee." Say it slowly in practice and the speed comes later.
+
+### 8. <span class="speak-en">"So what I did was…"</span>
+
+**When:** The "Action" — the heart of the answer. Note the deliberate "I," not "we."
+
+**Pronunciation tip:** Keep it short and even. The trap here isn't a hard word — it's slowing down and over-explaining. Land "what I did" with a small pause after it.
+
+### 9. <span class="speak-en">"As a result, [measurable outcome]."</span>
+
+**When:** The "Result" — always close with the number or the business impact.
+
+**Pronunciation tip:** <span class="speak-en" data-say="ri-ZULT">Result</span> — "ri-ZULT," stress on the second syllable, soft "z" in the middle. Not "REE-sult."
+
+### 10. <span class="speak-en">"The biggest challenge was…"</span>
+
+**When:** When they ask about a difficult project or a failure.
+
+**Pronunciation tip:** <span class="speak-en" data-say="CHAL-enj">Challenge</span> — "CHAL-enj," stress in front, soft "j" at the end. The "ch" is hard like "church," not "sh." Not "cha-LEN-ge."
+
+---
+
+## Stage 3: Phrases That Project Confidence
+
+Mexican professional culture rewards modesty and hedging. In a US interview, the same habits read as uncertainty. These phrases replace the hedge with a clear claim — without sounding arrogant.
+
+### 11. <span class="speak-en">"I'm confident that…"</span> (instead of *"I think maybe I could…"*)
+
+**When:** Any time you're about to undersell yourself. Lead with the claim.
+
+**Pronunciation tip:** <span class="speak-en" data-say="CON-fih-dent">Confident</span> — "CON-fih-dent," stress in front. Different word from "confidential" — don't blur them.
+
+### 12. <span class="speak-en">"In my experience, the most effective approach is…"</span>
+
+**When:** To state an opinion with authority instead of asking permission to have one.
+
+**Pronunciation tip:** <span class="speak-en" data-say="uh-PROHCH">Approach</span> — "uh-PROHCH," stress on the second syllable, soft "ch" ending. The "a" at the start is a quiet "uh," not a full "ah."
+
+### 13. <span class="speak-en">"I led the [project / team / initiative]."</span>
+
+**When:** Claiming ownership. "I led," not "we did" — they need to know *your* contribution.
+
+**Pronunciation tip:** <span class="speak-en" data-say="led">Led</span> is one syllable that rhymes with "bed." The past tense of "lead" is *not* "leaded" — just "led."
+
+### 14. <span class="speak-en">"That's a strength of mine."</span>
+
+**When:** Owning a strength directly when asked, without the usual deflection.
+
+**Pronunciation tip:** <span class="speak-en" data-say="strength">Strength</span> packs "str-" + "-ength" into one syllable. Don't add a vowel up front ("es-trength") and don't drop the final "-th."
+
+### 15. <span class="speak-en">"I'd describe my management style as…"</span>
+
+**When:** Leadership and self-awareness questions.
+
+**Pronunciation tip:** <span class="speak-en" data-say="MAN-ij-ment">Management</span> — "MAN-ij-ment," stress in front, soft "j" in the middle. Not "ma-nash-MENT."
+
+---
+
+## Stage 4: Talking About Salary
+
+Salary comes up early in US interviews, and hedging here costs you money. These phrases let you give a number with composure.
+
+### 16. <span class="speak-en">"Based on my research, I'm targeting a range of…"</span>
+
+**When:** Answering "What are your salary expectations?" Anchor to research, give a range.
+
+**Pronunciation tip:** <span class="speak-en" data-say="REE-surch">Research</span> as a noun stresses the first syllable — "REE-surch." Roll the American "r" lightly; don't trill it.
+
+### 17. <span class="speak-en">"That's aligned with market data for this level."</span>
+
+**When:** Justifying your number so it sounds informed, not invented.
+
+**Pronunciation tip:** <span class="speak-en" data-say="uh-LYND">Aligned</span> — "uh-LYND," one strong syllable after a quiet "uh." The "g" is silent.
+
+### 18. <span class="speak-en">"I'm open to discussing the full compensation package."</span>
+
+**When:** Signaling flexibility on the *total* deal without lowering your number.
+
+**Pronunciation tip:** <span class="speak-en" data-say="kom-pen-SAY-shun">Compensation</span> — "kom-pen-SAY-shun," stress on "SAY." The "-tion" is always "-shun," never "-see-on."
+
+### 19. <span class="speak-en">"Could you share the budgeted range for this position?"</span>
+
+**When:** Turning the question back when they push you to name a number first.
+
+**Pronunciation tip:** <span class="speak-en" data-say="BUH-jit-ed">Budgeted</span> — "BUH-jit-ed," soft "j." And <span class="speak-en" data-say="puh-ZISH-un">position</span> is "puh-ZISH-un" — "-si-tion" becomes "-zish-un."
+
+---
+
+## Stage 5: Asking Your Own Questions
+
+When they say *"Do you have any questions for us?"* — the wrong answer is "no." These phrases show engagement and seniority.
+
+### 20. <span class="speak-en">"What does success look like in the first 90 days?"</span>
+
+**When:** Your strongest go-to question. It signals you're already thinking about delivering.
+
+**Pronunciation tip:** <span class="speak-en" data-say="suk-SES">Success</span> — "suk-SES," stress on the second syllable, sharp "s" at the end. Not "SUK-ses."
+
+### 21. <span class="speak-en">"What's the biggest challenge the team is facing right now?"</span>
+
+**When:** Shows you think about problems, not perks.
+
+**Pronunciation tip:** <span class="speak-en" data-say="teem">Team</span> is one clean syllable — "teem." Don't stretch it into "tee-am."
+
+### 22. <span class="speak-en">"How would you describe the team's culture?"</span>
+
+**When:** Genuine and safe — and it keeps the conversation human.
+
+**Pronunciation tip:** <span class="speak-en" data-say="KUL-chur">Culture</span> — "KUL-chur," hard "ch" like "church," "r" at the end. Not "kul-TOO-ra."
+
+### 23. <span class="speak-en">"What are the next steps in the process?"</span>
+
+**When:** Closing the interview while signaling you're moving forward with them.
+
+**Pronunciation tip:** <span class="speak-en" data-say="PRAH-ses">Process</span> — American English says "PRAH-ses," stress in front, short "o." Keep the final "s" soft, not "-so."
+
+---
+
+## Stage 6: Closing Strong
+
+The last 30 seconds are your final impression. Don't let them trail off.
+
+### 24. <span class="speak-en">"Thank you for your time today — I really enjoyed the conversation."</span>
+
+**When:** A warm, professional close. Specific beats generic.
+
+**Pronunciation tip:** <span class="speak-en" data-say="kon-ver-SAY-shun">Conversation</span> — "kon-ver-SAY-shun," stress on "SAY," and again "-tion" is "-shun."
+
+### 25. <span class="speak-en">"This role is exactly the kind of challenge I'm looking for."</span>
+
+**When:** Reaffirming interest at the end, with conviction.
+
+**Pronunciation tip:** <span class="speak-en" data-say="ig-ZAKT-lee">Exactly</span> — "ig-ZAKT-lee." Pronounce the "ct" cluster fully; don't soften it to "exa-ly."
+
+### 26. <span class="speak-en">"I'm confident I can contribute to [specific goal]."</span>
+
+**When:** Leaving them with a picture of you already adding value.
+
+**Pronunciation tip:** <span class="speak-en" data-say="kun-TRIB-yoot">Contribute</span> — "kun-TRIB-yoot," stress on the *middle* syllable. A very common mistake is "CON-tri-bute" — move the stress to "TRIB."
+
+---
+
+## Stage 7: The Follow-Up Message
+
+In the US, a same-day follow-up is expected. These phrases give your email a professional spine.
+
+### 27. <span class="speak-en">"Thank you for taking the time to speak with me today."</span>
+
+**When:** Your opening line. Simple, warm, standard.
+
+**Pronunciation tip:** This is a written phrase, but you'll often say a version of it on a call too. Keep "taking the time" smooth — link the words, don't stamp each one.
+
+### 28. <span class="speak-en">"Our conversation reinforced my excitement about this role."</span>
+
+**When:** Stronger than "I'm still interested." It shows the interview *increased* your interest.
+
+**Pronunciation tip:** <span class="speak-en" data-say="ree-in-FORST">Reinforced</span> — "ree-in-FORST," stress on "FORST." And <span class="speak-en" data-say="ik-SYT-ment">excitement</span> is "ik-SYT-ment."
+
+### 29. <span class="speak-en">"Please don't hesitate to reach out if you need anything further."</span>
+
+**When:** A US professional convention that invites continued contact without pushing.
+
+**Pronunciation tip:** <span class="speak-en" data-say="HEZ-ih-tayt">Hesitate</span> — "HEZ-ih-tayt," stress in front, soft "z" sound for the "s." Not "eh-si-TAR."
+
+### 30. <span class="speak-en">"I look forward to the next steps."</span>
+
+**When:** Your closing line — forward-looking and confident.
+
+**Pronunciation tip:** <span class="speak-en" data-say="for-werd">Forward</span> — "FOR-werd," two syllables, stress in front. Don't pronounce it like "four-ward" with a heavy second beat.
+
+---
+
+## The Pattern Behind the Pronunciation
+
+If you noticed a theme in the tips, you've already learned the most valuable lesson:
+
+1. **English crushes unstressed syllables.** Spanish gives every vowel equal weight; English swallows the weak ones ("ex-PEER-ee-ence," not "ex-pee-ree-EN-cia"). Find the stressed syllable, hit it, and let the rest blur.
+2. **Don't add vowels before consonant clusters.** "Strength," not "es-trength." "Specialty," not "es-pecialty."
+3. **"-tion" is always "-shun."** Compensation, position, conversation — never "-see-on."
+4. **Drop the Spanish word endings.** No "-cia," no "-to," no "-ge." English words end harder and shorter than they look.
+
+These four rules fix the majority of interview pronunciation slips. For a deeper drill, our guide to the [50 English words Mexican professionals mispronounce](/en/blog/english-words-mexican-professionals-mispronounce/) breaks down the exact interference patterns word by word.
+
+---
+
+## Keep Reading
+
+- [Ace Your US Company Interview from Mexico](/en/blog/us-interview-prep/) — The full strategy: STAR stories, salary negotiation, video setup, and the cultural gaps that cost qualified candidates the offer.
+- [50 English Words Mexican Professionals Mispronounce](/en/blog/english-words-mexican-professionals-mispronounce/) — Fix the words inside these phrases, organized by business context.
+- [How to Negotiate in English: A Proven 5-Step Framework](/en/blog/how-to-negotiate-in-english-framework/) — When the salary line becomes a real negotiation, these phrases keep you in control.
+
+---
+
+## Practice Until the Words Belong to You
+
+A phrase you've rehearsed out loud is a phrase that won't abandon you when the interviewer is staring at you over Zoom. Pick your ten, say them daily until they feel automatic, and you'll walk into the interview with one less thing to fear — because the words will already be yours.
+
+If you want to drill these phrases with someone who can hear exactly where your pronunciation slips and fix it before the interview, **[book a free strategy session](/en/book/)** and we'll build your interview script together.
+
+You've earned the interview. Let's make sure the words earn you the offer.
+
+---
+
+*Robert Cushman is an English communication coach based in Mexico who helps Latin American professionals deliver under pressure — in interviews, meetings, and the high-stakes moments that decide careers.*

--- a/src/content/blog/es/frases-ingles-entrevista-trabajo.md
+++ b/src/content/blog/es/frases-ingles-entrevista-trabajo.md
@@ -1,0 +1,293 @@
+---
+title: "30 Frases en Inglés para Entrevistas de Trabajo — y Cómo Decirlas Exactamente"
+excerpt: "Las frases exactas en inglés que te hacen sonar seguro en una entrevista de trabajo — organizadas por etapa, cada una con un tip de pronunciación para que las palabras salgan como las pensaste."
+publishDate: "2026-06-09"
+lastmod: "2026-06-09"
+categories:
+  - "Inglés para Negocios"
+  - "Carrera & Liderazgo"
+readingTime: "9 min de lectura"
+audience: "Profesionales mexicanos que se preparan para una entrevista en inglés"
+featuredImage: "./images/us-interview-prep.webp"
+imageAlt: "Profesional mexicano hablando con seguridad en una entrevista de trabajo en inglés"
+translations:
+  en: "/en/blog/business-english-interview-phrases/"
+  es: "/es/blog/frases-ingles-entrevista-trabajo/"
+publish: true
+seo:
+  title: "30 Frases en Inglés para Entrevistas (+ Pronunciación)"
+  description: "Las frases exactas en inglés para sonar seguro en una entrevista, por etapa — con un tip de pronunciación para cada una. Inglés de negocios para profesionales."
+---
+
+Puedes saber exactamente qué quieres decir en una entrevista y aun así perder a tu entrevistador — porque *las palabras salieron mal.* No mal gramaticalmente. Mal pronunciadas, con demasiados rodeos, o entregadas con tanto relleno que la otra persona dejó de escuchar antes de que llegaras a tu punto.
+
+Esta es la brecha que la estrategia nunca cierra. Puedes leer todas las guías sobre la estructura de una entrevista y aun así congelarte cuando el reclutador dice: *"So, tell me about yourself."* Lo que necesitas en ese momento no es teoría. Es una **frase que ya dijiste en voz alta cincuenta veces** — una que sale limpia y con seguridad porque tu boca ya conoce su forma.
+
+Eso es lo que te da esta guía: 30 frases de inglés de negocios para la entrevista, organizadas por la etapa en la que las vas a usar. Para cada una tienes **cuándo usarla** y un **tip de pronunciación** para la palabra que más se te puede atorar — porque en una entrevista en inglés, *cómo* dices la frase es la mitad de lo que se evalúa.
+
+Este es el complemento táctico de nuestra guía completa sobre [cómo funcionan realmente las entrevistas en empresas estadounidenses](/es/blog/entrevista-trabajo-empresa-americana/). Ese artículo es la estrategia. Este es el guion.
+
+---
+
+## Cómo Usar Esta Guía
+
+No leas estas frases en silencio. Di cada una **en voz alta** — primero despacio, luego a velocidad natural — hasta que deje de sentirse como un objeto extraño en tu boca. Las notas de pronunciación usan una escritura fonética simple (cómo suena de verdad la palabra, no los símbolos del diccionario), con la **sílaba acentuada en mayúsculas.**
+
+Escoge las 8 a 10 frases que correspondan a las preguntas que esperas, y practica esas. Diez frases dichas a la perfección le ganan a treinta dichas con titubeos.
+
+---
+
+## Etapa 1: La Apertura — "Tell Me About Yourself"
+
+Los primeros 90 segundos marcan el tono. Estas frases te permiten abrir con una propuesta de valor en lugar de un repaso nervioso de tu currículum.
+
+### 1. <span class="speak-en">"I'm a [role] with [X] years of experience in [specialty]."</span>
+
+**Cuándo:** Tu primera oración. Te presenta como un profesional con un enfoque, no como una lista de empleos anteriores.
+
+**Tip de pronunciación:** La palabra <span class="speak-en" data-say="EX-peer-ee-ence">experience</span> tiene cuatro sílabas con el énfasis en la *segunda* — "ex-PIR-i-ens" — no "ex-pe-ri-EN-cia." Elimina por completo la terminación "-cia" del español.
+
+### 2. <span class="speak-en">"My specialty is [outcome you deliver]."</span>
+
+**Cuándo:** Justo después de tu apertura, para afinar el enfoque antes de dar números.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="SPEH-shul-tee">Specialty</span> lleva el énfasis adelante — "SPEH-shul-ti," tres sílabas. Evita el instinto del español de decir "es-pe-cia-li-DAD."
+
+### 3. <span class="speak-en">"What I'm most proud of is [quantified result]."</span>
+
+**Cuándo:** Para introducir tu número más fuerte — "I cut our delivery time from 14 days to 6."
+
+**Tip de pronunciación:** <span class="speak-en" data-say="prowd">Proud</span> rima con "loud" — una sola sílaba, "praud." No le agregues una vocal al inicio: no es "pe-raud."
+
+### 4. <span class="speak-en">"I'm excited about this role because [link to their need]."</span>
+
+**Cuándo:** Para cerrar tu apertura conectando tu experiencia con *su* vacante, no con tu carrera.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="ek-SY-ted">Excited</span> — "ek-SAI-ted," énfasis en medio. La "x" suena como "ks" y la "ci" es un sonido largo de "ai," no "si."
+
+---
+
+## Etapa 2: Preguntas de Comportamiento — Armar una Historia STAR
+
+Las entrevistas al estilo estadounidense viven del *"Tell me about a time when…"* Estas frases te dan una entrada con seguridad a tu ejemplo mientras tu cabeza se pone al día.
+
+### 5. <span class="speak-en">"A good example of that was when…"</span>
+
+**Cuándo:** Tu apertura por defecto para cualquier pregunta de comportamiento. Te da dos segundos y avisa que viene una historia real.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="ig-ZAM-pul">Example</span> — "ig-ZAM-pul." Aquí la "x" suena como una "z" suave, y no hay "e" al final: no es "ex-AM-ple."
+
+### 6. <span class="speak-en">"To give you some context…"</span>
+
+**Cuándo:** La parte de "Situación" del método STAR — poner el escenario antes de la acción.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="CON-text">Context</span> acentúa la primera sílaba — "CON-text." Marca bien la "t" final; no la suavices a "con-TEX-to."
+
+### 7. <span class="speak-en">"My responsibility was to…"</span>
+
+**Cuándo:** La "Tarea" — dejar claro qué te tocaba *a ti.*
+
+**Tip de pronunciación:** <span class="speak-en" data-say="ris-pon-suh-BIL-uh-tee">Responsibility</span> es una palabra maratón: seis sílabas, énfasis en "BIL" — "ris-pon-su-BIL-u-ti." Dila despacio al practicar y la velocidad llega después.
+
+### 8. <span class="speak-en">"So what I did was…"</span>
+
+**Cuándo:** La "Acción" — el corazón de la respuesta. Nota el "I" deliberado, no "we."
+
+**Tip de pronunciación:** Mantenla corta y pareja. Aquí la trampa no es una palabra difícil — es bajar el ritmo y dar demasiadas explicaciones. Remata "what I did" con una pequeña pausa después.
+
+### 9. <span class="speak-en">"As a result, [measurable outcome]."</span>
+
+**Cuándo:** El "Resultado" — siempre cierra con el número o el impacto en el negocio.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="ri-ZULT">Result</span> — "ri-ZULT," énfasis en la segunda sílaba, "z" suave en medio. No es "RI-sult."
+
+### 10. <span class="speak-en">"The biggest challenge was…"</span>
+
+**Cuándo:** Cuando preguntan por un proyecto difícil o un fracaso.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="CHAL-enj">Challenge</span> — "CHAL-enj," énfasis adelante, "j" suave al final. La "ch" es dura como en "church," no "sh." No es "cha-LEN-ge."
+
+---
+
+## Etapa 3: Frases que Proyectan Seguridad
+
+La cultura profesional mexicana premia la modestia y los rodeos. En una entrevista estadounidense, esos mismos hábitos se leen como inseguridad. Estas frases reemplazan el rodeo con una afirmación clara — sin sonar arrogante.
+
+### 11. <span class="speak-en">"I'm confident that…"</span> (en lugar de *"I think maybe I could…"*)
+
+**Cuándo:** Cada vez que estés a punto de minimizarte. Arranca con la afirmación.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="CON-fih-dent">Confident</span> — "CON-fi-dent," énfasis adelante. Es una palabra distinta de "confidential" — no las mezcles.
+
+### 12. <span class="speak-en">"In my experience, the most effective approach is…"</span>
+
+**Cuándo:** Para dar una opinión con autoridad en lugar de pedir permiso para tenerla.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="uh-PROHCH">Approach</span> — "a-PROUCH," énfasis en la segunda sílaba, "ch" suave al final. La "a" del inicio es una "a" callada, no una "a" abierta y fuerte.
+
+### 13. <span class="speak-en">"I led the [project / team / initiative]."</span>
+
+**Cuándo:** Reclamar la autoría. "I led," no "we did" — necesitan saber cuál fue *tu* contribución.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="led">Led</span> es una sílaba que rima con "bed." El pasado de "lead" *no* es "leaded" — es solo "led."
+
+### 14. <span class="speak-en">"That's a strength of mine."</span>
+
+**Cuándo:** Reconocer una fortaleza directamente cuando te preguntan, sin la evasión de costumbre.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="strength">Strength</span> mete "str-" + "-ength" en una sola sílaba. No agregues vocal al inicio ("es-trength") y no te comas el "-th" final.
+
+### 15. <span class="speak-en">"I'd describe my management style as…"</span>
+
+**Cuándo:** Preguntas de liderazgo y autoconocimiento.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="MAN-ij-ment">Management</span> — "MA-nish-ment," énfasis adelante, "j" suave en medio. No es "ma-nash-MENT."
+
+---
+
+## Etapa 4: Hablar de Salario
+
+El salario sale temprano en las entrevistas estadounidenses, y dar rodeos aquí te cuesta dinero. Estas frases te permiten dar un número con aplomo.
+
+### 16. <span class="speak-en">"Based on my research, I'm targeting a range of…"</span>
+
+**Cuándo:** Al responder "What are your salary expectations?" Ánclate en la investigación, da un rango.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="REE-surch">Research</span> como sustantivo acentúa la primera sílaba — "RI-surch." Marca la "r" americana ligera; no la hagas vibrar.
+
+### 17. <span class="speak-en">"That's aligned with market data for this level."</span>
+
+**Cuándo:** Para justificar tu número y que suene informado, no inventado.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="uh-LYND">Aligned</span> — "a-LAIND," una sílaba fuerte después de una "a" callada. La "g" es muda.
+
+### 18. <span class="speak-en">"I'm open to discussing the full compensation package."</span>
+
+**Cuándo:** Para señalar flexibilidad en el *paquete total* sin bajar tu número.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="kom-pen-SAY-shun">Compensation</span> — "kom-pen-SEI-shun," énfasis en "SEI." La terminación "-tion" siempre es "-shun," nunca "-cion."
+
+### 19. <span class="speak-en">"Could you share the budgeted range for this position?"</span>
+
+**Cuándo:** Para regresar la pregunta cuando te presionan a dar un número primero.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="BUH-jit-ed">Budgeted</span> — "BO-yet-ed," "j" suave. Y <span class="speak-en" data-say="puh-ZISH-un">position</span> es "po-ZISH-un" — "-si-tion" se vuelve "-zish-un."
+
+---
+
+## Etapa 5: Hacer Tus Propias Preguntas
+
+Cuando dicen *"Do you have any questions for us?"* — la respuesta equivocada es "no." Estas frases muestran interés y nivel.
+
+### 20. <span class="speak-en">"What does success look like in the first 90 days?"</span>
+
+**Cuándo:** Tu mejor pregunta de cabecera. Señala que ya estás pensando en entregar resultados.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="suk-SES">Success</span> — "suk-SES," énfasis en la segunda sílaba, "s" filosa al final. No es "SUK-ses."
+
+### 21. <span class="speak-en">"What's the biggest challenge the team is facing right now?"</span>
+
+**Cuándo:** Muestra que piensas en problemas, no en prestaciones.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="teem">Team</span> es una sílaba limpia — "tim." No la estires a "ti-am."
+
+### 22. <span class="speak-en">"How would you describe the team's culture?"</span>
+
+**Cuándo:** Genuina y segura — y mantiene la conversación humana.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="KUL-chur">Culture</span> — "KOL-chur," "ch" dura como en "church," "r" al final. No es "kul-TU-ra."
+
+### 23. <span class="speak-en">"What are the next steps in the process?"</span>
+
+**Cuándo:** Para cerrar la entrevista señalando que avanzas con ellos.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="PRAH-ses">Process</span> — el inglés americano dice "PRA-ses," énfasis adelante, "o" corta. Deja la "s" final suave, no "-so."
+
+---
+
+## Etapa 6: Cerrar con Fuerza
+
+Los últimos 30 segundos son tu impresión final. No dejes que se apague.
+
+### 24. <span class="speak-en">"Thank you for your time today — I really enjoyed the conversation."</span>
+
+**Cuándo:** Un cierre cálido y profesional. Lo específico le gana a lo genérico.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="kon-ver-SAY-shun">Conversation</span> — "kon-ver-SEI-shun," énfasis en "SEI," y otra vez "-tion" es "-shun."
+
+### 25. <span class="speak-en">"This role is exactly the kind of challenge I'm looking for."</span>
+
+**Cuándo:** Para reafirmar tu interés al final, con convicción.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="ig-ZAKT-lee">Exactly</span> — "ig-ZAKT-li." Pronuncia el grupo "ct" completo; no lo suavices a "exa-li."
+
+### 26. <span class="speak-en">"I'm confident I can contribute to [specific goal]."</span>
+
+**Cuándo:** Para dejarles una imagen de ti ya aportando valor.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="kun-TRIB-yoot">Contribute</span> — "kon-TRIB-yut," énfasis en la sílaba *de en medio.* Un error muy común es "CON-tri-bute" — mueve el énfasis a "TRIB."
+
+---
+
+## Etapa 7: El Mensaje de Seguimiento
+
+En Estados Unidos, un seguimiento el mismo día se espera. Estas frases le dan a tu correo una columna vertebral profesional.
+
+### 27. <span class="speak-en">"Thank you for taking the time to speak with me today."</span>
+
+**Cuándo:** Tu primera línea. Simple, cálida, estándar.
+
+**Tip de pronunciación:** Es una frase escrita, pero a menudo dirás una versión en una llamada también. Mantén "taking the time" fluido — liga las palabras, no marques cada una.
+
+### 28. <span class="speak-en">"Our conversation reinforced my excitement about this role."</span>
+
+**Cuándo:** Más fuerte que "I'm still interested." Muestra que la entrevista *aumentó* tu interés.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="ree-in-FORST">Reinforced</span> — "ri-in-FORST," énfasis en "FORST." Y <span class="speak-en" data-say="ik-SYT-ment">excitement</span> es "ik-SAIT-ment."
+
+### 29. <span class="speak-en">"Please don't hesitate to reach out if you need anything further."</span>
+
+**Cuándo:** Una convención profesional estadounidense que invita a seguir en contacto sin presionar.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="HEZ-ih-tayt">Hesitate</span> — "HE-si-teit," énfasis adelante, "s" suave como "z." No es "e-si-TAR."
+
+### 30. <span class="speak-en">"I look forward to the next steps."</span>
+
+**Cuándo:** Tu línea de cierre — mira hacia adelante y con seguridad.
+
+**Tip de pronunciación:** <span class="speak-en" data-say="for-werd">Forward</span> — "FOR-werd," dos sílabas, énfasis adelante. No lo pronuncies como "four-ward" con un segundo golpe pesado.
+
+---
+
+## El Patrón Detrás de la Pronunciación
+
+Si notaste un tema en los tips, ya aprendiste la lección más valiosa:
+
+1. **El inglés aplasta las sílabas átonas.** El español le da a cada vocal el mismo peso; el inglés se traga las débiles ("ex-PIR-i-ens," no "ex-pe-ri-EN-cia"). Encuentra la sílaba acentuada, pégale fuerte, y deja que el resto se difumine.
+2. **No agregues vocales antes de grupos de consonantes.** "Strength," no "es-trength." "Specialty," no "es-pecialty."
+3. **"-tion" siempre es "-shun."** Compensation, position, conversation — nunca "-cion."
+4. **Quita las terminaciones del español.** Nada de "-cia," nada de "-to," nada de "-ge." Las palabras en inglés terminan más duro y más corto de lo que se ven.
+
+Estas cuatro reglas corrigen la mayoría de los tropiezos de pronunciación en una entrevista. Para una práctica más a fondo, nuestra guía de las [50 palabras en inglés que los profesionales mexicanos pronuncian mal](/es/blog/palabras-en-ingles-que-profesionales-mexicanos-pronuncian-mal/) desglosa los patrones de interferencia palabra por palabra.
+
+---
+
+## Sigue Leyendo
+
+- [Cómo Brillar en una Entrevista con una Empresa Americana](/es/blog/entrevista-trabajo-empresa-americana/) — La estrategia completa: historias STAR, negociación de salario, configuración de video, y las brechas culturales que les cuestan la vacante a candidatos calificados.
+- [50 Palabras en Inglés que los Profesionales Mexicanos Pronuncian Mal](/es/blog/palabras-en-ingles-que-profesionales-mexicanos-pronuncian-mal/) — Corrige las palabras dentro de estas frases, organizadas por contexto de negocios.
+- [Cómo Negociar en Inglés: Un Marco Probado de 5 Pasos](/es/blog/como-negociar-en-ingles-marco/) — Cuando la línea del salario se vuelve una negociación real, estas frases te mantienen en control.
+
+---
+
+## Practica Hasta que las Palabras Sean Tuyas
+
+Una frase que ensayaste en voz alta es una frase que no te va a abandonar cuando el entrevistador te esté mirando por Zoom. Escoge tus diez, dilas a diario hasta que se sientan automáticas, y entrarás a la entrevista con una cosa menos que temer — porque las palabras ya serán tuyas.
+
+Si quieres practicar estas frases con alguien que pueda escuchar exactamente dónde se te resbala la pronunciación y corregirlo antes de la entrevista, **[agenda una sesión de estrategia gratuita](/es/reservar/)** y armamos juntos tu guion de entrevista.
+
+Te ganaste la entrevista. Asegurémonos de que las palabras te ganen la oferta.
+
+---
+
+*Robert Cushman es coach de comunicación en inglés radicado en México que ayuda a profesionales latinoamericanos a rendir bajo presión — en entrevistas, juntas, y los momentos de alto impacto que deciden carreras.*


### PR DESCRIPTION
## What

New phrasebook blog post **"30 Business English Interview Phrases — and Exactly How to Say Them"** in EN + Mexican Professional Spanish, plus a condensed Google Business Profile post.

## Why this angle
We already have `us-interview-prep` (interview *strategy/culture*). To avoid keyword cannibalization, this post takes a distinct **phrases + pronunciation** angle. The two cross-link as a topical cluster that should lift both, and this one directly targets the 'interview phrases' / 'consejos para entrevistas' search intent behind the #1 'business English Guadalajara' ranking.

## Contents
- `src/content/blog/en/business-english-interview-phrases.md` — 30 phrases by interview stage, each with a pronunciation tip (speak-en/data-say format)
- `src/content/blog/es/frases-ingles-entrevista-trabajo.md` — es-MX version (no Iberian markers)
- `astro.config.mjs` — EN↔ES sitemap hreflang mapping
- `content-marketing/business-english-interview-phrases-social.md` — GBP post (es-MX) + carousel slides + LinkedIn/X/FB

## Validation
- `npm run build` — exit 0, 402 sitemap URLs, 0 errors
- Meta-description gate: all pages 120–160 chars ✅
- Competitive positioning leads on practical outcomes; **no named competitor attacks** (GBP policy + legal/brand risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)