### PR TITLE
fix: read POSTGRES_URL at runtime via process.env, not import.meta.env

### DIFF
--- a/src/lib/neon.ts
+++ b/src/lib/neon.ts
@@ -7,7 +7,23 @@
 
 import { neon } from "@neondatabase/serverless";
 
-const databaseUrl = import.meta.env.POSTGRES_URL;
+/**
+ * Read POSTGRES_URL at RUNTIME, not build time.
+ *
+ * Vite statically inlines `import.meta.env.X` when the bundle is built — so a
+ * connection string added or rotated in the host's environment *after* the
+ * build (or reused via build cache) gets baked in as `undefined`, and every
+ * query silently fails. On a Node serverless runtime, `process.env` holds the
+ * deployment's live value and is never inlined for server code, so it is the
+ * reliable source. `import.meta.env` stays as a local-dev fallback.
+ *
+ * Typed via `globalThis` so this compiles under the project's `astro/client`-
+ * only tsconfig without pulling in `@types/node`.
+ */
+const runtimeEnv = (
+  globalThis as { process?: { env?: Record<string, string | undefined> } }
+).process?.env;
+const databaseUrl = runtimeEnv?.POSTGRES_URL ?? import.meta.env.POSTGRES_URL;
 
 if (!databaseUrl) {
   console.warn(


### PR DESCRIPTION
## What

Found by the cross-repo `import.meta.env` sweep. `src/lib/neon.ts` read the DB connection string via `import.meta.env.POSTGRES_URL`, which Vite **inlines at build time** — so a value added or rotated in the host environment *after* the build bakes in as `undefined` and every query silently fails. Same build-inlining trap fixed in the expat-driver-license-prep repo (PRs #43/#44).

## Scope / risk

`neon.ts` and `db.ts` have **no importers** — they're unwired dead code from the Supabase→Neon migration. So this is **preemptive**: it removes the landmine before the quiz-submission DB feature is built on top of it. Zero risk to any live path.

## Fix

- Read `process.env` first (live on Node serverless runtimes, never inlined for server code), `import.meta.env` as a local-dev fallback
- Typed via `globalThis` so it compiles under this repo's `astro/client`-only tsconfig without adding `@types/node`

## Verification

- `eslint src/lib/neon.ts` clean
- `astro check` 0 errors
- Runtime logic unit-checked: resolves from `process.env` when set, `undefined` when unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)